### PR TITLE
Fix subquery errors when using AsyncAppend

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -284,7 +284,7 @@ _guc_init(void)
 							 "Pick data fetcher type based on type of queries you plan to run "
 							 "(rowbyrow or cursor)",
 							 (int *) &ts_guc_remote_data_fetcher,
-							 RowByRowFetcherType,
+							 CursorFetcherType,
 							 remote_data_fetchers,
 							 PGC_USERSET,
 							 0,

--- a/tsl/src/async_append.h
+++ b/tsl/src/async_append.h
@@ -30,8 +30,12 @@ typedef struct AsyncAppendPath
 typedef struct AsyncScanState
 {
 	CustomScanState css;
+	/* Initialize the scan state */
 	void (*init)(struct AsyncScanState *state);
-	void (*fetch_tuples)(struct AsyncScanState *state);
+	/* Send a request for new data */
+	void (*send_fetch_request)(struct AsyncScanState *state);
+	/* Fetch the actual data */
+	void (*fetch_data)(struct AsyncScanState *state);
 } AsyncScanState;
 
 extern void async_append_add_paths(PlannerInfo *root, RelOptInfo *hyper_rel);

--- a/tsl/src/fdw/data_node_scan_exec.c
+++ b/tsl/src/fdw/data_node_scan_exec.c
@@ -155,7 +155,16 @@ static void
 create_fetcher(AsyncScanState *ass)
 {
 	DataNodeScanState *dnss = (DataNodeScanState *) ass;
-	create_data_fetcher(&dnss->async_state.css.ss, &dnss->fsstate, FETCH_ASYNC);
+	create_data_fetcher(&dnss->async_state.css.ss, &dnss->fsstate);
+}
+
+static void
+send_fetch_request(AsyncScanState *ass)
+{
+	DataNodeScanState *dnss = (DataNodeScanState *) ass;
+	DataFetcher *fetcher = dnss->fsstate.fetcher;
+
+	fetcher->funcs->send_fetch_request(fetcher);
 }
 
 static void
@@ -163,7 +172,8 @@ fetch_data(AsyncScanState *ass)
 {
 	DataNodeScanState *dnss = (DataNodeScanState *) ass;
 	DataFetcher *fetcher = dnss->fsstate.fetcher;
-	fetcher->funcs->fetch_data_start(fetcher);
+
+	fetcher->funcs->fetch_data(fetcher);
 }
 
 Node *
@@ -175,6 +185,7 @@ data_node_scan_state_create(CustomScan *cscan)
 	dnss->async_state.css.methods = &data_node_scan_state_methods;
 	dnss->systemcol = linitial_int(list_nth(cscan->custom_private, 1));
 	dnss->async_state.init = create_fetcher;
-	dnss->async_state.fetch_tuples = fetch_data;
+	dnss->async_state.send_fetch_request = send_fetch_request;
+	dnss->async_state.fetch_data = fetch_data;
 	return (Node *) dnss;
 }

--- a/tsl/src/fdw/option.c
+++ b/tsl/src/fdw/option.c
@@ -26,6 +26,7 @@
 #include <access/reloptions.h>
 #include <catalog/pg_foreign_server.h>
 #include <catalog/pg_foreign_table.h>
+#include <catalog/pg_foreign_data_wrapper.h>
 #include <commands/defrem.h>
 #include <commands/extension.h>
 #include <utils/builtins.h>
@@ -143,13 +144,16 @@ init_ts_fdw_options(void)
 	/* non-libpq FDW-specific FDW options */
 	static const TsFdwOption non_libpq_options[] = {
 		/* cost factors */
+		{ "fdw_startup_cost", ForeignDataWrapperRelationId },
 		{ "fdw_startup_cost", ForeignServerRelationId },
+		{ "fdw_tuple_cost", ForeignDataWrapperRelationId },
 		{ "fdw_tuple_cost", ForeignServerRelationId },
 		/* shippable extensions */
+		{ "extensions", ForeignDataWrapperRelationId },
 		{ "extensions", ForeignServerRelationId },
-		/* fetch_size is available on both server and table */
+		/* fetch_size is available on both foreign data wrapper and server */
+		{ "fetch_size", ForeignDataWrapperRelationId },
 		{ "fetch_size", ForeignServerRelationId },
-		{ "fetch_size", ForeignTableRelationId },
 		{ NULL, InvalidOid }
 	};
 

--- a/tsl/src/fdw/scan_exec.c
+++ b/tsl/src/fdw/scan_exec.c
@@ -90,12 +90,10 @@ fill_query_params_array(ExprContext *econtext, FmgrInfo *param_flinfo, List *par
 }
 
 /*
- * Create cursor for node's query with current parameter values.
- * Operation can be blocking or non-blocking, depending on the bool arg.
- * In non blocking case we just dispatch async request to create cursor
+ * Create data fetcher for node's query with current parameter values.
  */
 DataFetcher *
-create_data_fetcher(ScanState *ss, TsFdwScanState *fsstate, FetchMode mode)
+create_data_fetcher(ScanState *ss, TsFdwScanState *fsstate)
 {
 	ExprContext *econtext = ss->ps.ps_ExprContext;
 	int num_params = fsstate->num_params;
@@ -135,8 +133,7 @@ create_data_fetcher(ScanState *ss, TsFdwScanState *fsstate, FetchMode mode)
 										   ss,
 										   fsstate->retrieved_attrs,
 										   fsstate->query,
-										   params,
-										   mode);
+										   params);
 	fsstate->fetcher = fetcher;
 	MemoryContextSwitchTo(oldcontext);
 
@@ -318,7 +315,7 @@ fdw_scan_iterate(ScanState *ss, TsFdwScanState *fsstate)
 	DataFetcher *fetcher = fsstate->fetcher;
 
 	if (NULL == fetcher)
-		fetcher = create_data_fetcher(ss, fsstate, FETCH_NOASYNC);
+		fetcher = create_data_fetcher(ss, fsstate);
 
 	tuple = fetcher->funcs->get_next_tuple(fetcher);
 

--- a/tsl/src/fdw/scan_exec.h
+++ b/tsl/src/fdw/scan_exec.h
@@ -48,7 +48,7 @@ extern void fdw_scan_end(TsFdwScanState *fsstate);
 extern void fdw_scan_explain(ScanState *ss, List *fdw_private, ExplainState *es,
 							 TsFdwScanState *fsstate);
 
-extern DataFetcher *create_data_fetcher(ScanState *ss, TsFdwScanState *fsstate, FetchMode mode);
+extern DataFetcher *create_data_fetcher(ScanState *ss, TsFdwScanState *fsstate);
 
 #ifdef TS_DEBUG
 

--- a/tsl/src/fdw/scan_plan.c
+++ b/tsl/src/fdw/scan_plan.c
@@ -333,7 +333,7 @@ fdw_scan_info_init(ScanInfo *scaninfo, PlannerInfo *root, RelOptInfo *rel, Path 
  * For a join relation, FDW-specific information about the inner and outer
  * relations is provided using fpinfo_i and fpinfo_o.  For an upper relation,
  * fpinfo_o provides the information for the input relation; fpinfo_i is
- * expected to NULL.
+ * expected to be NULL.
  */
 static void
 merge_fdw_options(TsFdwRelInfo *fpinfo, const TsFdwRelInfo *fpinfo_o, const TsFdwRelInfo *fpinfo_i)
@@ -349,7 +349,7 @@ merge_fdw_options(TsFdwRelInfo *fpinfo, const TsFdwRelInfo *fpinfo_o, const TsFd
 	Assert(fpinfo_i == NULL);
 
 	/*
-	 * Copy the server specific FDW options.  (For a join, both relations come
+	 * Copy the server specific FDW options. (For a join, both relations come
 	 * from the same server, so the server options should have the same value
 	 * for both relations.)
 	 */

--- a/tsl/src/remote/cursor_fetcher.h
+++ b/tsl/src/remote/cursor_fetcher.h
@@ -15,6 +15,6 @@ extern DataFetcher *cursor_fetcher_create_for_rel(TSConnection *conn, Relation r
 												  StmtParams *params);
 extern DataFetcher *cursor_fetcher_create_for_scan(TSConnection *conn, ScanState *ss,
 												   List *retrieved_attrs, const char *stmt,
-												   StmtParams *params, FetchMode mode);
+												   StmtParams *params);
 
 #endif /* TIMESCALEDB_TSL_CURSOR_FETCHER_H */

--- a/tsl/src/remote/row_by_row_fetcher.h
+++ b/tsl/src/remote/row_by_row_fetcher.h
@@ -15,6 +15,6 @@ extern DataFetcher *row_by_row_fetcher_create_for_rel(TSConnection *conn, Relati
 													  StmtParams *params);
 extern DataFetcher *row_by_row_fetcher_create_for_scan(TSConnection *conn, ScanState *ss,
 													   List *retrieved_attrs, const char *stmt,
-													   StmtParams *params, FetchMode mode);
+													   StmtParams *params);
 
 #endif /* TIMESCALEDB_TSL_ROW_BY_ROW_FETCHER_H */

--- a/tsl/test/expected/dist_query-11.out
+++ b/tsl/test/expected/dist_query-11.out
@@ -18,6 +18,10 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_REFER
        format('\! diff %s %s', :'TEST_RESULTS_REPART_OPTIMIZED', :'TEST_RESULTS_REPART_REFERENCE') AS "DIFF_CMD_REPART",
        format('\! diff %s %s', :'TEST_RESULTS_1DIM', :'TEST_RESULTS_REPART_REFERENCE') AS "DIFF_CMD_1DIM"
 \gset
+-- Use a small fetch size to make sure that result are fetched across
+-- multiple fetches.
+--ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fetch_size '500');
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
 SET client_min_messages TO notice;
 -- Load the data
 \ir :TEST_LOAD_NAME
@@ -1025,6 +1029,135 @@ LIMIT 10
                      Output: join_test.device
 (27 rows)
 
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   CTE top_n
+     ->  Limit
+           Output: device, (avg(temp))
+           ->  Sort
+                 Output: device, (avg(temp))
+                 Sort Key: (avg(temp)) DESC
+                 ->  Custom Scan (AsyncAppend)
+                       Output: device, (avg(temp))
+                       ->  Append
+                             ->  Custom Scan (DataNodeScan)
+                                   Output: hyper_4.device, (avg(hyper_4.temp))
+                                   Relations: Aggregate on (public.hyper)
+                                   Data node: data_node_1
+                                   Chunks: _dist_hyper_1_1_chunk
+                                   Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                             ->  Custom Scan (DataNodeScan)
+                                   Output: hyper_5.device, (avg(hyper_5.temp))
+                                   Relations: Aggregate on (public.hyper)
+                                   Data node: data_node_2
+                                   Chunks: _dist_hyper_1_2_chunk
+                                   Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                             ->  GroupAggregate
+                                   Output: hyper_6.device, avg(hyper_6.temp)
+                                   Group Key: hyper_6.device
+                                   ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
+                                         Output: hyper_6.device, hyper_6.temp
+                                         Data node: data_node_3
+                                         Chunks: _dist_hyper_1_3_chunk
+                                         Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_1_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_2_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  CTE Scan on top_n
+                           Output: top_n.device
+(60 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h2."time")), h2.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                           Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_2_19_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(34 rows)
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
 %%% PREFIX: EXPLAIN (verbose, costs off)
@@ -1892,6 +2025,135 @@ LIMIT 10
                      Output: join_test.device
 (27 rows)
 
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   CTE top_n
+     ->  Limit
+           Output: device, (avg(temp))
+           ->  Sort
+                 Output: device, (avg(temp))
+                 Sort Key: (avg(temp)) DESC
+                 ->  Custom Scan (AsyncAppend)
+                       Output: device, (avg(temp))
+                       ->  Append
+                             ->  Custom Scan (DataNodeScan)
+                                   Output: hyper_4.device, (avg(hyper_4.temp))
+                                   Relations: Aggregate on (public.hyper)
+                                   Data node: data_node_1
+                                   Chunks: _dist_hyper_1_1_chunk
+                                   Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                             ->  Custom Scan (DataNodeScan)
+                                   Output: hyper_5.device, (avg(hyper_5.temp))
+                                   Relations: Aggregate on (public.hyper)
+                                   Data node: data_node_2
+                                   Chunks: _dist_hyper_1_2_chunk
+                                   Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                             ->  GroupAggregate
+                                   Output: hyper_6.device, avg(hyper_6.temp)
+                                   Group Key: hyper_6.device
+                                   ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
+                                         Output: hyper_6.device, hyper_6.temp
+                                         Data node: data_node_3
+                                         Chunks: _dist_hyper_1_3_chunk
+                                         Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_1_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_2_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  CTE Scan on top_n
+                           Output: top_n.device
+(60 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h2."time")), h2.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                           Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_2_19_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(34 rows)
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
 %%% PREFIX: EXPLAIN (verbose, costs off)
@@ -2538,6 +2800,101 @@ LIMIT 10
                ->  Seq Scan on public.join_test
                      Output: join_test.device
 (27 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND device = 1
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND device = 1
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   CTE top_n
+     ->  Limit
+           Output: hyper_1.device, (avg(hyper_1.temp))
+           ->  Merge Append
+                 Sort Key: (avg(hyper_1.temp)) DESC
+                 ->  Custom Scan (DataNodeScan)
+                       Output: hyper_1.device, (avg(hyper_1.temp))
+                       Relations: Aggregate on (public.hyper)
+                       Data node: data_node_1
+                       Chunks: _dist_hyper_1_1_chunk
+                       Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY avg(temp) DESC NULLS FIRST
+   ->  Nested Loop
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         ->  Merge Append
+               Sort Key: (time_bucket('@ 1 min'::interval, hyper."time"))
+               ->  Custom Scan (DataNodeScan) on public.hyper
+                     Output: hyper."time", hyper.device, hyper.temp, time_bucket('@ 1 min'::interval, hyper."time")
+                     Data node: data_node_1
+                     Chunks: _dist_hyper_1_1_chunk
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST
+         ->  CTE Scan on top_n
+               Output: top_n.device, top_n.avg
+               Filter: (top_n.device = 1)
+(26 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h2."time")), h2.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                           Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_2_19_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(34 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -3419,6 +3776,135 @@ LIMIT 10
                ->  Seq Scan on public.join_test
                      Output: join_test.device
 (27 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   CTE top_n
+     ->  Limit
+           Output: device, (avg(temp))
+           ->  Sort
+                 Output: device, (avg(temp))
+                 Sort Key: (avg(temp)) DESC
+                 ->  Custom Scan (AsyncAppend)
+                       Output: device, (avg(temp))
+                       ->  Append
+                             ->  Custom Scan (DataNodeScan)
+                                   Output: hyper_4.device, (avg(hyper_4.temp))
+                                   Relations: Aggregate on (public.hyper)
+                                   Data node: data_node_1
+                                   Chunks: _dist_hyper_1_1_chunk
+                                   Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                             ->  Custom Scan (DataNodeScan)
+                                   Output: hyper_5.device, (avg(hyper_5.temp))
+                                   Relations: Aggregate on (public.hyper)
+                                   Data node: data_node_2
+                                   Chunks: _dist_hyper_1_2_chunk
+                                   Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                             ->  GroupAggregate
+                                   Output: hyper_6.device, avg(hyper_6.temp)
+                                   Group Key: hyper_6.device
+                                   ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
+                                         Output: hyper_6.device, hyper_6.temp
+                                         Data node: data_node_3
+                                         Chunks: _dist_hyper_1_3_chunk
+                                         Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_1_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_2_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  CTE Scan on top_n
+                           Output: top_n.device
+(60 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h2."time")), h2.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                           Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_2_19_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(34 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -4309,6 +4795,136 @@ LIMIT 10
                      Output: join_test.device
 (27 rows)
 
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time >= '2019-01-01'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time >= '2019-01-01'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                    QUERY PLAN                                                                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   CTE top_n
+     ->  Limit
+           Output: device, (avg(temp))
+           ->  Sort
+                 Output: device, (avg(temp))
+                 Sort Key: (avg(temp)) DESC
+                 ->  Finalize HashAggregate
+                       Output: device, avg(temp)
+                       Group Key: device
+                       ->  Custom Scan (AsyncAppend)
+                             Output: device, (PARTIAL avg(temp))
+                             ->  Append
+                                   ->  Custom Scan (DataNodeScan)
+                                         Output: hyper_4.device, (PARTIAL avg(hyper_4.temp))
+                                         Relations: Aggregate on (public.hyper)
+                                         Data node: data_node_1
+                                         Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
+                                         Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+                                   ->  Custom Scan (DataNodeScan)
+                                         Output: hyper_5.device, (PARTIAL avg(hyper_5.temp))
+                                         Relations: Aggregate on (public.hyper)
+                                         Data node: data_node_2
+                                         Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
+                                         Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+                                   ->  Custom Scan (DataNodeScan)
+                                         Output: hyper_6.device, (PARTIAL avg(hyper_6.temp))
+                                         Relations: Aggregate on (public.hyper)
+                                         Data node: data_node_3
+                                         Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
+                                         Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  CTE Scan on top_n
+                           Output: top_n.device
+(61 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h2."time")), h2.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                           Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_2_19_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(34 rows)
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper1d
 %%% PREFIX: EXPLAIN (verbose, costs off)
@@ -5187,6 +5803,136 @@ LIMIT 10
                ->  Seq Scan on public.join_test
                      Output: join_test.device
 (27 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper1d
+	 WHERE time >= '2019-01-01'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper1d INNER JOIN top_n USING (device)
+WHERE time >= '2019-01-01'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                             QUERY PLAN                                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device, avg(hyper1d.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device
+   CTE top_n
+     ->  Limit
+           Output: device, (avg(temp))
+           ->  Sort
+                 Output: device, (avg(temp))
+                 Sort Key: (avg(temp)) DESC
+                 ->  Finalize HashAggregate
+                       Output: device, avg(temp)
+                       Group Key: device
+                       ->  Custom Scan (AsyncAppend)
+                             Output: device, (PARTIAL avg(temp))
+                             ->  Append
+                                   ->  Custom Scan (DataNodeScan)
+                                         Output: hyper1d_4.device, (PARTIAL avg(hyper1d_4.temp))
+                                         Relations: Aggregate on (public.hyper1d)
+                                         Data node: data_node_1
+                                         Chunks: _dist_hyper_2_19_chunk
+                                         Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                   ->  Custom Scan (DataNodeScan)
+                                         Output: hyper1d_5.device, (PARTIAL avg(hyper1d_5.temp))
+                                         Relations: Aggregate on (public.hyper1d)
+                                         Data node: data_node_2
+                                         Chunks: _dist_hyper_2_20_chunk
+                                         Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+                                   ->  Custom Scan (DataNodeScan)
+                                         Output: hyper1d_6.device, (PARTIAL avg(hyper1d_6.temp))
+                                         Relations: Aggregate on (public.hyper1d)
+                                         Data node: data_node_3
+                                         Chunks: _dist_hyper_2_21_chunk
+                                         Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device, hyper1d.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper1d."time"), hyper1d.device, hyper1d.temp
+               Hash Cond: (hyper1d.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper1d."time", hyper1d.device, hyper1d.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
+                                 Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_2_19_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
+                                 Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_2_20_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
+                                 Output: hyper1d_3."time", hyper1d_3.device, hyper1d_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_2_21_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  CTE Scan on top_n
+                           Output: top_n.device
+(61 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h2."time")), h2.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                           Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_2_19_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(34 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: reference

--- a/tsl/test/expected/dist_query-12.out
+++ b/tsl/test/expected/dist_query-12.out
@@ -18,6 +18,10 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_REFER
        format('\! diff %s %s', :'TEST_RESULTS_REPART_OPTIMIZED', :'TEST_RESULTS_REPART_REFERENCE') AS "DIFF_CMD_REPART",
        format('\! diff %s %s', :'TEST_RESULTS_1DIM', :'TEST_RESULTS_REPART_REFERENCE') AS "DIFF_CMD_1DIM"
 \gset
+-- Use a small fetch size to make sure that result are fetched across
+-- multiple fetches.
+--ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fetch_size '500');
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
 SET client_min_messages TO notice;
 -- Load the data
 \ir :TEST_LOAD_NAME
@@ -1025,6 +1029,133 @@ LIMIT 10
                      Output: join_test.device
 (27 rows)
 
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Inner Unique: true
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_1_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_2_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  Subquery Scan on top_n
+                           Output: top_n.device
+                           ->  Limit
+                                 Output: device, (avg(temp))
+                                 ->  Sort
+                                       Output: device, (avg(temp))
+                                       Sort Key: (avg(temp)) DESC
+                                       ->  Custom Scan (AsyncAppend)
+                                             Output: device, (avg(temp))
+                                             ->  Append
+                                                   ->  Custom Scan (DataNodeScan)
+                                                         Output: hyper_4.device, (avg(hyper_4.temp))
+                                                         Relations: Aggregate on (public.hyper)
+                                                         Data node: data_node_1
+                                                         Chunks: _dist_hyper_1_1_chunk
+                                                         Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                   ->  Custom Scan (DataNodeScan)
+                                                         Output: hyper_5.device, (avg(hyper_5.temp))
+                                                         Relations: Aggregate on (public.hyper)
+                                                         Data node: data_node_2
+                                                         Chunks: _dist_hyper_1_2_chunk
+                                                         Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                   ->  GroupAggregate
+                                                         Output: hyper_6.device, avg(hyper_6.temp)
+                                                         Group Key: hyper_6.device
+                                                         ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
+                                                               Output: hyper_6.device, hyper_6.temp
+                                                               Data node: data_node_3
+                                                               Chunks: _dist_hyper_1_3_chunk
+                                                               Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
+(60 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                     Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                     Data node: data_node_1
+                     Chunks: _dist_hyper_2_19_chunk
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(32 rows)
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
 %%% PREFIX: EXPLAIN (verbose, costs off)
@@ -1892,6 +2023,133 @@ LIMIT 10
                      Output: join_test.device
 (27 rows)
 
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Inner Unique: true
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_1_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_2_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  Subquery Scan on top_n
+                           Output: top_n.device
+                           ->  Limit
+                                 Output: device, (avg(temp))
+                                 ->  Sort
+                                       Output: device, (avg(temp))
+                                       Sort Key: (avg(temp)) DESC
+                                       ->  Custom Scan (AsyncAppend)
+                                             Output: device, (avg(temp))
+                                             ->  Append
+                                                   ->  Custom Scan (DataNodeScan)
+                                                         Output: hyper_4.device, (avg(hyper_4.temp))
+                                                         Relations: Aggregate on (public.hyper)
+                                                         Data node: data_node_1
+                                                         Chunks: _dist_hyper_1_1_chunk
+                                                         Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                   ->  Custom Scan (DataNodeScan)
+                                                         Output: hyper_5.device, (avg(hyper_5.temp))
+                                                         Relations: Aggregate on (public.hyper)
+                                                         Data node: data_node_2
+                                                         Chunks: _dist_hyper_1_2_chunk
+                                                         Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                   ->  GroupAggregate
+                                                         Output: hyper_6.device, avg(hyper_6.temp)
+                                                         Group Key: hyper_6.device
+                                                         ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
+                                                               Output: hyper_6.device, hyper_6.temp
+                                                               Data node: data_node_3
+                                                               Chunks: _dist_hyper_1_3_chunk
+                                                               Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
+(60 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                     Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                     Data node: data_node_1
+                     Chunks: _dist_hyper_2_19_chunk
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(32 rows)
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
 %%% PREFIX: EXPLAIN (verbose, costs off)
@@ -2510,6 +2768,96 @@ LIMIT 10
                ->  Seq Scan on public.join_test
                      Output: join_test.device
 (27 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND device = 1
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND device = 1
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   ->  Nested Loop
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         ->  Custom Scan (DataNodeScan) on public.hyper
+               Output: hyper."time", hyper.device, hyper.temp, time_bucket('@ 1 min'::interval, hyper."time")
+               Data node: data_node_1
+               Chunks: _dist_hyper_1_1_chunk
+               Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST
+         ->  Materialize
+               Output: top_n.device
+               ->  Subquery Scan on top_n
+                     Output: top_n.device
+                     Filter: (top_n.device = 1)
+                     ->  Limit
+                           Output: hyper_1.device, (avg(hyper_1.temp))
+                           ->  Custom Scan (DataNodeScan)
+                                 Output: hyper_1.device, (avg(hyper_1.temp))
+                                 Relations: Aggregate on (public.hyper)
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_1_chunk
+                                 Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY avg(temp) DESC NULLS FIRST
+(23 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                     Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                     Data node: data_node_1
+                     Chunks: _dist_hyper_2_19_chunk
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -3391,6 +3739,133 @@ LIMIT 10
                ->  Seq Scan on public.join_test
                      Output: join_test.device
 (27 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Inner Unique: true
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_1_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_2_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  Subquery Scan on top_n
+                           Output: top_n.device
+                           ->  Limit
+                                 Output: device, (avg(temp))
+                                 ->  Sort
+                                       Output: device, (avg(temp))
+                                       Sort Key: (avg(temp)) DESC
+                                       ->  Custom Scan (AsyncAppend)
+                                             Output: device, (avg(temp))
+                                             ->  Append
+                                                   ->  Custom Scan (DataNodeScan)
+                                                         Output: hyper_4.device, (avg(hyper_4.temp))
+                                                         Relations: Aggregate on (public.hyper)
+                                                         Data node: data_node_1
+                                                         Chunks: _dist_hyper_1_1_chunk
+                                                         Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                   ->  Custom Scan (DataNodeScan)
+                                                         Output: hyper_5.device, (avg(hyper_5.temp))
+                                                         Relations: Aggregate on (public.hyper)
+                                                         Data node: data_node_2
+                                                         Chunks: _dist_hyper_1_2_chunk
+                                                         Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                   ->  GroupAggregate
+                                                         Output: hyper_6.device, avg(hyper_6.temp)
+                                                         Group Key: hyper_6.device
+                                                         ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
+                                                               Output: hyper_6.device, hyper_6.temp
+                                                               Data node: data_node_3
+                                                               Chunks: _dist_hyper_1_3_chunk
+                                                               Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
+(60 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                     Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                     Data node: data_node_1
+                     Chunks: _dist_hyper_2_19_chunk
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -4281,6 +4756,134 @@ LIMIT 10
                      Output: join_test.device
 (27 rows)
 
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper
+	 WHERE time >= '2019-01-01'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper INNER JOIN top_n USING (device)
+WHERE time >= '2019-01-01'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                     QUERY PLAN                                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, avg(hyper.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device, hyper.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper."time")), hyper.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper."time"), hyper.device, hyper.temp
+               Inner Unique: true
+               Hash Cond: (hyper.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper."time", hyper.device, hyper.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
+                                 Output: hyper_1."time", hyper_1.device, hyper_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone))
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
+                                 Output: hyper_2."time", hyper_2.device, hyper_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone))
+                           ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
+                                 Output: hyper_3."time", hyper_3.device, hyper_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  Subquery Scan on top_n
+                           Output: top_n.device
+                           ->  Limit
+                                 Output: device, (avg(temp))
+                                 ->  Sort
+                                       Output: device, (avg(temp))
+                                       Sort Key: (avg(temp)) DESC
+                                       ->  Finalize HashAggregate
+                                             Output: device, avg(temp)
+                                             Group Key: device
+                                             ->  Custom Scan (AsyncAppend)
+                                                   Output: device, (PARTIAL avg(temp))
+                                                   ->  Append
+                                                         ->  Custom Scan (DataNodeScan)
+                                                               Output: hyper_4.device, (PARTIAL avg(hyper_4.temp))
+                                                               Relations: Aggregate on (public.hyper)
+                                                               Data node: data_node_1
+                                                               Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+                                                         ->  Custom Scan (DataNodeScan)
+                                                               Output: hyper_5.device, (PARTIAL avg(hyper_5.temp))
+                                                               Relations: Aggregate on (public.hyper)
+                                                               Data node: data_node_2
+                                                               Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+                                                         ->  Custom Scan (DataNodeScan)
+                                                               Output: hyper_6.device, (PARTIAL avg(hyper_6.temp))
+                                                               Relations: Aggregate on (public.hyper)
+                                                               Data node: data_node_3
+                                                               Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+(61 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                     Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                     Data node: data_node_1
+                     Chunks: _dist_hyper_2_19_chunk
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(32 rows)
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper1d
 %%% PREFIX: EXPLAIN (verbose, costs off)
@@ -5159,6 +5762,134 @@ LIMIT 10
                ->  Seq Scan on public.join_test
                      Output: join_test.device
 (27 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+WITH top_n AS (
+	 SELECT device, avg(temp)
+	 FROM hyper1d
+	 WHERE time >= '2019-01-01'
+     GROUP BY 1
+	 ORDER BY 2 DESC
+	 LIMIT 10
+)
+SELECT time_bucket('60s', time) AS "time", device, avg(temp)
+FROM hyper1d INNER JOIN top_n USING (device)
+WHERE time >= '2019-01-01'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                  QUERY PLAN                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device, avg(hyper1d.temp)
+   Group Key: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device
+   ->  Sort
+         Output: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device, hyper1d.temp
+         Sort Key: (time_bucket('@ 1 min'::interval, hyper1d."time")), hyper1d.device
+         ->  Hash Join
+               Output: time_bucket('@ 1 min'::interval, hyper1d."time"), hyper1d.device, hyper1d.temp
+               Inner Unique: true
+               Hash Cond: (hyper1d.device = top_n.device)
+               ->  Custom Scan (AsyncAppend)
+                     Output: hyper1d."time", hyper1d.device, hyper1d.temp
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
+                                 Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_2_19_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                           ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
+                                 Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_2_20_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone))
+                           ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
+                                 Output: hyper1d_3."time", hyper1d_3.device, hyper1d_3.temp
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_2_21_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+               ->  Hash
+                     Output: top_n.device
+                     ->  Subquery Scan on top_n
+                           Output: top_n.device
+                           ->  Limit
+                                 Output: device, (avg(temp))
+                                 ->  Sort
+                                       Output: device, (avg(temp))
+                                       Sort Key: (avg(temp)) DESC
+                                       ->  Finalize HashAggregate
+                                             Output: device, avg(temp)
+                                             Group Key: device
+                                             ->  Custom Scan (AsyncAppend)
+                                                   Output: device, (PARTIAL avg(temp))
+                                                   ->  Append
+                                                         ->  Custom Scan (DataNodeScan)
+                                                               Output: hyper1d_4.device, (PARTIAL avg(hyper1d_4.temp))
+                                                               Relations: Aggregate on (public.hyper1d)
+                                                               Data node: data_node_1
+                                                               Chunks: _dist_hyper_2_19_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                         ->  Custom Scan (DataNodeScan)
+                                                               Output: hyper1d_5.device, (PARTIAL avg(hyper1d_5.temp))
+                                                               Relations: Aggregate on (public.hyper1d)
+                                                               Data node: data_node_2
+                                                               Chunks: _dist_hyper_2_20_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+                                                         ->  Custom Scan (DataNodeScan)
+                                                               Output: hyper1d_6.device, (PARTIAL avg(hyper1d_6.temp))
+                                                               Relations: Aggregate on (public.hyper1d)
+                                                               Data node: data_node_3
+                                                               Chunks: _dist_hyper_2_21_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+(61 rows)
+
+
+######### CTEs/Sub-queries
+
+EXPLAIN (verbose, costs off)
+SELECT time_bucket('60s', h1.time) AS "time", h1.device, avg(h1.temp), max(h2.temp)
+FROM hyper h1 INNER JOIN hyper1d h2 ON (time_bucket('60', h1.time) = time_bucket('60', h2.time) AND h1.device = h2.device)
+WHERE h1.time BETWEEN '2019-01-01' AND '2019-01-01 15:00' AND
+	  h2.time BETWEEN '2019-01-01' AND '2019-01-01 15:00'
+GROUP BY 1,2
+ORDER BY 1,2
+                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ GroupAggregate
+   Output: (time_bucket('@ 1 min'::interval, h1."time")), h1.device, avg(h1.temp), max(h2.temp)
+   Group Key: time_bucket('@ 1 min'::interval, h1."time"), h1.device
+   ->  Merge Join
+         Output: time_bucket('@ 1 min'::interval, h1."time"), h1.device, h1.temp, h2.temp
+         Merge Cond: ((time_bucket('@ 1 min'::interval, h1."time") = (time_bucket('@ 1 min'::interval, h2."time"))) AND (h1.device = h2.device))
+         ->  Custom Scan (AsyncAppend)
+               Output: h1."time", h1.device, h1.temp
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 min'::interval, h1_1."time")), h1_1.device
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_1
+                           Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_1_1_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_2
+                           Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_1_2_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.hyper h1_3
+                           Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_1_3_chunk
+                           Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+         ->  Materialize
+               Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
+               ->  Custom Scan (DataNodeScan) on public.hyper1d h2
+                     Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
+                     Data node: data_node_1
+                     Chunks: _dist_hyper_2_19_chunk
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: reference

--- a/tsl/test/sql/data_fetcher.sql
+++ b/tsl/test/sql/data_fetcher.sql
@@ -19,12 +19,20 @@ SET client_min_messages TO warning;
 \set ECHO errors
 SET client_min_messages TO error;
 
+-- Set a smaller fetch size to ensure that the result is split into
+-- mutliple batches.
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fetch_size '100');
+
 -- run the queries using row by row fetcher
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
+\set ON_ERROR_STOP 0
 \o :TEST_RESULTS_ROW_BY_ROW
 \ir :TEST_QUERY_NAME
 \o
+\set ON_ERROR_STOP 1
+
 -- run queries using cursor fetcher
-SET timescaledb.remote_data_fetcher = cursor;
+SET timescaledb.remote_data_fetcher = 'cursor';
 \o :TEST_RESULTS_CURSOR
 \ir :TEST_QUERY_NAME
 \o

--- a/tsl/test/sql/dist_query.sql.in
+++ b/tsl/test/sql/dist_query.sql.in
@@ -21,6 +21,11 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_REFER
        format('\! diff %s %s', :'TEST_RESULTS_1DIM', :'TEST_RESULTS_REPART_REFERENCE') AS "DIFF_CMD_1DIM"
 \gset
 
+
+-- Use a small fetch size to make sure that result are fetched across
+-- multiple fetches.
+--ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fetch_size '500');
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
 SET client_min_messages TO notice;
 
 -- Load the data


### PR DESCRIPTION
This change fixes errors when using sub-queries together with
AsyncAppend on distributed hypertables.

Since all subqueries are sent to remote data nodes as separate queries
on the same connection, it is important that one query does not block
the connection once the other query starts to execute. In other words,
a query must complete a request and retrieve the result before another
(sub-)query can execute. During query execution, this means that the
following invariant must hold: An executor node cannot leave a request
(or result) pending on a connection after returning a tuple, since for
the next tuple a different executor node can be called to execute
another sub-query on the same connection. This would be the case if
two sub-queries are, e.g., joined with a nested loop.

AsyncAppend (and associated fetchers) failed the above invariant; the
executor node could leave a request unfinished after returning a
tuple, causing the connection to be in an unexpected state when
another AsyncAppend was called as part of a join with another
sub-query.

It turns out that only cursor fetcher can be used in these cases
without having to fetch and buffer the entire result set of a
sub-query (with a `CURSOR` the request can be broken up in multiple
separate `FETCH` requests that can be interleaved with other
sub-queries). Unfortunately, when executing a query using a `CURSOR`,
it doesn't support parallel execution (on the data node). Previously,
this was solved by defaulting to another "row-by-row" method of
fetching data. However, row-by-row suffers from the same issue of
leaving the connection in an unfinished state unless the whole result
set is read and buffered, which could potentially blow up memory.

The following changes are made to address the situation:

* The cursor fetcher is made the default fetcher so that all queries
  can be executed without errors.
* Fixes are also applied to the cursor fetcher to make sure it does
  not have pending queries after AsyncAppend returns a tuple.
* AsyncAppend is similarly tweaked to avoid leaving connections with
  pending queries.
* The ability to set the `fetch_size` (number of tuples to fetch in
  each `FETCH` request) and other options at the foreign data wrapper
  level is added. This allows changing FDW options globally for all
  data nodes, as the previous method of setting them on each foreign
  server is currently blocked. Setting a smaller `fetch_size` is
  often necessary to trigger the erroneous behavior.

Unfortunately, these changes might lead to a regression in query
performance. With cursor fetcher, queries cannot execute in parallel
mode on data nodes. Further, the previous code was more aggressive
with sending new fetch requests after each batch (for performance
reasons), but this is not possible when sub-query joins are present.

A future optimization could, for instance, use the row-by-row fetcher
by default and fall back to cursor fetcher if it detects joins between
sub-queries.

Fixes #2511 