### PR TITLE
Fix incorrect total_table_pages setting for compressed scan

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -973,8 +973,10 @@ create_compressed_scan_paths(PlannerInfo *root, RelOptInfo *compressed_rel, int 
 	Path *compressed_path;
 
 	/* clamp total_table_pages to 10 pages since this is the
-	 * minimum estimate for number of pages */
-	root->total_table_pages = Max(compressed_rel->pages, 10);
+	 * minimum estimate for number of pages.
+	 * Add the value to any existing estimates
+	 */
+	root->total_table_pages += Max(compressed_rel->pages, 10);
 
 	/* create non parallel scan path */
 	compressed_path = create_seqscan_path(root, compressed_rel, NULL, 0);

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -8695,3 +8695,67 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (7 rows)
 
+-- repro for core dump related to total_table_pages setting that get
+-- adjusted during decompress path.
+CREATE SEQUENCE vessel_id_seq 
+    INCREMENT 1
+    START 1    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;
+CREATE TABLE motion_table(
+  id bigint NOT NULL DEFAULT nextval('vessel_id_seq'::regclass) ,
+ datalogger_id     bigint                   ,
+ vessel_id         bigint                   ,
+ bus_id            smallint                 ,
+ src_id            smallint                 ,
+ dataloggertime    timestamp with time zone ,
+ interval_s        real                     );
+CREATE INDEX
+motion_table_t2_datalogger_id_idx on motion_table (datalogger_id);
+CREATE INDEX motion_table_t2_dataloggertime_idx on motion_table(dataloggertime DESC);
+CREATE INDEX motion_table_t2_vessel_id_idx on motion_table(vessel_id);
+SELECT create_hypertable( 'motion_table', 'dataloggertime', chunk_time_interval=> '7 days'::interval);
+NOTICE:  adding not-null constraint to column "dataloggertime"
+     create_hypertable      
+----------------------------
+ (15,public,motion_table,t)
+(1 row)
+
+--- do not modify the data. We need atleast this volume to reproduce issues with pages/tuple counts etc. ---
+INSERT into motion_table(datalogger_id, vessel_id, bus_id, src_id, 
+   dataloggertime, interval_s)
+SELECT 1, random(), random() , random() ,
+       generate_series( '2020-01-02 10:00'::timestamp, '2020-01-10 10::00'::timestamp, '1 min'::interval), 1.1;
+INSERT into motion_table(datalogger_id, vessel_id, bus_id, src_id, 
+   dataloggertime, interval_s)
+SELECT 1, random(), 2, 3, 
+       generate_series( '2020-01-10 8:00'::timestamp, '2020-01-10 10::00'::timestamp, '1 min'::interval), 1.1;
+ALTER TABLE motion_table SET ( timescaledb.compress,
+        timescaledb.compress_segmentby = 'vessel_id, datalogger_id, bus_id, src_id' , timescaledb.compress_orderby = 'dataloggertime' );
+--have 2 chunks --
+SELECT COUNT(*)
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'motion_table';
+ count 
+-------
+     2
+(1 row)
+
+-- compress only the first one ---
+SELECT compress_chunk( chunk_table) 
+FROM ( SELECT chunk_schema || '.' || chunk_name as chunk_table 
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'motion_table' ORDER BY range_start limit 1 ) q;
+               compress_chunk               
+--------------------------------------------
+ _timescaledb_internal._hyper_15_1438_chunk
+(1 row)
+
+--call to decompress chunk on 1 of the chunks
+SELECT count(*) from motion_table;
+ count 
+-------
+ 11642
+(1 row)
+
+--END of test for page settings

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -8622,3 +8622,67 @@ $sql$;
          ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
 (6 rows)
 
+-- repro for core dump related to total_table_pages setting that get
+-- adjusted during decompress path.
+CREATE SEQUENCE vessel_id_seq 
+    INCREMENT 1
+    START 1    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;
+CREATE TABLE motion_table(
+  id bigint NOT NULL DEFAULT nextval('vessel_id_seq'::regclass) ,
+ datalogger_id     bigint                   ,
+ vessel_id         bigint                   ,
+ bus_id            smallint                 ,
+ src_id            smallint                 ,
+ dataloggertime    timestamp with time zone ,
+ interval_s        real                     );
+CREATE INDEX
+motion_table_t2_datalogger_id_idx on motion_table (datalogger_id);
+CREATE INDEX motion_table_t2_dataloggertime_idx on motion_table(dataloggertime DESC);
+CREATE INDEX motion_table_t2_vessel_id_idx on motion_table(vessel_id);
+SELECT create_hypertable( 'motion_table', 'dataloggertime', chunk_time_interval=> '7 days'::interval);
+NOTICE:  adding not-null constraint to column "dataloggertime"
+     create_hypertable      
+----------------------------
+ (15,public,motion_table,t)
+(1 row)
+
+--- do not modify the data. We need atleast this volume to reproduce issues with pages/tuple counts etc. ---
+INSERT into motion_table(datalogger_id, vessel_id, bus_id, src_id, 
+   dataloggertime, interval_s)
+SELECT 1, random(), random() , random() ,
+       generate_series( '2020-01-02 10:00'::timestamp, '2020-01-10 10::00'::timestamp, '1 min'::interval), 1.1;
+INSERT into motion_table(datalogger_id, vessel_id, bus_id, src_id, 
+   dataloggertime, interval_s)
+SELECT 1, random(), 2, 3, 
+       generate_series( '2020-01-10 8:00'::timestamp, '2020-01-10 10::00'::timestamp, '1 min'::interval), 1.1;
+ALTER TABLE motion_table SET ( timescaledb.compress,
+        timescaledb.compress_segmentby = 'vessel_id, datalogger_id, bus_id, src_id' , timescaledb.compress_orderby = 'dataloggertime' );
+--have 2 chunks --
+SELECT COUNT(*)
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'motion_table';
+ count 
+-------
+     2
+(1 row)
+
+-- compress only the first one ---
+SELECT compress_chunk( chunk_table) 
+FROM ( SELECT chunk_schema || '.' || chunk_name as chunk_table 
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'motion_table' ORDER BY range_start limit 1 ) q;
+               compress_chunk               
+--------------------------------------------
+ _timescaledb_internal._hyper_15_1438_chunk
+(1 row)
+
+--call to decompress chunk on 1 of the chunks
+SELECT count(*) from motion_table;
+ count 
+-------
+ 11642
+(1 row)
+
+--END of test for page settings

--- a/tsl/test/sql/transparent_decompression.sql.in
+++ b/tsl/test/sql/transparent_decompression.sql.in
@@ -265,3 +265,57 @@ $sql$;
 \c
 -- plan should be identical to previous plan in fresh session
 :PREFIX SELECT * FROM ht_func();
+
+-- repro for core dump related to total_table_pages setting that get
+-- adjusted during decompress path.
+CREATE SEQUENCE vessel_id_seq 
+    INCREMENT 1
+    START 1    MINVALUE 1
+    MAXVALUE 9223372036854775807
+    CACHE 1;
+
+CREATE TABLE motion_table(
+  id bigint NOT NULL DEFAULT nextval('vessel_id_seq'::regclass) ,
+ datalogger_id     bigint                   ,
+ vessel_id         bigint                   ,
+ bus_id            smallint                 ,
+ src_id            smallint                 ,
+ dataloggertime    timestamp with time zone ,
+ interval_s        real                     );
+
+CREATE INDEX
+motion_table_t2_datalogger_id_idx on motion_table (datalogger_id);
+CREATE INDEX motion_table_t2_dataloggertime_idx on motion_table(dataloggertime DESC);
+CREATE INDEX motion_table_t2_vessel_id_idx on motion_table(vessel_id);
+
+SELECT create_hypertable( 'motion_table', 'dataloggertime', chunk_time_interval=> '7 days'::interval);
+
+--- do not modify the data. We need atleast this volume to reproduce issues with pages/tuple counts etc. ---
+INSERT into motion_table(datalogger_id, vessel_id, bus_id, src_id, 
+   dataloggertime, interval_s)
+SELECT 1, random(), random() , random() ,
+       generate_series( '2020-01-02 10:00'::timestamp, '2020-01-10 10::00'::timestamp, '1 min'::interval), 1.1;
+
+INSERT into motion_table(datalogger_id, vessel_id, bus_id, src_id, 
+   dataloggertime, interval_s)
+SELECT 1, random(), 2, 3, 
+       generate_series( '2020-01-10 8:00'::timestamp, '2020-01-10 10::00'::timestamp, '1 min'::interval), 1.1;
+
+ALTER TABLE motion_table SET ( timescaledb.compress,
+        timescaledb.compress_segmentby = 'vessel_id, datalogger_id, bus_id, src_id' , timescaledb.compress_orderby = 'dataloggertime' );
+
+--have 2 chunks --
+SELECT COUNT(*)
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'motion_table';
+
+-- compress only the first one ---
+SELECT compress_chunk( chunk_table) 
+FROM ( SELECT chunk_schema || '.' || chunk_name as chunk_table 
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'motion_table' ORDER BY range_start limit 1 ) q;
+
+--call to decompress chunk on 1 of the chunks
+SELECT count(*) from motion_table;
+
+--END of test for page settings


### PR DESCRIPTION
The compressed scan path overwrites the total_table_pages
setting on PlannerInfo. This results in an assertion failure in
index_pages_fetched function at
Assert(T <= total_pages)
When a hypertable has a mix of compressed and uncompressed chunks,
the total_table_pages value is calculated in reenable_inheritance code
path and create_compressed_scan_paths. create_compressed_scan_path
should not overwrite the value previously computed by
reenable_inheritance.