### PR TITLE
Fix segfault in decompress_chunk for chunks with dropped columns

### DIFF
--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -986,7 +986,6 @@ decompress_chunk(Oid in_table, Oid out_table)
 
 	Oid compressed_data_type_oid = ts_custom_type_cache_get(CUSTOM_TYPE_COMPRESSED_DATA)->type_oid;
 
-	Assert(in_desc->natts >= out_desc->natts);
 	Assert(OidIsValid(compressed_data_type_oid));
 
 	{
@@ -1007,6 +1006,14 @@ decompress_chunk(Oid in_table, Oid out_table)
 			.decompressed_datums = palloc(sizeof(Datum) * out_desc->natts),
 			.decompressed_is_nulls = palloc(sizeof(bool) * out_desc->natts),
 		};
+		/*
+		 * We need to make sure decompressed_is_nulls is in a defined state. While this
+		 * will get written for normal columns it will not get written for dropped columns
+		 * since dropped columns don't exist in the compressed chunk so we initiallize
+		 * with true here.
+		 */
+		memset(decompressor.decompressed_is_nulls, true, out_desc->natts);
+
 		Datum *compressed_datums = palloc(sizeof(*compressed_datums) * in_desc->natts);
 		bool *compressed_is_nulls = palloc(sizeof(*compressed_is_nulls) * in_desc->natts);
 


### PR DESCRIPTION
This patch fixes a segfault in decompress_chunk for chunks with dropped
columns. Since dropped columns don't exists in the compressed chunk
the values for those columns were undefined in the decompressed tuple
leading to a segfault when trying to build the heap tuple.

It's cherry pick of https://github.com/timescale/timescaledb/pull/2619 into 1.7.x branch