### PR TITLE
Ignore PostgreSQL's timetz test

### DIFF
--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -28,6 +28,9 @@ set(PG_IGNORE_TESTS
   rules
   opr_sanity
   sanity_check
+  # timetz fails without daylight savings. Likely to be fixed in PG
+  # 12.5
+  timetz
 )
 
 # Modify the test schedule to ignore some tests


### PR DESCRIPTION
PostgreSQL's `timetz` test fails outside of daylight savings. The
test is ignored until fixed in PostgreSQL (likely to happen in
12.5).

Cherry pick of https://github.com/timescale/timescaledb/pull/2615 into 1.7.x branch