### PR TITLE
Fix minor issues found by Coverity

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1778,11 +1778,14 @@ append_chunk(ChunkScanCtx *scanctx, ChunkStub *stub)
 		Chunk **chunks = scanctx->data;
 
 		Assert(chunk != NULL);
-
-		if (NULL == chunks && scanctx->num_complete_chunks > 0)
-			scanctx->data = chunks = palloc(sizeof(Chunk *) * scanctx->num_complete_chunks);
-
 		Assert(scanctx->num_processed < scanctx->num_complete_chunks);
+
+		if (NULL == chunks)
+		{
+			Assert(scanctx->num_complete_chunks > 0);
+			scanctx->data = chunks = palloc(sizeof(Chunk *) * scanctx->num_complete_chunks);
+		}
+
 		chunks[scanctx->num_processed] = chunk;
 	}
 

--- a/test/expected/constraint.out
+++ b/test/expected/constraint.out
@@ -800,6 +800,9 @@ ALTER TABLE test_validate
 VALIDATE CONSTRAINT c_not_null;
 DROP TABLE test_validate;
 -- test for hypetables constraints both using index tablespaces and not See #2604
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+SET client_min_messages = NOTICE;
 CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
 CREATE TABLE fk_tbl (
 id int,

--- a/test/sql/constraint.sql
+++ b/test/sql/constraint.sql
@@ -599,6 +599,9 @@ VALIDATE CONSTRAINT c_not_null;
 DROP TABLE test_validate;
 
 -- test for hypetables constraints both using index tablespaces and not See #2604
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+SET client_min_messages = NOTICE;
 CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
 
 CREATE TABLE fk_tbl (

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1799,6 +1799,7 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 		 * user. */
 		relid = get_relname_relid(stmt->into->rel->relname, nspid);
 		cagg = ts_continuous_agg_find_by_relid(relid);
+		Assert(cagg != NULL);
 		cagg_ht = ts_hypertable_get_by_id(cagg->data.mat_hypertable_id);
 		time_dim = hyperspace_get_open_dimension(cagg_ht->space, 0);
 		refresh_window.type = ts_dimension_get_partition_type(time_dim);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -65,7 +65,9 @@ get_largest_bucketed_window(Oid timetype, int64 bucket_width)
 		.start = ts_time_get_min(timetype),
 		.end = ts_time_get_end_or_max(timetype),
 	};
-	InternalTimeRange maxbuckets;
+	InternalTimeRange maxbuckets = {
+		.type = timetype,
+	};
 
 	/* For the MIN value, the corresponding bucket either falls on the exact
 	 * MIN or it will be below it. Therefore, we add (bucket_width - 1) to


### PR DESCRIPTION
Fix an uninitialized field in a struct in the refresh code for
continuous aggregates. Other fixes are mostly to silence false
positives.