### PR TITLE
Add raw hypertable to continuous aggregate view

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,1 +1,1 @@
-
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -113,9 +113,11 @@ SELECT cagg.user_view_schema AS view_schema,
   cagg.materialized_only,
   ht.schema_name AS materialization_hypertable_schema,
   ht.table_name AS materialization_hypertable_name,
+  format('%I.%I', raw_ht.schema_name, raw_ht.table_name)::regclass AS raw_hypertable,
   directview.viewdefinition AS view_definition
 FROM _timescaledb_catalog.continuous_agg cagg,
   _timescaledb_catalog.hypertable ht,
+  _timescaledb_catalog.hypertable raw_ht,
   LATERAL (
     SELECT C.oid,
       pg_get_userbyid(C.relowner) AS viewowner
@@ -131,7 +133,7 @@ FROM _timescaledb_catalog.continuous_agg cagg,
   WHERE C.relkind = 'v'
     AND C.relname = cagg.direct_view_name
     AND N.nspname = cagg.direct_view_schema) directview
-WHERE cagg.mat_hypertable_id = ht.id;
+WHERE cagg.mat_hypertable_id = ht.id AND raw_ht.id = raw_hypertable_id;
 
 CREATE OR REPLACE VIEW timescaledb_information.data_nodes AS
 SELECT s.node_name,

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -76,6 +76,7 @@ view_owner                        | default_perm_user
 materialized_only                 | t
 materialization_hypertable_schema | _timescaledb_internal
 materialization_hypertable_name   | _materialized_hypertable_2
+raw_hypertable                    | device_readings
 view_definition                   |  SELECT time_bucket('@ 1 hour'::interval, device_readings.observation_time) AS bucket,                      +
                                   |     device_readings.device_id,                                                                              +
                                   |     avg(device_readings.metric) AS metric_avg,                                                              +


### PR DESCRIPTION
Including REGCLASS of raw hypertable in view
timescaledb_information.continuous_aggregates is important for some
use cases. This commit adds it to the view.

Fixes #2653