### PR TITLE
Save compression metadata settings on access node

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -2,3 +2,125 @@ DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;
 DROP VIEW IF EXISTS timescaledb_information.job_stats;
 DROP FUNCTION IF EXISTS _timescaledb_internal.get_git_commit;
 
+-- Begin Modify hypertable table
+-- we make a copy of the data, remove dependencies, drop the table
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS timescaledb_information.dimensions;
+DROP VIEW IF EXISTS timescaledb_information.jobs;
+DROP VIEW IF EXISTS timescaledb_information.compression_settings;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP FUNCTION IF EXISTS _timescaledb_internal.hypertable_from_main_table;
+
+CREATE TABLE _timescaledb_catalog.hypertable_tmp
+AS SELECT * from _timescaledb_catalog.hypertable;
+
+--drop foreign keys on hypertable 
+ ALTER TABLE _timescaledb_catalog.hypertable DROP CONSTRAINT hypertable_compressed_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.hypertable_data_node DROP CONSTRAINT hypertable_data_node_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.tablespace DROP CONSTRAINT tablespace_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.dimension DROP CONSTRAINT dimension_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.chunk DROP CONSTRAINT chunk_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.chunk_index DROP CONSTRAINT chunk_index_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_config.bgw_job DROP CONSTRAINT bgw_job_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.continuous_agg DROP CONSTRAINT continuous_agg_mat_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.continuous_agg DROP CONSTRAINT continuous_agg_raw_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold DROP CONSTRAINT continuous_aggs_invalidation_threshold_hypertable_id_fkey ; 
+ ALTER TABLE _timescaledb_catalog.hypertable_compression DROP CONSTRAINT hypertable_compression_hypertable_id_fkey ;
+
+ 
+CREATE TABLE tmp_hypertable_seq_value AS 
+SELECT last_value, is_called FROM _timescaledb_catalog.hypertable_id_seq;
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.hypertable_id_seq;
+DROP TABLE _timescaledb_catalog.hypertable;
+
+CREATE SEQUENCE IF NOT EXISTS _timescaledb_catalog.hypertable_id_seq MINVALUE 1;
+
+-- now create table without self referential foreign key
+CREATE TABLE IF NOT EXISTS _timescaledb_catalog.hypertable(
+  id INTEGER PRIMARY KEY DEFAULT nextval('_timescaledb_catalog.hypertable_id_seq'),
+  schema_name name NOT NULL CHECK (schema_name != '_timescaledb_catalog'),
+  table_name name NOT NULL,
+  associated_schema_name name NOT NULL,
+  associated_table_prefix name NOT NULL,
+  num_dimensions smallint NOT NULL,
+  chunk_sizing_func_schema name NOT NULL,
+  chunk_sizing_func_name name NOT NULL,
+  chunk_target_size bigint NOT NULL CHECK (chunk_target_size >= 0), -- size in bytes
+  compression_state smallint NOT NULL DEFAULT 0,
+  compressed_hypertable_id integer ,
+  replication_factor smallint NULL CHECK (replication_factor > 0),
+  UNIQUE (associated_schema_name, associated_table_prefix),
+  CONSTRAINT hypertable_table_name_schema_name_key UNIQUE (table_name, schema_name),
+----internal compressed hypertables have compression state = 2
+  CONSTRAINT hypertable_dim_compress_check CHECK (num_dimensions > 0 OR compression_state = 2),
+  CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL))
+);
+ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');
+SELECT setval('_timescaledb_catalog.hypertable_id_seq', last_value, is_called) FROM tmp_hypertable_seq_value;
+
+INSERT INTO _timescaledb_catalog.hypertable
+( id, schema_name, table_name, associated_schema_name, associated_table_prefix,
+       num_dimensions, chunk_sizing_func_schema, chunk_sizing_func_name,
+       chunk_target_size, compression_state, compressed_hypertable_id,
+       replication_factor)
+SELECT id, schema_name, table_name, associated_schema_name, associated_table_prefix,
+       num_dimensions, chunk_sizing_func_schema, chunk_sizing_func_name,
+       chunk_target_size,
+       CASE WHEN compressed is FALSE  AND compressed_hypertable_id IS NOT NULL THEN 1
+            WHEN compressed is TRUE THEN 2
+            ELSE 0 
+       END,
+       compressed_hypertable_id,
+       replication_factor
+FROM _timescaledb_catalog.hypertable_tmp;
+ 
+-- add self referential foreign key
+ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_compressed_hypertable_id_fkey FOREIGN KEY ( compressed_hypertable_id )
+ REFERENCES _timescaledb_catalog.hypertable( id );
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', '');
+--cleanup
+DROP TABLE _timescaledb_catalog.hypertable_tmp;
+DROP TABLE tmp_hypertable_seq_value;
+
+-- add all the other foreign keys
+ ALTER TABLE _timescaledb_catalog.hypertable_data_node 
+ ADD CONSTRAINT hypertable_data_node_hypertable_id_fkey
+ FOREIGN KEY ( hypertable_id ) REFERENCES _timescaledb_catalog.hypertable( id ); 
+ ALTER TABLE _timescaledb_catalog.tablespace ADD CONSTRAINT tablespace_hypertable_id_fkey 
+ FOREIGN KEY ( hypertable_id ) REFERENCES _timescaledb_catalog.hypertable( id ) 
+ ON DELETE CASCADE; 
+ ALTER TABLE _timescaledb_catalog.dimension ADD CONSTRAINT dimension_hypertable_id_fkey 
+ FOREIGN KEY ( hypertable_id ) REFERENCES _timescaledb_catalog.hypertable( id ) 
+ ON DELETE CASCADE; 
+ ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_hypertable_id_fkey 
+ FOREIGN KEY ( hypertable_id ) REFERENCES _timescaledb_catalog.hypertable( id ); 
+ ALTER TABLE _timescaledb_catalog.chunk_index ADD CONSTRAINT chunk_index_hypertable_id_fkey 
+ FOREIGN KEY ( hypertable_id ) REFERENCES _timescaledb_catalog.hypertable( id ) 
+ ON DELETE CASCADE; 
+ ALTER TABLE _timescaledb_config.bgw_job ADD CONSTRAINT bgw_job_hypertable_id_fkey 
+ FOREIGN KEY ( hypertable_id ) REFERENCES _timescaledb_catalog.hypertable( id )
+ ON DELETE CASCADE; 
+ ALTER TABLE _timescaledb_catalog.continuous_agg ADD CONSTRAINT 
+ continuous_agg_mat_hypertable_id_fkey FOREIGN KEY ( mat_hypertable_id ) 
+ REFERENCES _timescaledb_catalog.hypertable( id ) 
+ ON DELETE CASCADE; 
+ ALTER TABLE _timescaledb_catalog.continuous_agg ADD CONSTRAINT 
+ continuous_agg_raw_hypertable_id_fkey FOREIGN KEY ( raw_hypertable_id ) 
+ REFERENCES _timescaledb_catalog.hypertable( id ) 
+ ON DELETE CASCADE; 
+ ALTER TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold 
+ ADD CONSTRAINT continuous_aggs_invalidation_threshold_hypertable_id_fkey 
+ FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable( id ) 
+ ON DELETE CASCADE; 
+ ALTER TABLE _timescaledb_catalog.hypertable_compression ADD CONSTRAINT 
+ hypertable_compression_hypertable_id_fkey FOREIGN KEY ( hypertable_id ) 
+ REFERENCES _timescaledb_catalog.hypertable( id )
+ ON DELETE CASCADE; 
+
+ GRANT SELECT ON _timescaledb_catalog.hypertable_id_seq TO PUBLIC;
+ GRANT SELECT ON _timescaledb_catalog.hypertable TO PUBLIC;
+--End Modify hypertable table

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -15,10 +15,10 @@ SELECT ht.schema_name AS hypertable_schema,
     FROM _timescaledb_catalog.chunk ch
     WHERE ch.hypertable_id = ht.id) AS num_chunks,
   (
-    CASE WHEN ht.compressed_hypertable_id IS NULL THEN
-      FALSE
+    CASE WHEN compression_state = 1 THEN
+      TRUE 
     ELSE
-      TRUE
+      FALSE 
     END) AS compression_enabled,
   (
     CASE WHEN ht.replication_factor > 0 THEN
@@ -43,7 +43,7 @@ FROM _timescaledb_catalog.hypertable ht
     array_agg(node_name ORDER BY node_name) AS node_list
   FROM _timescaledb_catalog.hypertable_data_node
   GROUP BY hypertable_id) dn ON ht.id = dn.hypertable_id
-WHERE ht.compressed IS FALSE --> no internal compression tables
+WHERE ht.compression_state != 2 --> no internal compression tables
   AND ca.mat_hypertable_id IS NULL;
 
 CREATE OR REPLACE VIEW timescaledb_information.job_stats AS
@@ -234,7 +234,7 @@ FROM (
     FROM _timescaledb_catalog.chunk_data_node
     GROUP BY chunk_id) chdn ON srcch.id = chdn.chunk_id
   WHERE srcch.dropped IS FALSE
-    AND ht.compressed = FALSE) finalq
+    AND ht.compression_state != 2 ) finalq
 WHERE chunk_dimension_num = 1;
 
 -- hypertable's dimension information

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -109,7 +109,7 @@ enum Anum_hypertable
 	Anum_hypertable_chunk_sizing_func_schema,
 	Anum_hypertable_chunk_sizing_func_name,
 	Anum_hypertable_chunk_target_size,
-	Anum_hypertable_compressed,
+	Anum_hypertable_compression_state,
 	Anum_hypertable_compressed_hypertable_id,
 	Anum_hypertable_replication_factor,
 	_Anum_hypertable_max,
@@ -128,7 +128,7 @@ typedef struct FormData_hypertable
 	NameData chunk_sizing_func_schema;
 	NameData chunk_sizing_func_name;
 	int64 chunk_target_size;
-	bool compressed;
+	int16 compression_state;
 	int32 compressed_hypertable_id;
 	int16 replication_factor;
 } FormData_hypertable;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1931,7 +1931,7 @@ get_chunks_in_time_range(Hypertable *ht, int64 older_than, int64 newer_than,
 				 errmsg("invalid time range"),
 				 errhint("The start of the time range must be before the end.")));
 
-	if (ht->fd.compressed)
+	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 		elog(ERROR, "invalid operation on compressed hypertable");
 
 	start_strategy = (newer_than == PG_INT64_MIN) ? InvalidStrategy : BTGreaterEqualStrategyNumber;

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -26,9 +26,24 @@ typedef struct SubspaceStore SubspaceStore;
 typedef struct Chunk Chunk;
 typedef struct Hypercube Hypercube;
 
-#define TS_HYPERTABLE_HAS_COMPRESSION(ht)                                                          \
-	((ht)->fd.compressed_hypertable_id != INVALID_HYPERTABLE_ID)
+/* For the distributed node case, we would have compression enabled
+ * but don't have a corresponding internal table on the access
+ * node
+ */
+enum
+{
+	HypertableCompressionOff = 0,
+	HypertableCompressionEnabled = 1,
+	HypertableInternalCompressionTable = 2,
+};
 
+#define TS_HYPERTABLE_HAS_COMPRESSION(ht) ts_hypertable_has_compression(ht)
+
+#define TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht)                                                  \
+	((ht)->fd.compression_state == HypertableCompressionEnabled)
+
+#define TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht)                                            \
+	((ht)->fd.compression_state == HypertableInternalCompressionTable)
 typedef struct Hypertable
 {
 	FormData_hypertable fd;
@@ -158,6 +173,8 @@ extern TSDLLEXPORT int16 ts_validate_replication_factor(int32 replication_factor
 														bool is_dist_call);
 extern TSDLLEXPORT Datum ts_hypertable_get_open_dim_max_value(const Hypertable *ht,
 															  int dimension_index, bool *isnull);
+
+extern TSDLLEXPORT bool ts_hypertable_has_compression(Hypertable *ht);
 
 #define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock)                       \
 	ts_hypertable_scan_with_memory_context(schema,                                                 \

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -594,7 +594,7 @@ add_compressed_chunk_to_vacuum(Hypertable *ht, Oid comp_chunk_relid, void *arg)
 
 	Chunk *chunk_parent;
 	/* chunk is from a compressed hypertable */
-	Assert(ht->fd.compressed);
+	Assert(TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht));
 
 	/*chunks for internal compression table have a parent */
 	chunk_parent = ts_chunk_get_compressed_chunk_parent(compressed_chunk);
@@ -774,7 +774,7 @@ process_vacuum(ProcessUtilityArgs *args)
 					if (hypertable_is_distributed(ht))
 						continue;
 
-					if (ht->fd.compressed)
+					if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 					{
 						ctx.ht_vacuum_rel = vacuum_rel;
 						foreach_chunk(ht, add_compressed_chunk_to_vacuum, &ctx);
@@ -1106,7 +1106,7 @@ process_drop_hypertable(ProcessUtilityArgs *args, DropStmt *stmt)
 				if (list_length(stmt->objects) != 1)
 					elog(ERROR, "cannot drop a hypertable along with other objects");
 
-				if (ht->fd.compressed)
+				if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("dropping compressed hypertables not supported"),

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -673,9 +673,9 @@ ALTER SCHEMA my_associated_schema RENAME TO new_associated_schema;
 INSERT INTO my_table (date, quantity) VALUES ('2018-08-10T23:00:00+00:00', 20);
 -- Make sure the schema name is changed in both catalog tables
 SELECT * from _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
- 12 | public      | my_table   | new_associated_schema  | _hyper_12               |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+ 12 | public      | my_table   | new_associated_schema  | _hyper_12               |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 SELECT * from _timescaledb_catalog.chunk;

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -134,12 +134,12 @@ SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name  |  table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+--------------+---------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public       | one_Partition | one_Partition          | _hyper_1                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  2 | public       | 1dim          | _timescaledb_internal  | _hyper_2                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  3 | public       | Hypertable_1  | _timescaledb_internal  | _hyper_3                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  4 | customSchema | Hypertable_1  | _timescaledb_internal  | _hyper_4                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name  |  table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+--------------+---------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public       | one_Partition | one_Partition          | _hyper_1                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  2 | public       | 1dim          | _timescaledb_internal  | _hyper_2                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  3 | public       | Hypertable_1  | _timescaledb_internal  | _hyper_3                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  4 | customSchema | Hypertable_1  | _timescaledb_internal  | _hyper_4                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (4 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -86,9 +86,9 @@ select add_dimension('test_schema.test_table', 'location', 4);
 (1 row)
 
 select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  2 | test_schema | test_table | chunk_schema           | _hyper_2                |              3 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  2 | test_schema | test_table | chunk_schema           | _hyper_2                |              3 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
@@ -149,9 +149,9 @@ NOTICE:  adding not-null constraint to column "id"
 (1 row)
 
 select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  2 | test_schema | test_table | chunk_schema           | _hyper_2                |              4 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  2 | test_schema | test_table | chunk_schema           | _hyper_2                |              4 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
@@ -403,9 +403,9 @@ NOTICE:  migrating data to chunks
 
 --there should be two new chunks
 select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
- id | schema_name |  table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+--------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  8 | test_schema | test_migrate | _timescaledb_internal  | _hyper_8                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name |  table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+--------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  8 | test_schema | test_migrate | _timescaledb_internal  | _hyper_8                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 select * from _timescaledb_catalog.chunk;

--- a/test/expected/ddl.out
+++ b/test/expected/ddl.out
@@ -43,10 +43,10 @@ SELECT * FROM create_hypertable('"customSchema"."Hypertable_1"', 'time', NULL, 1
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name  |  table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+--------------+--------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public       | Hypertable_1 | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  2 | customSchema | Hypertable_1 | _timescaledb_internal  | _hyper_2                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name  |  table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+--------------+--------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public       | Hypertable_1 | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  2 | customSchema | Hypertable_1 | _timescaledb_internal  | _hyper_2                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (2 rows)
 
 CREATE INDEX ON PUBLIC."Hypertable_1" (time, "temp_c");

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -10,9 +10,9 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | drop_test  | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | drop_test  | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 INSERT INTO drop_test VALUES('Mon Mar 20 09:17:00.936242 2017', 23.4, 'dev1');
@@ -55,9 +55,9 @@ SELECT create_hypertable('drop_test', 'time', 'device', 2);
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | drop_test  | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | drop_test  | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 INSERT INTO drop_test VALUES('Mon Mar 20 09:18:19.100462 2017', 22.1, 'dev1');

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -2,8 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 SELECT * from _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+------------+--------------------------+--------------------
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------------------
 (0 rows)
 
 SELECT * from _timescaledb_catalog.dimension;
@@ -73,9 +73,9 @@ NOTICE:  table "should_drop" is already a hypertable, skipping
 (1 row)
 
 SELECT * from _timescaledb_catalog.hypertable;
- id | schema_name | table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+-------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | should_drop | _timescaledb_internal  | _hyper_1                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+-------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | should_drop | _timescaledb_internal  | _hyper_1                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
@@ -95,9 +95,9 @@ NOTICE:  adding not-null constraint to column "time"
 
 INSERT INTO should_drop VALUES (now(), 1.0);
 SELECT * from _timescaledb_catalog.hypertable;
- id | schema_name | table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+-------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  4 | public      | should_drop | _timescaledb_internal  | _hyper_4                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+-------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  4 | public      | should_drop | _timescaledb_internal  | _hyper_4                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -25,10 +25,10 @@ NOTICE:  adding not-null constraint to column "time"
 
 INSERT INTO hypertable_schema.superuser VALUES ('2001-01-01 01:01:01', 23.3, 1);
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
- id |    schema_name    |    table_name     | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------------+-------------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id |    schema_name    |    table_name     | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------------+-------------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | hypertable_schema | default_perm_user | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  2 | hypertable_schema | superuser         | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
@@ -40,9 +40,9 @@ SELECT * FROM _timescaledb_catalog.chunk;
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
- id |    schema_name    | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id |    schema_name    | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  2 | hypertable_schema | superuser  | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
@@ -54,8 +54,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 DROP TABLE  hypertable_schema.superuser;
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+------------+--------------------------+--------------------
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -146,9 +146,9 @@ SELECT * FROM "newname";
 (12 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | newname    | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | newname    | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -173,15 +173,15 @@ SELECT * FROM "newschema"."newname";
 (12 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | newschema   | newname    | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | newschema   | newname    | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 DROP TABLE "newschema"."newname";
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+------------+--------------------------+--------------------
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------------------
 (0 rows)
 
 \dt  "public".*

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -30,10 +30,10 @@ NOTICE:  adding not-null constraint to column "time"
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 INSERT INTO hypertable_schema.test2 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
- id |    schema_name    | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | hypertable_schema | test1      | chunk_schema1          | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id |    schema_name    | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | hypertable_schema | test1      | chunk_schema1          | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
@@ -53,10 +53,10 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 --show that the metadata for the table using the dropped schema is
 --changed. The other table is not affected.
 SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
- id |    schema_name    | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | hypertable_schema | test1      | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id |    schema_name    | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | hypertable_schema | test1      | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  2 | hypertable_schema | test2      | chunk_schema2          | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
@@ -86,8 +86,8 @@ NOTICE:  drop cascades to 4 other objects
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 --everything should be cleaned up
 SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+------------+--------------------------+--------------------
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema | chunk_sizing_func_name | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+------------------------+-------------------+-------------------+--------------------------+--------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;

--- a/test/expected/dump_meta.out
+++ b/test/expected/dump_meta.out
@@ -67,9 +67,9 @@ List of tables
 \echo 'List of hypertables'
 List of hypertables
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 \echo 'List of chunk indexes'

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -72,9 +72,9 @@ WARNING:  target chunk size for adaptive chunking is less than 10 MB
 
 -- Chunk sizing func set
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |     chunk_sizing_func_name      | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+---------------------------------+-------------------+------------+--------------------------+--------------------
-  1 | test_schema | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | public                   | custom_calculate_chunk_interval |           1048576 | f          |                          |                   
+ id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |     chunk_sizing_func_name      | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+---------------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | test_schema | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | public                   | custom_calculate_chunk_interval |           1048576 |                 0 |                          |                   
 (1 row)
 
 SELECT proname, pronamespace, pronargs
@@ -503,9 +503,9 @@ SELECT * FROM _timescaledb_catalog.chunk_constraint;
 
 --Chunk sizing function should have been restored
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |     chunk_sizing_func_name      | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+---------------------------------+-------------------+------------+--------------------------+--------------------
-  1 | test_schema | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | public                   | custom_calculate_chunk_interval |           1048576 | f          |                          |                   
+ id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |     chunk_sizing_func_name      | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+---------------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | test_schema | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | public                   | custom_calculate_chunk_interval |           1048576 |                 0 |                          |                   
 (1 row)
 
 SELECT proname, pronamespace, pronargs

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -37,11 +37,11 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | test_ts    | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  2 | public      | test_tz    | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
-  3 | public      | test_dt    | _timescaledb_internal  | _hyper_3                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name | table_name | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | test_ts    | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  2 | public      | test_tz    | _timescaledb_internal  | _hyper_2                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+  3 | public      | test_dt    | _timescaledb_internal  | _hyper_3                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (3 rows)
 
 INSERT INTO test_ts VALUES('Mon Mar 20 09:17:00.936242 2017', 23.4, 'dev1');

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -35,9 +35,9 @@ INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 \set QUIET on
 \o
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
@@ -78,9 +78,9 @@ SELECT * FROM "two_Partitions";
 SET client_min_messages = WARNING;
 TRUNCATE "two_Partitions";
 SELECT * FROM _timescaledb_catalog.hypertable;
- id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                   
+ id | schema_name |   table_name   | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+-------------+----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public      | two_Partitions | _timescaledb_internal  | _hyper_1                |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -92,7 +92,7 @@ validate_drop_chunks_hypertable(Cache *hcache, Oid user_htoid)
 
 	if (ht != NULL)
 	{
-		if (ht->fd.compressed)
+		if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -44,12 +44,12 @@ SET timescaledb.enable_transparent_decompression to ON;
 update foo set c = 40
 where  a = (SELECT max(a) FROM foo);
 SET timescaledb.enable_transparent_decompression to OFF;
-select id, schema_name, table_name, compressed, compressed_hypertable_id from
+select id, schema_name, table_name, compression_state as compressed, compressed_hypertable_id from
 _timescaledb_catalog.hypertable order by id;
  id |      schema_name      |        table_name        | compressed | compressed_hypertable_id 
 ----+-----------------------+--------------------------+------------+--------------------------
-  1 | public                | foo                      | f          |                        2
-  2 | _timescaledb_internal | _compressed_hypertable_2 | t          |                         
+  1 | public                | foo                      |          1 |                        2
+  2 | _timescaledb_internal | _compressed_hypertable_2 |          2 |                         
 (2 rows)
 
 select * from _timescaledb_catalog.hypertable_compression order by hypertable_id, attname;

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -42,6 +42,31 @@ NOTICE:  adding not-null constraint to column "time"
 INSERT INTO compressed SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, random()*80
 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-04 1:00', '1 hour') t;
 ALTER TABLE compressed SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | compressed      | device  |                      1 |                      |             | 
+ public            | compressed      | time    |                        |                    1 | f           | t
+(2 rows)
+
+\x
+SELECT * FROM _timescaledb_catalog.hypertable
+WHERE table_name = 'compressed';
+-[ RECORD 1 ]------------+-------------------------
+id                       | 1
+schema_name              | public
+table_name               | compressed
+associated_schema_name   | _timescaledb_internal
+associated_table_prefix  | _dist_hyper_1
+num_dimensions           | 2
+chunk_sizing_func_schema | _timescaledb_internal
+chunk_sizing_func_name   | calculate_chunk_interval
+chunk_target_size        | 0
+compression_state        | 1
+compressed_hypertable_id | 
+replication_factor       | 2
+
+\x
 SELECT test.remote_exec(NULL, $$
 SELECT table_name, compressed_hypertable_id
 FROM _timescaledb_catalog.hypertable
@@ -222,7 +247,7 @@ hypertable_name     | compressed
 owner               | test_role_1
 num_dimensions      | 2
 num_chunks          | 3
-compression_enabled | f
+compression_enabled | t
 is_distributed      | t
 replication_factor  | 2
 data_nodes          | {db_dist_compression_1,db_dist_compression_2,db_dist_compression_3}

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -1777,11 +1777,11 @@ SELECT * FROM set_number_partitions('"Table\\Schema"."Param_Table"', 4);
 
 -- Verify hypertables on all data nodes
 SELECT * FROM _timescaledb_catalog.hypertable;
- id |  schema_name  |   table_name    | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+---------------+-----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public        | disttable       | _timescaledb_internal  | _dist_hyper_1           |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                  1
-  2 | public        | underreplicated | _timescaledb_internal  | _dist_hyper_2           |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                  4
-  4 | Table\\Schema | Param_Table     | T3sTSch                | test*pre_               |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                  2
+ id |  schema_name  |   table_name    | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+---------------+-----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public        | disttable       | _timescaledb_internal  | _dist_hyper_1           |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                  1
+  2 | public        | underreplicated | _timescaledb_internal  | _dist_hyper_2           |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                  4
+  4 | Table\\Schema | Param_Table     | T3sTSch                | test*pre_               |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                  2
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -1809,11 +1809,11 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.hypertable
 NOTICE:  [db_dist_hypertable_1]:
-id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compressed|compressed_hypertable_id|replication_factor
---+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+----------+------------------------+------------------
- 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
+id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compression_state|compressed_hypertable_id|replication_factor
+--+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
+ 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 
@@ -1843,11 +1843,11 @@ ts_insert_blocker|     7|_timescaledb_internal.insert_blocker
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.hypertable
 NOTICE:  [db_dist_hypertable_2]:
-id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compressed|compressed_hypertable_id|replication_factor
---+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+----------+------------------------+------------------
- 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
+id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compression_state|compressed_hypertable_id|replication_factor
+--+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
+ 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 
@@ -1877,11 +1877,11 @@ ts_insert_blocker|     7|_timescaledb_internal.insert_blocker
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.hypertable
 NOTICE:  [db_dist_hypertable_3]:
-id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compressed|compressed_hypertable_id|replication_factor
---+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+----------+------------------------+------------------
- 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
+id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compression_state|compressed_hypertable_id|replication_factor
+--+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
+ 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -1777,11 +1777,11 @@ SELECT * FROM set_number_partitions('"Table\\Schema"."Param_Table"', 4);
 
 -- Verify hypertables on all data nodes
 SELECT * FROM _timescaledb_catalog.hypertable;
- id |  schema_name  |   table_name    | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compressed | compressed_hypertable_id | replication_factor 
-----+---------------+-----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+------------+--------------------------+--------------------
-  1 | public        | disttable       | _timescaledb_internal  | _dist_hyper_1           |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                  1
-  2 | public        | underreplicated | _timescaledb_internal  | _dist_hyper_2           |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                  4
-  4 | Table\\Schema | Param_Table     | T3sTSch                | test*pre_               |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 | f          |                          |                  2
+ id |  schema_name  |   table_name    | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
+----+---------------+-----------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
+  1 | public        | disttable       | _timescaledb_internal  | _dist_hyper_1           |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                  1
+  2 | public        | underreplicated | _timescaledb_internal  | _dist_hyper_2           |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                  4
+  4 | Table\\Schema | Param_Table     | T3sTSch                | test*pre_               |              2 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                  2
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -1809,11 +1809,11 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.hypertable
 NOTICE:  [db_dist_hypertable_1]:
-id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compressed|compressed_hypertable_id|replication_factor
---+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+----------+------------------------+------------------
- 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
+id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compression_state|compressed_hypertable_id|replication_factor
+--+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
+ 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 
@@ -1843,11 +1843,11 @@ ts_insert_blocker|     7|_timescaledb_internal.insert_blocker
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.hypertable
 NOTICE:  [db_dist_hypertable_2]:
-id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compressed|compressed_hypertable_id|replication_factor
---+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+----------+------------------------+------------------
- 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
+id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compression_state|compressed_hypertable_id|replication_factor
+--+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
+ 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 
@@ -1877,11 +1877,11 @@ ts_insert_blocker|     7|_timescaledb_internal.insert_blocker
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.hypertable
 NOTICE:  [db_dist_hypertable_3]:
-id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compressed|compressed_hypertable_id|replication_factor
---+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+----------+------------------------+------------------
- 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|f         |                        |                -1
+id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|num_dimensions|chunk_sizing_func_schema|chunk_sizing_func_name  |chunk_target_size|compression_state|compressed_hypertable_id|replication_factor
+--+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
+ 1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -70,7 +70,7 @@ SELECT * FROM timescaledb_information.hypertables
 WHERE hypertable_name = 'dist_table';
  hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |              data_nodes               | tablespaces 
 -------------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+---------------------------------------+-------------
- public            | dist_table      | test_role_1 |              3 |          3 | f                   | t              |                  2 | {view_node_1,view_node_2,view_node_3} | 
+ public            | dist_table      | test_role_1 |              3 |          3 | t                   | t              |                  2 | {view_node_1,view_node_2,view_node_3} | 
 (1 row)
 
 SELECT * from timescaledb_information.chunks 

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -26,7 +26,7 @@ update foo set c = 40
 where  a = (SELECT max(a) FROM foo);
 SET timescaledb.enable_transparent_decompression to OFF;
 
-select id, schema_name, table_name, compressed, compressed_hypertable_id from
+select id, schema_name, table_name, compression_state as compressed, compressed_hypertable_id from
 _timescaledb_catalog.hypertable order by id;
 select * from _timescaledb_catalog.hypertable_compression order by hypertable_id, attname;
 select * from timescaledb_information.compression_settings ORDER BY hypertable_name;

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -26,6 +26,12 @@ INSERT INTO compressed SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, r
 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-04 1:00', '1 hour') t;
 ALTER TABLE compressed SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
 
+SELECT * FROM timescaledb_information.compression_settings;
+\x
+SELECT * FROM _timescaledb_catalog.hypertable
+WHERE table_name = 'compressed';
+\x
+
 SELECT test.remote_exec(NULL, $$
 SELECT table_name, compressed_hypertable_id
 FROM _timescaledb_catalog.hypertable


### PR DESCRIPTION
1. Add compression_state column for hypertable catalog
by renaming compressed column for the hypertable catalog
table. compression_state is a tri-state column.
This column indicates if the hypertable has
compression enabled (value = 2) or if it is an internal
compression table (value = 1).

2. Save compression settings on access node when compression
is turned on for a distributed hypertable
For a distributed hypertable, that has compresison enabled,
compression_state is set. We don't create any internal tables
on the access node.

Fixes #2660