### PR TITLE
Fix timeout handling in async library

### DIFF
--- a/tsl/src/remote/async.h
+++ b/tsl/src/remote/async.h
@@ -12,8 +12,6 @@
 
 #include "stmt_params.h"
 
-#define DEFAULT_TIMEOUT_MS (SECS_PER_HOUR * 1000)
-
 typedef struct AsyncRequest AsyncRequest;
 
 typedef struct TSConnection TSConnection;
@@ -106,6 +104,7 @@ extern bool async_request_set_single_row_mode(AsyncRequest *req);
 extern TSConnection *async_request_get_connection(AsyncRequest *req);
 extern AsyncResponseResult *async_request_wait_ok_result(AsyncRequest *request);
 extern AsyncResponseResult *async_request_wait_any_result(AsyncRequest *request);
+extern AsyncResponse *async_request_cleanup_result(AsyncRequest *req, TimestampTz endtime);
 
 /* Returns on successful commands, throwing errors otherwise */
 extern void async_request_wait_ok_command(AsyncRequest *set);
@@ -133,12 +132,8 @@ extern void async_request_set_add(AsyncRequestSet *set, AsyncRequest *req);
 extern AsyncResponse *async_request_set_wait_any_response_deadline(AsyncRequestSet *set,
 																   TimestampTz endtime);
 
-#define async_request_set_wait_any_response_timeout(set, timeout_ms)                               \
-	async_request_set_wait_any_response_deadline(                                                  \
-		set, TimestampTzPlusMilliseconds(GetCurrentTimestamp(), timeout_ms))
-
 #define async_request_set_wait_any_response(set)                                                   \
-	async_request_set_wait_any_response_timeout(set, DEFAULT_TIMEOUT_MS)
+	async_request_set_wait_any_response_deadline(set, TS_NO_TIMEOUT)
 
 /* Return only successful results, throwing errors otherwise */
 extern AsyncResponseResult *async_request_set_wait_ok_result(AsyncRequestSet *set);

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -71,6 +71,16 @@ extern bool remote_connection_configure(TSConnection *conn);
 extern bool remote_connection_check_extension(TSConnection *conn);
 extern void remote_validate_extension_version(TSConnection *conn, const char *data_node_version);
 
+typedef enum TSConnectionResult
+{
+	CONN_OK,
+	CONN_TIMEOUT,
+	CONN_DISCONNECT,
+	CONN_NO_RESPONSE,
+} TSConnectionResult;
+
+TSConnectionResult remote_connection_drain(TSConnection *conn, TimestampTz endtime,
+										   PGresult **result);
 extern bool remote_connection_cancel_query(TSConnection *conn);
 extern PGconn *remote_connection_get_pg_conn(const TSConnection *conn);
 extern bool remote_connection_is_processing(const TSConnection *conn);

--- a/tsl/test/expected/remote_txn.out
+++ b/tsl/test/expected/remote_txn.out
@@ -273,10 +273,13 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-0
  loopback  | OK                | INTRANS            |                 1 | f
 (1 row)
 
-ROLLBACK;
-WARNING:  kill event: pre-abort
-WARNING:  [loopback]: terminating connection due to administrator command
-WARNING:  transaction rollback on data node "loopback" failed
+-- since the error messages/warnings from this ROLLBACK varies between
+-- platforms/environments we remove it from test output and show
+-- SQLSTATE instead. SQLSTATE should be 00000 since we are not
+-- throwing errors during rollback/abort and it should succeed in any
+-- case.
+\echo 'ROLLBACK SQLSTATE' :SQLSTATE
+ROLLBACK SQLSTATE 00000
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20005;
  count 
 -------

--- a/tsl/test/sql/remote_txn.sql
+++ b/tsl/test/sql/remote_txn.sql
@@ -151,7 +151,17 @@ BEGIN;
     --connection in transaction
     SELECT node_name, connection_status, transaction_status, transaction_depth, processing
     FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
+
+-- since the error messages/warnings from this ROLLBACK varies between
+-- platforms/environments we remove it from test output and show
+-- SQLSTATE instead. SQLSTATE should be 00000 since we are not
+-- throwing errors during rollback/abort and it should succeed in any
+-- case.
+--<exclude_from_test>
 ROLLBACK;
+--</exclude_from_test>
+\echo 'ROLLBACK SQLSTATE' :SQLSTATE
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20005;
 SELECT count(*) FROM pg_prepared_xacts;
 

--- a/tsl/test/src/remote/async.c
+++ b/tsl/test/src/remote/async.c
@@ -288,10 +288,6 @@ test_timeout()
 		set, TimestampTzPlusMilliseconds(GetCurrentTimestamp(), 100));
 	TestAssertTrue(async_response_get_type(response) == RESPONSE_TIMEOUT);
 
-	/* try again, use timeout instead of deadline interface */
-	response = async_request_set_wait_any_response_timeout(set, 100);
-	TestAssertTrue(async_response_get_type(response) == RESPONSE_TIMEOUT);
-
 	/* cancel the locked query and do another query */
 	TestAssertTrue(remote_connection_cancel_query(conn));
 	/* the txn is aborted waiting for abort */


### PR DESCRIPTION
This change removes a hard-coded 1 minute connection timeout that
would cause long-running queries and commands (e.g., compressing a
chunk) to time out before completion. Queries can still be canceled by
the user or the database when `statement_timeout` is reached.

One exception where timeouts is still used is cleanup during
transaction abort (e.g., sending a `ROLLBACK` statement to a data node
in the abort handler). Queries sent at this stage should have a
timeout since they occur in the transaction abort handler after the
main query has already been canceled or reached `statement_timeout`.

Fixes #2645
Closes #2646