### PR TITLE
Add hypertable to continuous aggregates view

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,1 +1,1 @@
-
+DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;

--- a/tsl/test/expected/continuous_aggs_usage.out
+++ b/tsl/test/expected/continuous_aggs_usage.out
@@ -70,6 +70,8 @@ SELECT * FROM device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, de
 \x
 SELECT * FROM timescaledb_information.continuous_aggregates;
 -[ RECORD 1 ]---------------------+-------------------------------------------------------------------------------------------------------------
+hypertable_schema                 | public
+hypertable_name                   | device_readings
 view_schema                       | public
 view_name                         | device_summary
 view_owner                        | default_perm_user


### PR DESCRIPTION
Add the hypertable's schema and name to the continuous aggregates view
in the information schema, since these fields where missing.

The new fields use the same names and order in the view to be
consistent with other information views that reference the hypertable.

Fixes #2653