### PR TITLE
Include user actions into job stats view

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,1 +1,2 @@
 DROP VIEW IF EXISTS timescaledb_information.continuous_aggregates;
+DROP VIEW IF EXISTS timescaledb_information.job_stats;

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -78,8 +78,8 @@ SELECT ht.schema_name AS hypertable_schema,
   js.total_successes,
   js.total_failures
 FROM _timescaledb_config.bgw_job j
-  INNER JOIN _timescaledb_catalog.hypertable ht ON j.hypertable_id = ht.id
   INNER JOIN _timescaledb_internal.bgw_job_stat js ON j.id = js.job_id
+  LEFT JOIN _timescaledb_catalog.hypertable ht ON j.hypertable_id = ht.id
   LEFT JOIN pg_stat_activity pgs ON pgs.datname = current_database()
     AND pgs.application_name = j.application_name
   ORDER BY ht.schema_name,

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -146,6 +146,11 @@ SELECT * FROM _timescaledb_internal.bgw_job_stat;
 --------+------------+-------------+------------+------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
 (0 rows)
 
+SELECT * FROM timescaledb_information.job_stats;
+ hypertable_schema | hypertable_name | job_id | last_run_started_at | last_successful_finish | last_run_status | job_status | last_run_duration | next_start | total_runs | total_successes | total_failures 
+-------------------+-----------------+--------+---------------------+------------------------+-----------------+------------+-------------------+------------+------------+-----------------+----------------
+(0 rows)
+
 SELECT test_toggle_scheduled(1000);
  test_toggle_scheduled 
 -----------------------
@@ -162,6 +167,12 @@ SELECT * FROM _timescaledb_internal.bgw_job_stat;
  job_id |           last_start            |           last_finish           |           next_start            |     last_successful_finish      | last_run_success | total_runs | total_duration | total_successes | total_failures | total_crashes | consecutive_failures | consecutive_crashes 
 --------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+------------------+------------+----------------+-----------------+----------------+---------------+----------------------+---------------------
    1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.15 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | t                |          1 | @ 0            |               1 |              0 |             0 |                    0 |                   0
+(1 row)
+
+SELECT * FROM timescaledb_information.job_stats;
+ hypertable_schema | hypertable_name | job_id |       last_run_started_at       |     last_successful_finish      | last_run_status | job_status | last_run_duration |           next_start            | total_runs | total_successes | total_failures 
+-------------------+-----------------+--------+---------------------------------+---------------------------------+-----------------+------------+-------------------+---------------------------------+------------+-----------------+----------------
+                   |                 |   1000 | Fri Dec 31 16:00:00.05 1999 PST | Fri Dec 31 16:00:00.05 1999 PST | Success         | Scheduled  |                   | Fri Dec 31 16:00:00.15 1999 PST |          1 |               1 |              0
 (1 row)
 
 SELECT * FROM sorted_bgw_log;

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -130,10 +130,12 @@ SELECT insert_job('unscheduled', 'bgw_test_job_1', INTERVAL '100ms', INTERVAL '1
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50);
 -- empty
 SELECT * FROM _timescaledb_internal.bgw_job_stat;
+SELECT * FROM timescaledb_information.job_stats;
 
 SELECT test_toggle_scheduled(1000);
 SELECT ts_bgw_db_scheduler_test_run_and_wait_for_scheduler_finish(50);
 SELECT * FROM _timescaledb_internal.bgw_job_stat;
+SELECT * FROM timescaledb_information.job_stats;
 SELECT * FROM sorted_bgw_log;
 
 SELECT delete_job(1000);


### PR DESCRIPTION
timescale_infromation.job_stats view was missing information about
jobs running user actions. This commit fixes that the view includes
user jobs with.

Replaces https://github.com/timescale/timescaledb/pull/2674