### PR TITLE
Add check function to policies

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -939,8 +939,6 @@ bgw_job_tuple_update_by_id(TupleInfo *ti, void *const data)
 		slot_getattr(ti->slot, Anum_bgw_job_schedule_interval, &isnull[0]);
 	Assert(!isnull[0]);
 
-	ts_bgw_job_permission_check(updated_job);
-
 	/* when we update the schedule interval, modify the next start time as well*/
 	if (!DatumGetBool(DirectFunctionCall2(interval_eq,
 										  old_schedule_interval,

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -8,6 +8,8 @@
 #include <pgstat.h>
 #include <access/xact.h>
 #include <catalog/pg_authid.h>
+#include <nodes/makefuncs.h>
+#include <parser/parse_func.h>
 #include <postmaster/bgworker.h>
 #include <storage/ipc.h>
 #include <tcop/tcopprot.h>
@@ -21,6 +23,7 @@
 #include <storage/sinvaladt.h>
 #include <utils/elog.h>
 #include <utils/jsonb.h>
+#include <utils/snapmgr.h>
 
 #include "job.h"
 #include "scanner.h"
@@ -920,114 +923,4 @@ ts_bgw_job_insert_relation(Name application_name, Name job_type, Interval *sched
 
 	table_close(rel, RowExclusiveLock);
 	return values[AttrNumberGetAttrOffset(Anum_bgw_job_id)];
-}
-
-/* This function only updates the fields modifiable with alter_job. */
-static ScanTupleResult
-bgw_job_tuple_update_by_id(TupleInfo *ti, void *const data)
-{
-	BgwJob *updated_job = (BgwJob *) data;
-	bool should_free;
-	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
-	HeapTuple new_tuple;
-
-	Datum values[Natts_bgw_job] = { 0 };
-	bool isnull[Natts_bgw_job] = { 0 };
-	bool repl[Natts_bgw_job] = { 0 };
-
-	Datum old_schedule_interval =
-		slot_getattr(ti->slot, Anum_bgw_job_schedule_interval, &isnull[0]);
-	Assert(!isnull[0]);
-
-	/* when we update the schedule interval, modify the next start time as well*/
-	if (!DatumGetBool(DirectFunctionCall2(interval_eq,
-										  old_schedule_interval,
-										  IntervalPGetDatum(&updated_job->fd.schedule_interval))))
-	{
-		BgwJobStat *stat = ts_bgw_job_stat_find(updated_job->fd.id);
-
-		if (stat != NULL)
-		{
-			TimestampTz next_start = DatumGetTimestampTz(
-				DirectFunctionCall2(timestamptz_pl_interval,
-									TimestampTzGetDatum(stat->fd.last_finish),
-									IntervalPGetDatum(&updated_job->fd.schedule_interval)));
-			/* allow DT_NOBEGIN for next_start here through allow_unset=true in the case that
-			 * last_finish is DT_NOBEGIN,
-			 * This means the value is counted as unset which is what we want */
-			ts_bgw_job_stat_update_next_start(updated_job->fd.id, next_start, true);
-		}
-		values[AttrNumberGetAttrOffset(Anum_bgw_job_schedule_interval)] =
-			IntervalPGetDatum(&updated_job->fd.schedule_interval);
-		repl[AttrNumberGetAttrOffset(Anum_bgw_job_schedule_interval)] = true;
-	}
-
-	values[AttrNumberGetAttrOffset(Anum_bgw_job_max_runtime)] =
-		IntervalPGetDatum(&updated_job->fd.max_runtime);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_max_runtime)] = true;
-
-	values[AttrNumberGetAttrOffset(Anum_bgw_job_max_retries)] =
-		Int32GetDatum(updated_job->fd.max_retries);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_max_retries)] = true;
-
-	values[AttrNumberGetAttrOffset(Anum_bgw_job_retry_period)] =
-		IntervalPGetDatum(&updated_job->fd.retry_period);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_retry_period)] = true;
-
-	values[AttrNumberGetAttrOffset(Anum_bgw_job_scheduled)] =
-		BoolGetDatum(updated_job->fd.scheduled);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_scheduled)] = true;
-
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_config)] = true;
-	if (updated_job->fd.config)
-		values[AttrNumberGetAttrOffset(Anum_bgw_job_config)] =
-			JsonbPGetDatum(updated_job->fd.config);
-	else
-		isnull[AttrNumberGetAttrOffset(Anum_bgw_job_config)] = true;
-
-	new_tuple = heap_modify_tuple(tuple, ts_scanner_get_tupledesc(ti), values, isnull, repl);
-
-	ts_catalog_update(ti->scanrel, new_tuple);
-
-	heap_freetuple(new_tuple);
-	if (should_free)
-		heap_freetuple(tuple);
-
-	return SCAN_DONE;
-}
-
-/*
- * Overwrite job with specified job_id with the given fields
- *
- * This function only updates the fields modifiable with alter_job.
- */
-void
-ts_bgw_job_update_by_id(int32 job_id, BgwJob *job)
-{
-	ScanKeyData scankey[1];
-	Catalog *catalog = ts_catalog_get();
-	ScanTupLock scantuplock = {
-		.waitpolicy = LockWaitBlock,
-		.lockmode = LockTupleExclusive,
-		.lockflags = 0 /* don't follow updates, used in PG12 */
-	};
-	ScannerCtx scanctx = { .table = catalog_get_table_id(catalog, BGW_JOB),
-						   .index = catalog_get_index(catalog, BGW_JOB, BGW_JOB_PKEY_IDX),
-						   .nkeys = 1,
-						   .scankey = scankey,
-						   .data = job,
-						   .limit = 1,
-						   .tuple_found = bgw_job_tuple_update_by_id,
-						   .lockmode = RowExclusiveLock,
-						   .scandirection = ForwardScanDirection,
-						   .result_mctx = CurrentMemoryContext,
-						   .tuplock = &scantuplock };
-
-	ScanKeyInit(&scankey[0],
-				Anum_bgw_job_pkey_idx_id,
-				BTEqualStrategyNumber,
-				F_INT4EQ,
-				Int32GetDatum(job_id));
-
-	ts_scanner_scan(&scanctx);
 }

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -46,8 +46,6 @@ extern TSDLLEXPORT int32 ts_bgw_job_insert_relation(Name application_name, Name 
 													Interval *retry_period, Name proc_schema,
 													Name proc_name, Name owner, bool scheduled,
 													int32 hypertable_id, Jsonb *config);
-extern TSDLLEXPORT void ts_bgw_job_update_by_id(int32 job_id, BgwJob *updated_job);
-
 extern TSDLLEXPORT void ts_bgw_job_permission_check(BgwJob *job);
 
 extern TSDLLEXPORT void ts_bgw_job_validate_job_owner(Oid owner);

--- a/src/bgw_policy/policy.c
+++ b/src/bgw_policy/policy.c
@@ -6,8 +6,10 @@
 
 #include <postgres.h>
 #include <utils/builtins.h>
+#include <jsonb_utils.h>
 
 #include "bgw/job.h"
+#include "dimension.h"
 #include "policy.h"
 
 void

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -11,6 +11,7 @@
 #include <bgw/job.h>
 #include <hypertable.h>
 
+#include "continuous_aggs/materialize.h"
 #include "bgw_policy/chunk_stats.h"
 
 /* Reorder function type. Necessary for testing */
@@ -22,6 +23,15 @@ extern bool policy_reorder_execute(int32 job_id, Jsonb *config);
 extern bool policy_retention_execute(int32 job_id, Jsonb *config);
 extern bool policy_refresh_cagg_execute(int32 job_id, Jsonb *config);
 extern bool policy_compression_execute(int32 job_id, Jsonb *config);
+extern void policy_reorder_read_config(int32 job_id, Jsonb *config, Hypertable **hypertable,
+									   Oid *index_relid);
+extern void policy_retention_read_config(int32 job_id, Jsonb *config, Oid *object_relid,
+										 Datum *boundary, Datum *boundary_type);
+extern void policy_refresh_cagg_read_config(int32 job_id, Jsonb *config,
+											InternalTimeRange *refresh_window,
+											ContinuousAgg **cagg);
+extern void policy_compression_read_config(int32 job_id, Jsonb *config, bool show_notice,
+										   Dimension **dim, int32 *chunk_id);
 extern bool job_execute(BgwJob *job);
 
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_JOB_H */

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -50,18 +50,27 @@ as
 select a, count(b)
 from foo
 group by time_bucket(1, a), a WITH NO DATA;
-SELECT add_continuous_aggregate_policy('mat_m1', NULL, 2::integer, '12 h'::interval);
- add_continuous_aggregate_policy 
----------------------------------
-                            1000
-(1 row)
-
+SELECT add_continuous_aggregate_policy('mat_m1', NULL, 2::integer, '12 h'::interval) AS job_id
+\gset
 SELECT * FROM _timescaledb_config.bgw_job;
   id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner       | scheduled | hypertable_id |                             config                              
 ------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+-------------------+-----------+---------------+-----------------------------------------------------------------
  1000 | Refresh Continuous Aggregate Policy [1000] | @ 12 hours        | @ 0         |          -1 | @ 12 hours   | _timescaledb_internal | policy_refresh_continuous_aggregate | default_perm_user | t         |             2 | {"end_offset": 2, "start_offset": null, "mat_hypertable_id": 2}
 (1 row)
 
+-- These are all weird values for the parameters for the continuous
+-- aggregate jobs and should generate an error. Since the config will
+-- be replaced, we will also generate error for missing arguments.
+\set ON_ERROR_STOP 0
+SELECT alter_job(:job_id, config => '{"end_offset": "1 week", "start_offset": "2 weeks"}');
+ERROR:  could not find "mat_hypertable_id" in config for job
+SELECT alter_job(:job_id,
+       config => '{"mat_hypertable_id": "2", "end_offset": "chicken", "start_offset": "1 week"}');
+ERROR:  invalid input syntax for type bigint: "1 week"
+SELECT alter_job(:job_id,
+       config => '{"mat_hypertable_id": "2", "end_offset": "chicken", "start_offset": "1"}');
+ERROR:  invalid input syntax for type bigint: "chicken"
+\set ON_ERROR_STOP 1
 SELECT ca.raw_hypertable_id as "RAW_HYPERTABLE_ID",
        h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -797,6 +797,18 @@ select job_status from timescaledb_information.job_stats where job_id = :job_id;
 -- negative infinity disallowed (used as special value)
 select * from alter_job(:job_id, next_start=>'-infinity');
 ERROR:  cannot set next start to -infinity
+-- index should exist
+select * from alter_job(:job_id,
+       config => '{"index_name": "non-existent", "hypertable_id": 7}');
+ERROR:  reorder index not found
+-- index should be an index on the hypertable
+select * from alter_job(:job_id,
+       config => '{"index_name": "non_ht_index", "hypertable_id": 7}');
+ERROR:  invalid reorder index
+-- hypertable should exist
+select * from alter_job(:job_id,
+       config => '{"index_name": "test_table_time_idx", "hypertable_id": 47}');
+ERROR:  configuration hypertable id 47 not found
 \set ON_ERROR_STOP 1
 -- Check if_exists boolean works correctly
 select * from alter_job(1234, if_exists => TRUE);

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -40,6 +40,7 @@ SELECT add_job('custom_func', '1h', config:='{"type":"function"}'::jsonb);
 SELECT add_job('custom_func_definer', '1h', config:='{"type":"function"}'::jsonb);
 
 SELECT * FROM timescaledb_information.jobs ORDER BY 1;
+
 -- check for corrects counts in telemetry
 SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_user_defined_actions');
 

--- a/tsl/test/sql/tsl_tables.sql
+++ b/tsl/test/sql/tsl_tables.sql
@@ -310,6 +310,15 @@ select job_status from timescaledb_information.job_stats where job_id = :job_id;
 \set ON_ERROR_STOP 0
 -- negative infinity disallowed (used as special value)
 select * from alter_job(:job_id, next_start=>'-infinity');
+-- index should exist
+select * from alter_job(:job_id,
+       config => '{"index_name": "non-existent", "hypertable_id": 7}');
+-- index should be an index on the hypertable
+select * from alter_job(:job_id,
+       config => '{"index_name": "non_ht_index", "hypertable_id": 7}');
+-- hypertable should exist
+select * from alter_job(:job_id,
+       config => '{"index_name": "test_table_time_idx", "hypertable_id": 47}');
 \set ON_ERROR_STOP 1
 
 -- Check if_exists boolean works correctly


### PR DESCRIPTION
This commit adds a check function to the `bgw_job` table and also
create new validation functions for continuous aggregate, reorder,
compress, and retention policies.

The checking functions will check that the configuration is
semantically correct by reading the necessary fields for each job type
and validating that all fields are there and that they have the correct
type.

The checking function will be used to check the configuration structure
when altering the job using the `alter_job` function.

Closes #2607
