### PR TITLE
Fix crash in add_job when given NULL interval

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -26,6 +26,21 @@ BEGIN
   COMMIT;
 END
 $$;
+\set ON_ERROR_STOP 0
+-- test bad input
+SELECT add_job(NULL, '1h');
+ERROR:  function or procedure cannot be NULL
+SELECT add_job(0, '1h');
+ERROR:  function or procedure with OID 0 does not exist
+SELECT add_job(-1, '1h');
+ERROR:  function or procedure with OID -1 does not exist
+SELECT add_job('invalid_func', '1h');
+ERROR:  function "invalid_func" does not exist at character 16
+SELECT add_job('custom_func', NULL);
+ERROR:  schedule interval cannot be NULL
+SELECT add_job('custom_func', 'invalid interval');
+ERROR:  invalid input syntax for type interval: "invalid interval" at character 31
+\set ON_ERROR_STOP 1
 SELECT add_job('custom_func','1h', config:='{"type":"function"}'::jsonb);
  add_job 
 ---------
@@ -74,6 +89,13 @@ SELECT json_object_field(get_telemetry_report(always_display_report := true)::js
  5
 (1 row)
 
+\set ON_ERROR_STOP 0
+-- test bad input
+CALL run_job(NULL);
+ERROR:  job ID cannot be NULL
+CALL run_job(-1);
+ERROR:  job -1 not found
+\set ON_ERROR_STOP 1
 CALL run_job(1000);
 CALL run_job(1001);
 CALL run_job(1002);
@@ -90,6 +112,17 @@ SELECT * FROM custom_log ORDER BY job_id, extra;
    1004 | {"type": "function"}  | security definer     | default_perm_user
 (6 rows)
 
+\set ON_ERROR_STOP 0
+-- test bad input
+SELECT delete_job(NULL);
+ delete_job 
+------------
+ 
+(1 row)
+
+SELECT delete_job(-1);
+ERROR:  job -1 not found
+\set ON_ERROR_STOP 1
 SELECT delete_job(1000);
  delete_job 
 ------------
@@ -128,6 +161,28 @@ SELECT count(*) FROM timescaledb_information.jobs WHERE job_id >= 1000;
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+\set ON_ERROR_STOP 0
+-- test bad input
+SELECT alter_job(NULL, if_exists => false);
+ERROR:  job ID cannot be NULL
+SELECT alter_job(-1, if_exists => false);
+ERROR:  job -1 not found
+\set ON_ERROR_STOP 1
+-- test bad input but don't fail
+SELECT alter_job(NULL, if_exists => true);
+NOTICE:  job 0 not found, skipping
+ alter_job 
+-----------
+ 
+(1 row)
+
+SELECT alter_job(-1, if_exists => true);
+NOTICE:  job -1 not found, skipping
+ alter_job 
+-----------
+ 
+(1 row)
+
 -- test altering job with NULL config
 SELECT job_id FROM alter_job(1,scheduled:=false);
  job_id 

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -800,7 +800,7 @@ ERROR:  cannot set next start to -infinity
 \set ON_ERROR_STOP 1
 -- Check if_exists boolean works correctly
 select * from alter_job(1234, if_exists => TRUE);
-NOTICE:  job #1234 not found, skipping
+NOTICE:  job 1234 not found, skipping
  job_id | schedule_interval | max_runtime | max_retries | retry_period | scheduled | config | next_start 
 --------+-------------------+-------------+-------------+--------------+-----------+--------+------------
         |                   |             |             |              |           |        | 
@@ -808,7 +808,7 @@ NOTICE:  job #1234 not found, skipping
 
 \set ON_ERROR_STOP 0
 select * from alter_job(1234);
-ERROR:  job #1234 not found
+ERROR:  job 1234 not found
 \set ON_ERROR_STOP 1
 select remove_reorder_policy('test_table');
  remove_reorder_policy 
@@ -821,7 +821,7 @@ set session timescaledb.license_key='Community';
 -- Test for failure cases
 \set ON_ERROR_STOP 0
 select alter_job(12345);
-ERROR:  job #12345 not found
+ERROR:  job 12345 not found
 \set ON_ERROR_STOP 1
 select add_reorder_policy('test_table', 'test_table_time_idx') as reorder_job_id \gset
 select add_retention_policy('test_table', INTERVAL '4 months', true) as drop_chunks_job_id \gset

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -32,6 +32,16 @@ BEGIN
 END
 $$;
 
+\set ON_ERROR_STOP 0
+-- test bad input
+SELECT add_job(NULL, '1h');
+SELECT add_job(0, '1h');
+SELECT add_job(-1, '1h');
+SELECT add_job('invalid_func', '1h');
+SELECT add_job('custom_func', NULL);
+SELECT add_job('custom_func', 'invalid interval');
+\set ON_ERROR_STOP 1
+
 SELECT add_job('custom_func','1h', config:='{"type":"function"}'::jsonb);
 SELECT add_job('custom_proc','1h', config:='{"type":"procedure"}'::jsonb);
 SELECT add_job('custom_proc2','1h', config:= '{"type":"procedure"}'::jsonb);
@@ -43,6 +53,12 @@ SELECT * FROM timescaledb_information.jobs ORDER BY 1;
 -- check for corrects counts in telemetry
 SELECT json_object_field(get_telemetry_report(always_display_report := true)::json,'num_user_defined_actions');
 
+\set ON_ERROR_STOP 0
+-- test bad input
+CALL run_job(NULL);
+CALL run_job(-1);
+\set ON_ERROR_STOP 1
+
 CALL run_job(1000);
 CALL run_job(1001);
 CALL run_job(1002);
@@ -50,6 +66,13 @@ CALL run_job(1003);
 CALL run_job(1004);
 
 SELECT * FROM custom_log ORDER BY job_id, extra;
+
+
+\set ON_ERROR_STOP 0
+-- test bad input
+SELECT delete_job(NULL);
+SELECT delete_job(-1);
+\set ON_ERROR_STOP 1
 
 SELECT delete_job(1000);
 SELECT delete_job(1001);
@@ -61,6 +84,16 @@ SELECT delete_job(1004);
 SELECT count(*) FROM timescaledb_information.jobs WHERE job_id >= 1000;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
+
+\set ON_ERROR_STOP 0
+-- test bad input
+SELECT alter_job(NULL, if_exists => false);
+SELECT alter_job(-1, if_exists => false);
+\set ON_ERROR_STOP 1
+-- test bad input but don't fail
+SELECT alter_job(NULL, if_exists => true);
+SELECT alter_job(-1, if_exists => true);
+
 -- test altering job with NULL config
 SELECT job_id FROM alter_job(1,scheduled:=false);
 SELECT * FROM timescaledb_information.jobs WHERE job_id = 1;


### PR DESCRIPTION
This change fixes a crash in `add_job` when given an NULL
schedule interval as input. In addition, the following improvements
have been implemented for all job API functions:

* Validation of input parameters, specifically NULL checks
* Improved error messages for clarity and consistency
* Tests for bad input arguments