### PR TITLE
Support gapfill on distributed hypertable

### DIFF
--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -86,6 +86,7 @@
 #include "extension_constants.h"
 #include "plan_expand_hypertable.h"
 #include "partialize_finalize.h"
+#include "nodes/gapfill/planner.h"
 
 /*
  * Global context for foreign_expr_walker's search of an expression tree.
@@ -374,6 +375,12 @@ is_foreign_expr(PlannerInfo *root, RelOptInfo *baserel, Expr *expr)
 		glob_cxt.relids = baserel->relids;
 
 	if (!foreign_expr_walker((Node *) expr, &glob_cxt))
+		return false;
+
+	/*
+	 * It is not supported to execute time_bucket_gapfill on data node.
+	 */
+	if (gapfill_in_expression(expr))
 		return false;
 
 	/*

--- a/tsl/src/nodes/gapfill/planner.h
+++ b/tsl/src/nodes/gapfill/planner.h
@@ -8,7 +8,8 @@
 
 #include <postgres.h>
 
-void plan_add_gapfill(PlannerInfo *root, RelOptInfo *group_rel, bool dist_ht);
+bool gapfill_in_expression(Expr *node);
+void plan_add_gapfill(PlannerInfo *root, RelOptInfo *group_rel);
 void gapfill_adjust_window_targetlist(PlannerInfo *root, RelOptInfo *input_rel,
 									  RelOptInfo *output_rel);
 

--- a/tsl/test/expected/dist_api_calls.out
+++ b/tsl/test/expected/dist_api_calls.out
@@ -216,27 +216,150 @@ _timescaledb_internal._dist_hyper_1_8_chunk
  
 (1 row)
 
--- Simple test of time_bucket_gapfill, which is disabled for now.
-\set ON_ERROR_STOP 0
+-- Simple tests of time_bucket_gapfill
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-02 18:00'),
        first(value, time),
        avg(value)
 FROM disttable
 GROUP BY 1;
-ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+     time_bucket_gapfill      | first |   avg   
+------------------------------+-------+---------
+ Sun Jan 01 04:00:00 2017 PST |   1.2 |     1.2
+ Sun Jan 01 07:00:00 2017 PST |   7.3 |     5.8
+ Sun Jan 01 10:00:00 2017 PST |       |        
+ Sun Jan 01 13:00:00 2017 PST |       |        
+ Sun Jan 01 16:00:00 2017 PST |       |        
+ Sun Jan 01 19:00:00 2017 PST |       |        
+ Sun Jan 01 22:00:00 2017 PST |       |        
+ Mon Jan 02 01:00:00 2017 PST |       |        
+ Mon Jan 02 04:00:00 2017 PST |       |        
+ Mon Jan 02 07:00:00 2017 PST |  0.23 |    0.23
+ Mon Jan 02 10:00:00 2017 PST |       |        
+ Mon Jan 02 13:00:00 2017 PST |       |        
+ Mon Jan 02 16:00:00 2017 PST |       |        
+ Sun Jul 01 05:00:00 2018 PDT |   3.1 |     3.1
+ Sun Jul 01 08:00:00 2018 PDT |    64 | 5183.56
+ Mon Jul 02 08:00:00 2018 PDT |     0 |       0
+(16 rows)
+
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
        device,
        first(value, time),
        avg(value)
 FROM disttable
 GROUP BY 1,2;
-ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+     time_bucket_gapfill      | device |  first   |   avg    
+------------------------------+--------+----------+----------
+ Sun Jan 01 04:00:00 2017 PST |      1 |      1.2 |      1.2
+ Sun Jan 01 07:00:00 2017 PST |      1 |      7.3 |      7.3
+ Sun Jan 01 10:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 04:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 10:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      2 |          |         
+ Mon Jan 02 07:00:00 2017 PST |      2 |     0.23 |     0.23
+ Sun Jan 01 04:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      3 |      4.3 |      4.3
+ Sun Jan 01 10:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 04:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     13 |          |         
+ Sun Jul 01 05:00:00 2018 PDT |     13 |      3.1 |      3.1
+ Sun Jan 01 04:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     29 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     29 |       64 |       64
+ Sun Jan 01 04:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     87 |          |         
+ Mon Jul 02 08:00:00 2018 PDT |     87 |        0 |        0
+ Sun Jan 01 04:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     90 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     90 | 10303.12 | 10303.12
+(40 rows)
+
 SELECT
   time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
   lag(min(time)) OVER ()
 FROM disttable
 GROUP BY 1;
-ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+     time_bucket_gapfill      |             lag              
+------------------------------+------------------------------
+ Sun Jan 01 04:00:00 2017 PST | 
+ Sun Jan 01 07:00:00 2017 PST | Sun Jan 01 06:01:00 2017 PST
+ Sun Jan 01 10:00:00 2017 PST | Sun Jan 01 08:01:00 2017 PST
+ Sun Jan 01 13:00:00 2017 PST | 
+ Sun Jan 01 16:00:00 2017 PST | 
+ Mon Jan 02 07:00:00 2017 PST | 
+ Sun Jul 01 05:00:00 2018 PDT | Mon Jan 02 08:01:00 2017 PST
+ Sun Jul 01 08:00:00 2018 PDT | Sun Jul 01 06:01:00 2018 PDT
+ Mon Jul 02 08:00:00 2018 PDT | Sun Jul 01 08:01:00 2018 PDT
+(9 rows)
+
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
+       device,
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 2,1;
+     time_bucket_gapfill      | device |  first   |   avg    
+------------------------------+--------+----------+----------
+ Sun Jan 01 04:00:00 2017 PST |      1 |      1.2 |      1.2
+ Sun Jan 01 07:00:00 2017 PST |      1 |      7.3 |      7.3
+ Sun Jan 01 10:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 04:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 10:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      2 |          |         
+ Mon Jan 02 07:00:00 2017 PST |      2 |     0.23 |     0.23
+ Sun Jan 01 04:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      3 |      4.3 |      4.3
+ Sun Jan 01 10:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 04:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     13 |          |         
+ Sun Jul 01 05:00:00 2018 PDT |     13 |      3.1 |      3.1
+ Sun Jan 01 04:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     29 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     29 |       64 |       64
+ Sun Jan 01 04:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     87 |          |         
+ Mon Jul 02 08:00:00 2018 PDT |     87 |        0 |        0
+ Sun Jan 01 04:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     90 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     90 | 10303.12 | 10303.12
+(40 rows)
+
 -- Test the same queries with enabled partitionwise aggregate
 SET enable_partitionwise_aggregate = 'on';
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-02 18:00'),
@@ -244,16 +367,127 @@ SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-02 18:0
        avg(value)
 FROM disttable
 GROUP BY 1;
-ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+     time_bucket_gapfill      | first |   avg   
+------------------------------+-------+---------
+ Sun Jan 01 04:00:00 2017 PST |   1.2 |     1.2
+ Sun Jan 01 07:00:00 2017 PST |   7.3 |     5.8
+ Sun Jan 01 10:00:00 2017 PST |       |        
+ Sun Jan 01 13:00:00 2017 PST |       |        
+ Sun Jan 01 16:00:00 2017 PST |       |        
+ Sun Jan 01 19:00:00 2017 PST |       |        
+ Sun Jan 01 22:00:00 2017 PST |       |        
+ Mon Jan 02 01:00:00 2017 PST |       |        
+ Mon Jan 02 04:00:00 2017 PST |       |        
+ Mon Jan 02 07:00:00 2017 PST |  0.23 |    0.23
+ Mon Jan 02 10:00:00 2017 PST |       |        
+ Mon Jan 02 13:00:00 2017 PST |       |        
+ Mon Jan 02 16:00:00 2017 PST |       |        
+ Sun Jul 01 05:00:00 2018 PDT |   3.1 |     3.1
+ Sun Jul 01 08:00:00 2018 PDT |    64 | 5183.56
+ Mon Jul 02 08:00:00 2018 PDT |     0 |       0
+(16 rows)
+
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
        device,
        first(value, time),
        avg(value)
 FROM disttable
 GROUP BY 1,2;
-ERROR:  time_bucket_gapfill not implemented for distributed hypertable
+     time_bucket_gapfill      | device |  first   |   avg    
+------------------------------+--------+----------+----------
+ Sun Jan 01 04:00:00 2017 PST |      1 |      1.2 |      1.2
+ Sun Jan 01 07:00:00 2017 PST |      1 |      7.3 |      7.3
+ Sun Jan 01 10:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 04:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 10:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      2 |          |         
+ Mon Jan 02 07:00:00 2017 PST |      2 |     0.23 |     0.23
+ Sun Jan 01 04:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      3 |      4.3 |      4.3
+ Sun Jan 01 10:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 04:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     13 |          |         
+ Sun Jul 01 05:00:00 2018 PDT |     13 |      3.1 |      3.1
+ Sun Jan 01 04:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     29 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     29 |       64 |       64
+ Sun Jan 01 04:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     87 |          |         
+ Mon Jul 02 08:00:00 2018 PDT |     87 |        0 |        0
+ Sun Jan 01 04:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     90 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     90 | 10303.12 | 10303.12
+(40 rows)
+
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
+       device,
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 2,1;
+     time_bucket_gapfill      | device |  first   |   avg    
+------------------------------+--------+----------+----------
+ Sun Jan 01 04:00:00 2017 PST |      1 |      1.2 |      1.2
+ Sun Jan 01 07:00:00 2017 PST |      1 |      7.3 |      7.3
+ Sun Jan 01 10:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      1 |          |         
+ Sun Jan 01 04:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 10:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      2 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      2 |          |         
+ Mon Jan 02 07:00:00 2017 PST |      2 |     0.23 |     0.23
+ Sun Jan 01 04:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 07:00:00 2017 PST |      3 |      4.3 |      4.3
+ Sun Jan 01 10:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 13:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 16:00:00 2017 PST |      3 |          |         
+ Sun Jan 01 04:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     13 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     13 |          |         
+ Sun Jul 01 05:00:00 2018 PDT |     13 |      3.1 |      3.1
+ Sun Jan 01 04:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     29 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     29 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     29 |       64 |       64
+ Sun Jan 01 04:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     87 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     87 |          |         
+ Mon Jul 02 08:00:00 2018 PDT |     87 |        0 |        0
+ Sun Jan 01 04:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 07:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 10:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 13:00:00 2017 PST |     90 |          |         
+ Sun Jan 01 16:00:00 2017 PST |     90 |          |         
+ Sun Jul 01 08:00:00 2018 PDT |     90 | 10303.12 | 10303.12
+(40 rows)
+
 SET enable_partitionwise_aggregate = 'off';
-\set ON_ERROR_STOP 1
 -- Ensure that move_chunk() and reorder_chunk() functions cannot be used
 -- with distributed hypertable
 SET ROLE TO DEFAULT;

--- a/tsl/test/sql/dist_api_calls.sql
+++ b/tsl/test/sql/dist_api_calls.sql
@@ -67,8 +67,7 @@ SELECT * FROM disttable ORDER BY time;
 SELECT * FROM show_chunks('disttable');
 SELECT * FROM test.remote_exec(NULL, $$ SELECT show_chunks('disttable'); $$);
 
--- Simple test of time_bucket_gapfill, which is disabled for now.
-\set ON_ERROR_STOP 0
+-- Simple tests of time_bucket_gapfill
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-02 18:00'),
        first(value, time),
        avg(value)
@@ -85,6 +84,12 @@ SELECT
   lag(min(time)) OVER ()
 FROM disttable
 GROUP BY 1;
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
+       device,
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 2,1;
 -- Test the same queries with enabled partitionwise aggregate
 SET enable_partitionwise_aggregate = 'on';
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-02 18:00'),
@@ -98,8 +103,13 @@ SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:0
        avg(value)
 FROM disttable
 GROUP BY 1,2;
+SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
+       device,
+       first(value, time),
+       avg(value)
+FROM disttable
+GROUP BY 2,1;
 SET enable_partitionwise_aggregate = 'off';
-\set ON_ERROR_STOP 1
 
 -- Ensure that move_chunk() and reorder_chunk() functions cannot be used
 -- with distributed hypertable


### PR DESCRIPTION
This commits enables support for executing queries with
time_bucket_gapfill on distributed hypertables. Current implementation
always plans to execute time_bucket_gapfill on the access node. In
future, it can be optimized to be executed on data nodes in suitable
cases.