### PR TITLE
Fix postgres versions in build matrix

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [ 11.10, 12.5 ]
+        pg: [ "11.10", "12.5" ]
         build_type: [ Debug ]
         include:
           - pg: 11.10

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [11.10, 12.5]
+        pg: ["11.10", "12.5"]
         os: [ubuntu-18.04]
     env:
       PG_SRC_DIR: pgbuild

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-18.04'
     strategy:
       matrix:
-        pg: [11.10,12.5]
+        pg: ["11.10","12.5"]
         include:
           - pg: 11.10
             pg_major: 11


### PR DESCRIPTION
Versions in the build matrix with significant leading/trailing zeroes
need the version string quoted otherwise it will get treated as number
and those zeroes will be removed. As currently those tests fixed by
this patch run PG 11.1 instead of 11.10.