### PR TITLE
Improve memory handling for remote COPY

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -236,11 +236,12 @@ data_node_dispatch_path_create_default(PlannerInfo *root, ModifyTablePath *mtpat
 	return NULL;
 }
 
-static void
-distributed_copy_default(const CopyStmt *stmt, uint64 *processed, CopyChunkState *ccstate,
-						 List *attnums)
+static uint64
+distributed_copy_default(const CopyStmt *stmt, CopyChunkState *ccstate, List *attnums)
 {
 	error_no_default_fn_community();
+
+	return 0;
 }
 
 static bool

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -139,8 +139,7 @@ typedef struct CrossModuleFunctions
 	void (*create_chunk_on_data_nodes)(Chunk *chunk, Hypertable *ht);
 	Path *(*data_node_dispatch_path_create)(PlannerInfo *root, ModifyTablePath *mtpath,
 											Index hypertable_rti, int subpath_index);
-	void (*distributed_copy)(const CopyStmt *stmt, uint64 *processed, CopyChunkState *ccstate,
-							 List *attnums);
+	uint64 (*distributed_copy)(const CopyStmt *stmt, CopyChunkState *ccstate, List *attnums);
 	bool (*set_distributed_id)(Datum id);
 	void (*set_distributed_peer_id)(Datum id);
 	bool (*is_frontend_session)(void);

--- a/tsl/src/remote/dist_copy.h
+++ b/tsl/src/remote/dist_copy.h
@@ -12,7 +12,6 @@
 typedef struct Hypertable Hypertable;
 typedef struct CopyChunkState CopyChunkState;
 
-extern void remote_distributed_copy(const CopyStmt *stmt, uint64 *processed,
-									CopyChunkState *ccstate, List *attnums);
+extern uint64 remote_distributed_copy(const CopyStmt *stmt, CopyChunkState *ccstate, List *attnums);
 
 #endif /* TIMESCALEDB_TSL_REMOTE_DIST_COPY_H */

--- a/tsl/test/expected/remote_copy.out
+++ b/tsl/test/expected/remote_copy.out
@@ -66,15 +66,9 @@ ERROR:  unable to use default value for partitioning column "pH"
 -- Missing required column, these generate a WARNING with a transaction id in them (too flimsy to output)
 SET client_min_messages TO ERROR;
 COPY "+ri(k33_')" (thyme, flavor, "pH") FROM STDIN WITH DELIMITER ',';
-ERROR:  error during copy completion: ERROR:  null value in column "))_" violates not-null constraint
-DETAIL:  Failing row contains (5, null, blue, 2, null).
-CONTEXT:  COPY +ri(k33_'), line 1: "5,blue,2.0"
-
+ERROR:  null value in column "))_" violates not-null constraint
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';
-ERROR:  error during copy completion: ERROR:  null value in column "))_" violates not-null constraint
-DETAIL:  Failing row contains (5, null, blue, 1, blah).
-CONTEXT:  COPY +ri(k33_'), line 1: "5,\N,blue,1,blah"
-
+ERROR:  null value in column "))_" violates not-null constraint
 SET client_min_messages TO INFO;
 -- Invalid data after new chunk creation, data and chunks should be rolled back
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';


### PR DESCRIPTION
This change improves memory usage in the `COPY` code used for
distributed hypertables. The following issues have been addressed:

* `PGresult` objects were not cleared, leading to memory leaks.
* The caching of chunk connections didn't work since the lookup
  compared ephemeral chunk pointers instead of chunk IDs. The effect
  was that cached chunk connection state was reallocated every time
  instead of being reused. This likely also caused worse performance.

To address these issues, the following changes are made:

* All `PGresult` objects are now cleared with `PQclear`.
* Lookup for chunk connections now compares chunk IDs instead of chunk
  pointers.
* The per-tuple memory context is moved the to the outer processing
  loop to ensure that everything in the loop is allocated on the
  per-tuple memory context, which is also reset at every iteration of
  the loop.
* The use of memory contexts is also simplified to have only one
  memory context for state that should survive across resets of the
  per-tuple memory context.

Fixes #2677