### PR TITLE
Fix clang-format wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ if (NOT CLANG_FORMAT)
 else()
   message(STATUS "Using local clang-format")
   add_custom_target(format
-    COMMAND ${PROJECT_SOURCE_DIR}/scripts/clang_format_all.sh
+    COMMAND ${CMAKE_COMMAND} -E env CLANG_FORMAT=${CLANG_FORMAT} ${PROJECT_SOURCE_DIR}/scripts/clang_format_all.sh
   )
 endif ()
 

--- a/scripts/clang_format_wrapper.sh
+++ b/scripts/clang_format_wrapper.sh
@@ -67,7 +67,7 @@ echo "formatting"
 
 cd ${TEMP_DIR}
 
-clang-format ${CLANG_FORMAT_FLAGS} ${FILE_NAMES}
+${CLANG_FORMAT:-clang-format} ${CLANG_FORMAT_FLAGS} ${FILE_NAMES}
 
 cd ${CURR_DIR}
 


### PR DESCRIPTION
The clang-format wrapper is always using `clang-format` even if a
different version of `clang-format` has been found and has the correct
version.

This commit fixes the issue by passing the name of the found version of
`clang-format` to the wrapper script using the `CLANG_FORMAT` variable.
It will default to use `clang-format` if `CLANG_FORMAT` is unset.