### PR TITLE
Rename macro TS_HYPERTABLE_HAS_COMPRESSION

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -436,7 +436,7 @@ hypertable_tuple_add_stat(TupleInfo *ti, void *data)
 	}
 
 	/* Number of hypertables with compression enabled */
-	if (TS_HYPERTABLE_HAS_COMPRESSION(ht))
+	if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 		stat->num_hypertables_compressed++;
 
 	return SCAN_CONTINUE;
@@ -2526,7 +2526,7 @@ ts_hypertable_clone_constraints_to_compressed(Hypertable *user_ht, List *constra
 	CatalogSecurityContext sec_ctx;
 
 	ListCell *lc;
-	Assert(TS_HYPERTABLE_HAS_COMPRESSION(user_ht));
+	Assert(TS_HYPERTABLE_HAS_COMPRESSION_TABLE(user_ht));
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	foreach (lc, constraint_list)
 	{
@@ -2749,7 +2749,7 @@ ts_hypertable_get_open_dim_max_value(const Hypertable *ht, int dimension_index, 
 }
 
 bool
-ts_hypertable_has_compression(Hypertable *ht)
+ts_hypertable_has_compression_table(Hypertable *ht)
 {
 	if (ht->fd.compressed_hypertable_id != INVALID_HYPERTABLE_ID)
 	{

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -37,7 +37,7 @@ enum
 	HypertableInternalCompressionTable = 2,
 };
 
-#define TS_HYPERTABLE_HAS_COMPRESSION(ht) ts_hypertable_has_compression(ht)
+#define TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) ts_hypertable_has_compression_table(ht)
 
 #define TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht)                                                  \
 	((ht)->fd.compression_state == HypertableCompressionEnabled)
@@ -174,7 +174,7 @@ extern TSDLLEXPORT int16 ts_validate_replication_factor(int32 replication_factor
 extern TSDLLEXPORT Datum ts_hypertable_get_open_dim_max_value(const Hypertable *ht,
 															  int dimension_index, bool *isnull);
 
-extern TSDLLEXPORT bool ts_hypertable_has_compression(Hypertable *ht);
+extern TSDLLEXPORT bool ts_hypertable_has_compression_table(Hypertable *ht);
 
 #define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock)                       \
 	ts_hypertable_scan_with_memory_context(schema,                                                 \

--- a/src/planner.c
+++ b/src/planner.c
@@ -255,7 +255,7 @@ preprocess_query(Node *node, Query *rootquery)
 							query->rowMarks == NIL && rte->inh)
 							rte_mark_for_expansion(rte);
 
-						if (TS_HYPERTABLE_HAS_COMPRESSION(ht))
+						if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 						{
 							int compr_htid = ht->fd.compressed_hypertable_id;
 
@@ -865,7 +865,7 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 		{
 			ts_create_private_reloptinfo(rel);
 
-			if (ts_guc_enable_transparent_decompression && TS_HYPERTABLE_HAS_COMPRESSION(ht))
+			if (ts_guc_enable_transparent_decompression && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 			{
 				RangeTblEntry *chunk_rte = planner_rt_fetch(rel->relid, root);
 				Chunk *chunk = ts_chunk_get_by_relid(chunk_rte->relid, true);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -185,7 +185,7 @@ static void
 check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt *stmt)
 {
 	ListCell *lc;
-	if (!TS_HYPERTABLE_HAS_COMPRESSION(ht))
+	if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 		return;
 
 	/* only allow if all commands are allowed */
@@ -974,7 +974,7 @@ process_truncate(ProcessUtilityArgs *args)
 		handle_truncate_hypertable(args, stmt, ht);
 
 		/* propagate to the compressed hypertable */
-		if (TS_HYPERTABLE_HAS_COMPRESSION(ht))
+		if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 		{
 			Hypertable *compressed_ht =
 				ts_hypertable_cache_get_entry_by_id(hcache, ht->fd.compressed_hypertable_id);
@@ -1122,7 +1122,7 @@ process_drop_hypertable(ProcessUtilityArgs *args, DropStmt *stmt)
 				 * DROP_RESTRICT But if we are using DROP_CASCADE we should propagate that down to
 				 * the compressed hypertable.
 				 */
-				if (stmt->behavior == DROP_CASCADE && TS_HYPERTABLE_HAS_COMPRESSION(ht))
+				if (stmt->behavior == DROP_CASCADE && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 				{
 					Hypertable *compressed_hypertable =
 						ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
@@ -1760,7 +1760,7 @@ process_altertable_change_owner(Hypertable *ht, AlterTableCmd *cmd)
 
 	foreach_chunk(ht, process_altertable_change_owner_chunk, cmd);
 
-	if (TS_HYPERTABLE_HAS_COMPRESSION(ht))
+	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
 		Hypertable *compressed_hypertable =
 			ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);
@@ -2701,7 +2701,7 @@ process_altertable_set_tablespace_end(Hypertable *ht, AlterTableCmd *cmd)
 
 	ts_tablespace_attach_internal(&tspc_name, ht->main_table_relid, true);
 	foreach_chunk(ht, process_altertable_chunk, cmd);
-	if (TS_HYPERTABLE_HAS_COMPRESSION(ht))
+	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
 		Hypertable *compressed_hypertable =
 			ts_hypertable_get_by_id(ht->fd.compressed_hypertable_id);

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -121,7 +121,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("compression policies not supported on distributed hypertables")));
 
-	if (!TS_HYPERTABLE_HAS_COMPRESSION(hypertable))
+	if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(hypertable))
 	{
 		ts_cache_release(hcache);
 		ereport(ERROR,

--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -185,7 +185,7 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 
 	ts_hypertable_permissions_check(srcht->main_table_relid, GetUserId());
 
-	if (!TS_HYPERTABLE_HAS_COMPRESSION(srcht))
+	if (!TS_HYPERTABLE_HAS_COMPRESSION_TABLE(srcht))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("compression not enabled on \"%s\"", NameStr(srcht->fd.table_name)),

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -960,7 +960,7 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 	LockRelationOid(catalog_get_table_id(ts_catalog_get(), HYPERTABLE_COMPRESSION),
 					RowExclusiveLock);
 
-	if (TS_HYPERTABLE_HAS_COMPRESSION(ht))
+	if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
 		/* compression is enabled */
 		drop_existing_compression_table(ht);

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -87,7 +87,7 @@ tsl_set_rel_pathlist_query(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeT
 						   Hypertable *ht)
 {
 	if (ts_guc_enable_transparent_decompression && ht != NULL &&
-		rel->reloptkind == RELOPT_OTHER_MEMBER_REL && TS_HYPERTABLE_HAS_COMPRESSION(ht) &&
+		rel->reloptkind == RELOPT_OTHER_MEMBER_REL && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) &&
 		rel->fdw_private != NULL && ((TimescaleDBPrivate *) rel->fdw_private)->compressed)
 	{
 		Chunk *chunk = ts_chunk_get_by_relid(rte->relid, true);
@@ -100,7 +100,7 @@ void
 tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntry *rte,
 						 Hypertable *ht)
 {
-	if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION(ht))
+	if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
 	{
 		ListCell *lc;
 		Chunk *chunk = ts_chunk_get_by_relid(rte->relid, true);


### PR DESCRIPTION
This PR cleans up some macro names.
Rename macro TS_HYPERTABLE_HAS_COMPRESSION
to TS_HYPERTABLE_HAS_COMPRESSION_TABLE.