### PR TITLE
Remove workaround for AT_CookedColumnDefault to build against snapshot

### DIFF
--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -37,15 +37,6 @@ if(APACHE_ONLY)
   add_definitions(-DAPACHE_ONLY)
 endif()
 
-# AT_CookedColumnDefault was backported to PG12 but is not yet in a released version.
-# To be able to build against snapshots and REL_12_STABLE branch we check header file
-# for existance. Once PG 12.5 is out this can safely be turned into a version check.
-file(READ ${PG_INCLUDEDIR_SERVER}/nodes/parsenodes.h PG_PARSENODES_H)
-string(REGEX MATCH "AT_CookedColumnDefault" PG_HAS_COOKEDCOLUMNDEFAULT ${PG_PARSENODES_H})
-if (PG_HAS_COOKEDCOLUMNDEFAULT)
-  add_definitions(-DPG_HAS_COOKEDCOLUMNDEFAULT)
-endif()
-
 include_directories(${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
 include_directories(SYSTEM ${PG_INCLUDEDIR_SERVER})
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3217,7 +3217,7 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_SetLogged:
 		case AT_SetStorage:
 		case AT_ColumnDefault:
-#ifdef PG_HAS_COOKEDCOLUMNDEFAULT
+#if PG_VERSION_NUM >= 120005
 		case AT_CookedColumnDefault:
 #endif
 		case AT_SetNotNull:


### PR DESCRIPTION
Since PG12.5 has been released the workaround for AT_CookedColumnDefault
is no longer needed and a simple PG version check is sufficient.