### PR TITLE
Allow building against PG13 source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,27 +207,25 @@ execute_process(
   OUTPUT_VARIABLE PG_VERSION_STRING
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-if (NOT ${PG_VERSION_STRING} MATCHES "^PostgreSQL[ ]+([0-9]+)\\.([0-9]+)(\\.([0-9]+))*")
+if (NOT ${PG_VERSION_STRING} MATCHES "^PostgreSQL[ ]+([0-9]+)(\\.([0-9]+)|devel|rc[0-9]+)")
   message(FATAL_ERROR "Could not parse PostgreSQL version ${PG_VERSION_STRING}")
 endif ()
 
 set(PG_VERSION_MAJOR ${CMAKE_MATCH_1})
-set(PG_VERSION_MINOR ${CMAKE_MATCH_2})
-set(PG_VERSION_PATCH ${CMAKE_MATCH_4})
-
-if (NOT ${PG_VERSION_PATCH} OR ${PG_VERSION_PATCH} EQUAL "")
-  set(PG_VERSION "${PG_VERSION_MAJOR}.${PG_VERSION_MINOR}")
-else ()
-  set(PG_VERSION "${PG_VERSION_MAJOR}.${PG_VERSION_MINOR}.${PG_VERSION_PATCH}")
+if (${CMAKE_MATCH_COUNT} GREATER "2" )
+  set(PG_VERSION_MINOR ${CMAKE_MATCH_3})
+else()
+  set(PG_VERSION_MINOR 0)
 endif ()
+set(PG_VERSION "${PG_VERSION_MAJOR}.${PG_VERSION_MINOR}")
 
 message(STATUS "Compiling against PostgreSQL version ${PG_VERSION}")
 
 # Ensure that PostgreSQL version is supported and consistent
 # with src/compat.h version check
 if ((${PG_VERSION_MAJOR} LESS "11") OR
-    (${PG_VERSION_MAJOR} GREATER "12"))
-  message(FATAL_ERROR "TimescaleDB only supports PostgreSQL 11 and 12")
+    (${PG_VERSION_MAJOR} GREATER "13"))
+  message(FATAL_ERROR "TimescaleDB only supports PostgreSQL 11, 12 and 13")
 endif()
 
 # Get PostgreSQL configuration from pg_config

--- a/src/compat.h
+++ b/src/compat.h
@@ -24,15 +24,20 @@
 
 #define is_supported_pg_version_11(version) ((version >= 110000) && (version < 120000))
 #define is_supported_pg_version_12(version) ((version >= 120000) && (version < 130000))
+#define is_supported_pg_version_13(version) ((version >= 130000) && (version < 140000))
 
 #define is_supported_pg_version(version)                                                           \
-	(is_supported_pg_version_11(version) || is_supported_pg_version_12(version))
+	(is_supported_pg_version_11(version) || is_supported_pg_version_12(version) ||                 \
+	 is_supported_pg_version_13(version))
 
 #define PG11 is_supported_pg_version_11(PG_VERSION_NUM)
 #define PG12 is_supported_pg_version_12(PG_VERSION_NUM)
+#define PG13 is_supported_pg_version_13(PG_VERSION_NUM)
 
 #define PG12_LT PG11
 #define PG12_GE !(PG12_LT)
+#define PG13_LT !(PG13)
+#define PG13_GE PG13
 
 #if !(is_supported_pg_version(PG_VERSION_NUM))
 #error "Unsupported PostgreSQL version"


### PR DESCRIPTION
This patch adjusts the version checks to allow building against
postgres 13. It also adjusts the cmake version check to allow
building against RC and devel versions.