### PR TITLE
Add compatibilty wrapper functions for base64 encoding/decoding

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -347,4 +347,15 @@ get_vacuum_options(const VacuumStmt *stmt)
 #endif
 }
 
+/* PG13 added a dstlen parameter to pg_b64_decode and pg_b64_encode */
+#if PG13_LT
+#define pg_b64_encode_compat(src, srclen, dst, dstlen) pg_b64_encode((src), (srclen), (dst))
+#define pg_b64_decode_compat(src, srclen, dst, dstlen) pg_b64_decode((src), (srclen), (dst))
+#else
+#define pg_b64_encode_compat(src, srclen, dst, dstlen)                                             \
+	pg_b64_encode((src), (srclen), (dst), (dstlen))
+#define pg_b64_decode_compat(src, srclen, dst, dstlen)                                             \
+	pg_b64_decode((src), (srclen), (dst), (dstlen))
+#endif
+
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1424,7 +1424,11 @@ tsl_compressed_data_in(PG_FUNCTION_ARGS)
 
 	decoded_len = pg_b64_dec_len(input_len);
 	decoded = palloc(decoded_len + 1);
-	decoded_len = pg_b64_decode(input, input_len, decoded);
+	decoded_len = pg_b64_decode_compat(input, input_len, decoded, decoded_len);
+
+	if (decoded_len < 0)
+		elog(ERROR, "could not decode base64-encoded compressed data");
+
 	decoded[decoded_len] = '\0';
 	data = (StringInfoData){
 		.data = decoded,
@@ -1446,7 +1450,11 @@ tsl_compressed_data_out(PG_FUNCTION_ARGS)
 	const char *raw_data = VARDATA(bytes);
 	int encoded_len = pg_b64_enc_len(raw_len);
 	char *encoded = palloc(encoded_len + 1);
-	encoded_len = pg_b64_encode(raw_data, raw_len, encoded);
+	encoded_len = pg_b64_encode_compat(raw_data, raw_len, encoded, encoded_len);
+
+	if (encoded_len < 0)
+		elog(ERROR, "could not base64-encode compressed data");
+
 	encoded[encoded_len] = '\0';
 
 	PG_RETURN_CSTRING(encoded);


### PR DESCRIPTION
PG13 adds a destination length 4th argument to pg_b64_decode and
pg_b64_encode functions so this patch adds a macro that translates
to the 3 argument and 4 argument calls depending on postgres version.
This patch also adds checking of return values for those functions.

https://github.com/postgres/postgres/commit/cfc40d384a