### PR TITLE
Increase test coverage for rename

### DIFF
--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -189,6 +189,24 @@ SELECT * FROM rename_c_aggregate;
 (0 rows)
 
 ALTER VIEW rename_schema.:"PART_VIEW_NAME" RENAME TO partial_view;
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+      direct_view_schema, direct_view_name
+      FROM _timescaledb_catalog.continuous_agg;
+ user_view_schema |   user_view_name   | partial_view_schema | partial_view_name | direct_view_schema | direct_view_name 
+------------------+--------------------+---------------------+-------------------+--------------------+------------------
+ public           | rename_c_aggregate | rename_schema       | partial_view      | rename_schema      | _direct_view_3
+(1 row)
+
+--rename direct view
+ALTER VIEW rename_schema.:"DIR_VIEW_NAME" RENAME TO direct_view;
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+      direct_view_schema, direct_view_name
+      FROM _timescaledb_catalog.continuous_agg;
+ user_view_schema |   user_view_name   | partial_view_schema | partial_view_name | direct_view_schema | direct_view_name 
+------------------+--------------------+---------------------+-------------------+--------------------+------------------
+ public           | rename_c_aggregate | rename_schema       | partial_view      | rename_schema      | direct_view
+(1 row)
+
 -- drop_chunks tests
 DROP TABLE conditions CASCADE;
 DROP TABLE foo CASCADE;

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -116,19 +116,22 @@ SELECT current_user;
 
 ALTER SCHEMA rename_schema RENAME TO new_name_schema;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+       direct_view_schema, direct_view_name
       FROM _timescaledb_catalog.continuous_agg;
- user_view_schema | user_view_name | partial_view_schema | partial_view_name 
-------------------+----------------+---------------------+-------------------
- new_name_schema  | rename_test    | public              | _partial_view_3
+ user_view_schema | user_view_name | partial_view_schema | partial_view_name | direct_view_schema | direct_view_name 
+------------------+----------------+---------------------+-------------------+--------------------+------------------
+ new_name_schema  | rename_test    | public              | _partial_view_3   | public             | _direct_view_3
 (1 row)
 
 ALTER VIEW :"PART_VIEW_NAME" SET SCHEMA new_name_schema;
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
+ALTER VIEW :"DIR_VIEW_NAME" SET SCHEMA new_name_schema;
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+       direct_view_schema, direct_view_name
       FROM _timescaledb_catalog.continuous_agg;
- user_view_schema | user_view_name | partial_view_schema | partial_view_name 
-------------------+----------------+---------------------+-------------------
- new_name_schema  | rename_test    | new_name_schema     | _partial_view_3
+ user_view_schema | user_view_name | partial_view_schema | partial_view_name | direct_view_schema | direct_view_name 
+------------------+----------------+---------------------+-------------------+--------------------+------------------
+ new_name_schema  | rename_test    | new_name_schema     | _partial_view_3   | new_name_schema    | _direct_view_3
 (1 row)
 
 RESET ROLE;
@@ -186,24 +189,6 @@ SELECT * FROM rename_c_aggregate;
 (0 rows)
 
 ALTER VIEW rename_schema.:"PART_VIEW_NAME" RENAME TO partial_view;
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
-      direct_view_schema, direct_view_name
-      FROM _timescaledb_catalog.continuous_agg;
- user_view_schema |   user_view_name   | partial_view_schema | partial_view_name | direct_view_schema | direct_view_name 
-------------------+--------------------+---------------------+-------------------+--------------------+------------------
- public           | rename_c_aggregate | rename_schema       | partial_view      | public             | _direct_view_3
-(1 row)
-
---rename direct view
-ALTER VIEW :"DIR_VIEW_NAME" RENAME TO direct_view;
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
-      direct_view_schema, direct_view_name
-      FROM _timescaledb_catalog.continuous_agg;
- user_view_schema |   user_view_name   | partial_view_schema | partial_view_name | direct_view_schema | direct_view_name 
-------------------+--------------------+---------------------+-------------------+--------------------+------------------
- public           | rename_c_aggregate | rename_schema       | partial_view      | public             | direct_view
-(1 row)
-
 -- drop_chunks tests
 DROP TABLE conditions CASCADE;
 DROP TABLE foo CASCADE;

--- a/tsl/test/sql/continuous_aggs_ddl.sql
+++ b/tsl/test/sql/continuous_aggs_ddl.sql
@@ -131,6 +131,17 @@ SELECT * FROM rename_c_aggregate;
 
 ALTER VIEW rename_schema.:"PART_VIEW_NAME" RENAME TO partial_view;
 
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+      direct_view_schema, direct_view_name
+      FROM _timescaledb_catalog.continuous_agg;
+
+--rename direct view
+ALTER VIEW rename_schema.:"DIR_VIEW_NAME" RENAME TO direct_view;
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+      direct_view_schema, direct_view_name
+      FROM _timescaledb_catalog.continuous_agg;
+
+
 -- drop_chunks tests
 DROP TABLE conditions CASCADE;
 DROP TABLE foo CASCADE;

--- a/tsl/test/sql/continuous_aggs_ddl.sql
+++ b/tsl/test/sql/continuous_aggs_ddl.sql
@@ -88,12 +88,15 @@ SELECT current_user;
 ALTER SCHEMA rename_schema RENAME TO new_name_schema;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+       direct_view_schema, direct_view_name
       FROM _timescaledb_catalog.continuous_agg;
 
 ALTER VIEW :"PART_VIEW_NAME" SET SCHEMA new_name_schema;
+ALTER VIEW :"DIR_VIEW_NAME" SET SCHEMA new_name_schema;
 
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
+SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
+       direct_view_schema, direct_view_name
       FROM _timescaledb_catalog.continuous_agg;
 
 RESET ROLE;
@@ -127,16 +130,6 @@ SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
 SELECT * FROM rename_c_aggregate;
 
 ALTER VIEW rename_schema.:"PART_VIEW_NAME" RENAME TO partial_view;
-
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
-      direct_view_schema, direct_view_name
-      FROM _timescaledb_catalog.continuous_agg;
-
---rename direct view
-ALTER VIEW :"DIR_VIEW_NAME" RENAME TO direct_view;
-SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name,
-      direct_view_schema, direct_view_name
-      FROM _timescaledb_catalog.continuous_agg;
 
 -- drop_chunks tests
 DROP TABLE conditions CASCADE;


### PR DESCRIPTION
When renaming views of a continuous aggregate, schema rename with the
direct view was not covered. This commit move an explicit rename of a
direct view so that we can test a schema rename including a direct view
as well as a partial view.

Closes #2138
