### PR TITLE
Do not allow unique index on compressed hypertables.

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2199,6 +2199,18 @@ process_index_start(ProcessUtilityArgs *args)
 		ts_cache_release(hcache);
 		return DDL_CONTINUE;
 	}
+	else if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
+	{
+		/* unique indexes are not allowed on compressed hypertables*/
+		if (stmt->unique || stmt->primary || stmt->isconstraint)
+		{
+			ts_cache_release(hcache);
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("operation not supported on hypertables that have compression "
+							"enabled")));
+		}
+	}
 
 	ts_hypertable_permissions_check_by_id(ht->fd.id);
 	process_add_hypertable(args, ht);

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -194,6 +194,10 @@ ALTER TABLE foo ADD CONSTRAINT chk UNIQUE(b);
 ERROR:  operation not supported on hypertables that have compression enabled
 ALTER TABLE foo DROP CONSTRAINT chk_existing;
 ERROR:  operation not supported on hypertables that have compression enabled
+--can add index , but not unique index
+CREATE UNIQUE INDEX foo_idx ON foo ( a, c );
+ERROR:  operation not supported on hypertables that have compression enabled
+CREATE INDEX foo_idx ON foo ( a, c );
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _timescaledb_catalog.hypertable h on (h.id = hc.hypertable_id) where h.table_name = 'foo' order by attname;
  hypertable_id | attname | compression_algorithm_id | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -97,6 +97,9 @@ ALTER TABLE foo RESET (timescaledb.compress);
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
 ALTER TABLE foo ADD CONSTRAINT chk UNIQUE(b);
 ALTER TABLE foo DROP CONSTRAINT chk_existing;
+--can add index , but not unique index
+CREATE UNIQUE INDEX foo_idx ON foo ( a, c );
+CREATE INDEX foo_idx ON foo ( a, c );
 
 --note that the time column "a" should not be added to the end of the order by list again (should appear first)
 select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _timescaledb_catalog.hypertable h on (h.id = hc.hypertable_id) where h.table_name = 'foo' order by attname;


### PR DESCRIPTION
CREATE UNIQUE INDEX is not supported on a hypertable
that has compression enabled.