### PR TITLE
Exclude PostgreSQL compiler flags when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,16 @@ if (WARNINGS_AS_ERRORS)
   endif ()
 endif (WARNINGS_AS_ERRORS)
 
+# Function that will add a compile option if the compiler supports it.
+function(add_compile_options_if_supported)
+  foreach(_flag ${ARGN})
+    check_c_compiler_flag(${_flag} _supported)
+    if (_supported)
+      add_compile_options(${_flag})
+    endif()
+  endforeach()
+endfunction()
+
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
   # These two flags generate too many errors currently, but we
   # probably want these optimizations enabled.
@@ -113,12 +123,14 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
   #
   # -Wconversions
 
-  add_compile_options(-Wempty-body -Wvla)
-  check_c_compiler_flag(-Wimplicit-fallthrough CC_SUPPORTS_IMPLICIT_FALLTHROUGH)
+  # These flags are supported on all compilers.
+  add_compile_options(
+    -Wempty-body -Wvla -Wall -Wmissing-prototypes -Wpointer-arith
+    -Werror=vla -Wendif-labels -fno-strict-aliasing -fno-omit-frame-pointer)
 
-  if (CC_SUPPORTS_IMPLICIT_FALLTHROUGH)
-    add_compile_options(-Wimplicit-fallthrough)
-  endif ()
+  # These flags are just supported on some of the compilers, so we
+  # check them before adding them.
+  add_compile_options_if_supported(-Wno-format-truncation -Wimplicit-fallthrough)
 
   # On UNIX, the compiler needs to support -fvisibility=hidden to hide symbols by default
   check_c_compiler_flag(-fvisibility=hidden CC_SUPPORTS_VISIBILITY_HIDDEN)
@@ -236,7 +248,6 @@ get_pg_config(PG_PKGLIBDIR --pkglibdir)
 get_pg_config(PG_SHAREDIR --sharedir)
 get_pg_config(PG_BINDIR --bindir)
 get_pg_config(PG_CPPFLAGS --cppflags)
-get_pg_config(PG_CFLAGS --cflags)
 get_pg_config(PG_LDFLAGS --ldflags)
 get_pg_config(PG_LIBS --libs)
 

--- a/src/build-defs.cmake
+++ b/src/build-defs.cmake
@@ -3,17 +3,10 @@ if(NOT USE_DEFAULT_VISIBILITY)
   set(CMAKE_C_VISIBILITY_PRESET "hidden")
 endif()
 
-# postgres CFLAGS includes -Wdeclaration-after-statement which leads
-# to problems when compiling with -Werror since we aim for C99 and allow
-# that so we strip this flag from PG_CFLAGS before adding postgres flags
-# to our own
-string(REPLACE "-Wdeclaration-after-statement" "" PG_CFLAGS "${PG_CFLAGS}")
-
 if(UNIX)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${PG_LIBDIR}")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -L${PG_LIBDIR}")
-  set(CMAKE_C_FLAGS "${PG_CFLAGS} ${CMAKE_C_FLAGS}")
   set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${PG_CPPFLAGS}")
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
 endif ()

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -87,7 +87,7 @@ extern TSDLLEXPORT int64 ts_time_saturating_add(int64 timeval, int64 interval, O
 extern TSDLLEXPORT int64 ts_time_saturating_sub(int64 timeval, int64 interval, Oid timetype);
 extern TSDLLEXPORT int64 ts_subtract_integer_from_now_saturating(Oid now_func, int64 interval,
 																 Oid timetype);
-#if TS_DEBUG
+#ifdef TS_DEBUG
 extern TSDLLEXPORT Datum ts_get_mock_time_or_current_time(void);
 #endif
 

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SOLO_TESTS
   alternate_users
   bgw_launcher
   index
+  loader
   net
   pg_dump_unprivileged
   tablespace

--- a/tsl/src/build-defs.cmake
+++ b/tsl/src/build-defs.cmake
@@ -1,17 +1,10 @@
 # Hide symbols by default in shared libraries
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
 
-# postgres CFLAGS includes -Wdeclaration-after-statement which leads
-# to problems when compiling with -Werror since we aim for C99 and allow
-# that so we strip this flag from PG_CFLAGS before adding postgres flags
-# to our own
-string(REPLACE "-Wdeclaration-after-statement" "" PG_CFLAGS "${PG_CFLAGS}")
-
 if (UNIX)
   set(CMAKE_C_STANDARD 11)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${PG_LIBDIR}")
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -L${PG_LIBDIR}")
-  set(CMAKE_C_FLAGS "${PG_CFLAGS} ${CMAKE_C_FLAGS}")
   set(CMAKE_CPP_FLAGS "${CMAKE_CPP_FLAGS} ${PG_CPPFLAGS}")
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
 endif()

--- a/tsl/src/fdw/fdw_utils.c
+++ b/tsl/src/fdw/fdw_utils.c
@@ -11,7 +11,7 @@
 #include "fdw_utils.h"
 #include "fdw/relinfo.h"
 
-#if TS_DEBUG
+#ifdef TS_DEBUG
 
 /*
  * Copy a path.

--- a/tsl/src/fdw/fdw_utils.h
+++ b/tsl/src/fdw/fdw_utils.h
@@ -12,7 +12,7 @@
 
 #include "relinfo.h"
 
-#if TS_DEBUG
+#ifdef TS_DEBUG
 
 extern void fdw_utils_add_path(RelOptInfo *rel, Path *new_path);
 extern void fdw_utils_free_path(ConsideredPath *path);

--- a/tsl/src/fdw/relinfo.h
+++ b/tsl/src/fdw/relinfo.h
@@ -37,7 +37,7 @@ typedef enum
 	TS_FDW_RELINFO_FOREIGN_TABLE,
 } TsFdwRelInfoType;
 
-#if TS_DEBUG
+#ifdef TS_DEBUG
 /* A path considered during planning but which may have been pruned. Used for
  * debugging purposes. */
 typedef struct ConsideredPath
@@ -130,7 +130,7 @@ typedef struct TsFdwRelInfo
 	 */
 	int relation_index;
 	DataNodeChunkAssignment *sca;
-#if TS_DEBUG
+#ifdef TS_DEBUG
 	List *considered_paths; /* List of ConsideredPath objects of all the paths
 							   that planner has considered. This is intended
 							   to be only used for printing cost debug

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -1758,7 +1758,7 @@ remote_connection_set_single_row_mode(TSConnection *conn)
 	return PQsetSingleRowMode(conn->pg_conn);
 }
 
-#if TS_DEBUG
+#ifdef TS_DEBUG
 /*
  * Reset the current connection stats.
  */

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -110,7 +110,7 @@ typedef struct RemoteConnectionStats
 	unsigned int results_cleared;
 } RemoteConnectionStats;
 
-#if TS_DEBUG
+#ifdef TS_DEBUG
 extern void remote_connection_stats_reset(void);
 extern RemoteConnectionStats *remote_connection_stats_get(void);
 #endif

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -278,7 +278,7 @@ exec_cleanup_command(TSConnection *conn, const char *query)
 	return success;
 }
 
-#if DEBUG
+#ifdef DEBUG
 /* Prepared statements can leak if the were created during a subtxn
  * and the subtxn rolled back before the prepared stmt was deallocated.
  * This function checks for such leaks inside of tests (thus only compiled

--- a/tsl/src/remote/txn.h
+++ b/tsl/src/remote/txn.h
@@ -52,7 +52,7 @@ extern RemoteTxnId *remote_txn_persistent_record_write(TSConnectionId id);
 extern bool remote_txn_persistent_record_exists(const RemoteTxnId *gid);
 extern int remote_txn_persistent_record_delete_for_data_node(Oid foreign_server_oid);
 
-#if DEBUG
+#ifdef DEBUG
 /* Debugging functions used in testing */
 extern void remote_txn_check_for_leaked_prepared_statements(RemoteTxn *entry);
 #endif

--- a/tsl/src/remote/txn_store.c
+++ b/tsl/src/remote/txn_store.c
@@ -92,7 +92,7 @@ remote_txn_store_remove(RemoteTxnStore *store, TSConnectionId id)
 void
 remote_txn_store_destroy(RemoteTxnStore *store)
 {
-#if DEBUG
+#ifdef DEBUG
 	RemoteTxn *txn;
 	remote_txn_store_foreach(store, txn) { remote_txn_check_for_leaked_prepared_statements(txn); }
 #endif


### PR DESCRIPTION
From `pg_config` it is possible to get the flags that were used to
build PostgreSQL and we include when building the extension. However,
on some platforms and some compilers (CentOS 8 and gcc, for example)
flags are included that cannot be used when building the extension and
will result in a compiler error.

If the compiler used to build the extension is different from the
compiler used when building PostgreSQL, we can also get errors because
some options are not supported (PostgreSQL built using GCC and
extension built using CLang, for example).

This commit solves this by not adding the C compile flags from
`pg_config` and explicitly add the flags that we need for building the
extension.

In addition, some compilers do not support using `#if SYMBOL` when
`SYMBOL` is undefined and give an error, so this commit replaces those
usages with `#ifdef SYMBOL`.