### PR TITLE
Fix compression status in chunks view for distributed chunks

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -206,10 +206,12 @@ FROM (
     ELSE
       dimsl.range_end
     END AS integer_range_end,
-    CASE WHEN srcch.compressed_chunk_id IS NOT NULL THEN
-      TRUE
-    ELSE
-      FALSE
+    CASE WHEN node_list IS NULL THEN 
+      CASE WHEN srcch.compressed_chunk_id IS NOT NULL THEN
+         TRUE
+      ELSE FALSE
+      END
+    ELSE NULL   --distributed chunk case
     END AS is_compressed,
     pgtab.spcname AS chunk_table_space,
     chdn.node_list

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -274,7 +274,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | f
+is_compressed          | 
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_1,db_dist_compression_2}
 -[ RECORD 2 ]----------+----------------------------------------------
@@ -288,7 +288,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | f
+is_compressed          | 
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_2,db_dist_compression_3}
 -[ RECORD 3 ]----------+----------------------------------------------
@@ -302,7 +302,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | f
+is_compressed          | 
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_1,db_dist_compression_3}
 

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -77,9 +77,9 @@ SELECT * from timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |      chunk_name       | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace |        data_nodes         
 -------------------+-----------------+-----------------------+-----------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+---------------------------
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_1_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_1,view_node_2}
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_2_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_2,view_node_3}
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_3_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_1,view_node_3}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_1_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   |               |                  | {view_node_1,view_node_2}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_2_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   |               |                  | {view_node_2,view_node_3}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_3_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   |               |                  | {view_node_1,view_node_3}
 (3 rows)
 
 SELECT * from timescaledb_information.dimensions 


### PR DESCRIPTION
The compression status of individual chunks for distributed tables is
unknown on the access node. Fix the view so that is_compressed is NULL
 instead of false for distributed chunks.