### PR TITLE
Optimize locking for create chunk API

### DIFF
--- a/src/debug_wait.c
+++ b/src/debug_wait.c
@@ -17,11 +17,17 @@
 
 #include "export.h"
 
+static uint64
+ts_debug_waitpoint_tag_to_id(const char *tagname)
+{
+	return DatumGetUInt32(hash_any((const unsigned char *) tagname, strlen(tagname)));
+}
+
 void
 ts_debug_waitpoint_init(DebugWait *waitpoint, const char *tagname)
 {
 	/* Use 64-bit hashing to get two independent 32-bit hashes */
-	uint64 hash = DatumGetUInt32(hash_any((const unsigned char *) tagname, strlen(tagname)));
+	uint64 hash = ts_debug_waitpoint_tag_to_id(tagname);
 
 	SET_LOCKTAG_ADVISORY(waitpoint->tag, MyDatabaseId, (uint32)(hash >> 32), (uint32) hash, 1);
 	waitpoint->tagname = pstrdup(tagname);
@@ -112,4 +118,20 @@ ts_debug_waitpoint_release(PG_FUNCTION_ARGS)
 	ts_debug_waitpoint_init(&waitpoint, text_to_cstring(tag));
 	debug_waitpoint_release(&waitpoint);
 	PG_RETURN_VOID();
+}
+
+/*
+ * Get the waitpoint identifier from the tag name.
+ */
+TS_FUNCTION_INFO_V1(ts_debug_waitpoint_id);
+
+Datum
+ts_debug_waitpoint_id(PG_FUNCTION_ARGS)
+{
+	text *tag = PG_GETARG_TEXT_PP(0);
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("no tag provided")));
+
+	PG_RETURN_UINT64(ts_debug_waitpoint_tag_to_id(text_to_cstring(tag)));
 }

--- a/tsl/test/isolation/expected/remote_create_chunk.out
+++ b/tsl/test/isolation/expected/remote_create_chunk.out
@@ -1,0 +1,160 @@
+Parsed test spec with 4 sessions
+
+starting permutation: s4_wait_created s4_wait_found s1_create_chunk_1 s2_create_chunk_1 s3_conditions_locks s4_release_created s3_conditions_locks s4_release_found
+step s4_wait_created: SELECT debug_waitpoint_enable('find_or_create_chunk_created');
+debug_waitpoint_enable
+
+               
+step s4_wait_found: SELECT debug_waitpoint_enable('find_or_create_chunk_found');
+debug_waitpoint_enable
+
+               
+step s1_create_chunk_1: 
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[-9223372036854775808, 1073741823]));
+ <waiting ...>
+step s2_create_chunk_1: 
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[-9223372036854775808, 1073741823]));
+ <waiting ...>
+step s3_conditions_locks: 
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+
+table_lock     at_start       at_created     at_found       
+
+2              0              1              0              
+step s4_release_created: SELECT debug_waitpoint_release('find_or_create_chunk_created');
+debug_waitpoint_release
+
+               
+step s1_create_chunk_1: <... completed>
+slices         created        
+
+{"time": [1514764800000000, 1514851200000000], "device": [-9223372036854775808, 1073741823]}t              
+step s3_conditions_locks: 
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+
+table_lock     at_start       at_created     at_found       
+
+0              0              0              1              
+step s4_release_found: SELECT debug_waitpoint_release('find_or_create_chunk_found');
+debug_waitpoint_release
+
+               
+step s2_create_chunk_1: <... completed>
+slices         created        
+
+{"time": [1514764800000000, 1514851200000000], "device": [-9223372036854775808, 1073741823]}f              
+
+starting permutation: s4_wait_created s4_wait_found s1_create_chunk_1 s2_create_chunk_2 s3_conditions_locks s4_release_created s3_conditions_locks s4_release_found
+step s4_wait_created: SELECT debug_waitpoint_enable('find_or_create_chunk_created');
+debug_waitpoint_enable
+
+               
+step s4_wait_found: SELECT debug_waitpoint_enable('find_or_create_chunk_found');
+debug_waitpoint_enable
+
+               
+step s1_create_chunk_1: 
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[-9223372036854775808, 1073741823]));
+ <waiting ...>
+step s2_create_chunk_2: 
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[1073741823, 9223372036854775807]));
+ <waiting ...>
+step s3_conditions_locks: 
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+
+table_lock     at_start       at_created     at_found       
+
+2              0              1              0              
+step s4_release_created: SELECT debug_waitpoint_release('find_or_create_chunk_created');
+debug_waitpoint_release
+
+               
+step s1_create_chunk_1: <... completed>
+slices         created        
+
+{"time": [1514764800000000, 1514851200000000], "device": [-9223372036854775808, 1073741823]}t              
+step s2_create_chunk_2: <... completed>
+slices         created        
+
+{"time": [1514764800000000, 1514851200000000], "device": [1073741823, 9223372036854775807]}t              
+step s3_conditions_locks: 
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+
+table_lock     at_start       at_created     at_found       
+
+0              0              0              0              
+step s4_release_found: SELECT debug_waitpoint_release('find_or_create_chunk_found');
+debug_waitpoint_release
+
+               
+
+starting permutation: s4_wait_created s1_create_chunk_1 s4_wait_start s2_create_chunk_1 s3_conditions_locks s4_release_created s3_conditions_locks s4_release_start s3_conditions_locks
+step s4_wait_created: SELECT debug_waitpoint_enable('find_or_create_chunk_created');
+debug_waitpoint_enable
+
+               
+step s1_create_chunk_1: 
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[-9223372036854775808, 1073741823]));
+ <waiting ...>
+step s4_wait_start: SELECT debug_waitpoint_enable('find_or_create_chunk_start');
+debug_waitpoint_enable
+
+               
+step s2_create_chunk_1: 
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[-9223372036854775808, 1073741823]));
+ <waiting ...>
+step s3_conditions_locks: 
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+
+table_lock     at_start       at_created     at_found       
+
+1              1              1              0              
+step s4_release_created: SELECT debug_waitpoint_release('find_or_create_chunk_created');
+debug_waitpoint_release
+
+               
+step s1_create_chunk_1: <... completed>
+slices         created        
+
+{"time": [1514764800000000, 1514851200000000], "device": [-9223372036854775808, 1073741823]}t              
+step s3_conditions_locks: 
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+
+table_lock     at_start       at_created     at_found       
+
+0              1              0              0              
+step s4_release_start: SELECT debug_waitpoint_release('find_or_create_chunk_start');
+debug_waitpoint_release
+
+               
+step s2_create_chunk_1: <... completed>
+slices         created        
+
+{"time": [1514764800000000, 1514851200000000], "device": [-9223372036854775808, 1073741823]}f              
+step s3_conditions_locks: 
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+
+table_lock     at_start       at_created     at_found       
+
+0              0              0              0              

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_TEMPLATES_MODULE
 set(TEST_TEMPLATES_MODULE_DEBUG
   reorder_vs_insert.spec.in
   reorder_vs_select.spec.in
+  remote_create_chunk.spec.in
 )
 
 list(APPEND TEST_FILES

--- a/tsl/test/isolation/specs/remote_create_chunk.spec.in
+++ b/tsl/test/isolation/specs/remote_create_chunk.spec.in
@@ -1,0 +1,125 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# Test concurrent remote chunk creation
+#
+
+setup
+{
+	CREATE TABLE conditions (time timestamptz, device int, temp float);
+	SELECT create_hypertable('conditions', 'time', 'device', 2, chunk_time_interval => interval '1 day');
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_enable';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_release';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_id(TEXT) RETURNS BIGINT LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_id';
+
+	CREATE OR REPLACE FUNCTION waitpoint_count(tag TEXT) RETURNS bigint AS
+	$$
+		SELECT count(*)
+		FROM pg_locks
+		WHERE locktype = 'advisory'
+		AND mode = 'ShareLock'
+		AND objid = debug_waitpoint_id(tag)
+		AND granted = false;
+	$$ LANGUAGE SQL;
+
+	CREATE OR REPLACE FUNCTION root_table_lock_count() RETURNS bigint AS
+	$$
+		SELECT count(*) AS num_locks_on_conditions_table
+		FROM pg_locks
+		WHERE locktype = 'relation'
+		AND relation = 'conditions'::regclass
+		AND mode = 'ShareUpdateExclusiveLock';
+	$$ LANGUAGE SQL;
+}
+
+teardown {
+	DROP TABLE conditions;
+}
+
+
+session "s1"
+setup	{
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL deadlock_timeout = '300ms';
+	SET application_name = 's1';
+}
+
+# Try to create a chunk
+step "s1_create_chunk_1" {
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[-9223372036854775808, 1073741823]));
+}
+
+step "s1_create_chunk_2" {
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[1073741823, 9223372036854775807]));
+}
+
+# Create a chunk that does not exist
+session "s2"
+setup	{
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET LOCAL lock_timeout = '500ms';
+	SET LOCAL deadlock_timeout = '300ms';
+	SET application_name = 's1';
+}
+
+step "s2_create_chunk_1" {
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[-9223372036854775808, 1073741823]));
+}
+
+step "s2_create_chunk_2" {
+	SELECT slices, created FROM _timescaledb_internal.create_chunk('conditions', jsonb_build_object('time', ARRAY[1514764800000000, 1514851200000000], 'device', ARRAY[1073741823, 9223372036854775807]));
+}
+
+session "s3"
+setup {
+	SET application_name = 's3';
+}
+
+step "s3_conditions_locks" {
+	SELECT root_table_lock_count() AS table_lock,
+	waitpoint_count('find_or_create_chunk_start') AS at_start,
+	waitpoint_count('find_or_create_chunk_created') AS at_created,
+	waitpoint_count('find_or_create_chunk_found') AS at_found;
+}
+
+session "s4"
+step "s4_wait_all"  {
+	SELECT * FROM debug_waitpoint_id('find_or_create_chunk_start');
+	SELECT * FROM debug_waitpoint_id('find_or_create_chunk_created');
+	SELECT * FROM debug_waitpoint_id('find_or_create_chunk_found');
+	SELECT debug_waitpoint_enable('find_or_create_chunk_start');
+	SELECT debug_waitpoint_enable('find_or_create_chunk_created');
+	SELECT debug_waitpoint_enable('find_or_create_chunk_found');
+}
+
+step "s4_wait_start"           { SELECT debug_waitpoint_enable('find_or_create_chunk_start'); }
+step "s4_wait_created"           { SELECT debug_waitpoint_enable('find_or_create_chunk_created'); }
+step "s4_wait_found"           { SELECT debug_waitpoint_enable('find_or_create_chunk_found'); }
+step "s4_release_start"      { SELECT debug_waitpoint_release('find_or_create_chunk_start'); }
+step "s4_release_created"      { SELECT debug_waitpoint_release('find_or_create_chunk_created'); }
+step "s4_release_found"      { SELECT debug_waitpoint_release('find_or_create_chunk_found'); }
+
+# s1 and s2 will try create the same chunk and both take the lock on
+# the root table. However, s2 will find the chunk created by s1 after
+# s1 releases the root lock and then s2 will also release the root
+# lock before transaction end.
+permutation "s4_wait_created" "s4_wait_found" "s1_create_chunk_1" "s2_create_chunk_1" "s3_conditions_locks" "s4_release_created" "s3_conditions_locks" "s4_release_found"
+
+# s1 and s2 will create different chunks and both will try to lock the
+# root table. They will each create their own unique chunks, so s2
+# won't block on the "found" wait point.
+permutation "s4_wait_created" "s4_wait_found" "s1_create_chunk_1" "s2_create_chunk_2" "s3_conditions_locks" "s4_release_created" "s3_conditions_locks" "s4_release_found"
+
+# s1 and s2 runs concurrently and both try to create the same
+# chunk. However, s1 completes its transaction before s2 looks up the
+# chunk. Therefore s2 will find the new chunk and need not take the
+# lock on the root table.
+permutation "s4_wait_created" "s1_create_chunk_1" "s4_wait_start" "s2_create_chunk_1" "s3_conditions_locks" "s4_release_created" "s3_conditions_locks" "s4_release_start" "s3_conditions_locks"


### PR DESCRIPTION
The create-chunk API, which is used by the access node to create
chunks on data nodes, always grabs a lock on the root hypertable. This
change optimizes this locking so that the lock is only taken when the
chunk doesn't already exist.