### PR TITLE
Run chunk_utils test in solo to reduce flakiness

### DIFF
--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SOLO_TESTS
   alter
   alternate_users
   bgw_launcher
+  chunk_utils.sql
   index
   loader
   net


### PR DESCRIPTION
chunk_utils test experiences some inconsistency in permissions
sometimes. To avoid this the test is run solo without other tests
interfering.

PR note: 
[link](https://github.com/timescale/timescaledb/runs/1563206122?check_suite_focus=true#step:15:25) to a failed test.