### PR TITLE
Fix crash and cancel when adding data node

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -726,6 +726,12 @@ data_node_add_internal(PG_FUNCTION_ARGS, bool set_distid)
 		{
 			TSConnection *conn =
 				connect_for_bootstrapping(node_name, host, port, username, password);
+
+			if (NULL == conn)
+				ereport(ERROR,
+						(errcode(ERRCODE_SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION),
+						 errmsg("could not connect to \"%s\"", node_name)));
+
 			data_node_validate_extension_availability(conn);
 			database_created = data_node_bootstrap_database(conn, &database);
 			remote_connection_close(conn);
@@ -742,6 +748,7 @@ data_node_add_internal(PG_FUNCTION_ARGS, bool set_distid)
 		 * we do not need 2PC support. */
 		node_options = create_data_node_options(host, port, dbname, username, password);
 		conn = remote_connection_open_with_options(node_name, node_options, false);
+		Assert(NULL != conn);
 		remote_connection_cmd_ok(conn, "BEGIN");
 
 		if (bootstrap)

--- a/tsl/src/dist_util.c
+++ b/tsl/src/dist_util.c
@@ -130,8 +130,8 @@ dist_util_set_id_with_uuid_check(Datum dist_id, bool check_uuid)
 				 (errmsg("cannot add the current database as a data node to itself"),
 				  errdetail("Adding the current database as a data node to itself would create a "
 							"cycle. Use a different instance or database for the data node."),
-				  errhint("Check that the 'port' parameter is given and refer to a different "
-						  "instance or that the 'database' parameter is given and refer to a "
+				  errhint("Check that the 'port' parameter refers to a different "
+						  "instance or that the 'database' parameter refers to a "
 						  "different database."))));
 
 	ts_metadata_insert(CStringGetDatum(METADATA_DISTRIBUTED_UUID_KEY_NAME),

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -1324,8 +1324,7 @@ SET ROLE :ROLE_3;
 -- ROLE_3 doesn't have a password in the passfile and has not way to
 -- authenticate so adding a data node will still fail.
 SELECT * FROM add_data_node('data_node_6', host => 'localhost', database => 'data_node_6');
-ERROR:  no connection to the server
-
+ERROR:  could not connect to "data_node_6"
 \set ON_ERROR_STOP 0
 -- Providing the password on the command line should work
 SELECT * FROM add_data_node('data_node_6', host => 'localhost', database => 'data_node_6', password => :'ROLE_3_PASS');


### PR DESCRIPTION
This change fixes two issues with `add_data_node`:

1. In one case, a check for a valid connection pointer was not done,
   causing a segmentation fault when connection attempts failed.

2. Connections were made with a blocking API that would hang
   indefinitely if the receiving end is not responding. The user
   couldn't cancel the connection attempt with CTRL-C, since no wait
   latch or interrupt checking was used. The code is now updated to
   use a non-blocking connection API, where it is possible to wait on
   the socket and latch, respecting interrupts.

This was tested locally by setting up a bogus listening socket with `netcat -l` that would not respond to connection attempts by `add_data_node`. Without the fix, the command could not be canceled with CTRL-C. With the update code, this works as expected. Naturally, this is a test case that is difficult to test for in the regression tests.