### PR TITLE
Fix crash when user mapping has no username

### DIFF
--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -39,7 +39,8 @@ extern TSConnection *remote_connection_open_with_options(const char *node_name,
 														 List *connection_options,
 														 bool set_dist_id);
 extern TSConnection *remote_connection_open_with_options_nothrow(const char *node_name,
-																 List *connection_options);
+																 List *connection_options,
+																 char **errmsg);
 extern TSConnection *remote_connection_open_by_id(TSConnectionId id);
 extern TSConnection *remote_connection_open(Oid server_id, Oid user_id);
 extern TSConnection *remote_connection_open_nothrow(Oid server_id, Oid user_id, char **errmsg);

--- a/tsl/test/expected/dist_grant.out
+++ b/tsl/test/expected/dist_grant.out
@@ -752,7 +752,9 @@ NOTICE:  adding not-null constraint to column "time"
 ERROR:  could not connect to "data2"
 \set ON_ERROR_STOP 1
 RESET ROLE;
-CREATE USER MAPPING FOR :ROLE_3 SERVER data2 OPTIONS (user :'ROLE_3', password :'ROLE_3_PASS');
+-- Create user mapping for ROLE_3, but don't specify user in
+-- options. The "current user" will instead be used when connecting.
+CREATE USER MAPPING FOR :ROLE_3 SERVER data2 OPTIONS (password :'ROLE_3_PASS');
 SET ROLE :ROLE_3;
 -- User should be able to connect and create the distributed
 -- hypertable at this point.
@@ -771,3 +773,5 @@ SELECT * FROM disttable_role_3;
  Tue Jan 01 00:00:00 2019 PST |      1 | 23.4
 (1 row)
 
+DROP USER MAPPING FOR :ROLE_3 SERVER data1;
+DROP USER MAPPING FOR :ROLE_3 SERVER data2;

--- a/tsl/test/sql/dist_grant.sql
+++ b/tsl/test/sql/dist_grant.sql
@@ -262,7 +262,9 @@ SELECT * FROM create_distributed_hypertable('disttable_role_3', 'time', data_nod
 \set ON_ERROR_STOP 1
 
 RESET ROLE;
-CREATE USER MAPPING FOR :ROLE_3 SERVER data2 OPTIONS (user :'ROLE_3', password :'ROLE_3_PASS');
+-- Create user mapping for ROLE_3, but don't specify user in
+-- options. The "current user" will instead be used when connecting.
+CREATE USER MAPPING FOR :ROLE_3 SERVER data2 OPTIONS (password :'ROLE_3_PASS');
 SET ROLE :ROLE_3;
 
 -- User should be able to connect and create the distributed
@@ -273,3 +275,5 @@ SELECT * FROM create_distributed_hypertable('disttable_role_3', 'time', data_nod
 INSERT INTO disttable_role_3 VALUES ('2019-01-01 00:00:00', 1, 23.4);
 SELECT * FROM disttable_role_3;
 
+DROP USER MAPPING FOR :ROLE_3 SERVER data1;
+DROP USER MAPPING FOR :ROLE_3 SERVER data2;


### PR DESCRIPTION
If a user mapping is created without a user name in the options, a
crash would happen when querying a distributed hypertable.

This change fixes the crash by assuming that the user to connect with
is the "current user" (i.e., no username mapping is done). This makes
it possible to create user mappings that only provide a password
option.