### PR TITLE
Remove unused field for ignoring invalidations

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -249,7 +249,6 @@ ts_hypertable_from_tupleinfo(const TupleInfo *ti)
 	h->chunk_cache =
 		ts_subspace_store_init(h->space, ti->mctx, ts_guc_max_cached_chunks_per_hypertable);
 	h->chunk_sizing_func = get_chunk_sizing_func_oid(&h->fd);
-	h->max_ignore_invalidation_older_than = -1;
 	h->data_nodes = ts_hypertable_data_node_scan(h->fd.id, ti->mctx);
 
 	return h;

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -51,8 +51,6 @@ typedef struct Hypertable
 	Oid chunk_sizing_func;
 	Hyperspace *space;
 	SubspaceStore *chunk_cache;
-	int64 max_ignore_invalidation_older_than; /* lazy-loaded, do not access directly, use
-											ts_hypertable_get_ignore_invalidation_older_than */
 	/*
 	 * Allows restricting the data nodes to use for the hypertable. Default is to
 	 * use all available data nodes.


### PR DESCRIPTION
Remove an unused field called `max_ignore_invalidation_older_than`
that was left in the `Hypertable` struct after refactoring of
continuous aggregates.