### PR TITLE
Fix check constraint on hypertable metadata table

### DIFF
--- a/sql/updates/2.0.0-rc3--2.0.0-rc4.sql
+++ b/sql/updates/2.0.0-rc3--2.0.0-rc4.sql
@@ -50,12 +50,16 @@ CREATE TABLE IF NOT EXISTS _timescaledb_catalog.hypertable(
   chunk_target_size bigint NOT NULL CHECK (chunk_target_size >= 0), -- size in bytes
   compression_state smallint NOT NULL DEFAULT 0,
   compressed_hypertable_id integer ,
-  replication_factor smallint NULL CHECK (replication_factor > 0),
+  replication_factor smallint NULL,
   UNIQUE (associated_schema_name, associated_table_prefix),
   CONSTRAINT hypertable_table_name_schema_name_key UNIQUE (table_name, schema_name),
-----internal compressed hypertables have compression state = 2
+  -- internal compressed hypertables have compression state = 2
   CONSTRAINT hypertable_dim_compress_check CHECK (num_dimensions > 0 OR compression_state = 2),
-  CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL))
+  CONSTRAINT hypertable_compress_check CHECK ( (compression_state = 0 OR compression_state = 1 )  OR (compression_state = 2 AND compressed_hypertable_id IS NULL)),
+  -- replication_factor NULL: regular hypertable
+  -- replication_factor > 0: distributed hypertable on access node
+  -- replication_factor -1: distributed hypertable on data node, which is part of a larger table
+  CONSTRAINT hypertable_replication_factor_check CHECK (replication_factor > 0 OR replication_factor = -1)
 );
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,3 @@
+ALTER TABLE _timescaledb_catalog.hypertable
+  DROP CONSTRAINT hypertable_replication_factor_check,
+  ADD CONSTRAINT hypertable_replication_factor_check CHECK (replication_factor > 0 OR replication_factor = -1);

--- a/test/sql/updates/post.integrity_test.sql
+++ b/test/sql/updates/post.integrity_test.sql
@@ -17,12 +17,14 @@ DECLARE
     chunk_constraint_count INTEGER;
     chunk_index_count      INTEGER;
 BEGIN
-    -- Check integrity of chunk indexes
+    -- Check integrity of chunk indexes on non-distributed hypertables
+    -- (distributed ones do not have chunk indexes on the access node)
     FOR index_row IN
     SELECT h.schema_name, c.relname AS index_name, h.id AS hypertable_id, h.table_name AS hypertable_name
     FROM _timescaledb_catalog.hypertable h
     INNER JOIN pg_index i ON (i.indrelid = format('%I.%I', h.schema_name, h.table_name)::regclass)
     INNER JOIN pg_class c ON (i.indexrelid = c.oid)
+    WHERE h.replication_factor IS NULL
     EXCEPT
     SELECT h.schema_name, c.relname AS index_name, h.id AS hypertable_id, h.table_name AS hypertable_name
     FROM _timescaledb_catalog.hypertable h

--- a/test/sql/updates/post.update.sql
+++ b/test/sql/updates/post.update.sql
@@ -1,0 +1,23 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+DO LANGUAGE PLPGSQL $$
+DECLARE
+  relid regclass = NULL;
+  ts_version TEXT;
+BEGIN
+  SELECT oid INTO relid FROM pg_class WHERE relname='disthyper';
+  SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
+
+  -- Can only run multinode on 2.0.0+
+  IF relid IS NULL AND ts_version >= '2.0.0' THEN
+    RAISE NOTICE 'creating multinode setup for version % on database %',
+		  ts_version, current_database();
+    PERFORM add_data_node('dn1', host=>'localhost', database=>'dn1');
+	CREATE TABLE disthyper (time timestamptz, device int, temp float);
+	PERFORM create_distributed_hypertable('disthyper', 'time', 'device');
+	INSERT INTO disthyper VALUES ('2020-12-20 12:18', 1, 27.9);	
+  END IF;
+END
+$$;

--- a/test/sql/updates/post.v6.sql
+++ b/test/sql/updates/post.v6.sql
@@ -11,4 +11,3 @@
 \ir post.policies.sql
 \ir post.sequences.sql
 \ir post.functions.sql
-

--- a/test/sql/updates/setup.bigint.sql
+++ b/test/sql/updates/setup.bigint.sql
@@ -2,11 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE DATABASE single;
-
-\c single
-CREATE EXTENSION IF NOT EXISTS timescaledb;
-
 CREATE TABLE PUBLIC."two_Partitions" (
   "timeCustom" BIGINT NOT NULL,
   device_id TEXT NOT NULL,

--- a/test/sql/updates/setup.multinode.sql
+++ b/test/sql/updates/setup.multinode.sql
@@ -1,0 +1,21 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+DO LANGUAGE PLPGSQL $$
+DECLARE
+  ts_version TEXT;
+BEGIN
+  SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
+
+  -- Can only run multinode on 2.0.0+
+  IF ts_version >= '2.0.0' THEN
+    RAISE NOTICE 'creating multinode setup for version % on database %',
+		  ts_version, current_database();
+    PERFORM add_data_node('dn1', host=>'localhost', database=>'dn1');
+	CREATE TABLE disthyper (time timestamptz, device int, temp float);
+	PERFORM create_distributed_hypertable('disthyper', 'time', 'device');
+	INSERT INTO disthyper VALUES ('2020-12-20 12:18', 1, 27.9);	
+  END IF;
+END
+$$;

--- a/test/sql/updates/setup.v2.sql
+++ b/test/sql/updates/setup.v2.sql
@@ -2,6 +2,23 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+CREATE DATABASE single;
+-- Always pre-create the data node database 'dn1' so that we can dump
+-- and restore it even on TimescaleDB versions that don't support
+-- multinode. Otherwise, we'd have to create version-dependent scripts
+-- to specifically handle multinode tests. We use template0, or
+-- otherwise dn1 will have the same UUID as 'single' since template1
+-- has the extension pre-installed.
+CREATE DATABASE dn1 TEMPLATE template0;
+\c dn1
+-- Make sure the extension is installed so that extension versions
+-- that don't support multinode will still be able to update the
+-- extension with ALTER EXTENSION ... UPDATE.
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
 \ir setup.bigint.sql
 \ir setup.constraints.sql
 \ir setup.insert_bigint.v2.sql

--- a/test/sql/updates/setup.v6.sql
+++ b/test/sql/updates/setup.v6.sql
@@ -6,4 +6,4 @@
 \ir setup.continuous_aggs.v2.sql
 \ir setup.compression.sql
 \ir setup.policies.sql
-
+\ir setup.multinode.sql


### PR DESCRIPTION
The `replication_factor` is set to `-1` on hypertables that are
created on data nodes as part of a larger distributed
hypertable. However, the check constraint on the hypertable metadata
table doesn't allow such values, causing update scripts to fail when
this check constraint is recreated as part of updating to version
`2.0.0-rc4`.

The reason it is possible to insert violating rows is because check
constraints aren't validated when inserting data using PostgreSQL's
internal catalog functions (in C). Therefore, the violating row can
exist until one tries to update a data node to `2.0.0-rc4`, at which
point the update script tries to recreate the `hypertable` metadata
table due to other changes that were made to the table.

This change fixes the check constraint to account for `-1` as a valid
value, and also changes the update scripts to account for the new
check constraint so that updates to the latest version will no longer
fail.