### PR TITLE
Bootstrap data nodes with versioned extension

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -303,8 +303,17 @@ ts_extension_is_loaded(void)
 	}
 }
 
-char *
-ts_extension_get_so_name()
+const char *
+ts_extension_get_so_name(void)
 {
 	return EXTENSION_NAME "-" TIMESCALEDB_VERSION_MOD;
+}
+
+/*
+ * Get the currently installed extension version.
+ */
+const char *
+ts_extension_get_version(void)
+{
+	return extension_version();
 }

--- a/src/extension.h
+++ b/src/extension.h
@@ -15,7 +15,7 @@ extern void ts_extension_check_version(const char *so_version);
 extern void ts_extension_check_server_version(void);
 extern Oid ts_extension_schema_oid(void);
 extern TSDLLEXPORT char *ts_extension_schema_name(void);
-
-extern char *ts_extension_get_so_name(void);
+extern const char *ts_extension_get_so_name(void);
+extern TSDLLEXPORT const char *ts_extension_get_version(void);
 
 #endif /* TIMESCALEDB_EXTENSION_H */

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -33,6 +33,7 @@
 #include <utils/syscache.h>
 
 #include "config.h"
+#include "extension.h"
 #include "fdw/fdw.h"
 #include "remote/async.h"
 #include "remote/connection.h"
@@ -509,8 +510,10 @@ data_node_bootstrap_extension(TSConnection *conn)
 		}
 
 		remote_connection_cmdf_ok(conn,
-								  "CREATE EXTENSION " EXTENSION_NAME " WITH SCHEMA %s CASCADE",
-								  schema_name_quoted);
+								  "CREATE EXTENSION " EXTENSION_NAME
+								  " WITH SCHEMA %s VERSION %s CASCADE",
+								  schema_name_quoted,
+								  quote_literal_cstr(ts_extension_get_version()));
 		return true;
 	}
 	else


### PR DESCRIPTION
When the access node bootstraps a data node and creates the extension,
it should use the extension version of the access node. This change
adds the `VERSION` option to the `CREATE EXTENSION` statement sent to
a data node so that the extension versions on the access node and data
nodes will be the same. Without the version option, data nodes will be
bootstrapped with the latest version installed, potentially leading to
data nodes running different versions of the extension compared to the
access node.