### PR TITLE
Use cppflags and ldflags from pg_config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,11 @@ get_pg_config(PG_CPPFLAGS --cppflags)
 get_pg_config(PG_LDFLAGS --ldflags)
 get_pg_config(PG_LIBS --libs)
 
+string(REGEX REPLACE " -I" ";" EXTRA_INCLUDES   ${PG_CPPFLAGS})
+include_directories(${PROJECT_NAME} ${EXTRA_INCLUDES})
+string(REGEX REPLACE " -L" ";" EXTRA_LIBRARIES  ${PG_LDFLAGS})
+link_directories(${PROJECT_NAME} ${EXTRA_LIBRARIES})
+
 find_path(PG_SOURCE_DIR
   src/include/pg_config.h.in
   HINTS


### PR DESCRIPTION
Unlike projects built with PGXS infrastructure, Timescale provided
CMakeLists.txt doesn't include CPPFLAGS and LDFLAGS used when building
PostgreSQ. As a result, TimescaleDB compilation fails in the PostgreSQL
code, i.e. being unable to localte neccessary includes.