### PR TITLE
Fix config enum entries for remote data fetcher

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -35,7 +35,9 @@ static const struct config_enum_entry telemetry_level_options[] = {
 };
 
 static const struct config_enum_entry remote_data_fetchers[] = {
-	{ "rowbyrow", RowByRowFetcherType, false }, { "cursor", CursorFetcherType, false }
+	{ "rowbyrow", RowByRowFetcherType, false },
+	{ "cursor", CursorFetcherType, false },
+	{ NULL, 0, false }
 };
 
 bool ts_guc_enable_optimizations = true;


### PR DESCRIPTION
config_enum entries, which are used for GUC values, need to contain 
the end mark. Missing the end mark in the data fetcher entries 
resulted in crashing TimescaleDB in Release on Windows. This commit 
fixes the end mark for data fetcher config_enum entries.

Fixes #2775

PR note:
No test is added, since there is no Release test on Windows, and the bug doesn't happen in Debug or on other platforms.