### PR TITLE
Adjust decompress code to Var field renames

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -739,11 +739,15 @@ create_var_for_compressed_equivalence_member(Var *var, const EMCreationContext *
 	if (var->varlevelsup == 0)
 	{
 		var->varno = context->compressed_relid_idx;
-		var->varnoold = context->compressed_relid_idx;
 		var->varattno =
 			get_attnum(context->compressed_relid, NameStr(context->current_col_info->attname));
-
+#if PG13_GE
+		var->varnosyn = var->varno;
+		var->varattnosyn = var->varattno;
+#else
+		var->varnoold = var->varno;
 		var->varoattno = var->varattno;
+#endif
 
 		return (Node *) var;
 	}


### PR DESCRIPTION
PG13 renames the varnoold and varoattno field of Var to varnosyn and
varattnosyn.

https://github.com/postgres/postgres/commit/9ce77d75c5