### PR TITLE
Adjust code to PG13 tuptoaster changes

### DIFF
--- a/tsl/src/remote/async.c
+++ b/tsl/src/remote/async.c
@@ -13,7 +13,6 @@
 #include <fmgr.h>
 #include <utils/lsyscache.h>
 #include <catalog/pg_type.h>
-#include <access/tuptoaster.h>
 
 #include "compat.h"
 #if PG12_GE

--- a/tsl/src/remote/stmt_params.c
+++ b/tsl/src/remote/stmt_params.c
@@ -6,7 +6,6 @@
 #include <postgres.h>
 #include <catalog/pg_type.h>
 #include <access/htup_details.h>
-#include <access/tuptoaster.h>
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
 #include <utils/builtins.h>

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -19,7 +19,6 @@
 #include <access/relscan.h>
 #include <access/rewriteheap.h>
 #include <access/transam.h>
-#include <access/tuptoaster.h>
 #include <access/xact.h>
 #include <access/xlog.h>
 #include <catalog/catalog.h>
@@ -56,6 +55,12 @@
 #include "compat.h"
 #if PG12_LT
 #include <utils/tqual.h>
+#endif
+
+#if PG13_LT
+#include <access/tuptoaster.h>
+#else
+#include <access/toast_internals.h>
 #endif
 
 #include "chunk.h"


### PR DESCRIPTION
PG13 split tuptoaster.c into three separate files. This patch also
removes unnecesary tuptoaster.h includes.

https://github.com/postgres/postgres/commit/8b94dab066