### PR TITLE
Fix for_each_cell_compat macro for PG13

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -371,7 +371,7 @@ get_vacuum_options(const VacuumStmt *stmt)
 #define list_delete_cell_compat(l, lc, prev) list_delete_cell((l), (lc))
 #define list_make5(x1, x2, x3, x4, x5) lappend(list_make4(x1, x2, x3, x4), x5)
 #define list_make5_oid(x1, x2, x3, x4, x5) lappend_oid(list_make4_oid(x1, x2, x3, x4), x5)
-#define for_each_cell_compat(cell, list, initcell) for_each_cell ((cell), (list), (initcell))
+#define for_each_cell_compat(cell, list, initcell) for_each_cell (cell, list, initcell)
 #endif
 
 /* PG13 removes the natts parameter from map_variable_attnos */


### PR DESCRIPTION
In PG 13:
	define for_each_cell(cell, lst, initcell) \
	for (ForEachState cell##__state = for_each_cell_setup(lst, initcell); \
	(cell##__state.l != NIL && \ cell##__state.i < cell##__state.l->length) ? \
	(cell = &cell##__state.l->elements[cell##__state.i], true) : \
	(cell = NULL, false); \
	cell##__state.i++)

Extra brackets is wrong. Trying to concatenate parameters with brackets generate
an preprocessor error.