### PR TITLE
Add check for dropped chunk on update

### DIFF
--- a/sql/updates/1.7.4--2.0.0-rc1.sql
+++ b/sql/updates/1.7.4--2.0.0-rc1.sql
@@ -400,7 +400,7 @@ DECLARE
 BEGIN
   FOR chunk IN
   SELECT format('%I.%I', schema_name, table_name)::regclass
-    FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL
+    FROM _timescaledb_catalog.chunk WHERE compressed_chunk_id IS NOT NULL AND NOT dropped
   LOOP
     EXECUTE format('ALTER TABLE %s SET (autovacuum_enabled=false);', chunk::text);
   END LOOP;

--- a/test/sql/updates/post.integrity_test.sql
+++ b/test/sql/updates/post.integrity_test.sql
@@ -33,7 +33,7 @@ BEGIN
     INNER JOIN pg_constraint cc ON (c.oid = cc.conindid)
     LOOP
         SELECT count(*) FROM _timescaledb_catalog.chunk c
-        WHERE c.hypertable_id = index_row.hypertable_id
+        WHERE c.hypertable_id = index_row.hypertable_id AND NOT dropped
         INTO STRICT chunk_count;
 
         SELECT count(c.*) FROM _timescaledb_catalog.chunk_index c


### PR DESCRIPTION
If `drop_chunks` has been executed on a hypertable that has a
continuous aggregate defined, the chunks will be removed and marked as
dropped in `_timescaledb_catalog.chunk` but the lines will not be
removed. This will cause problems for the update script since it is
missing a check to only process chunks that are not dropped and will
try to cast the chunk name into a `REGCLASS` for a table that does not
exist.

This commit fixes this by adding a check that the chunk is not dropped
and also fixes the update test to not count dropped chunks when
comparing with the chunk index since the chunk index does not count
dropped chunks.

Fixes #2791
