### PR TITLE
Improve logic of placing dispatches into plan

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -227,7 +227,7 @@ create_chunk_on_data_nodes_default(Chunk *chunk, Hypertable *ht)
 }
 
 static Path *
-data_node_dispatch_path_create_default(PlannerInfo *root, ModifyTablePath *mtpath,
+data_node_dispatch_path_create_default(PlannerInfo *root, ModifyTablePath *mtpath, Path *subpath,
 									   Index hypertable_rti, int subpath_index)
 {
 	error_no_default_fn_community();

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -138,7 +138,7 @@ typedef struct CrossModuleFunctions
 	PGFunction remote_connection_cache_show;
 	void (*create_chunk_on_data_nodes)(Chunk *chunk, Hypertable *ht);
 	Path *(*data_node_dispatch_path_create)(PlannerInfo *root, ModifyTablePath *mtpath,
-											Index hypertable_rti, int subpath_index);
+											Path *subpath, Index hypertable_rti, int subpath_index);
 	uint64 (*distributed_copy)(const CopyStmt *stmt, CopyChunkState *ccstate, List *attnums);
 	bool (*set_distributed_id)(Datum id);
 	void (*set_distributed_peer_id)(Datum id);

--- a/src/hypertable_insert.c
+++ b/src/hypertable_insert.c
@@ -471,16 +471,16 @@ ts_hypertable_insert_path_create(PlannerInfo *root, ModifyTablePath *mtpath)
 								"constraints"),
 						 errhint("Use column names to infer indexes instead.")));
 
+			subpath = ts_chunk_dispatch_path_create(root, mtpath, rti, i);
 			if (hypertable_is_distributed(ht) && ts_guc_max_insert_batch_size > 0)
 			{
 				/* Remember that this will become a data node dispatch plan. We
 				 * need to know later whether or not to plan this using the
 				 * FDW API. */
 				data_node_dispatch_plans = bms_add_member(data_node_dispatch_plans, i);
-				subpath = ts_cm_functions->data_node_dispatch_path_create(root, mtpath, rti, i);
+				subpath =
+					ts_cm_functions->data_node_dispatch_path_create(root, mtpath, subpath, rti, i);
 			}
-			else
-				subpath = ts_chunk_dispatch_path_create(root, mtpath, rti, i);
 		}
 
 		i++;

--- a/tsl/src/data_node_dispatch.c
+++ b/tsl/src/data_node_dispatch.c
@@ -1154,11 +1154,10 @@ static CustomPathMethods data_node_dispatch_path_methods = {
 };
 
 Path *
-data_node_dispatch_path_create(PlannerInfo *root, ModifyTablePath *mtpath, Index hypertable_rti,
-							   int subplan_index)
+data_node_dispatch_path_create(PlannerInfo *root, ModifyTablePath *mtpath, Path *subpath,
+							   Index hypertable_rti, int subplan_index)
 {
 	DataNodeDispatchPath *sdpath = palloc0(sizeof(DataNodeDispatchPath));
-	Path *subpath = ts_chunk_dispatch_path_create(root, mtpath, hypertable_rti, subplan_index);
 
 	/* Copy costs, etc. from the subpath */
 	memcpy(&sdpath->cpath.path, subpath, sizeof(Path));

--- a/tsl/src/data_node_dispatch.h
+++ b/tsl/src/data_node_dispatch.h
@@ -12,7 +12,7 @@
 
 #include "fdw/deparse.h"
 
-Path *data_node_dispatch_path_create(PlannerInfo *root, ModifyTablePath *mtpath,
+Path *data_node_dispatch_path_create(PlannerInfo *root, ModifyTablePath *mtpath, Path *subpath,
 									 Index hypertable_rti, int subplan_index);
 
 #endif /* TIMESCALEDB_TSL_DATA_NODE_DISPATCH_H */


### PR DESCRIPTION
TimescaleDB planner adds a chunk dispatch node to a query plan. If a
hypertable is distributed, a data node dispatch node is also added
into the query plan. However, it wasn't clear, since the logic flow
was either to add the chunk dispatch or the data node dispatch, which
encapsulated the chunk dispatch. This minor refactor makes it more
clear to help with code understanding.