### PR TITLE
Improve cagg watermark caching

### DIFF
--- a/tsl/test/expected/continuous_aggs_query-11.out
+++ b/tsl/test/expected/continuous_aggs_query-11.out
@@ -24,19 +24,19 @@ select table_name from create_hypertable( 'conditions', 'timec');
  conditions
 (1 row)
 
-insert into conditions values ( '2018-01-01 09:00:00-08', 'SFO', 55, 45);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'por', 100, 100);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'SFO', 65, 45);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'NYC', 65, 45);
-insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 30);
-insert into conditions values ( '2018-11-01 10:00:00-08', 'NYC', 55, 35);
-insert into conditions values ( '2018-11-01 11:00:00-08', 'NYC', 65, 40);
-insert into conditions values ( '2018-11-01 12:00:00-08', 'NYC', 75, 45);
-insert into conditions values ( '2018-11-01 13:00:00-08', 'NYC', 85, 50);
-insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 10, 10);
-insert into conditions values ( '2018-11-02 10:00:00-08', 'NYC', 20, 15);
-insert into conditions values ( '2018-11-02 11:00:00-08', 'NYC', null, null);
-insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-01-01 09:20:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-01-02 09:30:00-08', 'por', 100, 100);
+insert into conditions values ( '2018-01-02 09:20:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-01-02 09:10:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-11-01 09:20:00-08', 'NYC', 45, 30);
+insert into conditions values ( '2018-11-01 10:40:00-08', 'NYC', 55, 35);
+insert into conditions values ( '2018-11-01 11:50:00-08', 'NYC', 65, 40);
+insert into conditions values ( '2018-11-01 12:10:00-08', 'NYC', 75, 45);
+insert into conditions values ( '2018-11-01 13:10:00-08', 'NYC', 85, 50);
+insert into conditions values ( '2018-11-02 09:20:00-08', 'NYC', 10, 10);
+insert into conditions values ( '2018-11-02 10:30:00-08', 'NYC', 20, 15);
+insert into conditions values ( '2018-11-02 11:40:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-11-03 09:50:00-08', 'NYC', null, null);
 create table location_tab( locid integer, locname text );
 insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
@@ -721,3 +721,187 @@ select * from mat_m1 order by timec desc, location;
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
 (35 rows)
 
+-----------------------------------------------------------------------
+-- Test the cagg_watermark function. The watermark gives the point
+-- where to UNION raw and materialized data in real-time
+-- aggregation. Specifically, test that the watermark caching works as
+-- expected.
+-----------------------------------------------------------------------
+-- Insert some more data so that there is something to UNION in
+-- real-time aggregation.
+insert into conditions values ( '2018-12-02 20:10:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-12-02 21:20:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-12-02 20:30:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-12-02 21:50:00-08', 'NYC', 45, 30);
+-- Test join of two caggs. Joining two caggs will force the cache to
+-- reset every time the watermark function is invoked on a different
+-- cagg in the same query.
+SELECT mat_hypertable_id AS mat_id,
+	   raw_hypertable_id AS raw_id,
+	   schema_name AS mat_schema,
+	   table_name AS mat_name,
+	   format('%I.%I', schema_name, table_name) AS mat_table
+FROM _timescaledb_catalog.continuous_agg ca, _timescaledb_catalog.hypertable h
+WHERE user_view_name='mat_m1'
+AND h.id = ca.mat_hypertable_id \gset
+BEGIN;
+-- Query without join
+SELECT m1.location, m1.timec, sumt, sumh
+FROM mat_m1 m1
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh 
+----------+------------------------------+------+------
+ NYC      | Sun Dec 02 16:00:00 2018 PST |  110 |   75
+ NYC      | Fri Nov 02 17:00:00 2018 PDT |      |     
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |   30 |   25
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  325 |  200
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45
+ SFO      | Sun Dec 02 16:00:00 2018 PST |  120 |   90
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100
+(9 rows)
+
+-- Query that joins two caggs. This should force the watermark cache
+-- to reset when the materialized hypertable ID changes. A hash join
+-- could potentially read all values from mat_m1 then all values from
+-- mat_m2. This would be the optimal situation for cagg_watermark
+-- caching. We want to avoid it in tests to see that caching doesn't
+-- do anything wrong in worse situations (e.g., a nested loop join).
+SET enable_hashjoin=false;
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
+----------+------------------------------+------+------+--------+-------+---------+---------
+ NYC      | Sun Dec 02 16:00:00 2018 PST |  110 |   75 |     45 |    30 |      65 |      45
+ NYC      | Fri Nov 02 17:00:00 2018 PDT |      |      |        |       |         |        
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |   30 |   25 |     10 |       |      20 |      10
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  325 |  200 |     30 |    50 |      85 |      45
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 02 16:00:00 2018 PST |  120 |   90 |     45 |    45 |      65 |      55
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
+(9 rows)
+
+-- Show the current watermark
+SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:mat_id));
+         to_timestamp         
+------------------------------
+ Sat Nov 03 17:00:00 2018 PDT
+(1 row)
+
+-- The watermark should, in this case, be the same as the invalidation
+-- threshold
+SELECT _timescaledb_internal.to_timestamp(watermark)
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :raw_id;
+         to_timestamp         
+------------------------------
+ Sat Nov 03 17:00:00 2018 PDT
+(1 row)
+
+-- The watermark is the end of materialization (end of last bucket)
+-- while the MAX is the start of the last bucket
+SELECT max(timec) FROM :mat_table;
+             max              
+------------------------------
+ Fri Nov 02 17:00:00 2018 PDT
+(1 row)
+
+-- Drop the most recent chunk
+SELECT chunk_name, range_start, range_end
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'mat_name';
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_2_3_chunk | Wed Nov 29 16:00:00 2017 PST | Wed Feb 07 16:00:00 2018 PST
+ _hyper_2_4_chunk | Wed Sep 05 17:00:00 2018 PDT | Wed Nov 14 16:00:00 2018 PST
+(2 rows)
+
+SELECT drop_chunks('mat_m1', newer_than=>'2018-01-01'::timestamptz);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_4_chunk
+(1 row)
+
+SELECT chunk_name, range_start, range_end
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'mat_name';
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_2_3_chunk | Wed Nov 29 16:00:00 2017 PST | Wed Feb 07 16:00:00 2018 PST
+(1 row)
+
+-- The watermark should be updated to reflect the dropped data (i.e.,
+-- the cache should be reset)
+SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:mat_id));
+         to_timestamp         
+------------------------------
+ Tue Jan 02 16:00:00 2018 PST
+(1 row)
+
+-- Since we removed the last chunk, the invalidation threshold doesn't
+-- move back, while the watermark does.
+SELECT _timescaledb_internal.to_timestamp(watermark)
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :raw_id;
+         to_timestamp         
+------------------------------
+ Sat Nov 03 17:00:00 2018 PDT
+(1 row)
+
+-- Compare the new watermark to the MAX time in the table
+SELECT max(timec) FROM :mat_table;
+             max              
+------------------------------
+ Mon Jan 01 16:00:00 2018 PST
+(1 row)
+
+-- Try a subtransaction
+SAVEPOINT clear_cagg;
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
+----------+------------------------------+------+------+--------+-------+---------+---------
+ NYC      | Sun Dec 02 16:00:00 2018 PST |  110 |   75 |     45 |    30 |      65 |      45
+ NYC      | Fri Nov 02 17:00:00 2018 PDT |      |      |        |       |         |        
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |   30 |   25 |     10 |       |      20 |      10
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  325 |  200 |     30 |    50 |      85 |      45
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 02 16:00:00 2018 PST |  120 |   90 |     45 |    45 |      65 |      55
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
+(9 rows)
+
+ALTER MATERIALIZED VIEW mat_m1 SET (timescaledb.materialized_only=true);
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
+----------+------------------------------+------+------+--------+-------+---------+---------
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
+          |                              |      |      |     45 |    30 |      65 |      45
+          |                              |      |      |     45 |    45 |      65 |      55
+          |                              |      |      |     30 |    50 |      85 |      45
+          |                              |      |      |     10 |       |      20 |      10
+          |                              |      |      |        |       |         |        
+(9 rows)
+
+ROLLBACK;

--- a/tsl/test/expected/continuous_aggs_query-12.out
+++ b/tsl/test/expected/continuous_aggs_query-12.out
@@ -24,19 +24,19 @@ select table_name from create_hypertable( 'conditions', 'timec');
  conditions
 (1 row)
 
-insert into conditions values ( '2018-01-01 09:00:00-08', 'SFO', 55, 45);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'por', 100, 100);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'SFO', 65, 45);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'NYC', 65, 45);
-insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 30);
-insert into conditions values ( '2018-11-01 10:00:00-08', 'NYC', 55, 35);
-insert into conditions values ( '2018-11-01 11:00:00-08', 'NYC', 65, 40);
-insert into conditions values ( '2018-11-01 12:00:00-08', 'NYC', 75, 45);
-insert into conditions values ( '2018-11-01 13:00:00-08', 'NYC', 85, 50);
-insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 10, 10);
-insert into conditions values ( '2018-11-02 10:00:00-08', 'NYC', 20, 15);
-insert into conditions values ( '2018-11-02 11:00:00-08', 'NYC', null, null);
-insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-01-01 09:20:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-01-02 09:30:00-08', 'por', 100, 100);
+insert into conditions values ( '2018-01-02 09:20:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-01-02 09:10:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-11-01 09:20:00-08', 'NYC', 45, 30);
+insert into conditions values ( '2018-11-01 10:40:00-08', 'NYC', 55, 35);
+insert into conditions values ( '2018-11-01 11:50:00-08', 'NYC', 65, 40);
+insert into conditions values ( '2018-11-01 12:10:00-08', 'NYC', 75, 45);
+insert into conditions values ( '2018-11-01 13:10:00-08', 'NYC', 85, 50);
+insert into conditions values ( '2018-11-02 09:20:00-08', 'NYC', 10, 10);
+insert into conditions values ( '2018-11-02 10:30:00-08', 'NYC', 20, 15);
+insert into conditions values ( '2018-11-02 11:40:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-11-03 09:50:00-08', 'NYC', null, null);
 create table location_tab( locid integer, locname text );
 insert into location_tab values( 1, 'SFO');
 insert into location_tab values( 2, 'NYC');
@@ -718,3 +718,187 @@ select * from mat_m1 order by timec desc, location;
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
 (35 rows)
 
+-----------------------------------------------------------------------
+-- Test the cagg_watermark function. The watermark gives the point
+-- where to UNION raw and materialized data in real-time
+-- aggregation. Specifically, test that the watermark caching works as
+-- expected.
+-----------------------------------------------------------------------
+-- Insert some more data so that there is something to UNION in
+-- real-time aggregation.
+insert into conditions values ( '2018-12-02 20:10:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-12-02 21:20:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-12-02 20:30:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-12-02 21:50:00-08', 'NYC', 45, 30);
+-- Test join of two caggs. Joining two caggs will force the cache to
+-- reset every time the watermark function is invoked on a different
+-- cagg in the same query.
+SELECT mat_hypertable_id AS mat_id,
+	   raw_hypertable_id AS raw_id,
+	   schema_name AS mat_schema,
+	   table_name AS mat_name,
+	   format('%I.%I', schema_name, table_name) AS mat_table
+FROM _timescaledb_catalog.continuous_agg ca, _timescaledb_catalog.hypertable h
+WHERE user_view_name='mat_m1'
+AND h.id = ca.mat_hypertable_id \gset
+BEGIN;
+-- Query without join
+SELECT m1.location, m1.timec, sumt, sumh
+FROM mat_m1 m1
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh 
+----------+------------------------------+------+------
+ NYC      | Sun Dec 02 16:00:00 2018 PST |  110 |   75
+ NYC      | Fri Nov 02 17:00:00 2018 PDT |      |     
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |   30 |   25
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  325 |  200
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45
+ SFO      | Sun Dec 02 16:00:00 2018 PST |  120 |   90
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100
+(9 rows)
+
+-- Query that joins two caggs. This should force the watermark cache
+-- to reset when the materialized hypertable ID changes. A hash join
+-- could potentially read all values from mat_m1 then all values from
+-- mat_m2. This would be the optimal situation for cagg_watermark
+-- caching. We want to avoid it in tests to see that caching doesn't
+-- do anything wrong in worse situations (e.g., a nested loop join).
+SET enable_hashjoin=false;
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
+----------+------------------------------+------+------+--------+-------+---------+---------
+ NYC      | Sun Dec 02 16:00:00 2018 PST |  110 |   75 |     45 |    30 |      65 |      45
+ NYC      | Fri Nov 02 17:00:00 2018 PDT |      |      |        |       |         |        
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |   30 |   25 |     10 |       |      20 |      10
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  325 |  200 |     30 |    50 |      85 |      45
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 02 16:00:00 2018 PST |  120 |   90 |     45 |    45 |      65 |      55
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
+(9 rows)
+
+-- Show the current watermark
+SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:mat_id));
+         to_timestamp         
+------------------------------
+ Sat Nov 03 17:00:00 2018 PDT
+(1 row)
+
+-- The watermark should, in this case, be the same as the invalidation
+-- threshold
+SELECT _timescaledb_internal.to_timestamp(watermark)
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :raw_id;
+         to_timestamp         
+------------------------------
+ Sat Nov 03 17:00:00 2018 PDT
+(1 row)
+
+-- The watermark is the end of materialization (end of last bucket)
+-- while the MAX is the start of the last bucket
+SELECT max(timec) FROM :mat_table;
+             max              
+------------------------------
+ Fri Nov 02 17:00:00 2018 PDT
+(1 row)
+
+-- Drop the most recent chunk
+SELECT chunk_name, range_start, range_end
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'mat_name';
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_2_3_chunk | Wed Nov 29 16:00:00 2017 PST | Wed Feb 07 16:00:00 2018 PST
+ _hyper_2_4_chunk | Wed Sep 05 17:00:00 2018 PDT | Wed Nov 14 16:00:00 2018 PST
+(2 rows)
+
+SELECT drop_chunks('mat_m1', newer_than=>'2018-01-01'::timestamptz);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_2_4_chunk
+(1 row)
+
+SELECT chunk_name, range_start, range_end
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'mat_name';
+    chunk_name    |         range_start          |          range_end           
+------------------+------------------------------+------------------------------
+ _hyper_2_3_chunk | Wed Nov 29 16:00:00 2017 PST | Wed Feb 07 16:00:00 2018 PST
+(1 row)
+
+-- The watermark should be updated to reflect the dropped data (i.e.,
+-- the cache should be reset)
+SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:mat_id));
+         to_timestamp         
+------------------------------
+ Tue Jan 02 16:00:00 2018 PST
+(1 row)
+
+-- Since we removed the last chunk, the invalidation threshold doesn't
+-- move back, while the watermark does.
+SELECT _timescaledb_internal.to_timestamp(watermark)
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :raw_id;
+         to_timestamp         
+------------------------------
+ Sat Nov 03 17:00:00 2018 PDT
+(1 row)
+
+-- Compare the new watermark to the MAX time in the table
+SELECT max(timec) FROM :mat_table;
+             max              
+------------------------------
+ Mon Jan 01 16:00:00 2018 PST
+(1 row)
+
+-- Try a subtransaction
+SAVEPOINT clear_cagg;
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
+----------+------------------------------+------+------+--------+-------+---------+---------
+ NYC      | Sun Dec 02 16:00:00 2018 PST |  110 |   75 |     45 |    30 |      65 |      45
+ NYC      | Fri Nov 02 17:00:00 2018 PDT |      |      |        |       |         |        
+ NYC      | Thu Nov 01 17:00:00 2018 PDT |   30 |   25 |     10 |       |      20 |      10
+ NYC      | Wed Oct 31 17:00:00 2018 PDT |  325 |  200 |     30 |    50 |      85 |      45
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 02 16:00:00 2018 PST |  120 |   90 |     45 |    45 |      65 |      55
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
+(9 rows)
+
+ALTER MATERIALIZED VIEW mat_m1 SET (timescaledb.materialized_only=true);
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+ location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
+----------+------------------------------+------+------+--------+-------+---------+---------
+ NYC      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
+ SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
+ por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
+          |                              |      |      |     45 |    30 |      65 |      45
+          |                              |      |      |     45 |    45 |      65 |      55
+          |                              |      |      |     30 |    50 |      85 |      45
+          |                              |      |      |     10 |       |      20 |      10
+          |                              |      |      |        |       |         |        
+(9 rows)
+
+ROLLBACK;

--- a/tsl/test/sql/continuous_aggs_query.sql.in
+++ b/tsl/test/sql/continuous_aggs_query.sql.in
@@ -26,19 +26,19 @@ CREATE TABLE conditions (
 
 select table_name from create_hypertable( 'conditions', 'timec');
 
-insert into conditions values ( '2018-01-01 09:00:00-08', 'SFO', 55, 45);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'por', 100, 100);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'SFO', 65, 45);
-insert into conditions values ( '2018-01-02 09:00:00-08', 'NYC', 65, 45);
-insert into conditions values ( '2018-11-01 09:00:00-08', 'NYC', 45, 30);
-insert into conditions values ( '2018-11-01 10:00:00-08', 'NYC', 55, 35);
-insert into conditions values ( '2018-11-01 11:00:00-08', 'NYC', 65, 40);
-insert into conditions values ( '2018-11-01 12:00:00-08', 'NYC', 75, 45);
-insert into conditions values ( '2018-11-01 13:00:00-08', 'NYC', 85, 50);
-insert into conditions values ( '2018-11-02 09:00:00-08', 'NYC', 10, 10);
-insert into conditions values ( '2018-11-02 10:00:00-08', 'NYC', 20, 15);
-insert into conditions values ( '2018-11-02 11:00:00-08', 'NYC', null, null);
-insert into conditions values ( '2018-11-03 09:00:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-01-01 09:20:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-01-02 09:30:00-08', 'por', 100, 100);
+insert into conditions values ( '2018-01-02 09:20:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-01-02 09:10:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-11-01 09:20:00-08', 'NYC', 45, 30);
+insert into conditions values ( '2018-11-01 10:40:00-08', 'NYC', 55, 35);
+insert into conditions values ( '2018-11-01 11:50:00-08', 'NYC', 65, 40);
+insert into conditions values ( '2018-11-01 12:10:00-08', 'NYC', 75, 45);
+insert into conditions values ( '2018-11-01 13:10:00-08', 'NYC', 85, 50);
+insert into conditions values ( '2018-11-02 09:20:00-08', 'NYC', 10, 10);
+insert into conditions values ( '2018-11-02 10:30:00-08', 'NYC', 20, 15);
+insert into conditions values ( '2018-11-02 11:40:00-08', 'NYC', null, null);
+insert into conditions values ( '2018-11-03 09:50:00-08', 'NYC', null, null);
 
 create table location_tab( locid integer, locname text );
 insert into location_tab values( 1, 'SFO');
@@ -187,3 +187,111 @@ set timescaledb.enable_cagg_reorder_groupby = false;
 set enable_hashagg = false;
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
+
+-----------------------------------------------------------------------
+-- Test the cagg_watermark function. The watermark gives the point
+-- where to UNION raw and materialized data in real-time
+-- aggregation. Specifically, test that the watermark caching works as
+-- expected.
+-----------------------------------------------------------------------
+
+-- Insert some more data so that there is something to UNION in
+-- real-time aggregation.
+
+insert into conditions values ( '2018-12-02 20:10:00-08', 'SFO', 55, 45);
+insert into conditions values ( '2018-12-02 21:20:00-08', 'SFO', 65, 45);
+insert into conditions values ( '2018-12-02 20:30:00-08', 'NYC', 65, 45);
+insert into conditions values ( '2018-12-02 21:50:00-08', 'NYC', 45, 30);
+
+-- Test join of two caggs. Joining two caggs will force the cache to
+-- reset every time the watermark function is invoked on a different
+-- cagg in the same query.
+SELECT mat_hypertable_id AS mat_id,
+	   raw_hypertable_id AS raw_id,
+	   schema_name AS mat_schema,
+	   table_name AS mat_name,
+	   format('%I.%I', schema_name, table_name) AS mat_table
+FROM _timescaledb_catalog.continuous_agg ca, _timescaledb_catalog.hypertable h
+WHERE user_view_name='mat_m1'
+AND h.id = ca.mat_hypertable_id \gset
+
+BEGIN;
+
+-- Query without join
+SELECT m1.location, m1.timec, sumt, sumh
+FROM mat_m1 m1
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+
+-- Query that joins two caggs. This should force the watermark cache
+-- to reset when the materialized hypertable ID changes. A hash join
+-- could potentially read all values from mat_m1 then all values from
+-- mat_m2. This would be the optimal situation for cagg_watermark
+-- caching. We want to avoid it in tests to see that caching doesn't
+-- do anything wrong in worse situations (e.g., a nested loop join).
+SET enable_hashjoin=false;
+
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+
+-- Show the current watermark
+SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:mat_id));
+
+-- The watermark should, in this case, be the same as the invalidation
+-- threshold
+SELECT _timescaledb_internal.to_timestamp(watermark)
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :raw_id;
+
+-- The watermark is the end of materialization (end of last bucket)
+-- while the MAX is the start of the last bucket
+SELECT max(timec) FROM :mat_table;
+
+-- Drop the most recent chunk
+SELECT chunk_name, range_start, range_end
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'mat_name';
+
+SELECT drop_chunks('mat_m1', newer_than=>'2018-01-01'::timestamptz);
+
+SELECT chunk_name, range_start, range_end
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'mat_name';
+
+-- The watermark should be updated to reflect the dropped data (i.e.,
+-- the cache should be reset)
+SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:mat_id));
+
+-- Since we removed the last chunk, the invalidation threshold doesn't
+-- move back, while the watermark does.
+SELECT _timescaledb_internal.to_timestamp(watermark)
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :raw_id;
+
+-- Compare the new watermark to the MAX time in the table
+SELECT max(timec) FROM :mat_table;
+
+-- Try a subtransaction
+SAVEPOINT clear_cagg;
+
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+
+ALTER MATERIALIZED VIEW mat_m1 SET (timescaledb.materialized_only=true);
+
+SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
+FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
+ON (m1.location = m2.location
+AND m1.timec = m2.timec)
+ORDER BY m1.location COLLATE "C", m1.timec DESC
+LIMIT 10;
+
+ROLLBACK;


### PR DESCRIPTION
The internal function `cagg_watermark` returns the last/max bucket in
a continuous aggregate and is used to get the point where to union the
raw and materialized data when using real-time aggregation.

Since the function is marked `STABLE` the planner should be able to
constify the function so that it need not be called repeatedly during
execution. However, this optimization is not guaranteed and the
function might be constified many times during planning if it occurs,
e.g., as an index scan condition on many chunks. This leads to slow
queries due to repeated calls to the function.

Previously, the watermark was cached in the function's `fn_extra`
state, but this state doesn't survive all repeated calls of the
function and doesn't help if the function occurs many times in the
same plan.

To make the performance more reliable, the watermark is now cached in
a global variable that is cleared at transaction end, when the input
argument (materialized hypertable queried) changes, or a new command
is executed. This should guarantee that the watermark only needs to be
looked up once per query.

Fixes #2826