### PR TITLE
Do not mark job as started when setting next_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Latest
 
+**Bugfixes**
+* #2842 Do not mark job as started when seting next_start field
+
 **Minor features**
 * #2736 Support adding columns to hypertables with compression enabled
 

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -508,7 +508,7 @@ ts_bgw_job_stat_upsert_next_start(int32 bgw_job_id, TimestampTz next_start)
 									  NULL,
 									  &next_start,
 									  RowExclusiveLock))
-			bgw_job_stat_insert_relation(rel, bgw_job_id, true, next_start);
+			bgw_job_stat_insert_relation(rel, bgw_job_id, false, next_start);
 		table_close(rel, ShareRowExclusiveLock);
 	}
 }

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -55,7 +55,15 @@ enable_fast_restart(int32 job_id, const char *job_name)
 {
 	BgwJobStat *job_stat = ts_bgw_job_stat_find(job_id);
 	if (job_stat != NULL)
-		ts_bgw_job_stat_set_next_start(job_id, job_stat->fd.last_start);
+	{
+		/* job might not have a valid last_start if it was not
+		 * run by the bgw framework.
+		 */
+		ts_bgw_job_stat_set_next_start(job_id,
+									   job_stat->fd.last_start != DT_NOBEGIN ?
+										   job_stat->fd.last_start :
+										   GetCurrentTransactionStartTimestamp());
+	}
 	else
 		ts_bgw_job_stat_upsert_next_start(job_id, GetCurrentTransactionStartTimestamp());
 

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -233,3 +233,37 @@ SELECT * FROM timescaledb_information.jobs WHERE job_id = 1;
       1 | Telemetry Reporter [1] | @ 24 hours        | @ 1 min 40 secs |          -1 | @ 1 hour     | _timescaledb_internal | policy_telemetry | super_user | f         | {"test": "test"} |            |                   | 
 (1 row)
 
+--test for #2793
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- background workers are disabled, so the job will not run --
+SELECT add_job( proc=>'custom_func',
+     schedule_interval=>'1h', initial_start =>'2018-01-01 10:00:00-05');
+ add_job 
+---------
+    1005
+(1 row)
+
+SELECT job_id, next_start, scheduled, schedule_interval 
+FROM timescaledb_information.jobs WHERE job_id > 1000;
+ job_id |          next_start          | scheduled | schedule_interval 
+--------+------------------------------+-----------+-------------------
+   1005 | Mon Jan 01 07:00:00 2018 PST | t         | @ 1 hour
+(1 row)
+
+\x
+SELECT * FROM timescaledb_information.job_stats WHERE job_id > 1000;
+-[ RECORD 1 ]----------+-----------------------------
+hypertable_schema      | 
+hypertable_name        | 
+job_id                 | 1005
+last_run_started_at    | -infinity
+last_successful_finish | -infinity
+last_run_status        | 
+job_status             | Scheduled
+last_run_duration      | 
+next_start             | Mon Jan 01 07:00:00 2018 PST
+total_runs             | 0
+total_successes        | 0
+total_failures         | 0
+
+\x

--- a/tsl/test/sql/bgw_custom.sql
+++ b/tsl/test/sql/bgw_custom.sql
@@ -106,3 +106,15 @@ SELECT job_id FROM alter_job(1,scheduled:=true);
 SELECT * FROM timescaledb_information.jobs WHERE job_id = 1;
 SELECT job_id FROM alter_job(1,scheduled:=false);
 SELECT * FROM timescaledb_information.jobs WHERE job_id = 1;
+
+--test for #2793
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- background workers are disabled, so the job will not run --
+SELECT add_job( proc=>'custom_func',
+     schedule_interval=>'1h', initial_start =>'2018-01-01 10:00:00-05');
+
+SELECT job_id, next_start, scheduled, schedule_interval 
+FROM timescaledb_information.jobs WHERE job_id > 1000;
+\x
+SELECT * FROM timescaledb_information.job_stats WHERE job_id > 1000;
+\x


### PR DESCRIPTION
The mark_start field should be set to false when
a new job stat record is created.

Fixes #2793