### PR TITLE
Add distributed restore point functionality

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -194,6 +194,12 @@ CREATE OR REPLACE PROCEDURE distributed_exec(
        transactional BOOLEAN = TRUE)
 AS '@MODULE_PATHNAME@', 'ts_distributed_exec' LANGUAGE C;
 
+-- Execute pg_create_restore_point() on each data node
+CREATE OR REPLACE FUNCTION create_distributed_restore_point(
+    name                   TEXT
+) RETURNS TABLE(node_name NAME, node_type TEXT, restore_point pg_lsn)
+AS '@MODULE_PATHNAME@', 'ts_create_distributed_restore_point' LANGUAGE C VOLATILE STRICT;
+
 -- Sets new replication factor for distributed hypertable
 CREATE OR REPLACE FUNCTION  set_replication_factor(
     hypertable              REGCLASS,

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -93,6 +93,7 @@ CROSSMODULE_WRAPPER(dist_remote_chunk_info);
 CROSSMODULE_WRAPPER(dist_remote_compressed_chunk_info);
 CROSSMODULE_WRAPPER(dist_remote_hypertable_index_info);
 CROSSMODULE_WRAPPER(distributed_exec);
+CROSSMODULE_WRAPPER(create_distributed_restore_point);
 CROSSMODULE_WRAPPER(hypertable_distributed_set_replication_factor);
 
 TS_FUNCTION_INFO_V1(ts_dist_set_id);
@@ -363,6 +364,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.data_node_allow_new_chunks = error_no_default_fn_pg_community,
 	.data_node_block_new_chunks = error_no_default_fn_pg_community,
 	.distributed_exec = error_no_default_fn_pg_community,
+	.create_distributed_restore_point = error_no_default_fn_pg_community,
 	.chunk_set_default_data_node = error_no_default_fn_pg_community,
 	.show_chunk = error_no_default_fn_pg_community,
 	.create_chunk = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -153,6 +153,7 @@ typedef struct CrossModuleFunctions
 	void (*validate_as_data_node)(void);
 	void (*func_call_on_data_nodes)(FunctionCallInfo fcinfo, List *data_node_oids);
 	PGFunction distributed_exec;
+	PGFunction create_distributed_restore_point;
 	PGFunction chunk_get_relstats;
 	PGFunction chunk_get_colstats;
 	PGFunction hypertable_distributed_set_replication_factor;

--- a/src/debug_wait.h
+++ b/src/debug_wait.h
@@ -10,6 +10,7 @@
 #include <postgres.h>
 
 #include <storage/lock.h>
+#include "export.h"
 
 /* Tag for debug waitpoints.
  *
@@ -31,8 +32,8 @@ typedef struct DebugWait
 	LOCKTAG tag;
 } DebugWait;
 
-void ts_debug_waitpoint_init(DebugWait *waitpoint, const char *tagname);
-void ts_debug_waitpoint_wait(DebugWait *waitpoint);
+extern TSDLLEXPORT void ts_debug_waitpoint_init(DebugWait *waitpoint, const char *tagname);
+extern TSDLLEXPORT void ts_debug_waitpoint_wait(DebugWait *waitpoint);
 
 #ifdef TS_DEBUG
 #define DEBUG_WAITPOINT(TAG)                                                                       \

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -34,6 +34,7 @@ WHERE oid IN (
  chunks_detailed_size
  compress_chunk
  create_distributed_hypertable
+ create_distributed_restore_point
  create_hypertable
  decompress_chunk
  delete_data_node
@@ -74,5 +75,5 @@ WHERE oid IN (
  timescaledb_fdw_validator
  timescaledb_post_restore
  timescaledb_pre_restore
-(55 rows)
+(56 rows)
 

--- a/tsl/src/CMakeLists.txt
+++ b/tsl/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
   data_node_dispatch.c
   deparse.c
   dist_util.c
+  dist_backup.c
   hypertable.c
   init.c
   partialize_finalize.c

--- a/tsl/src/dist_backup.c
+++ b/tsl/src/dist_backup.c
@@ -1,0 +1,196 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include <funcapi.h>
+#include <utils/builtins.h>
+#include <utils/pg_lsn.h>
+#include <utils/guc.h>
+#include <access/xlog_internal.h>
+#include <access/xlog.h>
+#include <access/xact.h>
+#include <catalog/pg_foreign_server.h>
+#include <storage/lmgr.h>
+#include <miscadmin.h>
+
+#include "errors.h"
+#include "guc.h"
+#include "catalog.h"
+#include "debug_wait.h"
+#include "dist_util.h"
+#include "remote/dist_commands.h"
+#include "dist_backup.h"
+
+#define TS_ACCESS_NODE_TYPE "access_node"
+#define TS_DATA_NODE_TYPE "data_node"
+
+enum
+{
+	Anum_restore_point_node_name = 1,
+	Anum_restore_point_node_type,
+	Anum_restore_point_lsn,
+	_Anum_restore_point_max
+};
+
+static Datum
+create_restore_point_datum(TupleDesc tupdesc, const char *node_name, XLogRecPtr lsn)
+{
+	Datum values[_Anum_restore_point_max] = { 0 };
+	bool nulls[_Anum_restore_point_max] = { false };
+	HeapTuple tuple;
+
+	tupdesc = BlessTupleDesc(tupdesc);
+	if (node_name == NULL)
+	{
+		nulls[AttrNumberGetAttrOffset(Anum_restore_point_node_name)] = true;
+		values[AttrNumberGetAttrOffset(Anum_restore_point_node_type)] =
+			CStringGetTextDatum(TS_ACCESS_NODE_TYPE);
+	}
+	else
+	{
+		values[AttrNumberGetAttrOffset(Anum_restore_point_node_name)] = CStringGetDatum(node_name);
+		values[AttrNumberGetAttrOffset(Anum_restore_point_node_type)] =
+			CStringGetTextDatum(TS_DATA_NODE_TYPE);
+	}
+	values[AttrNumberGetAttrOffset(Anum_restore_point_lsn)] = LSNGetDatum(lsn);
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	return HeapTupleGetDatum(tuple);
+}
+
+Datum
+create_distributed_restore_point(PG_FUNCTION_ARGS)
+{
+	const char *name = TextDatumGetCString(PG_GETARG_DATUM(0));
+	DistCmdResult *result_cmd;
+	FuncCallContext *funcctx;
+	XLogRecPtr lsn;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		int name_len = strlen(name);
+		MemoryContext oldctx;
+		TupleDesc tupdesc;
+		char *sql;
+
+		if (name_len >= MAXFNAMELEN)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("restore point name is too long"),
+					 errdetail("Maximum length is %d, while provided name has %d chars.",
+							   MAXFNAMELEN - 1,
+							   name_len)));
+
+		if (RecoveryInProgress())
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 (errmsg("recovery is in progress"),
+					  errdetail("WAL control functions cannot be executed during recovery."))));
+
+		if (!XLogIsNeeded())
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("WAL level '%s' is not sufficient for creating a restore point",
+							GetConfigOptionByName("wal_level", NULL, false)),
+					 errhint("Set wal_level to \"replica\" or \"logical\" at server start.")));
+
+		if (!superuser())
+			ereport(ERROR,
+					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+					 errmsg("must be superuser to create restore point")));
+
+		if (!ts_guc_enable_2pc)
+			ereport(ERROR,
+					(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
+					 errmsg("two-phase commit transactions are not enabled"),
+					 errhint("Set timescaledb.enable_2pc to TRUE.")));
+
+		if (dist_util_membership() != DIST_MEMBER_ACCESS_NODE)
+			ereport(ERROR,
+					(errcode(ERRCODE_TS_OPERATION_NOT_SUPPORTED),
+					 errmsg("distributed restore point must be created on the access node"),
+					 errhint("Connect to the access node and create the distributed restore point "
+							 "from there.")));
+
+		/*
+		 * In order to achieve synchronization across the multinode cluster,
+		 * we must ensure that the restore point created on the access node is
+		 * synchronized with each data node.
+		 *
+		 * We must ensure that no concurrent prepared transactions are
+		 * committed (COMMIT PREPARED) while we create the restore point.
+		 * Otherwise, the distributed restore point might include prepared transactions
+		 * that have committed on some data nodes but not others, leading to an
+		 * inconsistent state when the distributed database is restored from a backup
+		 * using the restore point.
+		 *
+		 * To do that we take an exclusive lock on the remote transaction
+		 * table, which will force any concurrent transaction
+		 * wait during their PREPARE phase.
+		 */
+		LockRelationOid(ts_catalog_get()->tables[REMOTE_TXN].id, ExclusiveLock);
+
+		/* Prevent situation when new data node added during the execution */
+		LockRelationOid(ForeignServerRelationId, ExclusiveLock);
+
+		DEBUG_WAITPOINT("create_distributed_restore_point_lock");
+
+		funcctx = SRF_FIRSTCALL_INIT();
+		oldctx = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("function returning record called in context "
+							"that cannot accept type record")));
+
+		/* Create local restore point and on each data node */
+		lsn = XLogRestorePoint(name);
+
+		sql = psprintf("SELECT pg_create_restore_point AS lsn "
+					   "FROM "
+					   "pg_catalog.pg_create_restore_point(%s)",
+					   quote_literal_cstr(name));
+
+		result_cmd = ts_dist_cmd_invoke_on_all_data_nodes(sql);
+
+		funcctx->attinmeta = TupleDescGetAttInMetadata(tupdesc);
+		funcctx->user_fctx = result_cmd;
+
+		MemoryContextSwitchTo(oldctx);
+
+		/* Return access node restore point first */
+		SRF_RETURN_NEXT(funcctx, create_restore_point_datum(tupdesc, NULL, lsn));
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+	result_cmd = funcctx->user_fctx;
+
+	/* Return data node restore point data */
+	if (result_cmd)
+	{
+		int result_index = funcctx->call_cntr - 1;
+
+		if (result_index < ts_dist_cmd_response_count(result_cmd))
+		{
+			const char *node_name;
+			PGresult *result =
+				ts_dist_cmd_get_result_by_index(result_cmd, result_index, &node_name);
+			AttInMetadata *attinmeta = funcctx->attinmeta;
+			const int lsn_attr_pos = AttrNumberGetAttrOffset(Anum_restore_point_lsn);
+
+			lsn = DatumGetLSN(InputFunctionCall(&attinmeta->attinfuncs[lsn_attr_pos],
+												PQgetvalue(result, 0, 0),
+												attinmeta->attioparams[lsn_attr_pos],
+												attinmeta->atttypmods[lsn_attr_pos]));
+
+			SRF_RETURN_NEXT(funcctx,
+							create_restore_point_datum(attinmeta->tupdesc, node_name, lsn));
+		}
+
+		ts_dist_cmd_close_response(result_cmd);
+	}
+
+	SRF_RETURN_DONE(funcctx);
+}

--- a/tsl/src/dist_backup.h
+++ b/tsl/src/dist_backup.h
@@ -1,0 +1,13 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_TSL_DIST_BACKUP_H
+#define TIMESCALEDB_TSL_DIST_BACKUP_H
+
+#include <postgres.h>
+
+extern Datum create_distributed_restore_point(PG_FUNCTION_ARGS);
+
+#endif /* TIMESCALEDB_TSL_DIST_BACKUP_H */

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -50,6 +50,7 @@
 #include "remote/txn_resolve.h"
 #include "reorder.h"
 #include "telemetry.h"
+#include "dist_backup.h"
 
 #ifdef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -179,6 +180,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.dist_remote_hypertable_index_info = dist_util_remote_hypertable_index_info,
 	.validate_as_data_node = validate_data_node_settings,
 	.distributed_exec = ts_dist_cmd_exec,
+	.create_distributed_restore_point = create_distributed_restore_point,
 	.func_call_on_data_nodes = ts_dist_cmd_func_call_on_data_nodes,
 	.chunk_get_relstats = chunk_api_get_chunk_relstats,
 	.chunk_get_colstats = chunk_api_get_chunk_colstats,

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -754,7 +754,9 @@ remote_txn_persistent_record_write(TSConnectionId cid)
 
 	rel = table_open(catalog->tables[REMOTE_TXN].id, RowExclusiveLock);
 	persistent_record_insert_relation(rel, id);
-	table_close(rel, RowExclusiveLock);
 
+	/* Keep the table lock until transaction completes in order to
+	 * synchronize with distributed restore point creation */
+	table_close(rel, NoLock);
 	return id;
 }

--- a/tsl/test/expected/dist_backup.out
+++ b/tsl/test/expected/dist_backup.out
@@ -1,0 +1,139 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Need to be super user to create extension and add data nodes
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+\unset ECHO
+psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
+psql:include/filter_exec.sql:5: NOTICE:  schema "test" already exists, skipping
+\set MY_DB1 :TEST_DBNAME _1
+\set MY_DB2 :TEST_DBNAME _2
+\set MY_DB3 :TEST_DBNAME _3
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => :'MY_DB1');
+  node_name  |   host    | port  |     database     | node_created | database_created | extension_created 
+-------------+-----------+-------+------------------+--------------+------------------+-------------------
+ data_node_1 | localhost | 55432 | db_dist_backup_1 | t            | t                | t
+(1 row)
+
+SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => :'MY_DB2');
+  node_name  |   host    | port  |     database     | node_created | database_created | extension_created 
+-------------+-----------+-------+------------------+--------------+------------------+-------------------
+ data_node_2 | localhost | 55432 | db_dist_backup_2 | t            | t                | t
+(1 row)
+
+SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => :'MY_DB3');
+  node_name  |   host    | port  |     database     | node_created | database_created | extension_created 
+-------------+-----------+-------+------------------+--------------+------------------+-------------------
+ data_node_3 | localhost | 55432 | db_dist_backup_3 | t            | t                | t
+(1 row)
+
+GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
+-- Import testsupport.sql file to data nodes
+\unset ECHO
+-- test NULL (STRICT function)
+SELECT create_distributed_restore_point(NULL);
+ create_distributed_restore_point 
+----------------------------------
+(0 rows)
+
+-- test long restore point name (>= 64 chars)
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('0123456789012345678901234567890123456789012345678901234567890123456789');
+ERROR:  restore point name is too long
+\set ON_ERROR_STOP 1
+-- test super user check
+\set ON_ERROR_STOP 0
+SET ROLE :ROLE_1;
+SELECT create_distributed_restore_point('test');
+ERROR:  must be superuser to create restore point
+RESET ROLE;
+\set ON_ERROR_STOP 1
+-- make sure 2pc are enabled
+SET timescaledb.enable_2pc = false;
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('test');
+ERROR:  two-phase commit transactions are not enabled
+\set ON_ERROR_STOP 1
+SET timescaledb.enable_2pc = true;
+SHOW timescaledb.enable_2pc;
+ timescaledb.enable_2pc 
+------------------------
+ on
+(1 row)
+
+-- make sure wal_level is replica or logical
+SHOW wal_level;
+ wal_level 
+-----------
+ replica
+(1 row)
+
+-- make sure not in recovery mode
+SELECT pg_is_in_recovery();
+ pg_is_in_recovery 
+-------------------
+ f
+(1 row)
+
+-- test on single node (not part of a cluster)
+CREATE DATABASE dist_rp_test;
+\c dist_rp_test :ROLE_CLUSTER_SUPERUSER
+SET client_min_messages TO ERROR;
+CREATE EXTENSION timescaledb;
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('test');
+ERROR:  distributed restore point must be created on the access node
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+DROP DATABASE dist_rp_test;
+-- test on data node
+\c :MY_DB1 :ROLE_CLUSTER_SUPERUSER;
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('test');
+ERROR:  distributed restore point must be created on the access node
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+-- test with distributed_exec()
+\set ON_ERROR_STOP 0
+SELECT test.execute_sql_and_filter_data_node_name_on_error($$
+CALL distributed_exec('SELECT create_distributed_restore_point(''test'')')
+$$);
+ERROR:  [data_node_x]: distributed restore point must be created on the access node
+\set ON_ERROR_STOP 1
+-- test on access node
+SELECT node_name, node_type, pg_lsn(restore_point) > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('dist_rp') ORDER BY node_name;
+  node_name  |  node_type  | valid_lsn 
+-------------+-------------+-----------
+ data_node_1 | data_node   | t
+ data_node_2 | data_node   | t
+ data_node_3 | data_node   | t
+             | access_node | t
+(4 rows)
+
+-- restore point can be have duplicates
+SELECT node_name, node_type, pg_lsn(restore_point) > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('dist_rp') ORDER BY node_name;
+  node_name  |  node_type  | valid_lsn 
+-------------+-------------+-----------
+ data_node_1 | data_node   | t
+ data_node_2 | data_node   | t
+ data_node_3 | data_node   | t
+             | access_node | t
+(4 rows)
+
+-- make sure each new restore point have lsn greater then previous one (access node lsn)
+SELECT restore_point as lsn_1 FROM create_distributed_restore_point('dist_rp_1') WHERE node_type = 'access_node' \gset
+SELECT restore_point as lsn_2 FROM create_distributed_restore_point('dist_rp_2') WHERE node_type = 'access_node' \gset
+SELECT pg_lsn(:'lsn_2') > pg_lsn(:'lsn_1') as valid_lsn;
+ valid_lsn 
+-----------
+ t
+(1 row)
+
+-- make sure it is compatible with local restore point
+SELECT pg_create_restore_point('dist_rp') as lsn_3 \gset
+SELECT pg_lsn(:'lsn_3') > pg_lsn(:'lsn_2') as valid_lsn;
+ valid_lsn 
+-----------
+ t
+(1 row)
+

--- a/tsl/test/isolation/expected/dist_restore_point.out
+++ b/tsl/test/isolation/expected/dist_restore_point.out
@@ -1,0 +1,351 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s3_lock_enable s1_create_dist_rp s2_insert s3_lock_count s3_lock_release
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         t              t              t              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         t              t              t              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         t              t              t              
+created        
+
+t              
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+step s2_insert: INSERT INTO disttable VALUES ('2019-08-02 10:45', 0, 0.0); <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+step s2_insert: <... completed>
+
+starting permutation: s2_begin s2_insert s3_lock_enable s1_create_dist_rp s3_lock_count s2_commit s3_lock_count s3_lock_release
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         f              f              f              
+created        
+
+t              
+step s2_begin: BEGIN;
+step s2_insert: INSERT INTO disttable VALUES ('2019-08-02 10:45', 0, 0.0);
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              1              
+step s2_commit: COMMIT; <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+step s2_commit: <... completed>
+
+starting permutation: s3_lock_enable s1_create_dist_rp s2_create_dist_rp s3_lock_count s3_lock_release
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         f              f              f              
+created        
+
+t              
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+step s2_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s2_test'); <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+step s2_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+
+starting permutation: s3_lock_enable s1_create_dist_rp s2_dist_exec s3_lock_count s3_lock_release
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         f              f              f              
+created        
+
+t              
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+step s2_dist_exec: CALL distributed_exec('SELECT true;', transactional => true); <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+step s2_dist_exec: <... completed>
+
+starting permutation: s3_lock_enable s1_create_dist_rp s2_create_dist_ht s3_lock_count s3_lock_release
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         f              f              f              
+created        
+
+t              
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+step s2_create_dist_ht: 
+	CREATE TABLE disttable2(time timestamptz NOT NULL, device int, temp float);
+	SELECT created FROM create_distributed_hypertable('disttable2', 'time', 'device');
+ <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+step s2_create_dist_ht: <... completed>
+created        
+
+t              
+
+starting permutation: s3_lock_enable s1_create_dist_rp s2_drop_dist_ht s3_lock_count s3_lock_release
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         f              f              f              
+created        
+
+t              
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+step s2_drop_dist_ht: DROP TABLE disttable2; <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+step s2_drop_dist_ht: <... completed>
+
+starting permutation: s3_lock_enable s1_create_dist_rp s2_add_dn s3_lock_count s3_lock_count_fs s3_lock_release s3_lock_count_fs
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         f              f              f              
+created        
+
+t              
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+step s2_add_dn: SELECT * FROM add_data_node('data_node_4', host => 'localhost', database => 'cdrp_4'); <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              1              
+step s3_lock_count_fs: SELECT foreign_server_locks() as foreign_server_locks;
+foreign_server_locks
+
+2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+step s2_add_dn: <... completed>
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_4    localhost      55432          cdrp_4         t              t              t              
+step s3_lock_count_fs: SELECT foreign_server_locks() as foreign_server_locks;
+foreign_server_locks
+
+0              
+
+starting permutation: s3_lock_enable s1_create_dist_rp s2_del_dn s3_lock_count s3_lock_release
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_1    localhost      55432          cdrp_1         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_2    localhost      55432          cdrp_2         f              f              f              
+node_name      host           port           database       node_created   database_createdextension_created
+
+data_node_3    localhost      55432          cdrp_3         f              f              f              
+created        
+
+t              
+step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
+debug_waitpoint_enable
+
+               
+step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
+s2: NOTICE:  the number of partitions in dimension "device" was decreased to 3
+DETAIL:  To make efficient use of all attached data nodes, the number of space partitions was set to match the number of data nodes.
+step s2_del_dn: SELECT * FROM delete_data_node('data_node_4'); <waiting ...>
+step s3_lock_count: 
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+
+cdrp_locks     remote_txn_locks
+
+2              2              
+step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
+debug_waitpoint_release
+
+               
+step s1_create_dist_rp: <... completed>
+valid_lsn      
+
+t              
+t              
+t              
+t              
+t              
+step s2_del_dn: <... completed>
+delete_data_node
+
+t              

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_TEMPLATES_MODULE_DEBUG
   reorder_vs_insert.spec.in
   reorder_vs_select.spec.in
   remote_create_chunk.spec.in
+  dist_restore_point.spec.in
 )
 
 list(APPEND TEST_FILES

--- a/tsl/test/isolation/specs/dist_restore_point.spec.in
+++ b/tsl/test/isolation/specs/dist_restore_point.spec.in
@@ -1,0 +1,111 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# Test create_distributed_restore_point() concurrency cases
+#
+setup
+{
+	CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_enable';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_release';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_id(TEXT) RETURNS BIGINT LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_id';
+
+	CREATE OR REPLACE FUNCTION waitpoint_locks(tag TEXT) RETURNS bigint AS
+	$$
+		SELECT count(*) FROM pg_locks WHERE objid = debug_waitpoint_id(tag);
+	$$ LANGUAGE SQL;
+
+	CREATE OR REPLACE FUNCTION remote_txn_locks() RETURNS bigint AS
+	$$
+		SELECT count(*) FROM pg_locks WHERE relation = '_timescaledb_catalog.remote_txn'::regclass;
+	$$ LANGUAGE SQL;
+
+	CREATE OR REPLACE FUNCTION foreign_server_locks() RETURNS bigint AS
+	$$
+		SELECT count(*) FROM pg_locks WHERE relation = 'pg_catalog.pg_foreign_server'::regclass;
+	$$ LANGUAGE SQL;
+
+	CREATE TABLE IF NOT EXISTS disttable(time timestamptz NOT NULL, device int, temp float);
+}
+setup { SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => 'cdrp_1', if_not_exists => true); }
+setup { SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => 'cdrp_2', if_not_exists => true); }
+setup { SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => 'cdrp_3', if_not_exists => true); }
+setup { SELECT created FROM create_distributed_hypertable('disttable', 'time', 'device'); }
+
+teardown
+{
+   DROP TABLE disttable;
+}
+
+# create distributed restore point
+session "s1"
+setup
+{
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET application_name = 's1';
+}
+step "s1_create_dist_rp" { SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); }
+
+# concurrent remote transaction
+session "s2"
+setup
+{
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET application_name = 's2';
+}
+step "s2_create_dist_rp" { SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s2_test'); }
+step "s2_insert"         { INSERT INTO disttable VALUES ('2019-08-02 10:45', 0, 0.0); }
+step "s2_begin"          { BEGIN; }
+step "s2_commit"         { COMMIT; }
+step "s2_add_dn"         { SELECT * FROM add_data_node('data_node_4', host => 'localhost', database => 'cdrp_4'); }
+step "s2_del_dn"         { SELECT * FROM delete_data_node('data_node_4'); }
+step "s2_create_dist_ht" {
+	CREATE TABLE disttable2(time timestamptz NOT NULL, device int, temp float);
+	SELECT created FROM create_distributed_hypertable('disttable2', 'time', 'device');
+}
+step "s2_drop_dist_ht"   { DROP TABLE disttable2; }
+step "s2_dist_exec"      { CALL distributed_exec('SELECT true;', transactional => true); }
+
+# locking session
+session "s3"
+setup
+{
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET application_name = 's3';
+}
+step "s3_lock_enable"   { SELECT debug_waitpoint_enable('create_distributed_restore_point_lock'); }
+step "s3_lock_release"  { SELECT debug_waitpoint_release('create_distributed_restore_point_lock'); }
+step "s3_lock_count"    {
+	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
+	       remote_txn_locks() as remote_txn_locks;
+}
+step "s3_lock_count_fs" { SELECT foreign_server_locks() as foreign_server_locks; }
+
+# case 1: new transaction DML/commit during the create_distributed_restore_point()
+permutation "s3_lock_enable" "s1_create_dist_rp" "s2_insert" "s3_lock_count" "s3_lock_release"
+
+# case 2: ongoing transaction DML/commit during the create_distributed_restore_point()
+permutation "s2_begin" "s2_insert" "s3_lock_enable" "s1_create_dist_rp" "s3_lock_count" "s2_commit" "s3_lock_count" "s3_lock_release"
+
+# case 3: concurrent create_distributed_restore_point() call
+permutation "s3_lock_enable" "s1_create_dist_rp" "s2_create_dist_rp" "s3_lock_count" "s3_lock_release"
+
+# case 4: concurrent distributed_exec() call during the the create_distributed_restore_point()
+permutation "s3_lock_enable" "s1_create_dist_rp" "s2_dist_exec" "s3_lock_count" "s3_lock_release"
+
+# case 5: concurrent create_distributed_hypertable() during the the create_distributed_restore_point()
+permutation "s3_lock_enable" "s1_create_dist_rp" "s2_create_dist_ht" "s3_lock_count" "s3_lock_release"
+
+# case 6: concurrent DDL/commit during the create_distributed_restore_point()
+permutation "s3_lock_enable" "s1_create_dist_rp" "s2_drop_dist_ht" "s3_lock_count" "s3_lock_release"
+
+# case 7: concurrent add_data_node() during the create_distributed_restore_point()
+permutation "s3_lock_enable" "s1_create_dist_rp" "s2_add_dn" "s3_lock_count" "s3_lock_count_fs" "s3_lock_release" "s3_lock_count_fs"
+
+# case 8: concurrent delete_data_node() during the create_distributed_restore_point()
+permutation "s3_lock_enable" "s1_create_dist_rp" "s2_del_dn" "s3_lock_count" "s3_lock_release"

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TEST_FILES_DEBUG
   dist_partial_agg.sql
   dist_policy.sql
   dist_util.sql
+  dist_backup.sql
   read_only.sql
   remote_connection_cache.sql
   remote_connection.sql
@@ -128,6 +129,7 @@ set(SOLO_TESTS
   dist_hypertable_am
   dist_hypertable_with_oids
   dist_partial_agg
+  dist_backup
   move-11
   move-12
   move-13

--- a/tsl/test/sql/dist_backup.sql
+++ b/tsl/test/sql/dist_backup.sql
@@ -1,0 +1,109 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Need to be super user to create extension and add data nodes
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+
+\unset ECHO
+\o /dev/null
+\ir include/remote_exec.sql
+\ir include/filter_exec.sql
+\o
+\set ECHO all
+
+\set MY_DB1 :TEST_DBNAME _1
+\set MY_DB2 :TEST_DBNAME _2
+\set MY_DB3 :TEST_DBNAME _3
+
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => :'MY_DB1');
+SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => :'MY_DB2');
+SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => :'MY_DB3');
+GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
+
+-- Import testsupport.sql file to data nodes
+\unset ECHO
+\o /dev/null
+\c :MY_DB1
+SET client_min_messages TO ERROR;
+\ir :TEST_SUPPORT_FILE
+\c :MY_DB2
+SET client_min_messages TO ERROR;
+\ir :TEST_SUPPORT_FILE
+\c :MY_DB3
+SET client_min_messages TO ERROR;
+\ir :TEST_SUPPORT_FILE
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+\o
+SET client_min_messages TO NOTICE;
+\set ECHO all
+
+-- test NULL (STRICT function)
+SELECT create_distributed_restore_point(NULL);
+
+-- test long restore point name (>= 64 chars)
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('0123456789012345678901234567890123456789012345678901234567890123456789');
+\set ON_ERROR_STOP 1
+
+-- test super user check
+\set ON_ERROR_STOP 0
+SET ROLE :ROLE_1;
+SELECT create_distributed_restore_point('test');
+RESET ROLE;
+\set ON_ERROR_STOP 1
+
+-- make sure 2pc are enabled
+SET timescaledb.enable_2pc = false;
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('test');
+\set ON_ERROR_STOP 1
+
+SET timescaledb.enable_2pc = true;
+SHOW timescaledb.enable_2pc;
+
+-- make sure wal_level is replica or logical
+SHOW wal_level;
+
+-- make sure not in recovery mode
+SELECT pg_is_in_recovery();
+
+-- test on single node (not part of a cluster)
+CREATE DATABASE dist_rp_test;
+\c dist_rp_test :ROLE_CLUSTER_SUPERUSER
+SET client_min_messages TO ERROR;
+CREATE EXTENSION timescaledb;
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('test');
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+DROP DATABASE dist_rp_test;
+
+-- test on data node
+\c :MY_DB1 :ROLE_CLUSTER_SUPERUSER;
+\set ON_ERROR_STOP 0
+SELECT create_distributed_restore_point('test');
+\set ON_ERROR_STOP 1
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+
+-- test with distributed_exec()
+\set ON_ERROR_STOP 0
+SELECT test.execute_sql_and_filter_data_node_name_on_error($$
+CALL distributed_exec('SELECT create_distributed_restore_point(''test'')')
+$$);
+\set ON_ERROR_STOP 1
+
+-- test on access node
+SELECT node_name, node_type, pg_lsn(restore_point) > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('dist_rp') ORDER BY node_name;
+
+-- restore point can be have duplicates
+SELECT node_name, node_type, pg_lsn(restore_point) > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('dist_rp') ORDER BY node_name;
+
+-- make sure each new restore point have lsn greater then previous one (access node lsn)
+SELECT restore_point as lsn_1 FROM create_distributed_restore_point('dist_rp_1') WHERE node_type = 'access_node' \gset
+SELECT restore_point as lsn_2 FROM create_distributed_restore_point('dist_rp_2') WHERE node_type = 'access_node' \gset
+SELECT pg_lsn(:'lsn_2') > pg_lsn(:'lsn_1') as valid_lsn;
+
+-- make sure it is compatible with local restore point
+SELECT pg_create_restore_point('dist_rp') as lsn_3 \gset
+SELECT pg_lsn(:'lsn_3') > pg_lsn(:'lsn_2') as valid_lsn;


### PR DESCRIPTION
This change adds `create_distributed_restore_point()` function
which allows to create recovery restore point across
nodes.

Issue: https://github.com/timescale/timescaledb/issues/2846