### PR TITLE
Fix continuous aggregate privileges during upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #2842 Do not mark job as started when seting next_start field
+* #2845 Fix continuous aggregate privileges during upgrade
 
 **Minor features**
 * #2736 Support adding columns to hypertables with compression enabled

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,38 @@
+-- For continuous aggregates: Copy ACL privileges (grants) from the
+-- query view (user-facing object) to the internal objects (e.g.,
+-- materialized hypertable, direct, and partial views). We want to
+-- maintain the abstraction that a continuous aggregates is similar to
+-- a materialized view (which is one object), so privileges on the
+-- user-facing object should apply also to the internal objects that
+-- implement the continuous aggregate. Having the right permissions on
+-- internal objects is necessary for the watermark function used by
+-- real-time aggregation since it queries the materialized hypertable
+-- directly.
+
+WITH rels_and_acl AS (
+    -- For each cagg, collect an array of all relations (including
+    -- chunks) to copy the ACL to
+    SELECT array_cat(ARRAY[format('%I.%I', h.schema_name, h.table_name)::regclass,
+	                       format('%I.%I', direct_view_schema, direct_view_name)::regclass,
+                           format('%I.%I', partial_view_schema, partial_view_name)::regclass],
+                     (SELECT array_agg(inhrelid::regclass)
+                      FROM pg_inherits
+                      WHERE inhparent = format('%I.%I', h.schema_name, h.table_name)::regclass)) AS relarr,
+           relacl AS user_view_acl
+    FROM _timescaledb_catalog.continuous_agg ca
+    LEFT JOIN pg_class cl
+    ON (cl.oid = format('%I.%I', user_view_schema, user_view_name)::regclass)
+    LEFT JOIN _timescaledb_catalog.hypertable h
+    ON (ca.mat_hypertable_id = h.id)
+    WHERE relacl IS NOT NULL
+)
+-- Set the ACL on all internal cagg relations, including
+-- chunks. Note that we cannot use GRANT statements because
+-- such statements are recorded as privileges on extension
+-- objects when run in an update script. The result is that
+-- the privileges will become init privileges, which will then
+-- be ignored by, e.g., pg_dump.
+UPDATE pg_class
+SET relacl = user_view_acl
+FROM rels_and_acl
+WHERE oid = ANY (relarr);

--- a/test/sql/updates/post.continuous_aggs.sql
+++ b/test/sql/updates/post.continuous_aggs.sql
@@ -17,3 +17,72 @@ CALL refresh_continuous_aggregate('mat_before',NULL,NULL);
 
 --the max of the temp for the POR should now be 165
 SELECT * FROM mat_before ORDER BY bucket, location;
+
+SET ROLE cagg_user;
+--should be able to query as cagg_user
+SELECT * FROM mat_before ORDER BY bucket, location;
+RESET ROLE;
+
+-- Output the ACLs for each internal cagg object
+SELECT cl.oid::regclass::text AS reloid,
+       relacl
+FROM _timescaledb_catalog.continuous_agg ca
+JOIN _timescaledb_catalog.hypertable h
+ON (ca.mat_hypertable_id = h.id)
+JOIN pg_class cl
+ON (cl.oid IN (format('%I.%I', h.schema_name, h.table_name)::regclass,
+               format('%I.%I', direct_view_schema, direct_view_name)::regclass,
+               format('%I.%I', partial_view_schema, partial_view_name)::regclass))
+ORDER BY reloid;
+
+-- Output ACLs for chunks on materialized hypertables
+SELECT inhparent::regclass::text AS parent,
+       cl.oid::regclass::text AS chunk,
+       relacl
+FROM _timescaledb_catalog.continuous_agg ca
+JOIN _timescaledb_catalog.hypertable h
+ON (ca.mat_hypertable_id = h.id)
+JOIN pg_inherits inh ON (inh.inhparent = format('%I.%I', h.schema_name, h.table_name)::regclass)
+JOIN pg_class cl
+ON (cl.oid = inh.inhrelid)
+ORDER BY parent, chunk;
+
+-- Verify privileges on internal cagg objects.  The privileges on the
+-- materialized hypertable, partial view, and direct view should match
+-- the user-facing user view.
+DO $$
+DECLARE
+    user_view_rel regclass;
+    user_view_acl aclitem[];
+    rel regclass;
+    acl aclitem[];
+    acl_matches boolean;
+BEGIN
+    FOR user_view_rel, user_view_acl IN
+        SELECT cl.oid, cl.relacl
+        FROM pg_class cl
+        JOIN _timescaledb_catalog.continuous_agg ca
+        ON (format('%I.%I', ca.user_view_schema, ca.user_view_name)::regclass = cl.oid)
+    LOOP
+        FOR rel, acl, acl_matches IN
+            SELECT cl.oid,
+                   cl.relacl,
+                   COALESCE(cl.relacl, ARRAY[]::aclitem[]) @> COALESCE(user_view_acl, ARRAY[]::aclitem[])
+            FROM _timescaledb_catalog.continuous_agg ca
+            JOIN _timescaledb_catalog.hypertable h
+            ON (ca.mat_hypertable_id = h.id)
+            JOIN pg_class cl
+            ON (cl.oid IN (format('%I.%I', h.schema_name, h.table_name)::regclass,
+                           format('%I.%I', direct_view_schema, direct_view_name)::regclass,
+                           format('%I.%I', partial_view_schema, partial_view_name)::regclass))
+            WHERE format('%I.%I', ca.user_view_schema, ca.user_view_name)::regclass = user_view_rel
+        LOOP
+            IF NOT acl_matches THEN
+               RAISE EXCEPTION 'privileges mismatch for continuous aggregate "%"', user_view_rel
+                     USING DETAIL = format('Privileges for internal object "%s" are [%s], expected [%s].',
+                            rel, acl, user_view_acl);
+            END IF;
+        END LOOP;
+    END LOOP;
+END
+$$ LANGUAGE PLPGSQL;

--- a/test/sql/updates/setup.continuous_aggs.sql
+++ b/test/sql/updates/setup.continuous_aggs.sql
@@ -130,6 +130,8 @@ BEGIN
   END IF;
 END $$;
 
+GRANT SELECT ON mat_before TO cagg_user WITH GRANT OPTION;
+
 -- have to use psql conditional here because the procedure call can't be in transaction
 SELECT extversion < '2.0.0' AS has_refresh_mat_view from pg_extension WHERE extname = 'timescaledb' \gset
 \if :has_refresh_mat_view

--- a/test/sql/updates/setup.roles.sql
+++ b/test/sql/updates/setup.roles.sql
@@ -1,0 +1,5 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE ROLE cagg_user;


### PR DESCRIPTION
Copy ACL privileges (grants) from the query view (user-facing object)
to the internal objects (e.g., materialized hypertable, direct view,
and partial view) when updating the extension to the new version. A
previous change added such propagation of privileges when executing
`GRANT` statements, but didn't apply it retrospectively to the
internal objects of existing continuous aggregates.

Having the right permissions on internal objects is also necessary for
the watermark function used by real-time aggregation since it queries
the materialized hypertable directly.

The update script copies the ACL information from the user-facing view
of every continuous aggregate to its internal objects (including the
materialized hypertable and its chunks). This is done by direct insert
into `pg_class` instead of executing a `GRANT` statement in the update
script, since the latter will record the grant/ACL as an init
privilege (i.e., the system believes the GRANT is for an extension
object). The init privilege will prevent this ACL from being included
in future dump files, since `pg_dump` only includes non-init
privileges as it believes such privileges will be recreated with the
extension.

Fixes #2825