### PR TITLE
Improve CI coredump detection

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -129,7 +129,11 @@ jobs:
       run: |
         find . -name regression.diffs -exec cat {} + > regression.log
         find . -name postmaster.log -exec cat {} + > postgres.log
-        if [[ "${{ runner.os }}" == "Linux" ]] && coredumpctl -q list >/dev/null; then echo "::set-output name=coredumps::true"; fi
+        if [[ "${{ runner.os }}" == "Linux" ]] ; then
+          # wait in case there are in-progress coredumps
+          sleep 10
+          if coredumpctl -q list >/dev/null; then echo "::set-output name=coredumps::true"; fi
+        fi
         if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
         cat regression.log
@@ -151,7 +155,6 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        sleep 10 # wait for in progress coredumps to finish
         echo "bt full" | sudo coredumpctl gdb
         ./scripts/bundle_coredumps.sh
         false


### PR DESCRIPTION
Occasionally tests would segfault but the coredump would not be
uploaded as artefact because the coredump was still in progress.
This patch changes CI to wait for potential in progress coredumps
to upload coredumps more reliably.