### PR TITLE
Apply volatile function quals at decompresschunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #2842 Do not mark job as started when seting next_start field
 * #2845 Fix continuous aggregate privileges during upgrade
+* #2865 Apply volatile function quals at decompresschunk node
 
 **Minor features**
 * #2736 Support adding columns to hypertables with compression enabled

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -63,7 +63,10 @@ pushdown_quals(PlannerInfo *root, RelOptInfo *chunk_rel, RelOptInfo *compressed_
 
 		/* pushdown is not safe for volatile expressions */
 		if (contain_volatile_functions((Node *) ri->clause))
+		{
+			decompress_clauses = lappend(decompress_clauses, ri);
 			continue;
+		}
 
 		context.can_pushdown = true;
 		context.needs_recheck = false;

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -163,3 +163,42 @@ GROUP BY 2, 3;
 (27 rows)
 
 RESET enable_hashagg;
+-- test if volatile function quals are applied to compressed chunks
+CREATE FUNCTION check_equal_228( intval INTEGER) RETURNS BOOL 
+LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+    retval BOOL;
+BEGIN
+   IF intval = 228 THEN RETURN TRUE;
+   ELSE RETURN FALSE;
+   END IF;
+END;
+$BODY$;
+-- the function cannot be pushed down to compressed chunk
+-- but should be applied as a filter on decompresschunk
+SELECT * from test_chartab 
+WHERE check_equal_228(rtt) ORDER BY ts;
+ job_run_id |      mac_id      | rtt |              ts              
+------------+------------------+-----+------------------------------
+       8864 | 001407000001DD2E | 228 | Sat Dec 14 02:52:05.863 2019
+       8890 | 001407000001DD2E | 228 | Fri Dec 20 02:52:05.863 2019
+(2 rows)
+
+EXPLAIN (analyze,costs off,timing off,summary off) 
+SELECT * from test_chartab 
+WHERE check_equal_228(rtt) and ts < '2019-12-15 00:00:00' order by ts;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: test_chartab.ts
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on test_chartab (actual rows=1 loops=1)
+         Chunks excluded during startup: 0
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               Filter: ((ts < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone) AND check_equal_228(rtt))
+               Rows Removed by Filter: 2
+               ->  Seq Scan on compress_hyper_2_3_chunk (actual rows=3 loops=1)
+                     Filter: (_ts_meta_min_1 < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone)
+(10 rows)
+


### PR DESCRIPTION
Volatile functions that are in chunk's baserestrictinfo
list were not correctly handled when we inserted a
DecompressChunk node. This PR adds these quals as a filter
to the DecompressChunk node.

Fixes #2864