### PR TITLE
Avoid partitionwise planning of partialize_agg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ accidentally triggering the load of a previous DB version.**
 ## Latest
 
 **Bugfixes**
-* #2842 Do not mark job as started when seting next_start field
+* #2842 Do not mark job as started when setting next_start field
 * #2845 Fix continuous aggregate privileges during upgrade
 * #2851 Fix nested loop joins that involve compressed chunks
 * #2865 Apply volatile function quals at decompresschunk node
+* #2866 Avoid partitionwise planning of partialize_agg
 * #2868 Fix corruption in gapfill plan
 
 **Minor features**

--- a/src/plan_partialize.h
+++ b/src/plan_partialize.h
@@ -8,7 +8,13 @@
 #include <postgres.h>
 #include <optimizer/planner.h>
 
-bool ts_plan_process_partialize_agg(PlannerInfo *root, RelOptInfo *input_rel,
-									RelOptInfo *output_rel);
+typedef enum PartializeAggFixAggref
+{
+	TS_DO_NOT_FIX_AGGREF = 0,
+	TS_FIX_AGGREF = 1
+} PartializeAggFixAggref;
+
+bool has_partialize_function(Query *parse, PartializeAggFixAggref fix_aggref);
+bool ts_plan_process_partialize_agg(PlannerInfo *root, RelOptInfo *output_rel);
 
 #endif /* TIMESCALEDB_PLAN_PARTIALIZE_H */

--- a/src/planner.c
+++ b/src/planner.c
@@ -1060,10 +1060,10 @@ timescale_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, Re
 			output_rel->pathlist = replace_hypertable_insert_paths(root, output_rel->pathlist);
 		if (parse->hasAggs && stage == UPPERREL_GROUP_AGG)
 		{
-			/* existing AggPaths are modified here.
+			/* Existing AggPaths are modified here.
 			 * No new AggPaths should be added after this if there
-			 * are partials*/
-			partials_found = ts_plan_process_partialize_agg(root, input_rel, output_rel);
+			 * are partials. */
+			partials_found = ts_plan_process_partialize_agg(root, output_rel);
 		}
 	}
 

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -96,6 +96,13 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- TEST2 ---
 DROP MATERIALIZED VIEW mat_m1;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_2_chunk
+SHOW enable_partitionwise_aggregate;
+ enable_partitionwise_aggregate 
+--------------------------------
+ off
+(1 row)
+
+SET enable_partitionwise_aggregate = on;
 SELECT * FROM _timescaledb_config.bgw_job;
  id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | hypertable_id | config 
 ----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+---------------+--------
@@ -176,6 +183,7 @@ order by 1;
  Thu Nov 01 17:00:00 2018 PDT | NYC |  35 |  15
 (4 rows)
 
+SET enable_partitionwise_aggregate = off;
 -- TEST3 --
 -- drop on table conditions should cascade to materialized mat_v1
 drop table conditions cascade;

--- a/tsl/test/expected/partialize_finalize.out
+++ b/tsl/test/expected/partialize_finalize.out
@@ -2,6 +2,13 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 -- TEST1 count with integers
+SHOW enable_partitionwise_aggregate;
+ enable_partitionwise_aggregate 
+--------------------------------
+ off
+(1 row)
+
+SET enable_partitionwise_aggregate = on;
 create table foo (a integer, b integer, c integer);
 insert into foo values( 1 , 10 , 20);
 insert into foo values( 1 , 11 , 20);
@@ -76,6 +83,7 @@ select a, _timescaledb_internal.finalize_agg( 'sum(numeric)', null, null, null, 
  5 |   80 |    0
 (4 rows)
 
+SET enable_partitionwise_aggregate = off;
 --TEST3 sum with expressions
 drop table t1;
 drop view v1;

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -82,6 +82,9 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- TEST2 ---
 DROP MATERIALIZED VIEW mat_m1;
 
+SHOW enable_partitionwise_aggregate;
+SET enable_partitionwise_aggregate = on;
+
 SELECT * FROM _timescaledb_config.bgw_job;
 
 CREATE TABLE conditions (
@@ -141,6 +144,8 @@ select time_bucket('1day', timec), min(location), sum(temperature), sum(humidity
 from conditions
 group by time_bucket('1day', timec)
 order by 1;
+
+SET enable_partitionwise_aggregate = off;
 
 -- TEST3 --
 -- drop on table conditions should cascade to materialized mat_v1

--- a/tsl/test/sql/dist_partial_agg.sql
+++ b/tsl/test/sql/dist_partial_agg.sql
@@ -95,6 +95,7 @@ SET enable_partitionwise_aggregate = OFF;
 \o
 \o :RESULTS_TEST2
 SET enable_partitionwise_aggregate = ON;
+CALL distributed_exec($$ SET enable_partitionwise_aggregate = ON $$);
 \ir 'include/aggregate_queries.sql'
 \o
 \set ECHO all

--- a/tsl/test/sql/dist_query.sql.in
+++ b/tsl/test/sql/dist_query.sql.in
@@ -168,6 +168,7 @@ SET enable_partitionwise_aggregate = ON;
 \set ORDER_BY_1_2 'ORDER BY 1,2'
 \set LIMIT ''
 SET enable_partitionwise_aggregate = ON;
+CALL distributed_exec($$ SET enable_partitionwise_aggregate = ON $$);
 \ir :TEST_QUERY_NAME
 
 -----------------------------------------------------------------------

--- a/tsl/test/sql/partialize_finalize.sql
+++ b/tsl/test/sql/partialize_finalize.sql
@@ -3,6 +3,9 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 
 -- TEST1 count with integers
+SHOW enable_partitionwise_aggregate;
+SET enable_partitionwise_aggregate = on;
+
 create table foo (a integer, b integer, c integer);
 insert into foo values( 1 , 10 , 20);
 insert into foo values( 1 , 11 , 20);
@@ -60,6 +63,8 @@ insert into foo values( 5, 40, 0);
 --sum aggfnoid 2114, min aggfnoid is 2136 oid  numeric is 1700
 insert into t1 select * from v1 where ( a = 3 ) or a = 5;
 select a, _timescaledb_internal.finalize_agg( 'sum(numeric)', null, null, null, partialb, cast('1' as numeric) ) sumb, _timescaledb_internal.finalize_agg( 'min(double precision)', null, null, null, partialminc, cast('1' as float8) ) minc from t1 group by a order by a ;
+
+SET enable_partitionwise_aggregate = off;
 
 --TEST3 sum with expressions
 drop table t1;


### PR DESCRIPTION
partialize_agg is an internal function, which serializes partial
aggregate results. It is used to prepare partials for materialization
in continuous aggregates and partial results on data nodes in
distributed query execution. paritalize_agg doesn't expect push down of
aggregates, which happens when partitionwise aggregate is enabled, and
produces a query plan, which either crashes on assert during execution
or produces incorrect result.

This fix avoids adding partition info if the function is present in the
query. This can be seen as a work around and it is good to fix planning
of partialize_agg in the case of pushed down aggregates.

This commit also contains few minor fixes of readability of comments
and code around the changes.

Fixes #2849 and fixes #2858