### PR TITLE
Fix partitionwise agg crash due to uninitialized memory

### DIFF
--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -1081,6 +1081,7 @@ build_hypertable_partition_info(Hypertable *ht, PlannerInfo *root, RelOptInfo *h
 								int nparts)
 {
 	PartitionScheme part_scheme = palloc0(sizeof(PartitionSchemeData));
+	PartitionBoundInfo boundinfo = palloc0(sizeof(PartitionBoundInfoData));
 
 	/* We only set the info needed for planning */
 	part_scheme->partnatts = ht->space->num_dimensions;
@@ -1089,7 +1090,14 @@ build_hypertable_partition_info(Hypertable *ht, PlannerInfo *root, RelOptInfo *h
 	hyper_rel->part_scheme = part_scheme;
 	hyper_rel->partexprs = get_hypertable_partexprs(ht, root->parse, hyper_rel->relid);
 	hyper_rel->nullable_partexprs = (List **) palloc0(sizeof(List *) * part_scheme->partnatts);
-	hyper_rel->boundinfo = palloc(sizeof(PartitionBoundInfoData));
+
+	/* PartitionBoundInfo is used for ordered append. We use a strategy that
+	 * will avoid triggering an ordered append. */
+	boundinfo->strategy = PARTITION_STRATEGY_MULTIDIM;
+	boundinfo->default_index = -1;
+	boundinfo->null_index = -1;
+
+	hyper_rel->boundinfo = boundinfo;
 	hyper_rel->part_rels = palloc0(sizeof(*hyper_rel->part_rels) * nparts);
 }
 


### PR DESCRIPTION
When building the partition information for hypertables, the memory
for partition bound information wasn't properly initialized. The
uninitialized memory could make the planner believe it could plan an
ordered append (PostgreSQL's built-in version) when the contents of
the memory happened to have the "right" value (specifically the
`strategy` char field of the partition bound info).

This change fixes the crash by properly initializing the partition
bound info so that PostgreSQL's ordered append plans are not triggered
on hypertables.

Due to the randomness of the uninitialized memory, it isn't possible
to reproduce the crash reliably and create a test for it. But the
crash was manually reproduced by initializing the `strategy` field of
the partition bound info to a value that triggered the crash in the
same place reported by the issue below.

Fixes #2873