### PR TITLE
Fix repair in update scripts

### DIFF
--- a/sql/updates/1.7.1--1.7.2.sql
+++ b/sql/updates/1.7.1--1.7.2.sql
@@ -14,61 +14,70 @@ RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_time_to_internal' LANGUAGE C VOLATILE
 INSERT INTO _timescaledb_catalog.dimension_slice
 WITH
    -- All dimension slices that are mentioned in the chunk_constraint
-   -- table but are missing from the dimension_slice table.
+   -- table but are missing from the dimension_slice table. There can
+   -- be duplicates since several chunk constraints can refer to one
+   -- dimension slice.
    missing_slices AS (
-      SELECT dimension_slice_id,
-      	     constraint_name,
-	     attname AS column_name,
-	     pg_get_expr(conbin, conrelid) AS constraint_expr
+      SELECT DISTINCT ch.hypertable_id,
+             di.id as dimension_id,
+             dimension_slice_id,
+             constraint_name,
+             di.column_type,
+             attname AS column_name,
+             pg_get_expr(conbin, conrelid) AS constraint_expr
       FROM _timescaledb_catalog.chunk_constraint cc
       JOIN _timescaledb_catalog.chunk ch ON cc.chunk_id = ch.id
       JOIN pg_constraint ON conname = constraint_name
       JOIN pg_namespace ns ON connamespace = ns.oid AND ns.nspname = ch.schema_name
       JOIN pg_attribute ON attnum = conkey[1] AND attrelid = conrelid
+      JOIN _timescaledb_catalog.dimension di
+           ON ch.hypertable_id = di.hypertable_id AND di.column_name = attname
       WHERE
-	 dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice)
+         dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice)
    ),
 
   -- Unparsed range start and end for each dimension slice id that
   -- is missing.
    unparsed_missing_slices AS (
-      SELECT dimension_slice_id,
+      SELECT dimension_id,
+             dimension_slice_id,
              constraint_name,
-	     column_name,
-	     (SELECT SUBSTRING(constraint_expr, $$>=\s*'?([\d\s:+-]+)'?$$)) AS range_start,
-	     (SELECT SUBSTRING(constraint_expr, $$<\s*'?([\d\s:+-]+)'?$$)) AS range_end
-	FROM missing_slices
+             column_type,
+             column_name,
+             (SELECT SUBSTRING(constraint_expr, $$>=\s*'?([\d\s:+-]+)'?$$)) AS range_start,
+             (SELECT SUBSTRING(constraint_expr, $$<\s*'?([\d\s:+-]+)'?$$)) AS range_end
+        FROM missing_slices
    )
 SELECT dimension_slice_id,
-       di.id AS dimension_id,
+       dimension_id,
        CASE
-       WHEN di.column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
-       	    CASE
-	    WHEN range_start IS NULL
-	    THEN -9223372036854775808
-	    ELSE _timescaledb_internal.time_to_internal(range_start::bigint)
-	    END
-       WHEN di.column_type = 'timestamptz'::regtype THEN
-       	    _timescaledb_internal.time_to_internal(range_start::timestamptz)
-       WHEN di.column_type = 'timestamp'::regtype THEN
-       	    _timescaledb_internal.time_to_internal(range_start::timestamp)
-       WHEN di.column_type = 'date'::regtype THEN
-       	    _timescaledb_internal.time_to_internal(range_start::date)
+       WHEN column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
+            CASE
+            WHEN range_start IS NULL
+            THEN -9223372036854775808
+            ELSE _timescaledb_internal.time_to_internal(range_start::bigint)
+            END
+       WHEN column_type = 'timestamptz'::regtype THEN
+            _timescaledb_internal.time_to_internal(range_start::timestamptz)
+       WHEN column_type = 'timestamp'::regtype THEN
+            _timescaledb_internal.time_to_internal(range_start::timestamp)
+       WHEN column_type = 'date'::regtype THEN
+            _timescaledb_internal.time_to_internal(range_start::date)
        ELSE
-	    NULL
+            NULL
        END AS range_start,
-       CASE 
-       WHEN di.column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
-       	    CASE WHEN range_end IS NULL
-	    THEN 9223372036854775807
-	    ELSE _timescaledb_internal.time_to_internal(range_end::bigint)
-	    END
-       WHEN di.column_type = 'timestamptz'::regtype THEN
-       	    _timescaledb_internal.time_to_internal(range_end::timestamptz)
-       WHEN di.column_type = 'timestamp'::regtype THEN
-       	    _timescaledb_internal.time_to_internal(range_end::timestamp)
-       WHEN di.column_type = 'date'::regtype THEN
-       	    _timescaledb_internal.time_to_internal(range_end::date)
+       CASE
+       WHEN column_type IN ('smallint'::regtype, 'bigint'::regtype, 'integer'::regtype) THEN
+            CASE WHEN range_end IS NULL
+            THEN 9223372036854775807
+            ELSE _timescaledb_internal.time_to_internal(range_end::bigint)
+            END
+       WHEN column_type = 'timestamptz'::regtype THEN
+            _timescaledb_internal.time_to_internal(range_end::timestamptz)
+       WHEN column_type = 'timestamp'::regtype THEN
+            _timescaledb_internal.time_to_internal(range_end::timestamp)
+       WHEN column_type = 'date'::regtype THEN
+            _timescaledb_internal.time_to_internal(range_end::date)
        ELSE NULL
        END AS range_end
-  FROM unparsed_missing_slices JOIN _timescaledb_catalog.dimension di USING (column_name);
+  FROM unparsed_missing_slices;

--- a/sql/updates/2.0.0-rc1--2.0.0-rc2.sql
+++ b/sql/updates/2.0.0-rc1--2.0.0-rc2.sql
@@ -137,28 +137,28 @@ SELECT DISTINCT
        dimension_id,
        CASE
        WHEN column_type = 'timestamptz'::regtype THEN
-            EXTRACT(EPOCH FROM range_start::timestamptz) * 1000000
+            EXTRACT(EPOCH FROM range_start::timestamptz)::bigint * 1000000
        WHEN column_type = 'timestamp'::regtype THEN
-            EXTRACT(EPOCH FROM range_start::timestamp) * 1000000
+            EXTRACT(EPOCH FROM range_start::timestamp)::bigint * 1000000
        WHEN column_type = 'date'::regtype THEN
-            EXTRACT(EPOCH FROM range_start::date) * 1000000
+            EXTRACT(EPOCH FROM range_start::date)::bigint * 1000000
        ELSE
             CASE
             WHEN range_start IS NULL
-            THEN -9223372036854775808
+            THEN (-9223372036854775808)::bigint
             ELSE range_start::bigint
             END
        END AS range_start,
        CASE
        WHEN column_type = 'timestamptz'::regtype THEN
-            EXTRACT(EPOCH FROM range_end::timestamptz) * 1000000
+            EXTRACT(EPOCH FROM range_end::timestamptz)::bigint * 1000000
        WHEN column_type = 'timestamp'::regtype THEN
-            EXTRACT(EPOCH FROM range_end::timestamp) * 1000000
+            EXTRACT(EPOCH FROM range_end::timestamp)::bigint * 1000000
        WHEN column_type = 'date'::regtype THEN
-            EXTRACT(EPOCH FROM range_end::date) * 1000000
+            EXTRACT(EPOCH FROM range_end::date)::bigint * 1000000
        ELSE
             CASE WHEN range_end IS NULL
-            THEN 9223372036854775807
+            THEN 9223372036854775807::bigint
             ELSE range_end::bigint
             END
        END AS range_end


### PR DESCRIPTION
The commit fixes two bugs in the repair scripts that could
prevent an update in rare circumstances.

For the 1.7.1--1.7.2 repair script: if there were several missing
dimension slices in different hypertables with the same column name,
the repair script would be confused on what constraint had what type
and generate an error.

For the 2.0.0-rc1--2.0.0-rc2 repair script: if a partition constraint
was broken, it would generate an error rather than repairing the
dimension slices because BIGINT_MIN would be cast to a double float and
then an attempt would be made to cast it back to bigint, causing an
overflow error.
