### PR TITLE
Fix join propagation for nested joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ accidentally triggering the load of a previous DB version.**
 * #2736 Support adding columns to hypertables with compression enabled
 
 **Bugfixes**
+* #2883 Fix join qual propagation for nested joins
 * #2908 Fix changing column type of clustered hypertables
+
+**Thanks**
+* @zeeshanshabbir93 for reporting an issue with joins
 
 ## 2.0.1 (2021-01-28)
 

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -57,6 +57,7 @@ typedef struct CollectQualCtx
 	List *join_conditions;
 	List *propagate_conditions;
 	List *all_quals;
+	int join_level;
 } CollectQualCtx;
 
 static void propagate_join_quals(PlannerInfo *root, RelOptInfo *rel, CollectQualCtx *ctx);
@@ -782,7 +783,7 @@ timebucket_annotate(Node *quals, CollectQualCtx *ctx)
  * a JOIN.
  */
 static void
-collect_join_quals(Node *quals, CollectQualCtx *ctx, bool is_outer_join)
+collect_join_quals(Node *quals, CollectQualCtx *ctx, bool can_propagate)
 {
 	ListCell *lc;
 
@@ -795,7 +796,7 @@ collect_join_quals(Node *quals, CollectQualCtx *ctx, bool is_outer_join)
 		/*
 		 * collect quals to propagate to join relations
 		 */
-		if (num_rels == 1 && !is_outer_join && IsA(qual, OpExpr) &&
+		if (num_rels == 1 && can_propagate && IsA(qual, OpExpr) &&
 			list_length(castNode(OpExpr, qual)->args) == 2)
 			ctx->all_quals = lappend(ctx->all_quals, qual);
 
@@ -819,7 +820,7 @@ collect_join_quals(Node *quals, CollectQualCtx *ctx, bool is_outer_join)
 				{
 					ctx->join_conditions = lappend(ctx->join_conditions, op);
 
-					if (!is_outer_join)
+					if (can_propagate)
 						ctx->propagate_conditions = lappend(ctx->propagate_conditions, op);
 				}
 			}
@@ -838,13 +839,22 @@ collect_quals_walker(Node *node, CollectQualCtx *ctx)
 	{
 		FromExpr *f = castNode(FromExpr, node);
 		f->quals = process_quals(f->quals, ctx, false);
-		collect_join_quals(f->quals, ctx, false);
+		/* if this is a nested join we don't propagate join quals */
+		collect_join_quals(f->quals, ctx, ctx->join_level == 0);
 	}
 	else if (IsA(node, JoinExpr))
 	{
 		JoinExpr *j = castNode(JoinExpr, node);
 		j->quals = process_quals(j->quals, ctx, IS_OUTER_JOIN(j->jointype));
-		collect_join_quals(j->quals, ctx, IS_OUTER_JOIN(j->jointype));
+		collect_join_quals(j->quals, ctx, ctx->join_level == 0 && !IS_OUTER_JOIN(j->jointype));
+
+		if (IS_OUTER_JOIN(j->jointype))
+		{
+			ctx->join_level++;
+			bool result = expression_tree_walker(node, collect_quals_walker, ctx);
+			ctx->join_level--;
+			return result;
+		}
 	}
 
 	/* skip processing if we found a chunks_in call for current relation */
@@ -1111,13 +1121,11 @@ timebucket_annotate_walker(Node *node, CollectQualCtx *ctx)
 	{
 		FromExpr *f = castNode(FromExpr, node);
 		f->quals = timebucket_annotate(f->quals, ctx);
-		collect_join_quals(f->quals, ctx, true);
 	}
 	else if (IsA(node, JoinExpr))
 	{
 		JoinExpr *j = castNode(JoinExpr, node);
 		j->quals = timebucket_annotate(j->quals, ctx);
-		collect_join_quals(j->quals, ctx, IS_OUTER_JOIN(j->jointype));
 	}
 
 	/* skip processing if we found a chunks_in call for current relation */
@@ -1172,6 +1180,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 		.all_quals = NIL,
 		.join_conditions = NIL,
 		.propagate_conditions = NIL,
+		.join_level = 0,
 	};
 	Index first_chunk_index = 0;
 #if PG12_GE
@@ -1195,6 +1204,8 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 
 	/* Walk the tree and find restrictions or chunk exclusion functions */
 	collect_quals_walker((Node *) root->parse->jointree, &ctx);
+	/* check join_level bookkeeping is balanced */
+	Assert(ctx.join_level == 0);
 
 #if PG12_GE
 	rel->baserestrictinfo = remove_exclusion_fns(rel->baserestrictinfo);

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -2475,6 +2475,143 @@ SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestam
  Tue Feb 01 00:00:00 2000 PST
 (128 rows)
 
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
 \ir include/plan_expand_hypertable_chunks_in_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/plan_expand_hypertable-12.out
+++ b/test/expected/plan_expand_hypertable-12.out
@@ -2425,6 +2425,143 @@ SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestam
  Tue Feb 01 00:00:00 2000 PST
 (128 rows)
 
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
 \ir include/plan_expand_hypertable_chunks_in_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -2425,6 +2425,143 @@ SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestam
  Tue Feb 01 00:00:00 2000 PST
 (128 rows)
 
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1_1."time", o2_m1_1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1_1."time" = o1_m1_1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2_1."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_3
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_5
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_5
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1_1."time", o2_m1_1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1_1."time" = o1_m1_1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2_1."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_3
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_5
+                           Index Cond: ("time" = o2_m2_1."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_5
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
 \ir include/plan_expand_hypertable_chunks_in_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -306,3 +306,18 @@ SELECT time FROM regular_timestamptz UNION SELECT time FROM metrics_timestamptz 
 
 -- test UNION ALL between regular table and hypertable
 SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestamptz ORDER BY 1;
+
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;


### PR DESCRIPTION
Join propagation would propagate join quals for nested joins even
when it was not safe to do so leading to wrong query results.

Fixes #2790