### PR TITLE
Add GUC to control join qual propagation

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -48,6 +48,7 @@ bool ts_guc_enable_chunk_append = true;
 bool ts_guc_enable_parallel_chunk_append = true;
 bool ts_guc_enable_runtime_exclusion = true;
 bool ts_guc_enable_constraint_exclusion = true;
+bool ts_guc_enable_qual_propagation = true;
 bool ts_guc_enable_cagg_reorder_groupby = true;
 TSDLLEXPORT bool ts_guc_enable_transparent_decompression = true;
 bool ts_guc_enable_per_data_node_queries = true;
@@ -167,6 +168,17 @@ _guc_init(void)
 							 "Enable constraint exclusion",
 							 "Enable planner constraint exclusion",
 							 &ts_guc_enable_constraint_exclusion,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("timescaledb.enable_qual_propagation",
+							 "Enable qualifier propagation",
+							 "Enable propagation of qualifiers in JOINs",
+							 &ts_guc_enable_qual_propagation,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -16,6 +16,7 @@ extern bool ts_guc_enable_constraint_aware_append;
 extern bool ts_guc_enable_ordered_append;
 extern bool ts_guc_enable_chunk_append;
 extern bool ts_guc_enable_parallel_chunk_append;
+extern bool ts_guc_enable_qual_propagation;
 extern bool ts_guc_enable_runtime_exclusion;
 extern bool ts_guc_enable_constraint_exclusion;
 extern bool ts_guc_enable_cagg_reorder_groupby;

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -1376,6 +1376,9 @@ propagate_join_quals(PlannerInfo *root, RelOptInfo *rel, CollectQualCtx *ctx)
 {
 	ListCell *lc;
 
+	if (!ts_guc_enable_qual_propagation)
+		return;
+
 	/* propagate join constraints */
 	foreach (lc, ctx->propagate_conditions)
 	{

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -2754,11 +2754,60 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 
 \set ECHO errors
 RESET timescaledb.enable_optimizations;
+CREATE TABLE t(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('t','time');
+ table_name 
+------------
+ t
+(1 row)
+
+INSERT INTO t VALUES ('2000-01-01'), ('2010-01-01'), ('2020-01-01');
+EXPLAIN (costs off) SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Merge Join
+   Merge Cond: (t1."time" = t2."time")
+   ->  Merge Append
+         Sort Key: t1."time"
+         ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t1_1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+   ->  Materialize
+         ->  Merge Append
+               Sort Key: t2."time"
+               ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t2
+                     Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+               ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t2_1
+                     Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+(15 rows)
+
+SET timescaledb.enable_qual_propagation TO false;
+EXPLAIN (costs off) SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Merge Join
+   Merge Cond: (t1."time" = t2."time")
+   ->  Merge Append
+         Sort Key: t1."time"
+         ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t1_1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+   ->  Materialize
+         ->  Merge Append
+               Sort Key: t2."time"
+               ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t2
+               ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t2_1
+               ->  Index Only Scan Backward using _hyper_15_184_chunk_t_time_idx on _hyper_15_184_chunk t2_2
+(14 rows)
+
+RESET timescaledb.enable_qual_propagation;
 CREATE TABLE test (a int, time timestamptz NOT NULL);
-SELECT create_hypertable('public.test', 'time');
- create_hypertable  
---------------------
- (15,public,test,t)
+SELECT table_name FROM create_hypertable('public.test', 'time');
+ table_name 
+------------
+ test
 (1 row)
 
 INSERT INTO test SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;

--- a/test/expected/plan_expand_hypertable-12.out
+++ b/test/expected/plan_expand_hypertable-12.out
@@ -2699,11 +2699,60 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 
 \set ECHO errors
 RESET timescaledb.enable_optimizations;
+CREATE TABLE t(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('t','time');
+ table_name 
+------------
+ t
+(1 row)
+
+INSERT INTO t VALUES ('2000-01-01'), ('2010-01-01'), ('2020-01-01');
+EXPLAIN (costs off) SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Merge Join
+   Merge Cond: (t1."time" = t2."time")
+   ->  Merge Append
+         Sort Key: t1."time"
+         ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t1_1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+   ->  Materialize
+         ->  Merge Append
+               Sort Key: t2."time"
+               ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t2
+                     Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+               ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t2_1
+                     Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+(15 rows)
+
+SET timescaledb.enable_qual_propagation TO false;
+EXPLAIN (costs off) SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Merge Join
+   Merge Cond: (t1."time" = t2."time")
+   ->  Merge Append
+         Sort Key: t1."time"
+         ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t1_1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+   ->  Materialize
+         ->  Merge Append
+               Sort Key: t2."time"
+               ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t2
+               ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t2_1
+               ->  Index Only Scan Backward using _hyper_15_184_chunk_t_time_idx on _hyper_15_184_chunk t2_2
+(14 rows)
+
+RESET timescaledb.enable_qual_propagation;
 CREATE TABLE test (a int, time timestamptz NOT NULL);
-SELECT create_hypertable('public.test', 'time');
- create_hypertable  
---------------------
- (15,public,test,t)
+SELECT table_name FROM create_hypertable('public.test', 'time');
+ table_name 
+------------
+ test
 (1 row)
 
 INSERT INTO test SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;

--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -2699,11 +2699,60 @@ SELECT * FROM hyper h WHERE _timescaledb_internal.chunks_in(h, NULL);
 
 \set ECHO errors
 RESET timescaledb.enable_optimizations;
+CREATE TABLE t(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('t','time');
+ table_name 
+------------
+ t
+(1 row)
+
+INSERT INTO t VALUES ('2000-01-01'), ('2010-01-01'), ('2020-01-01');
+EXPLAIN (costs off) SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Merge Join
+   Merge Cond: (t1_1."time" = t2_1."time")
+   ->  Merge Append
+         Sort Key: t1_1."time"
+         ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t1_1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t1_2
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+   ->  Materialize
+         ->  Merge Append
+               Sort Key: t2_1."time"
+               ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t2_1
+                     Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+               ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t2_2
+                     Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+(15 rows)
+
+SET timescaledb.enable_qual_propagation TO false;
+EXPLAIN (costs off) SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Merge Join
+   Merge Cond: (t1_1."time" = t2_1."time")
+   ->  Merge Append
+         Sort Key: t1_1."time"
+         ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t1_1
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+         ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t1_2
+               Index Cond: ("time" < 'Fri Jan 01 00:00:00 2010 PST'::timestamp with time zone)
+   ->  Materialize
+         ->  Merge Append
+               Sort Key: t2_1."time"
+               ->  Index Only Scan Backward using _hyper_15_182_chunk_t_time_idx on _hyper_15_182_chunk t2_1
+               ->  Index Only Scan Backward using _hyper_15_183_chunk_t_time_idx on _hyper_15_183_chunk t2_2
+               ->  Index Only Scan Backward using _hyper_15_184_chunk_t_time_idx on _hyper_15_184_chunk t2_3
+(14 rows)
+
+RESET timescaledb.enable_qual_propagation;
 CREATE TABLE test (a int, time timestamptz NOT NULL);
-SELECT create_hypertable('public.test', 'time');
- create_hypertable  
---------------------
- (15,public,test,t)
+SELECT table_name FROM create_hypertable('public.test', 'time');
+ table_name 
+------------
+ test
 (1 row)
 
 INSERT INTO test SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;

--- a/test/sql/plan_expand_hypertable.sql.in
+++ b/test/sql/plan_expand_hypertable.sql.in
@@ -31,14 +31,26 @@ SET timescaledb.enable_optimizations TO false;
 :DIFF_CMD
 \set ECHO queries
 
+\set PREFIX 'EXPLAIN (costs off)'
 RESET timescaledb.enable_optimizations;
+
+-- test enable_qual_propagation GUC
+CREATE TABLE t(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('t','time');
+INSERT INTO t VALUES ('2000-01-01'), ('2010-01-01'), ('2020-01-01');
+
+-- time constraint should be in both scans
+:PREFIX SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+
+SET timescaledb.enable_qual_propagation TO false;
+-- time constraint should only be in t1 scan
+:PREFIX SELECT * FROM t t1 INNER JOIN t t2 ON t1.time = t2.time WHERE t1.time < timestamptz '2010-01-01';
+RESET timescaledb.enable_qual_propagation;
+
 -- test hypertable classification when hypertable is not in cache
 -- https://github.com/timescale/timescaledb/issues/1832
-
-\set PREFIX 'EXPLAIN (costs off)'
-
 CREATE TABLE test (a int, time timestamptz NOT NULL);
-SELECT create_hypertable('public.test', 'time');
+SELECT table_name FROM create_hypertable('public.test', 'time');
 INSERT INTO test SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
 
 CREATE OR REPLACE FUNCTION test_f(_ts timestamptz)


### PR DESCRIPTION
This patch adds a `enable_qual_propagation` GUC to control
propagation of JOIN quals. Since there have been a few instances
where JOIN qual propagation was too aggressive this GUC can be
used to disable qual propagation.