### PR TITLE
Fix compressed chunk check when disabling compression

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,4 @@
+
+-- set compressed_chunk_id to NULL for dropped chunks
+UPDATE _timescaledb_catalog.chunk SET compressed_chunk_id = NULL WHERE dropped = true AND compressed_chunk_id IS NOT NULL;
+

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2606,6 +2606,7 @@ chunk_tuple_delete(TupleInfo *ti, DropBehavior behavior, bool preserve_chunk_cat
 
 		Assert(!form.dropped);
 
+		form.compressed_chunk_id = INVALID_CHUNK_ID;
 		form.dropped = true;
 		new_tuple = chunk_formdata_make_tuple(&form, ts_scanner_get_tupledesc(ti));
 		ts_catalog_update_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti), new_tuple);
@@ -2728,10 +2729,15 @@ ts_chunk_exists_with_compression(int32 hypertable_id)
 	init_scan_by_hypertable_id(&iterator, hypertable_id);
 	ts_scanner_foreach(&iterator)
 	{
-		bool isnull =
+		bool isnull_dropped;
+		bool isnull_chunk_id =
 			slot_attisnull(ts_scan_iterator_slot(&iterator), Anum_chunk_compressed_chunk_id);
+		bool dropped = DatumGetBool(
+			slot_getattr(ts_scan_iterator_slot(&iterator), Anum_chunk_dropped, &isnull_dropped));
+		/* dropped is not NULLABLE */
+		Assert(!isnull_dropped);
 
-		if (!isnull)
+		if (!isnull_chunk_id && !dropped)
 		{
 			found = true;
 			break;

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -810,3 +810,42 @@ SELECT count(*) from test1 where new_colv  = '101t';
 (1 row)
 
 CREATE INDEX new_index ON test1(new_colv);
+-- test disabling compression on hypertables with caggs and dropped chunks
+-- github issue 2844
+CREATE TABLE i2844 (created_at timestamptz NOT NULL,c1 float);
+SELECT create_hypertable('i2844', 'created_at', chunk_time_interval => '6 hour'::interval);
+ create_hypertable  
+--------------------
+ (9,public,i2844,t)
+(1 row)
+
+INSERT INTO i2844 SELECT generate_series('2000-01-01'::timestamptz, '2000-01-02'::timestamptz,'1h'::interval);
+CREATE MATERIALIZED VIEW test_agg WITH (timescaledb.continuous) AS SELECT time_bucket('1 hour', created_at) AS bucket, AVG(c1) AS avg_c1 FROM i2844 GROUP BY bucket;
+psql:include/compression_alter.sql:76: NOTICE:  refreshing continuous aggregate "test_agg"
+ALTER TABLE i2844 SET (timescaledb.compress);
+SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('i2844');
+            compressed_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_9_75_chunk
+ _timescaledb_internal._hyper_9_76_chunk
+ _timescaledb_internal._hyper_9_77_chunk
+ _timescaledb_internal._hyper_9_78_chunk
+ _timescaledb_internal._hyper_9_79_chunk
+(5 rows)
+
+SELECT drop_chunks('i2844', older_than => '2000-01-01 18:00'::timestamptz);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_9_75_chunk
+ _timescaledb_internal._hyper_9_76_chunk
+ _timescaledb_internal._hyper_9_77_chunk
+(3 rows)
+
+SELECT decompress_chunk(show_chunks, if_compressed => TRUE) AS decompressed_chunks FROM show_chunks('i2844');
+           decompressed_chunks           
+-----------------------------------------
+ _timescaledb_internal._hyper_9_78_chunk
+ _timescaledb_internal._hyper_9_79_chunk
+(2 rows)
+
+ALTER TABLE i2844 SET (timescaledb.compress = FALSE);

--- a/tsl/test/sql/include/compression_alter.sql
+++ b/tsl/test/sql/include/compression_alter.sql
@@ -67,4 +67,21 @@ SELECT count(*) from test1 where new_colv  = '101t';
 
 CREATE INDEX new_index ON test1(new_colv);
 
+-- test disabling compression on hypertables with caggs and dropped chunks
+-- github issue 2844
+CREATE TABLE i2844 (created_at timestamptz NOT NULL,c1 float);
+SELECT create_hypertable('i2844', 'created_at', chunk_time_interval => '6 hour'::interval);
+INSERT INTO i2844 SELECT generate_series('2000-01-01'::timestamptz, '2000-01-02'::timestamptz,'1h'::interval);
+
+CREATE MATERIALIZED VIEW test_agg WITH (timescaledb.continuous) AS SELECT time_bucket('1 hour', created_at) AS bucket, AVG(c1) AS avg_c1 FROM i2844 GROUP BY bucket;
+
+ALTER TABLE i2844 SET (timescaledb.compress);
+
+SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('i2844');
+SELECT drop_chunks('i2844', older_than => '2000-01-01 18:00'::timestamptz);
+SELECT decompress_chunk(show_chunks, if_compressed => TRUE) AS decompressed_chunks FROM show_chunks('i2844');
+
+ALTER TABLE i2844 SET (timescaledb.compress = FALSE);
+
+
 


### PR DESCRIPTION
The check for existence of compressed chunks when disabling
compression would not ignore dropped chunks making it impossible
to disable compression on hypertables with continuous aggregates
that had dropped chunks.
This patch ignores dropped chunks in this check and also sets
compressed_chunk_id to NULL in the metadata for deleted chunks.

Fixes #2844 