### PR TITLE
Fix changing column type of clustered hypertables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ accidentally triggering the load of a previous DB version.**
 **Minor features**
 * #2736 Support adding columns to hypertables with compression enabled
 
+**Bugfixes**
+* #2908 Fix changing column type of clustered hypertables
+
 ## 2.0.1 (2021-01-28)
 
 This maintenance release contains bugfixes since the 2.0.0 release.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -191,7 +191,7 @@ test_script:
 
     #right now we only run timescale regression tests, others will be set up later
 
-    docker exec -e IGNORES="chunk_utils loader" -e TEST_TABLESPACE1_PREFIX="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PREFIX="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
+    docker exec -e IGNORES="chunk_utils cluster-12 loader" -e TEST_TABLESPACE1_PREFIX="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PREFIX="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
 
     $TESTS1 = $?
 

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -114,12 +114,16 @@ if event_type != "pull_request":
     "llvm_config": "/usr/bin/llvm-config-8",
     "clang": "clang-8",
     "extra_packages": "llvm-8 llvm-8-dev llvm-8-tools",
-    "installcheck_args": "IGNORES='continuous_aggs_insert continuous_aggs_multi continuous_aggs_concurrent_refresh'"
+    "installcheck_args": "IGNORES='cluster-11 continuous_aggs_insert continuous_aggs_multi continuous_aggs_concurrent_refresh'"
   }
   m["include"].append(build_debug_config(pg11_debug_earliest))
 
   # add debug test for first supported PG12 version
-  m["include"].append(build_debug_config({"pg":PG12_EARLIEST}))
+  pg12_debug_earliest = {
+    "pg": PG11_EARLIEST,
+    "installcheck_args": "IGNORES='cluster-12'"
+  }
+  m["include"].append(build_debug_config(pg12_debug_earliest))
 
   # add debug test for MacOS
   m["include"].append(build_debug_config(macos_config({})))

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2685,6 +2685,13 @@ process_altertable_clusteron_end(Hypertable *ht, AlterTableCmd *cmd)
 {
 	Oid index_relid =
 		get_relname_relid(cmd->name, get_namespace_oid(NameStr(ht->fd.schema_name), false));
+
+	/* If this is part of changing the type of a column that is used in a clustered index
+	 * the above lookup might fail. But in this case we don't need to mark the index clustered
+	 * as postgres takes care of that already (except PG11 < 11.8 and PG12 < 12.3) */
+	if (!OidIsValid(index_relid))
+		return;
+
 	List *chunk_indexes = ts_chunk_index_get_mappings(ht, index_relid);
 	ListCell *lc;
 

--- a/test/expected/cluster-11.out
+++ b/test/expected/cluster-11.out
@@ -149,3 +149,23 @@ ORDER BY 1,2;
 CLUSTER VERBOSE _timescaledb_internal._hyper_1_1_chunk;
 ERROR:  there is no previously clustered index for table "_hyper_1_1_chunk"
 \set ON_ERROR_STOP 1
+-- test alter column type on hypertable with clustering
+CREATE TABLE cluster_alter(time timestamp, id text, val int);
+CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
+SELECT table_name FROM create_hypertable('cluster_alter', 'time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+---------------
+ cluster_alter
+(1 row)
+
+INSERT INTO cluster_alter VALUES('2020-01-01', '123', 1);
+CLUSTER cluster_alter using idstuff;
+--attempt the alter table
+ALTER TABLE cluster_alter ALTER COLUMN id TYPE int USING id::int;
+-- try recluster
+-- this fails on PG11 < 11.8 and PG12 < 12.3
+\set ON_ERROR_STOP 0
+CLUSTER cluster_alter;
+\set ON_ERROR_STOP 1
+CLUSTER cluster_alter using idstuff;

--- a/test/expected/cluster-12.out
+++ b/test/expected/cluster-12.out
@@ -149,3 +149,23 @@ ORDER BY 1,2;
 CLUSTER VERBOSE _timescaledb_internal._hyper_1_1_chunk;
 ERROR:  there is no previously clustered index for table "_hyper_1_1_chunk"
 \set ON_ERROR_STOP 1
+-- test alter column type on hypertable with clustering
+CREATE TABLE cluster_alter(time timestamp, id text, val int);
+CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
+SELECT table_name FROM create_hypertable('cluster_alter', 'time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+---------------
+ cluster_alter
+(1 row)
+
+INSERT INTO cluster_alter VALUES('2020-01-01', '123', 1);
+CLUSTER cluster_alter using idstuff;
+--attempt the alter table
+ALTER TABLE cluster_alter ALTER COLUMN id TYPE int USING id::int;
+-- try recluster
+-- this fails on PG11 < 11.8 and PG12 < 12.3
+\set ON_ERROR_STOP 0
+CLUSTER cluster_alter;
+\set ON_ERROR_STOP 1
+CLUSTER cluster_alter using idstuff;

--- a/test/expected/cluster-13.out
+++ b/test/expected/cluster-13.out
@@ -149,3 +149,23 @@ ORDER BY 1,2;
 CLUSTER VERBOSE _timescaledb_internal._hyper_1_1_chunk;
 ERROR:  there is no previously clustered index for table "_hyper_1_1_chunk"
 \set ON_ERROR_STOP 1
+-- test alter column type on hypertable with clustering
+CREATE TABLE cluster_alter(time timestamp, id text, val int);
+CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
+SELECT table_name FROM create_hypertable('cluster_alter', 'time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+---------------
+ cluster_alter
+(1 row)
+
+INSERT INTO cluster_alter VALUES('2020-01-01', '123', 1);
+CLUSTER cluster_alter using idstuff;
+--attempt the alter table
+ALTER TABLE cluster_alter ALTER COLUMN id TYPE int USING id::int;
+-- try recluster
+-- this fails on PG11 < 11.8 and PG12 < 12.3
+\set ON_ERROR_STOP 0
+CLUSTER cluster_alter;
+\set ON_ERROR_STOP 1
+CLUSTER cluster_alter using idstuff;


### PR DESCRIPTION
When changing the column type of a column that is part of an index
that is being clustered on with either postgres CLUSTER or reorder
the alter type operation would fail with a segfault because it
couldn't lookup the index.