### PR TITLE
1.7.5 backporting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -151,7 +151,7 @@ test_script:
 
     #right now we only run timescale regression tests, others will be set up later
 
-    docker exec -e IGNORES="bgw_db_scheduler chunk_utils loader" -e TEST_TABLESPACE1_PREFIX="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PREFIX="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
+    docker exec -e IGNORES="bgw_db_scheduler chunk_utils loader cluster-12" -e TEST_TABLESPACE1_PREFIX="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PREFIX="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
 
     $TESTS1 = $?
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -125,11 +125,11 @@ build_script:
 
     docker-switch-linux
 
-    # docker run -d --name pgregress -v c:/projects/timescaledb:/timescale timescaledev/postgresdev:exec_backend-10-alpine
+    docker run -d --name pgregress alpine:3.12 sh -c "while sleep 3600; do :; done"
 
-    docker run -d --name pgregress timescaledev/postgresdev:exec_backend-10-alpine
+    docker exec -it pgregress /bin/sh -c "apk add --no-cache --virtual .build-deps bash coreutils findutils gcc libc-dev make util-linux-dev diffutils cmake curl git openssl-dev openssl postgresql-client postgresql-dev"
 
-    docker exec -it pgregress /bin/bash -c "apk add cmake git diffutils"
+    docker exec -it pgregress /bin/sh -c "ln -s /usr/lib/postgresql/pgxs/src/test/regress/pg_regress /usr/local/bin/pg_regress"
 
     # we clone the current commit in the docker instance to ensure the correct tests run
     # (Ideally we'd use the same folder, but that's difficult to set up)
@@ -151,7 +151,7 @@ test_script:
 
     #right now we only run timescale regression tests, others will be set up later
 
-    docker exec -e IGNORES="bgw_db_scheduler" -e TEST_TABLESPACE1_PATH="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PATH="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
+    docker exec -e IGNORES="bgw_db_scheduler chunk_utils loader" -e TEST_TABLESPACE1_PREFIX="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PREFIX="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal"
 
     $TESTS1 = $?
 
@@ -161,7 +161,7 @@ test_script:
 
     Restart-Service postgresql-x64-10
 
-    docker exec -e IGNORES="bgw_db_scheduler" -e TEST_TABLESPACE1_PATH="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PATH="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal-t"
+    docker exec -e IGNORES="bgw_db_scheduler compression_algos continuous_aggs_bgw remote_connection remote_txn " -e SKIPS="bgw_db_scheduler" -e TEST_TABLESPACE1_PREFIX="C:\Users\$env:UserName\Documents\tablespace1\" -e TEST_TABLESPACE2_PREFIX="C:\Users\$env:UserName\Documents\tablespace2\" -e TEST_SPINWAIT_ITERS=10000 -e USER=postgres -it pgregress /bin/bash -c "cd /timescaledb/build && make regresschecklocal-t"
 
     if( -not $? -or -not $TESTS1 ) { exit 1 }
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -76,3 +76,6 @@ SELECT DISTINCT
             END
        END AS range_end
   FROM unparsed_missing_slices;
+
+-- set compressed_chunk_id to NULL for dropped chunks
+UPDATE _timescaledb_catalog.chunk SET compressed_chunk_id = NULL WHERE dropped = true AND compressed_chunk_id IS NOT NULL;

--- a/src/chunk_append/planner.c
+++ b/src/chunk_append/planner.c
@@ -104,7 +104,6 @@ ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path
 	cscan->scan.scanrelid = rel->relid;
 
 	tlist = ts_build_path_tlist(root, (Path *) path);
-	cscan->custom_scan_tlist = tlist;
 	cscan->scan.plan.targetlist = tlist;
 
 	if (path->path.pathkeys == NIL)
@@ -227,6 +226,8 @@ ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path
 		}
 	}
 
+	/* decouple input tlist from output tlist in case output tlist gets modified later */
+	cscan->custom_scan_tlist = list_copy(tlist);
 	cscan->custom_plans = custom_plans;
 
 	/*

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2342,6 +2342,13 @@ process_altertable_clusteron_end(Hypertable *ht, AlterTableCmd *cmd)
 {
 	Oid index_relid =
 		get_relname_relid(cmd->name, get_namespace_oid(NameStr(ht->fd.schema_name), false));
+
+	/* If this is part of changing the type of a column that is used in a clustered index
+	 * the above lookup might fail. But in this case we don't need to mark the index clustered
+	 * as postgres takes care of that already (except PG11 < 11.8 and PG12 < 12.3) */
+	if (!OidIsValid(index_relid))
+		return;
+
 	List *chunk_indexes = ts_chunk_index_get_mappings(ht, index_relid);
 	ListCell *lc;
 

--- a/test/expected/append-10.out
+++ b/test/expected/append-10.out
@@ -119,6 +119,21 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m':
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
 ANALYZE metrics_space;
+-- test ChunkAppend projection #2661
+CREATE TABLE i2661 (
+  machine_id int4 NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "timestamp" timestamptz NOT NULL,
+  "first" float4 NULL
+);
+SELECT create_hypertable('i2661', 'timestamp');
+ create_hypertable  
+--------------------
+ (7,public,i2661,t)
+(1 row)
+
+INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
+ANALYZE i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -2163,13 +2178,13 @@ DROP INDEX :INDEX_NAME;
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: m2_1."time", m2_1.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_7_32_chunk m2_1 (actual rows=2710 loops=1)
+                     ->  Seq Scan on _hyper_8_35_chunk m2_1 (actual rows=2710 loops=1)
                            Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            Rows Removed by Filter: 650
-               ->  Index Only Scan using _hyper_7_33_chunk_join_limit_time_device_id_idx on _hyper_7_33_chunk m2_2 (never executed)
+               ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      Heap Fetches: 0
-               ->  Index Only Scan using _hyper_7_34_chunk_join_limit_time_device_id_idx on _hyper_7_34_chunk m2_3 (never executed)
+               ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      Heap Fetches: 0
          ->  Materialize (actual rows=24 loops=1)
@@ -2186,6 +2201,41 @@ DROP INDEX :INDEX_NAME;
 (30 rows)
 
 DROP TABLE join_limit;
+-- test ChunkAppend projection #2661
+:PREFIX SELECT ts.timestamp, ht.timestamp
+FROM (
+  SELECT generate_series(
+    to_timestamp(FLOOR(EXTRACT (EPOCH FROM '2020-01-01T00:01:00Z'::timestamp) / 300) * 300) AT TIME ZONE 'UTC',
+    '2020-01-01T01:00:00Z',
+    '5 minutes'::interval
+  ) AS timestamp
+) ts
+LEFT JOIN i2661 ht ON
+  (FLOOR(EXTRACT (EPOCH FROM ht."timestamp") / 300) * 300 = EXTRACT (EPOCH FROM ts.timestamp))
+  AND ht.timestamp > '2019-12-30T00:00:00Z'::timestamp;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Left Join (actual rows=33 loops=1)
+   Merge Cond: ((date_part('epoch'::text, ts."timestamp")) = ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision)))
+   ->  Sort (actual rows=13 loops=1)
+         Sort Key: (date_part('epoch'::text, ts."timestamp"))
+         Sort Method: quicksort 
+         ->  Subquery Scan on ts (actual rows=13 loops=1)
+               ->  ProjectSet (actual rows=13 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+   ->  Sort (actual rows=514 loops=1)
+         Sort Key: ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision))
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on i2661 ht (actual rows=7201 loops=1)
+               Chunks excluded during startup: 0
+               ->  Seq Scan on _hyper_7_31_chunk ht_1 (actual rows=1200 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_32_chunk ht_2 (actual rows=5040 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_33_chunk ht_3 (actual rows=961 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+(19 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -119,6 +119,21 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m':
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
 ANALYZE metrics_space;
+-- test ChunkAppend projection #2661
+CREATE TABLE i2661 (
+  machine_id int4 NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "timestamp" timestamptz NOT NULL,
+  "first" float4 NULL
+);
+SELECT create_hypertable('i2661', 'timestamp');
+ create_hypertable  
+--------------------
+ (7,public,i2661,t)
+(1 row)
+
+INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
+ANALYZE i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -2163,13 +2178,13 @@ DROP INDEX :INDEX_NAME;
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: m2_1."time", m2_1.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_7_32_chunk m2_1 (actual rows=2710 loops=1)
+                     ->  Seq Scan on _hyper_8_35_chunk m2_1 (actual rows=2710 loops=1)
                            Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            Rows Removed by Filter: 650
-               ->  Index Only Scan using _hyper_7_33_chunk_join_limit_time_device_id_idx on _hyper_7_33_chunk m2_2 (never executed)
+               ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      Heap Fetches: 0
-               ->  Index Only Scan using _hyper_7_34_chunk_join_limit_time_device_id_idx on _hyper_7_34_chunk m2_3 (never executed)
+               ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      Heap Fetches: 0
          ->  Materialize (actual rows=24 loops=1)
@@ -2186,6 +2201,41 @@ DROP INDEX :INDEX_NAME;
 (30 rows)
 
 DROP TABLE join_limit;
+-- test ChunkAppend projection #2661
+:PREFIX SELECT ts.timestamp, ht.timestamp
+FROM (
+  SELECT generate_series(
+    to_timestamp(FLOOR(EXTRACT (EPOCH FROM '2020-01-01T00:01:00Z'::timestamp) / 300) * 300) AT TIME ZONE 'UTC',
+    '2020-01-01T01:00:00Z',
+    '5 minutes'::interval
+  ) AS timestamp
+) ts
+LEFT JOIN i2661 ht ON
+  (FLOOR(EXTRACT (EPOCH FROM ht."timestamp") / 300) * 300 = EXTRACT (EPOCH FROM ts.timestamp))
+  AND ht.timestamp > '2019-12-30T00:00:00Z'::timestamp;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Left Join (actual rows=33 loops=1)
+   Merge Cond: ((date_part('epoch'::text, ts."timestamp")) = ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision)))
+   ->  Sort (actual rows=13 loops=1)
+         Sort Key: (date_part('epoch'::text, ts."timestamp"))
+         Sort Method: quicksort 
+         ->  Subquery Scan on ts (actual rows=13 loops=1)
+               ->  ProjectSet (actual rows=13 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+   ->  Sort (actual rows=514 loops=1)
+         Sort Key: ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision))
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on i2661 ht (actual rows=7201 loops=1)
+               Chunks excluded during startup: 0
+               ->  Seq Scan on _hyper_7_31_chunk ht_1 (actual rows=1200 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_32_chunk ht_2 (actual rows=5040 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_33_chunk ht_3 (actual rows=961 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+(19 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-12.out
+++ b/test/expected/append-12.out
@@ -119,6 +119,21 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m':
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
 ANALYZE metrics_space;
+-- test ChunkAppend projection #2661
+CREATE TABLE i2661 (
+  machine_id int4 NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "timestamp" timestamptz NOT NULL,
+  "first" float4 NULL
+);
+SELECT create_hypertable('i2661', 'timestamp');
+ create_hypertable  
+--------------------
+ (7,public,i2661,t)
+(1 row)
+
+INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
+ANALYZE i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -2158,13 +2173,13 @@ DROP INDEX :INDEX_NAME;
                ->  Sort (actual rows=3 loops=1)
                      Sort Key: m2_1."time", m2_1.device_id
                      Sort Method: quicksort 
-                     ->  Seq Scan on _hyper_7_32_chunk m2_1 (actual rows=2710 loops=1)
+                     ->  Seq Scan on _hyper_8_35_chunk m2_1 (actual rows=2710 loops=1)
                            Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                            Rows Removed by Filter: 650
-               ->  Index Only Scan using _hyper_7_33_chunk_join_limit_time_device_id_idx on _hyper_7_33_chunk m2_2 (never executed)
+               ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      Heap Fetches: 0
-               ->  Index Only Scan using _hyper_7_34_chunk_join_limit_time_device_id_idx on _hyper_7_34_chunk m2_3 (never executed)
+               ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3 (never executed)
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
                      Heap Fetches: 0
          ->  Materialize (actual rows=22 loops=1)
@@ -2181,6 +2196,41 @@ DROP INDEX :INDEX_NAME;
 (30 rows)
 
 DROP TABLE join_limit;
+-- test ChunkAppend projection #2661
+:PREFIX SELECT ts.timestamp, ht.timestamp
+FROM (
+  SELECT generate_series(
+    to_timestamp(FLOOR(EXTRACT (EPOCH FROM '2020-01-01T00:01:00Z'::timestamp) / 300) * 300) AT TIME ZONE 'UTC',
+    '2020-01-01T01:00:00Z',
+    '5 minutes'::interval
+  ) AS timestamp
+) ts
+LEFT JOIN i2661 ht ON
+  (FLOOR(EXTRACT (EPOCH FROM ht."timestamp") / 300) * 300 = EXTRACT (EPOCH FROM ts.timestamp))
+  AND ht.timestamp > '2019-12-30T00:00:00Z'::timestamp;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Left Join (actual rows=33 loops=1)
+   Merge Cond: ((date_part('epoch'::text, ts."timestamp")) = ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision)))
+   ->  Sort (actual rows=13 loops=1)
+         Sort Key: (date_part('epoch'::text, ts."timestamp"))
+         Sort Method: quicksort 
+         ->  Subquery Scan on ts (actual rows=13 loops=1)
+               ->  ProjectSet (actual rows=13 loops=1)
+                     ->  Result (actual rows=1 loops=1)
+   ->  Sort (actual rows=514 loops=1)
+         Sort Key: ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision))
+         Sort Method: quicksort 
+         ->  Custom Scan (ChunkAppend) on i2661 ht (actual rows=7201 loops=1)
+               Chunks excluded during startup: 0
+               ->  Seq Scan on _hyper_7_31_chunk ht_1 (actual rows=1200 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_32_chunk ht_2 (actual rows=5040 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_33_chunk ht_3 (actual rows=961 loops=1)
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+(19 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-9.6.out
+++ b/test/expected/append-9.6.out
@@ -119,6 +119,21 @@ FROM generate_series('2000-01-01'::timestamptz, '2000-01-14'::timestamptz, '5m':
   generate_series(1,10,1) g2(device_id)
 ORDER BY time, device_id;
 ANALYZE metrics_space;
+-- test ChunkAppend projection #2661
+CREATE TABLE i2661 (
+  machine_id int4 NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "timestamp" timestamptz NOT NULL,
+  "first" float4 NULL
+);
+SELECT create_hypertable('i2661', 'timestamp');
+ create_hypertable  
+--------------------
+ (7,public,i2661,t)
+(1 row)
+
+INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
+ANALYZE i2661;
 \ir :TEST_QUERY_NAME
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
@@ -1847,11 +1862,11 @@ DROP INDEX :INDEX_NAME;
                Order: m2."time", m2.device_id
                ->  Sort
                      Sort Key: m2_1."time", m2_1.device_id
-                     ->  Seq Scan on _hyper_7_32_chunk m2_1
+                     ->  Seq Scan on _hyper_8_35_chunk m2_1
                            Filter: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Only Scan using _hyper_7_33_chunk_join_limit_time_device_id_idx on _hyper_7_33_chunk m2_2
+               ->  Index Only Scan using _hyper_8_36_chunk_join_limit_time_device_id_idx on _hyper_8_36_chunk m2_2
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Only Scan using _hyper_7_34_chunk_join_limit_time_device_id_idx on _hyper_7_34_chunk m2_3
+               ->  Index Only Scan using _hyper_8_37_chunk_join_limit_time_device_id_idx on _hyper_8_37_chunk m2_3
                      Index Cond: ("time" > 'Fri Jan 07 00:00:00 2000 PST'::timestamp with time zone)
          ->  Materialize
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
@@ -1867,6 +1882,38 @@ DROP INDEX :INDEX_NAME;
 (25 rows)
 
 DROP TABLE join_limit;
+-- test ChunkAppend projection #2661
+:PREFIX SELECT ts.timestamp, ht.timestamp
+FROM (
+  SELECT generate_series(
+    to_timestamp(FLOOR(EXTRACT (EPOCH FROM '2020-01-01T00:01:00Z'::timestamp) / 300) * 300) AT TIME ZONE 'UTC',
+    '2020-01-01T01:00:00Z',
+    '5 minutes'::interval
+  ) AS timestamp
+) ts
+LEFT JOIN i2661 ht ON
+  (FLOOR(EXTRACT (EPOCH FROM ht."timestamp") / 300) * 300 = EXTRACT (EPOCH FROM ts.timestamp))
+  AND ht.timestamp > '2019-12-30T00:00:00Z'::timestamp;
+                                                                               QUERY PLAN                                                                               
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Left Join
+   Merge Cond: ((date_part('epoch'::text, ts."timestamp")) = ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision)))
+   ->  Sort
+         Sort Key: (date_part('epoch'::text, ts."timestamp"))
+         ->  Subquery Scan on ts
+               ->  Result
+   ->  Sort
+         Sort Key: ((floor((date_part('epoch'::text, ht."timestamp") / '300'::double precision)) * '300'::double precision))
+         ->  Custom Scan (ChunkAppend) on i2661 ht
+               Chunks excluded during startup: 0
+               ->  Seq Scan on _hyper_7_31_chunk ht_1
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_32_chunk ht_2
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+               ->  Seq Scan on _hyper_7_33_chunk ht_3
+                     Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
+(16 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/cluster.out
+++ b/test/expected/cluster.out
@@ -149,3 +149,23 @@ ORDER BY 1,2;
 CLUSTER VERBOSE _timescaledb_internal._hyper_1_1_chunk;
 ERROR:  there is no previously clustered index for table "_hyper_1_1_chunk"
 \set ON_ERROR_STOP 1
+-- test alter column type on hypertable with clustering
+CREATE TABLE cluster_alter(time timestamp, id text, val int);
+CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
+SELECT table_name FROM create_hypertable('cluster_alter', 'time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+---------------
+ cluster_alter
+(1 row)
+
+INSERT INTO cluster_alter VALUES('2020-01-01', '123', 1);
+CLUSTER cluster_alter using idstuff;
+--attempt the alter table
+ALTER TABLE cluster_alter ALTER COLUMN id TYPE int USING id::int;
+-- try recluster
+-- this fails on PG11 < 11.8 and PG12 < 12.3
+\set ON_ERROR_STOP 0
+CLUSTER cluster_alter;
+\set ON_ERROR_STOP 1
+CLUSTER cluster_alter using idstuff;

--- a/test/expected/plan_expand_hypertable-10.out
+++ b/test/expected/plan_expand_hypertable-10.out
@@ -2465,6 +2465,143 @@ SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestam
  Tue Feb 01 00:00:00 2000 PST
 (128 rows)
 
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
 \ir include/plan_expand_hypertable_chunks_in_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/plan_expand_hypertable-11.out
+++ b/test/expected/plan_expand_hypertable-11.out
@@ -2462,6 +2462,143 @@ SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestam
  Tue Feb 01 00:00:00 2000 PST
 (128 rows)
 
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
 \ir include/plan_expand_hypertable_chunks_in_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/expected/plan_expand_hypertable-12.out
+++ b/test/expected/plan_expand_hypertable-12.out
@@ -977,18 +977,12 @@ must not exclude on m1
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                Order: m2."time"
                ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk m2_1
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk m2_2
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_167_chunk_metrics_timestamptz_2_time_idx on _hyper_7_167_chunk m2_3
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk m2_4
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk m2_5
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk m2_6
-                     Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(25 rows)
+(19 rows)
 
 \qecho should exclude chunks on m2
 should exclude chunks on m2
@@ -1000,15 +994,10 @@ should exclude chunks on m2
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk m1_3
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk m1_4
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
          ->  Index Only Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk m1_5
-               Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
    ->  Materialize
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                Order: m2."time"
@@ -1024,7 +1013,7 @@ should exclude chunks on m2
                      Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                ->  Index Only Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk m2_6
                      Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(29 rows)
+(24 rows)
 
 \qecho should exclude chunks on m1
 should exclude chunks on m1
@@ -1051,18 +1040,12 @@ should exclude chunks on m1
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                      Order: m2."time"
                      ->  Index Only Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk m2_1
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk m2_2
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_167_chunk_metrics_timestamptz_2_time_idx on _hyper_7_167_chunk m2_3
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk m2_4
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk m2_5
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk m2_6
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(31 rows)
+(25 rows)
 
 \qecho must not exclude chunks on m2
 must not exclude chunks on m2
@@ -1086,16 +1069,11 @@ must not exclude chunks on m2
                ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
                      Order: m1."time"
                      ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk m1_3
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk m1_4
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
                      ->  Index Only Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk m1_5
-                           Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
-(26 rows)
+(21 rows)
 
 \qecho time_bucket exclusion
 time_bucket exclusion
@@ -1912,9 +1890,10 @@ must not propagate
    ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
          Order: m1."time"
          ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-               Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
          ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-               Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  Index Only Scan Backward using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk m1_3
+         ->  Index Only Scan Backward using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk m1_4
+         ->  Index Only Scan Backward using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk m1_5
    ->  Materialize
          ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 m2
                Order: m2."time"
@@ -1922,35 +1901,37 @@ must not propagate
                      Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
                ->  Index Only Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk m2_2
                      Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(15 rows)
+(16 rows)
 
 \qecho test constraints in ON clause of RIGHT JOIN
 test constraints in ON clause of RIGHT JOIN
 \qecho must not propagate
 must not propagate
 :PREFIX SELECT m1.time FROM metrics_timestamptz m1 RIGHT JOIN metrics_timestamptz_2 m2 ON m1.time = m2.time AND m2.time > '2000-01-01' AND m2.time < '2000-01-10' ORDER BY m1.time;
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort
-   Sort Key: m1."time"
-   ->  Hash Left Join
-         Hash Cond: (m2."time" = m1."time")
-         Join Filter: ((m2."time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND (m2."time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-         ->  Append
-               ->  Seq Scan on _hyper_7_165_chunk m2
-               ->  Seq Scan on _hyper_7_166_chunk m2_1
-               ->  Seq Scan on _hyper_7_167_chunk m2_2
-               ->  Seq Scan on _hyper_7_168_chunk m2_3
-               ->  Seq Scan on _hyper_7_169_chunk m2_4
-               ->  Seq Scan on _hyper_7_170_chunk m2_5
-         ->  Hash
-               ->  Custom Scan (ChunkAppend) on metrics_timestamptz m1
-                     Order: m1."time"
-                     ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk m1_1
-                           Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-                     ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk m1_2
-                           Index Cond: (("time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
-(19 rows)
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Workers Planned: 2
+   ->  Sort
+         Sort Key: m1."time"
+         ->  Parallel Hash Left Join
+               Hash Cond: (m2."time" = m1."time")
+               Join Filter: ((m2."time" > 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone) AND (m2."time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+               ->  Parallel Append
+                     ->  Parallel Seq Scan on _hyper_7_165_chunk m2
+                     ->  Parallel Seq Scan on _hyper_7_166_chunk m2_1
+                     ->  Parallel Seq Scan on _hyper_7_167_chunk m2_2
+                     ->  Parallel Seq Scan on _hyper_7_168_chunk m2_3
+                     ->  Parallel Seq Scan on _hyper_7_169_chunk m2_4
+                     ->  Parallel Seq Scan on _hyper_7_170_chunk m2_5
+               ->  Parallel Hash
+                     ->  Parallel Append
+                           ->  Parallel Seq Scan on _hyper_6_160_chunk m1
+                           ->  Parallel Seq Scan on _hyper_6_161_chunk m1_1
+                           ->  Parallel Seq Scan on _hyper_6_162_chunk m1_2
+                           ->  Parallel Seq Scan on _hyper_6_163_chunk m1_3
+                           ->  Parallel Seq Scan on _hyper_6_164_chunk m1_4
+(21 rows)
 
 \qecho test equality condition not in ON clause
 test equality condition not in ON clause
@@ -2430,6 +2411,143 @@ SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestam
  Tue Feb 01 00:00:00 2000 PST
  Tue Feb 01 00:00:00 2000 PST
 (128 rows)
+
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
 
 \ir include/plan_expand_hypertable_chunks_in_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.

--- a/test/expected/plan_expand_hypertable-9.6.out
+++ b/test/expected/plan_expand_hypertable-9.6.out
@@ -2462,6 +2462,143 @@ SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestam
  Tue Feb 01 00:00:00 2000 PST
 (128 rows)
 
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: o1_m1."time", o2_m1."time"
+   ->  Merge Full Join
+         Merge Cond: (o2_m1."time" = o1_m1."time")
+         ->  Nested Loop
+               ->  Merge Append
+                     Sort Key: o2_m2."time"
+                     ->  Index Scan Backward using _hyper_7_170_chunk_metrics_timestamptz_2_time_idx on _hyper_7_170_chunk o2_m2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_168_chunk_metrics_timestamptz_2_time_idx on _hyper_7_168_chunk o2_m2_1
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+                     ->  Index Scan Backward using _hyper_7_169_chunk_metrics_timestamptz_2_time_idx on _hyper_7_169_chunk o2_m2_2
+                           Index Cond: ("time" > 'Thu Jan 20 00:00:00 2000 PST'::timestamp with time zone)
+                           Filter: (device_id = 2)
+               ->  Append
+                     ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o2_m1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o2_m1_1
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o2_m1_2
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o2_m1_3
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+                     ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o2_m1_4
+                           Index Cond: ("time" = o2_m2."time")
+                           Filter: (device_id = 2)
+         ->  Materialize
+               ->  Nested Loop
+                     ->  Custom Scan (ChunkAppend) on metrics_timestamptz_2 o1_m2
+                           Order: o1_m2."time"
+                           ->  Index Scan Backward using _hyper_7_165_chunk_metrics_timestamptz_2_time_idx on _hyper_7_165_chunk o1_m2_1
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                           ->  Index Scan Backward using _hyper_7_166_chunk_metrics_timestamptz_2_time_idx on _hyper_7_166_chunk o1_m2_2
+                                 Index Cond: ("time" < 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+                                 Filter: (device_id = 1)
+                     ->  Append
+                           ->  Index Scan using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk o1_m1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk o1_m1_1
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_162_chunk_metrics_timestamptz_time_idx on _hyper_6_162_chunk o1_m1_2
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_163_chunk_metrics_timestamptz_time_idx on _hyper_6_163_chunk o1_m1_3
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+                           ->  Index Scan using _hyper_6_164_chunk_metrics_timestamptz_time_idx on _hyper_6_164_chunk o1_m1_4
+                                 Index Cond: ("time" = o1_m2."time")
+                                 Filter: (device_id = 1)
+(58 rows)
+
 \ir include/plan_expand_hypertable_chunks_in_query.sql
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and

--- a/test/sql/include/append_load.sql
+++ b/test/sql/include/append_load.sql
@@ -82,3 +82,16 @@ ORDER BY time, device_id;
 
 ANALYZE metrics_space;
 
+-- test ChunkAppend projection #2661
+CREATE TABLE i2661 (
+  machine_id int4 NOT NULL,
+  "name" varchar(255) NOT NULL,
+  "timestamp" timestamptz NOT NULL,
+  "first" float4 NULL
+);
+SELECT create_hypertable('i2661', 'timestamp');
+
+INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
+ANALYZE i2661;
+
+

--- a/test/sql/include/append_query.sql
+++ b/test/sql/include/append_query.sql
@@ -333,3 +333,16 @@ DROP INDEX :INDEX_NAME;
 
 DROP TABLE join_limit;
 
+-- test ChunkAppend projection #2661
+:PREFIX SELECT ts.timestamp, ht.timestamp
+FROM (
+  SELECT generate_series(
+    to_timestamp(FLOOR(EXTRACT (EPOCH FROM '2020-01-01T00:01:00Z'::timestamp) / 300) * 300) AT TIME ZONE 'UTC',
+    '2020-01-01T01:00:00Z',
+    '5 minutes'::interval
+  ) AS timestamp
+) ts
+LEFT JOIN i2661 ht ON
+  (FLOOR(EXTRACT (EPOCH FROM ht."timestamp") / 300) * 300 = EXTRACT (EPOCH FROM ts.timestamp))
+  AND ht.timestamp > '2019-12-30T00:00:00Z'::timestamp;
+

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -303,3 +303,17 @@ SELECT time FROM regular_timestamptz UNION SELECT time FROM metrics_timestamptz 
 -- test UNION ALL between regular table and hypertable
 SELECT time FROM regular_timestamptz UNION ALL SELECT time FROM metrics_timestamptz ORDER BY 1;
 
+-- test nested join qual propagation
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON true WHERE o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id AND o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON true WHERE o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id AND o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;
+
+:PREFIX
+SELECT * FROM (
+SELECT o1_m1.time FROM metrics_timestamptz o1_m1 INNER JOIN metrics_timestamptz_2 o1_m2 ON o1_m2.time = o1_m1.time AND o1_m1.device_id = o1_m2.device_id WHERE o1_m2.time < '2000-01-10' AND o1_m1.device_id = 1
+) o1 FULL OUTER JOIN (
+SELECT o2_m1.time FROM metrics_timestamptz o2_m1 FULL OUTER JOIN metrics_timestamptz_2 o2_m2 ON o2_m2.time = o2_m1.time AND o2_m1.device_id = o2_m2.device_id WHERE o2_m2.time > '2000-01-20' AND o2_m1.device_id = 2
+) o2 ON o1.time = o2.time ORDER BY 1,2;

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -64,7 +64,10 @@ pushdown_quals(PlannerInfo *root, RelOptInfo *chunk_rel, RelOptInfo *compressed_
 
 		/* pushdown is not safe for volatile expressions */
 		if (contain_volatile_functions((Node *) ri->clause))
+		{
+			decompress_clauses = lappend(decompress_clauses, ri);
 			continue;
+		}
 
 		context.can_pushdown = true;
 		context.needs_recheck = false;

--- a/tsl/src/nodes/gapfill/planner.c
+++ b/tsl/src/nodes/gapfill/planner.c
@@ -184,9 +184,6 @@ gapfill_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path, List *
 	cscan->custom_private =
 		list_make4(gfpath->func, root->parse->groupClause, root->parse->jointree, args);
 
-	/* remove start and end argument from time_bucket call */
-	gfpath->func->args = list_make2(linitial(gfpath->func->args), lsecond(gfpath->func->args));
-
 	return &cscan->scan.plan;
 }
 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -678,3 +678,41 @@ WHERE hypertable.table_name like 'test1'  ORDER BY chunk.id ) as subq;
                 2
 (1 row)
 
+-- test disabling compression on hypertables with caggs and dropped chunks
+-- github issue 2844
+CREATE TABLE i2844 (created_at timestamptz NOT NULL,c1 float);
+SELECT create_hypertable('i2844', 'created_at', chunk_time_interval => '6 hour'::interval);
+ create_hypertable  
+--------------------
+ (7,public,i2844,t)
+(1 row)
+
+INSERT INTO i2844 SELECT generate_series('2000-01-01'::timestamptz, '2000-01-02'::timestamptz,'1h'::interval);
+CREATE VIEW test_agg WITH (timescaledb.continuous) AS SELECT time_bucket('1 hour', created_at) AS bucket, AVG(c1) AS avg_c1 FROM i2844 GROUP BY bucket;
+ALTER TABLE i2844 SET (timescaledb.compress);
+SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('i2844');
+            compressed_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_7_62_chunk
+ _timescaledb_internal._hyper_7_63_chunk
+ _timescaledb_internal._hyper_7_64_chunk
+ _timescaledb_internal._hyper_7_65_chunk
+ _timescaledb_internal._hyper_7_66_chunk
+(5 rows)
+
+SELECT drop_chunks(table_name => 'i2844', older_than => '2000-01-01 18:00'::timestamptz, cascade_to_materializations => true);
+               drop_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_7_62_chunk
+ _timescaledb_internal._hyper_7_63_chunk
+ _timescaledb_internal._hyper_7_64_chunk
+(3 rows)
+
+SELECT decompress_chunk(show_chunks, if_compressed => TRUE) AS decompressed_chunks FROM show_chunks('i2844');
+           decompressed_chunks           
+-----------------------------------------
+ _timescaledb_internal._hyper_7_65_chunk
+ _timescaledb_internal._hyper_7_66_chunk
+(2 rows)
+
+ALTER TABLE i2844 SET (timescaledb.compress = FALSE);

--- a/tsl/test/expected/gapfill.out
+++ b/tsl/test/expected/gapfill.out
@@ -2768,3 +2768,48 @@ GROUP BY 1 ORDER BY 1;
   9223372036854775807 |    32767 |  2147483647 |  9223372036854775807 |  2147483647 |  Infinity
 (3 rows)
 
+-- issue #2232: This query used to trigger error "could not find
+-- pathkey item to sort" due to a corrupt query plan
+SELECT time_bucket_gapfill('1 h', time) AS time,
+       locf(sum(v1)) AS v1_sum,
+	   interpolate(sum(v2)) AS v2_sum
+FROM metrics_tstz
+WHERE time >= '2018-01-01 04:00' AND time < '2018-01-01 08:00'
+GROUP BY 1
+ORDER BY 1 DESC;
+             time             | v1_sum | v2_sum 
+------------------------------+--------+--------
+ Mon Jan 01 07:00:00 2018 PST |    2.3 |     70
+ Mon Jan 01 06:00:00 2018 PST |    2.1 |     65
+ Mon Jan 01 05:00:00 2018 PST |    2.1 |     60
+ Mon Jan 01 04:00:00 2018 PST |        |       
+(4 rows)
+
+-- query without gapfill:
+SELECT time_bucket('1 h', time) AS time,
+       sum(v1) AS v1_sum,
+	   sum(v2) AS v1_sum
+FROM metrics_tstz
+WHERE time >= '2018-01-01 04:00' AND time < '2018-01-01 08:00'
+GROUP BY 1
+ORDER BY 1 DESC;
+             time             | v1_sum | v1_sum 
+------------------------------+--------+--------
+ Mon Jan 01 07:00:00 2018 PST |    2.3 |     70
+ Mon Jan 01 05:00:00 2018 PST |    2.1 |     60
+(2 rows)
+
+-- query to show original data
+SELECT * FROM metrics_tstz
+WHERE time >= '2018-01-01 04:00' AND time < '2018-01-01 08:00'
+ORDER BY 1 DESC, 2;
+             time             | device_id | v1  | v2 
+------------------------------+-----------+-----+----
+ Mon Jan 01 07:00:00 2018 PST |         1 |   0 |  0
+ Mon Jan 01 07:00:00 2018 PST |         2 | 1.4 | 40
+ Mon Jan 01 07:00:00 2018 PST |         3 | 0.9 | 30
+ Mon Jan 01 05:00:00 2018 PST |         1 | 0.5 | 10
+ Mon Jan 01 05:00:00 2018 PST |         2 | 0.7 | 20
+ Mon Jan 01 05:00:00 2018 PST |         3 | 0.9 | 30
+(6 rows)
+

--- a/tsl/test/expected/plan_gapfill-10.out
+++ b/tsl/test/expected/plan_gapfill-10.out
@@ -18,13 +18,13 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -36,15 +36,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (avg("*VALUES*".column2))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -56,15 +56,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1 DESC;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) DESC
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) DESC
    ->  Custom Scan (GapFill)
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) NULLS FIRST
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) NULLS FIRST
                ->  HashAggregate
-                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)
+                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -76,15 +76,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2,1;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -95,13 +95,13 @@ SELECT
   avg(c2)
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -113,17 +113,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                ->  Gather
                      Workers Planned: 1
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Append
                                        ->  Parallel Seq Scan on _hyper_1_1_chunk
@@ -140,17 +140,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                ->  Gather
                      Workers Planned: 1
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Append
                                        ->  Parallel Seq Scan on _hyper_1_1_chunk
@@ -167,17 +167,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                ->  Gather
                      Workers Planned: 1
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Append
                                        ->  Parallel Seq Scan on _hyper_1_1_chunk
@@ -196,20 +196,20 @@ FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 2
 LIMIT 1;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (interpolate(avg(value), NULL::record, NULL::record))
          ->  Custom Scan (GapFill)
                ->  Finalize GroupAggregate
-                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Sort
-                           Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+                           Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                            ->  Gather
                                  Workers Planned: 1
                                  ->  Partial HashAggregate
-                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                                        ->  Result
                                              ->  Append
                                                    ->  Parallel Seq Scan on _hyper_1_1_chunk

--- a/tsl/test/expected/plan_gapfill-11.out
+++ b/tsl/test/expected/plan_gapfill-11.out
@@ -18,13 +18,13 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -36,15 +36,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (avg("*VALUES*".column2))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -56,15 +56,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1 DESC;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) DESC
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) DESC
    ->  Custom Scan (GapFill)
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) NULLS FIRST
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) NULLS FIRST
                ->  HashAggregate
-                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)
+                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -76,15 +76,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2,1;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -95,13 +95,13 @@ SELECT
   avg(c2)
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -113,17 +113,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Gather Merge
                Workers Planned: 2
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Parallel Append
                                        ->  Parallel Seq Scan on _hyper_1_2_chunk
@@ -140,17 +140,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Gather Merge
                Workers Planned: 2
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Parallel Append
                                        ->  Parallel Seq Scan on _hyper_1_2_chunk
@@ -167,17 +167,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Gather Merge
                Workers Planned: 2
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Parallel Append
                                        ->  Parallel Seq Scan on _hyper_1_2_chunk
@@ -196,20 +196,20 @@ FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 2
 LIMIT 1;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (interpolate(avg(value), NULL::record, NULL::record))
          ->  Custom Scan (GapFill)
                ->  Finalize GroupAggregate
-                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Gather Merge
                            Workers Planned: 2
                            ->  Sort
-                                 Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                                 Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                                  ->  Partial HashAggregate
-                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                                        ->  Result
                                              ->  Parallel Append
                                                    ->  Parallel Seq Scan on _hyper_1_2_chunk

--- a/tsl/test/expected/plan_gapfill-12.out
+++ b/tsl/test/expected/plan_gapfill-12.out
@@ -18,13 +18,13 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -36,15 +36,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (avg("*VALUES*".column2))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -56,15 +56,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1 DESC;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) DESC
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) DESC
    ->  Custom Scan (GapFill)
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) NULLS FIRST
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) NULLS FIRST
                ->  HashAggregate
-                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)
+                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -76,15 +76,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2,1;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -95,13 +95,13 @@ SELECT
   avg(c2)
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -113,17 +113,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Gather Merge
                Workers Planned: 2
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Parallel Append
                                        ->  Parallel Seq Scan on _hyper_1_2_chunk
@@ -140,17 +140,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Gather Merge
                Workers Planned: 2
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Parallel Append
                                        ->  Parallel Seq Scan on _hyper_1_2_chunk
@@ -167,17 +167,17 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Finalize GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  Gather Merge
                Workers Planned: 2
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Partial HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Parallel Append
                                        ->  Parallel Seq Scan on _hyper_1_2_chunk
@@ -196,20 +196,20 @@ FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 2
 LIMIT 1;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (interpolate(avg(value), NULL::record, NULL::record))
          ->  Custom Scan (GapFill)
                ->  Finalize GroupAggregate
-                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                     Group Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  Gather Merge
                            Workers Planned: 2
                            ->  Sort
-                                 Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time"))
+                                 Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                                  ->  Partial HashAggregate
-                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time")
+                                       Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_2_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                                        ->  Result
                                              ->  Parallel Append
                                                    ->  Parallel Seq Scan on _hyper_1_2_chunk

--- a/tsl/test/expected/plan_gapfill-9.6.out
+++ b/tsl/test/expected/plan_gapfill-9.6.out
@@ -18,13 +18,13 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -36,15 +36,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
  Sort
    Sort Key: (avg("*VALUES*".column2))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -56,15 +56,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 1 DESC;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) DESC
+   Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) DESC
    ->  Custom Scan (GapFill)
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)) NULLS FIRST
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())) NULLS FIRST
                ->  HashAggregate
-                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1)
+                     Group Key: time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now())
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -76,15 +76,15 @@ SELECT
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1
 ORDER BY 2,1;
-                                               QUERY PLAN                                               
---------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+   Sort Key: (avg("*VALUES*".column2)), (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
    ->  Custom Scan (GapFill)
          ->  GroupAggregate
-               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                      ->  Values Scan on "*VALUES*"
 (8 rows)
 
@@ -95,13 +95,13 @@ SELECT
   avg(c2)
 FROM (VALUES (now(),1),(now(),NULL),(now(),NULL)) as t(time,c2)
 GROUP BY 1;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  GroupAggregate
-         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+         Group Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
          ->  Sort
-               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1))
+               Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, "*VALUES*".column1, now(), now()))
                ->  Values Scan on "*VALUES*"
 (6 rows)
 
@@ -113,13 +113,13 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                ->  Result
                      ->  Append
                            ->  Seq Scan on _hyper_1_1_chunk
@@ -136,13 +136,13 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                ->  Result
                      ->  Append
                            ->  Seq Scan on _hyper_1_1_chunk
@@ -159,13 +159,13 @@ SELECT
 FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 1;
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    ->  Sort
-         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+         Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
          ->  HashAggregate
-               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+               Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                ->  Result
                      ->  Append
                            ->  Seq Scan on _hyper_1_1_chunk
@@ -184,16 +184,16 @@ FROM gapfill_plan_test
 GROUP BY 1
 ORDER BY 2
 LIMIT 1;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: (interpolate(avg(value), NULL::record, NULL::record))
          ->  Custom Scan (GapFill)
                ->  Sort
-                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time"))
+                     Sort Key: (time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone))
                      ->  HashAggregate
-                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time")
+                           Group Key: time_bucket_gapfill('@ 5 mins'::interval, _hyper_1_1_chunk."time", 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone, 'Wed Dec 31 16:00:00 1969 PST'::timestamp with time zone)
                            ->  Result
                                  ->  Append
                                        ->  Seq Scan on _hyper_1_1_chunk

--- a/tsl/test/expected/transparent_decompression-10.out
+++ b/tsl/test/expected/transparent_decompression-10.out
@@ -8007,9 +8007,156 @@ where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_t
 (21 rows)
 
 --enable all joins after the tests
-set enable_mergejoin = true;
-set enable_hashjoin = true;
- --end github issue 1558
+SET enable_mergejoin = TRUE;
+SET enable_hashjoin = TRUE;
+--end github issue 1558
+-- github issue 2673 
+-- nested loop join with parameterized path
+-- join condition has a segment by column and another column.
+SET enable_hashjoin = false;
+SET enable_mergejoin=false;
+SET enable_material = false;
+SET enable_seqscan = false;
+-- restrict so that we select only 1 chunk.
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05'; 
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=2 loops=1)
+   ->  Append (actual rows=1 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=2)
+               Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (lookup.version = v0))
+               Rows Removed by Filter: 4290
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=2)
+                     Index Cond: (device_id = lookup.did)
+                     Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
+(11 rows)
+
+--add filter to segment by (device_id) and compressed attr column (v0)
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3 and met.v0 = 5;
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=1 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=1 loops=1)
+         Filter: ((did = 3) AND (version = 5))
+         Rows Removed by Filter: 1
+   ->  Append (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=1)
+               Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
+               Rows Removed by Filter: 4290
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+                     Index Cond: (device_id = 3)
+                     Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+WHERE met.time = '2000-01-19 19:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=0 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=1 loops=1)
+         Filter: ((did = 3) AND (version = 5))
+         Rows Removed by Filter: 1
+   ->  Append (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=0 loops=1)
+               Filter: ((v0 = 5) AND ("time" = 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id_peer = 3)
+                     Filter: ((device_id = 3) AND (_ts_meta_min_1 <= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
+                     Rows Removed by Filter: 4
+(14 rows)
+
+-- lateral subquery
+:PREFIX
+WITH f1 as ( SELECT * from (values( 7, 5, 4) , (4, 5, 5) ) as lu( device_id, device_id_peer, v0) )
+SELECT * FROM  metrics_ordered_idx met 
+JOIN LATERAL
+  ( SELECT node, f1.* from nodetime , f1
+    WHERE  node = f1.device_id) q
+ON met.device_id = q.node and met.device_id_peer = q.device_id_peer 
+   and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=0 loops=1)
+   Join Filter: (nodetime.node = met.device_id)
+   CTE f1
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Nested Loop (actual rows=1 loops=1)
+         Join Filter: (nodetime.node = f1.device_id)
+         Rows Removed by Join Filter: 1
+         ->  Seq Scan on nodetime (actual rows=1 loops=1)
+         ->  CTE Scan on f1 (actual rows=2 loops=1)
+   ->  Append (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk met (actual rows=0 loops=1)
+               Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (f1.device_id = device_id) AND (f1.v0 = v0))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id_peer = f1.device_id_peer)
+                     Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (f1.device_id = device_id))
+                     Rows Removed by Filter: 4
+(17 rows)
+
+-- filter on compressed attr (v0) with seqscan enabled and indexscan 
+-- disabled. filters on compressed attr should be above the seq scan.
+SET enable_seqscan = true;
+SET enable_indexscan = false;
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+   and met.device_id = 3
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=1 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=1 loops=1)
+         Filter: ((did = 3) AND (version = 5))
+         Rows Removed by Filter: 1
+   ->  Append (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=1)
+               Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
+               Rows Removed by Filter: 4290
+               ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+                     Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (device_id = 3) AND (device_id_peer = 3))
+(12 rows)
+
+RESET enable_hashjoin  ;
+RESET enable_mergejoin;
+RESET enable_material ;
+RESET enable_indexscan ;
+--end github issue 2673 
 set enable_seqscan = true;
 \ir include/transparent_decompression_constraintaware.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-11.out
+++ b/tsl/test/expected/transparent_decompression-11.out
@@ -8126,9 +8126,156 @@ where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_t
 (21 rows)
 
 --enable all joins after the tests
-set enable_mergejoin = true;
-set enable_hashjoin = true;
- --end github issue 1558
+SET enable_mergejoin = TRUE;
+SET enable_hashjoin = TRUE;
+--end github issue 1558
+-- github issue 2673 
+-- nested loop join with parameterized path
+-- join condition has a segment by column and another column.
+SET enable_hashjoin = false;
+SET enable_mergejoin=false;
+SET enable_material = false;
+SET enable_seqscan = false;
+-- restrict so that we select only 1 chunk.
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05'; 
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=2 loops=1)
+   ->  Append (actual rows=1 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=2)
+               Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (lookup.version = v0))
+               Rows Removed by Filter: 4290
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=2)
+                     Index Cond: (device_id = lookup.did)
+                     Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
+(11 rows)
+
+--add filter to segment by (device_id) and compressed attr column (v0)
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3 and met.v0 = 5;
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=1 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=1 loops=1)
+         Filter: ((did = 3) AND (version = 5))
+         Rows Removed by Filter: 1
+   ->  Append (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=1)
+               Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
+               Rows Removed by Filter: 4290
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+                     Index Cond: (device_id = 3)
+                     Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+WHERE met.time = '2000-01-19 19:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=0 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=1 loops=1)
+         Filter: ((did = 3) AND (version = 5))
+         Rows Removed by Filter: 1
+   ->  Append (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=0 loops=1)
+               Filter: ((v0 = 5) AND ("time" = 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id_peer = 3)
+                     Filter: ((device_id = 3) AND (_ts_meta_min_1 <= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
+                     Rows Removed by Filter: 4
+(14 rows)
+
+-- lateral subquery
+:PREFIX
+WITH f1 as ( SELECT * from (values( 7, 5, 4) , (4, 5, 5) ) as lu( device_id, device_id_peer, v0) )
+SELECT * FROM  metrics_ordered_idx met 
+JOIN LATERAL
+  ( SELECT node, f1.* from nodetime , f1
+    WHERE  node = f1.device_id) q
+ON met.device_id = q.node and met.device_id_peer = q.device_id_peer 
+   and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=0 loops=1)
+   Join Filter: (nodetime.node = met.device_id)
+   CTE f1
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Nested Loop (actual rows=1 loops=1)
+         Join Filter: (nodetime.node = f1.device_id)
+         Rows Removed by Join Filter: 1
+         ->  Seq Scan on nodetime (actual rows=1 loops=1)
+         ->  CTE Scan on f1 (actual rows=2 loops=1)
+   ->  Append (actual rows=0 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk met (actual rows=0 loops=1)
+               Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (f1.device_id = device_id) AND (f1.v0 = v0))
+               Rows Removed by Filter: 1000
+               ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id_peer = f1.device_id_peer)
+                     Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (f1.device_id = device_id))
+                     Rows Removed by Filter: 4
+(17 rows)
+
+-- filter on compressed attr (v0) with seqscan enabled and indexscan 
+-- disabled. filters on compressed attr should be above the seq scan.
+SET enable_seqscan = true;
+SET enable_indexscan = false;
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+   and met.device_id = 3
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=1 loops=1)
+   CTE lookup
+     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  CTE Scan on lookup (actual rows=1 loops=1)
+         Filter: ((did = 3) AND (version = 5))
+         Rows Removed by Filter: 1
+   ->  Append (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=1)
+               Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
+               Rows Removed by Filter: 4290
+               ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+                     Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (device_id = 3) AND (device_id_peer = 3))
+(12 rows)
+
+RESET enable_hashjoin  ;
+RESET enable_mergejoin;
+RESET enable_material ;
+RESET enable_indexscan ;
+--end github issue 2673 
 set enable_seqscan = true;
 \ir include/transparent_decompression_constraintaware.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -8011,9 +8011,141 @@ where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_t
 (21 rows)
 
 --enable all joins after the tests
-set enable_mergejoin = true;
-set enable_hashjoin = true;
- --end github issue 1558
+SET enable_mergejoin = TRUE;
+SET enable_hashjoin = TRUE;
+--end github issue 1558
+-- github issue 2673 
+-- nested loop join with parameterized path
+-- join condition has a segment by column and another column.
+SET enable_hashjoin = false;
+SET enable_mergejoin=false;
+SET enable_material = false;
+SET enable_seqscan = false;
+-- restrict so that we select only 1 chunk.
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05'; 
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=2 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=2)
+         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = v0))
+         Rows Removed by Filter: 4290
+         ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=2)
+               Index Cond: (device_id = "*VALUES*".column1)
+               Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
+--add filter to segment by (device_id) and compressed attr column (v0)
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3 and met.v0 = 5;
+                                                                                     QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=1 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
+         Filter: ((column1 = 3) AND (column2 = 5))
+         Rows Removed by Filter: 1
+   ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=1)
+         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
+         Rows Removed by Filter: 4290
+         ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_i on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+               Index Cond: (device_id = 3)
+               Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
+(10 rows)
+
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+WHERE met.time = '2000-01-19 19:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=0 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
+         Filter: ((column1 = 3) AND (column2 = 5))
+         Rows Removed by Filter: 1
+   ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=0 loops=1)
+         Filter: ((v0 = 5) AND ("time" = 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
+         Rows Removed by Filter: 1000
+         ->  Index Scan using compress_hyper_16_1445_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1445_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id_peer = 3)
+               Filter: ((device_id = 3) AND (_ts_meta_min_1 <= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone))
+               Rows Removed by Filter: 4
+(11 rows)
+
+-- lateral subquery
+:PREFIX
+WITH f1 as ( SELECT * from (values( 7, 5, 4) , (4, 5, 5) ) as lu( device_id, device_id_peer, v0) )
+SELECT * FROM  metrics_ordered_idx met 
+JOIN LATERAL
+  ( SELECT node, f1.* from nodetime , f1
+    WHERE  node = f1.device_id) q
+ON met.device_id = q.node and met.device_id_peer = q.device_id_peer 
+   and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=0 loops=1)
+   Join Filter: (nodetime.node = met.device_id)
+   ->  Nested Loop (actual rows=1 loops=1)
+         Join Filter: (nodetime.node = "*VALUES*".column1)
+         Rows Removed by Join Filter: 1
+         ->  Seq Scan on nodetime (actual rows=1 loops=1)
+         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_15_1441_chunk met (actual rows=0 loops=1)
+         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = device_id_peer) AND ("*VALUES*".column3 = v0))
+         Rows Removed by Filter: 1000
+         ->  Index Scan using compress_hyper_16_1446_chunk__compressed_hypertable_16_device_1 on compress_hyper_16_1446_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id_peer = "*VALUES*".column2)
+               Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id))
+               Rows Removed by Filter: 4
+(14 rows)
+
+-- filter on compressed attr (v0) with seqscan enabled and indexscan 
+-- disabled. filters on compressed attr should be above the seq scan.
+SET enable_seqscan = true;
+SET enable_indexscan = false;
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+   and met.device_id = 3
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=1 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=1 loops=1)
+         Filter: ((column1 = 3) AND (column2 = 5))
+         Rows Removed by Filter: 1
+   ->  Custom Scan (DecompressChunk) on _hyper_15_1440_chunk met (actual rows=1 loops=1)
+         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (v0 = 5))
+         Rows Removed by Filter: 4290
+         ->  Seq Scan on compress_hyper_16_1445_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND (device_id = 3) AND (device_id_peer = 3))
+(9 rows)
+
+RESET enable_hashjoin  ;
+RESET enable_mergejoin;
+RESET enable_material ;
+RESET enable_indexscan ;
+--end github issue 2673 
 set enable_seqscan = true;
 \ir include/transparent_decompression_constraintaware.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -166,3 +166,42 @@ GROUP BY 2, 3;
 (27 rows)
 
 RESET enable_hashagg;
+-- test if volatile function quals are applied to compressed chunks
+CREATE FUNCTION check_equal_228( intval INTEGER) RETURNS BOOL 
+LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+    retval BOOL;
+BEGIN
+   IF intval = 228 THEN RETURN TRUE;
+   ELSE RETURN FALSE;
+   END IF;
+END;
+$BODY$;
+-- the function cannot be pushed down to compressed chunk
+-- but should be applied as a filter on decompresschunk
+SELECT * from test_chartab 
+WHERE check_equal_228(rtt) ORDER BY ts;
+ job_run_id |      mac_id      | rtt |              ts              
+------------+------------------+-----+------------------------------
+       8864 | 001407000001DD2E | 228 | Sat Dec 14 02:52:05.863 2019
+       8890 | 001407000001DD2E | 228 | Fri Dec 20 02:52:05.863 2019
+(2 rows)
+
+EXPLAIN (analyze,costs off,timing off,summary off) 
+SELECT * from test_chartab 
+WHERE check_equal_228(rtt) and ts < '2019-12-15 00:00:00' order by ts;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=1 loops=1)
+   Sort Key: test_chartab.ts
+   Sort Method: quicksort 
+   ->  Custom Scan (ChunkAppend) on test_chartab (actual rows=1 loops=1)
+         Chunks excluded during startup: 0
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               Filter: ((ts < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone) AND check_equal_228(rtt))
+               Rows Removed by Filter: 2
+               ->  Seq Scan on compress_hyper_2_3_chunk (actual rows=3 loops=1)
+                     Filter: (_ts_meta_min_1 < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone)
+(10 rows)
+

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -445,8 +445,18 @@ FROM _timescaledb_catalog.chunk chunk
 INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
 WHERE hypertable.table_name like 'test1'  ORDER BY chunk.id ) as subq;
 
+-- test disabling compression on hypertables with caggs and dropped chunks
+-- github issue 2844
+CREATE TABLE i2844 (created_at timestamptz NOT NULL,c1 float);
+SELECT create_hypertable('i2844', 'created_at', chunk_time_interval => '6 hour'::interval);
+INSERT INTO i2844 SELECT generate_series('2000-01-01'::timestamptz, '2000-01-02'::timestamptz,'1h'::interval);
 
+CREATE VIEW test_agg WITH (timescaledb.continuous) AS SELECT time_bucket('1 hour', created_at) AS bucket, AVG(c1) AS avg_c1 FROM i2844 GROUP BY bucket;
 
+ALTER TABLE i2844 SET (timescaledb.compress);
 
+SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('i2844');
+SELECT drop_chunks(table_name => 'i2844', older_than => '2000-01-01 18:00'::timestamptz, cascade_to_materializations => true);
+SELECT decompress_chunk(show_chunks, if_compressed => TRUE) AS decompressed_chunks FROM show_chunks('i2844');
 
-
+ALTER TABLE i2844 SET (timescaledb.compress = FALSE);

--- a/tsl/test/sql/gapfill.sql
+++ b/tsl/test/sql/gapfill.sql
@@ -1507,3 +1507,27 @@ SELECT
 FROM (values (:big_int_min,(-32768)::smallint,(-2147483648)::int,:big_int_min,-2147483648::bigint, '-Infinity'::double precision),
              (:big_int_max, 32767::smallint, 2147483647::int,:big_int_max, 2147483647::bigint, 'Infinity'::double precision)) v(time,s,i,b,b2,d)
 GROUP BY 1 ORDER BY 1;
+
+-- issue #2232: This query used to trigger error "could not find
+-- pathkey item to sort" due to a corrupt query plan
+SELECT time_bucket_gapfill('1 h', time) AS time,
+       locf(sum(v1)) AS v1_sum,
+	   interpolate(sum(v2)) AS v2_sum
+FROM metrics_tstz
+WHERE time >= '2018-01-01 04:00' AND time < '2018-01-01 08:00'
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- query without gapfill:
+SELECT time_bucket('1 h', time) AS time,
+       sum(v1) AS v1_sum,
+	   sum(v2) AS v1_sum
+FROM metrics_tstz
+WHERE time >= '2018-01-01 04:00' AND time < '2018-01-01 08:00'
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- query to show original data
+SELECT * FROM metrics_tstz
+WHERE time >= '2018-01-01 04:00' AND time < '2018-01-01 08:00'
+ORDER BY 1 DESC, 2;

--- a/tsl/test/sql/include/transparent_decompression_ordered_index.sql
+++ b/tsl/test/sql/include/transparent_decompression_ordered_index.sql
@@ -48,6 +48,75 @@ set enable_hashjoin = true;
 where mt.time > nd.start_time and mt.device_id = nd.node and mt.time < nd.stop_time order by time;
 
 --enable all joins after the tests
-set enable_mergejoin = true;
-set enable_hashjoin = true;
- --end github issue 1558
+SET enable_mergejoin = TRUE;
+
+SET enable_hashjoin = TRUE;
+
+--end github issue 1558
+
+-- github issue 2673 
+-- nested loop join with parameterized path
+-- join condition has a segment by column and another column.
+SET enable_hashjoin = false;
+SET enable_mergejoin=false;
+SET enable_material = false;
+SET enable_seqscan = false;
+
+-- restrict so that we select only 1 chunk.
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05'; 
+
+--add filter to segment by (device_id) and compressed attr column (v0)
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3 and met.v0 = 5;
+
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+WHERE met.time = '2000-01-19 19:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+
+-- lateral subquery
+:PREFIX
+WITH f1 as ( SELECT * from (values( 7, 5, 4) , (4, 5, 5) ) as lu( device_id, device_id_peer, v0) )
+SELECT * FROM  metrics_ordered_idx met 
+JOIN LATERAL
+  ( SELECT node, f1.* from nodetime , f1
+    WHERE  node = f1.device_id) q
+ON met.device_id = q.node and met.device_id_peer = q.device_id_peer 
+   and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
+
+-- filter on compressed attr (v0) with seqscan enabled and indexscan 
+-- disabled. filters on compressed attr should be above the seq scan.
+SET enable_seqscan = true;
+SET enable_indexscan = false;
+:PREFIX
+WITH lookup as ( SELECT * from (values( 3, 5) , (3, 4) ) as lu( did, version) )
+SELECT met.*, lookup.*
+FROM metrics_ordered_idx met join lookup
+ON met.device_id = lookup.did and met.v0 = lookup.version 
+   and met.device_id = 3
+WHERE met.time > '2000-01-19 19:00:00-05' 
+      and met.time < '2000-01-20 20:00:00-05' 
+      and met.device_id = 3
+      and met.device_id_peer = 3 and met.v0 = 5;
+
+RESET enable_hashjoin  ;
+RESET enable_mergejoin;
+RESET enable_material ;
+RESET enable_indexscan ;
+--end github issue 2673 


### PR DESCRIPTION
Cherry-picks of the following commits:

Fix projection in ChunkAppend nodes timescale/timescaledb@302de38
Fix appveyor failures timescale/timescaledb@4cd95b9
Apply volatile function quals at decompresschunk timescale/timescaledb@5e73ff5
Fix nested loop joins for compressed chunk https://github.com/timescale/timescaledb/commit/87a190afcd35e266bdce71eff3eab0ab5b7e8413
Fix corruption in gapfill plan https://github.com/timescale/timescaledb/commit/36c1cd849a2ede6d1d3c08a18caaf3648d725bdb
Fix join propagation for nested joins https://github.com/timescale/timescaledb/commit/1461244bdb906d76c9b15b8de87360aee3498902
Fix compressed chunk check when disabling compression https://github.com/timescale/timescaledb/commit/e3c6725ad1471995902328fb512b989599f7ec99