### PR TITLE
Optimize cagg refresh for small invalidations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Minor features**
 * #2736 Support adding columns to hypertables with compression enabled
+* #2926 Optimize cagg refresh for small invalidations
 
 **Bugfixes**
 * #2883 Fix join qual propagation for nested joins
@@ -16,6 +17,8 @@ accidentally triggering the load of a previous DB version.**
 
 **Thanks**
 * @zeeshanshabbir93 for reporting an issue with joins
+* @Antiarchitect for reporting the issue with slow refreshes of
+  continuous aggregates.
 
 ## 1.7.5 (2021-02-12)
 

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -148,8 +148,8 @@ cache_inval_entry_init(ContinuousAggsCacheInvalEntry *cache_entry, int32 hyperta
 	}
 	cache_entry->previous_chunk_relid = InvalidOid;
 	cache_entry->value_is_set = false;
-	cache_entry->lowest_modified_value = PG_INT64_MAX;
-	cache_entry->greatest_modified_value = PG_INT64_MIN;
+	cache_entry->lowest_modified_value = INVAL_POS_INFINITY;
+	cache_entry->greatest_modified_value = INVAL_NEG_INFINITY;
 	ts_cache_release(ht_cache);
 }
 
@@ -370,7 +370,7 @@ invalidation_tuple_found(TupleInfo *ti, void *min)
 int64
 get_lowest_invalidated_time_for_hypertable(Oid hypertable_relid)
 {
-	int64 min_val = PG_INT64_MAX;
+	int64 min_val = INVAL_POS_INFINITY;
 	Catalog *catalog = ts_catalog_get();
 	ScanKeyData scankey[1];
 	ScannerCtx scanctx;
@@ -401,7 +401,7 @@ get_lowest_invalidated_time_for_hypertable(Oid hypertable_relid)
 	 * invalidations are redundant.
 	 */
 	if (!ts_scanner_scan_one(&scanctx, false, "invalidation watermark"))
-		return PG_INT64_MIN;
+		return INVAL_NEG_INFINITY;
 
 	return min_val;
 }

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -26,6 +26,9 @@ typedef struct Invalidation
 	ItemPointerData tid;
 } Invalidation;
 
+#define INVAL_NEG_INFINITY PG_INT64_MIN
+#define INVAL_POS_INFINITY PG_INT64_MAX
+
 typedef struct InvalidationStore
 {
 	Tuplestorestate *tupstore;
@@ -37,9 +40,7 @@ typedef struct Hypertable Hypertable;
 extern void invalidation_cagg_log_add_entry(int32 cagg_hyper_id, int64 start, int64 end);
 extern void invalidation_hyper_log_add_entry(int32 hyper_id, int64 start, int64 end);
 extern void invalidation_add_entry(const Hypertable *ht, int64 start, int64 end);
-extern void invalidation_entry_set_from_hyper_invalidation(Invalidation *entry, const TupleInfo *ti,
-														   int32 hyper_id);
-extern void invalidation_process_hypertable_log(const ContinuousAgg *cagg);
+extern void invalidation_process_hypertable_log(const ContinuousAgg *cagg, Oid dimtype);
 extern InvalidationStore *invalidation_process_cagg_log(const ContinuousAgg *cagg,
 														const InternalTimeRange *refresh_window);
 extern void invalidation_store_free(InvalidationStore *store);

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -536,7 +536,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	}
 
 	/* Process invalidations in the hypertable invalidation log */
-	invalidation_process_hypertable_log(cagg);
+	invalidation_process_hypertable_log(cagg, refresh_window.type);
 
 	/* Start a new transaction. Note that this invalidates previous memory
 	 * allocations (and locks). */
@@ -594,7 +594,7 @@ continuous_agg_refresh_chunk(PG_FUNCTION_ARGS)
 					AccessExclusiveLock);
 	invalidation_threshold_set_or_get(chunk->fd.hypertable_id, refresh_window.end);
 
-	invalidation_process_hypertable_log(cagg);
+	invalidation_process_hypertable_log(cagg, refresh_window.type);
 	/* Must make invalidation processing visible */
 	CommandCounterIncrement();
 	process_cagg_invalidations_and_refresh(cagg, &refresh_window, CAGG_REFRESH_CHUNK, chunk->fd.id);

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -1131,3 +1131,53 @@ WHERE cagg_id = :cond_10_id;
        3 |                   60 | 9223372036854775807
 (4 rows)
 
+-- should trigger two individual refreshes
+SET client_min_messages TO DEBUG1;
+CALL refresh_continuous_aggregate('cond_10', 0, 200);
+DEBUG:  refreshing continuous aggregate "cond_10" in window [ 0, 200 ]
+DEBUG:  invalidation refresh on "cond_10" in window [ 0, 30 ]
+DEBUG:  invalidation refresh on "cond_10" in window [ 40, 50 ]
+DEBUG:  invalidation refresh on "cond_10" in window [ 60, 200 ]
+RESET client_min_messages;
+-- Allow at most 5 individual invalidations per refreshe
+SET timescaledb.materializations_per_refresh_window=5;
+-- Insert into every second bucket
+INSERT INTO conditions VALUES (20, 1, 1.0);
+INSERT INTO conditions VALUES (40, 1, 1.0);
+INSERT INTO conditions VALUES (60, 1, 1.0);
+INSERT INTO conditions VALUES (80, 1, 1.0);
+INSERT INTO conditions VALUES (100, 1, 1.0);
+INSERT INTO conditions VALUES (120, 1, 1.0);
+INSERT INTO conditions VALUES (140, 1, 1.0);
+SET client_min_messages TO DEBUG1;
+CALL refresh_continuous_aggregate('cond_10', 0, 200);
+DEBUG:  refreshing continuous aggregate "cond_10" in window [ 0, 200 ]
+DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 200 200
+DEBUG:  merged 7 invalidations for refresh on "cond_10" in window [ 20, 150 ]
+RESET client_min_messages;
+\set VERBOSITY default
+-- Test acceptable values for materializations per refresh
+SET timescaledb.materializations_per_refresh_window=' 5 ';
+INSERT INTO conditions VALUES (140, 1, 1.0);
+CALL refresh_continuous_aggregate('cond_10', 0, 200);
+-- Large value will be treated as LONG_MAX
+SET timescaledb.materializations_per_refresh_window=342239897234023842394249234766923492347;
+INSERT INTO conditions VALUES (140, 1, 1.0);
+CALL refresh_continuous_aggregate('cond_10', 0, 200);
+-- Test bad values for materializations per refresh
+SET timescaledb.materializations_per_refresh_window='foo';
+INSERT INTO conditions VALUES (140, 1, 1.0);
+CALL refresh_continuous_aggregate('cond_10', 0, 200);
+WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+DETAIL:  Expected an integer but current value is "foo".
+SET timescaledb.materializations_per_refresh_window='2bar';
+INSERT INTO conditions VALUES (140, 1, 1.0);
+CALL refresh_continuous_aggregate('cond_10', 0, 200);
+WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+DETAIL:  Expected an integer but current value is "2bar".
+SET timescaledb.materializations_per_refresh_window='-';
+INSERT INTO conditions VALUES (140, 1, 1.0);
+CALL refresh_continuous_aggregate('cond_10', 0, 200);
+WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+DETAIL:  Expected an integer but current value is "-".
+\set VERBOSITY terse

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -328,8 +328,8 @@ SELECT * FROM cagg_invals;
        3 |                   10 |                  19
        3 |                   60 | 9223372036854775807
        4 | -9223372036854775808 |                  59
-       4 |                   10 |                  19
-       4 |                   60 |                  70
+       4 |                    0 |                  19
+       4 |                   60 |                  79
        4 |                  100 | 9223372036854775807
        5 | -9223372036854775808 |                  -1
        5 |                   30 | 9223372036854775807
@@ -374,8 +374,8 @@ SELECT * FROM cagg_invals;
        3 |                   10 |                  19
        3 |                   60 | 9223372036854775807
        4 | -9223372036854775808 |                  59
-       4 |                   10 |                  19
-       4 |                   60 |                  70
+       4 |                    0 |                  19
+       4 |                   60 |                  79
        4 |                  100 | 9223372036854775807
        5 | -9223372036854775808 |                  -1
        5 |                   30 | 9223372036854775807
@@ -395,17 +395,16 @@ SELECT * FROM hyper_invals;
 SELECT * FROM cagg_invals;
  cagg_id |        start         |         end         
 ---------+----------------------+---------------------
-       3 | -9223372036854775808 |                  -1
-       3 |                    1 |                  19
+       3 | -9223372036854775808 |                  19
        3 |                   60 | 9223372036854775807
        4 | -9223372036854775808 |                  59
-       4 |                    1 |                 100
-       4 |                   10 |                  19
-       4 |                   60 |                  70
+       4 |                    0 |                  19
+       4 |                    0 |                 119
+       4 |                   60 |                  79
        4 |                  100 | 9223372036854775807
        5 | -9223372036854775808 |                  -1
        5 |                   30 | 9223372036854775807
-(10 rows)
+(9 rows)
 
 -- Refresh also cond_20:
 CALL refresh_continuous_aggregate('cond_20', 20, 60);
@@ -413,14 +412,13 @@ CALL refresh_continuous_aggregate('cond_20', 20, 60);
 SELECT * FROM cagg_invals;
  cagg_id |        start         |         end         
 ---------+----------------------+---------------------
-       3 | -9223372036854775808 |                  -1
-       3 |                    1 |                  19
+       3 | -9223372036854775808 |                  19
        3 |                   60 | 9223372036854775807
        4 | -9223372036854775808 |                  19
        4 |                   60 | 9223372036854775807
        5 | -9223372036854775808 |                  -1
        5 |                   30 | 9223372036854775807
-(7 rows)
+(6 rows)
 
 -- Refresh cond_10 to completely remove an invalidation:
 CALL refresh_continuous_aggregate('cond_10', 0, 20);
@@ -447,15 +445,14 @@ SELECT * FROM cagg_invals;
  cagg_id |        start         |         end         
 ---------+----------------------+---------------------
        3 | -9223372036854775808 |                  -1
-       3 |                   40 |                  46
+       3 |                   40 |                  49
        3 |                  100 | 9223372036854775807
        4 | -9223372036854775808 |                  19
-       4 |                   20 |                  25
-       4 |                   30 |                  46
+       4 |                   20 |                  59
        4 |                   60 | 9223372036854775807
        5 | -9223372036854775808 |                  -1
        5 |                   30 | 9223372036854775807
-(9 rows)
+(8 rows)
 
 -- Refresh whithout cutting (in area where there are no
 -- invalidations). Merging of overlapping entries should still happen:
@@ -466,16 +463,15 @@ SELECT * FROM cagg_invals;
  cagg_id |        start         |         end         
 ---------+----------------------+---------------------
        3 | -9223372036854775808 |                  -1
-       3 |                   15 |                  46
+       3 |                   10 |                  49
        3 |                  100 | 9223372036854775807
        4 | -9223372036854775808 |                  19
-       4 |                   15 |                  42
-       4 |                   20 |                  25
-       4 |                   30 |                  46
+       4 |                    0 |                  59
+       4 |                   20 |                  59
        4 |                   60 | 9223372036854775807
        5 | -9223372036854775808 |                  -1
        5 |                   30 | 9223372036854775807
-(10 rows)
+(9 rows)
 
 -- Test max refresh window
 CALL refresh_continuous_aggregate('cond_10', NULL, NULL);
@@ -485,13 +481,12 @@ SELECT * FROM cagg_invals;
        3 | -9223372036854775808 | -9223372036854775801
        3 |                  110 |  9223372036854775807
        4 | -9223372036854775808 |                   19
-       4 |                   15 |                   42
-       4 |                   20 |                   25
-       4 |                   30 |                   46
+       4 |                    0 |                   59
+       4 |                   20 |                   59
        4 |                   60 |  9223372036854775807
        5 | -9223372036854775808 |                   -1
        5 |                   30 |  9223372036854775807
-(9 rows)
+(8 rows)
 
 SELECT * FROM hyper_invals;
  hyper_id | start | end 
@@ -1106,4 +1101,33 @@ WHERE cagg_id = :cond_1_id;
        6 |     6 |                   6
        6 |   110 | 9223372036854775807
 (3 rows)
+
+---------------------------------------------------------------------
+-- Test that single timestamp invalidations are expanded to buckets,
+-- and adjacent buckets merged.
+---------------------------------------------------------------------
+-- First clear invalidations in a range:
+CALL refresh_continuous_aggregate('cond_10', -20, 60);
+-- The following three should be merged to one range 0-29
+INSERT INTO conditions VALUES (5, 1, 1.0);
+INSERT INTO conditions VALUES (15, 1, 1.0);
+INSERT INTO conditions VALUES (25, 1, 1.0);
+-- The last one should not merge with the others
+INSERT INTO conditions VALUES (40, 1, 1.0);
+-- Refresh to process invalidations, but outside the range of
+-- invalidations we inserted so that we don't clear them.
+CALL refresh_continuous_aggregate('cond_10', 50, 60);
+NOTICE:  continuous aggregate "cond_10" is already up-to-date
+SELECT mat_hypertable_id AS cond_10_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'cond_10' \gset
+SELECT * FROM cagg_invals
+WHERE cagg_id = :cond_10_id;
+ cagg_id |        start         |         end         
+---------+----------------------+---------------------
+       3 | -9223372036854775808 |                 -21
+       3 |                    0 |                  29
+       3 |                   40 |                  49
+       3 |                   60 | 9223372036854775807
+(4 rows)
 

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -358,7 +358,7 @@ select * from _timescaledb_catalog.continuous_aggs_materialization_invalidation_
                   5 |                    20 |     9223372036854775807
                   6 |  -9223372036854775808 |             -2147483649
                   6 |                    16 |     9223372036854775807
-                  6 |                    18 |                      18
+                  6 |                    18 |                      19
 (5 rows)
 
 DROP MATERIALIZED VIEW cagg_1;


### PR DESCRIPTION
This PR includes two changes:

**Change 1:**
 
The refreshing of a continuous aggregate is slow when many small
invalidations are generated by frequent single row insert
backfills. This change adds an optimization that merges small
invalidations by first expanding invalidations to full bucket
boundaries. There is really no reason to maintain invalidations that
aren't covering full buckets since refresh windows are already aligned
to buckets anyway.

**Change 2:**

When there are many small (e.g., single timestamp) invalidations that
cannot be merged despite expanding invalidations to full buckets
(e.g., invalidations are spread across every second bucket in the
worst case), it might no longer be beneficial to materialize every
invalidation separately.

Instead, this change adds a threshold for the number of invalidations
used by the refresh (currently 10 by default) above which
invalidations are merged into one range based on the lowest and
greatest invalidated time value.

The limit can be controlled by an anonymous session variable for
debugging and tweaking purposes. It might be considered for promotion
to an official GUC in the future.

Fixes #2867