### PR TITLE
Add test to check incremental sort functionality with PG13+

### DIFF
--- a/tsl/test/shared/expected/incremental_sort.out
+++ b/tsl/test/shared/expected/incremental_sort.out
@@ -1,0 +1,98 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SELECT
+       format('include/%s.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
+       format('%s/shared/results/%s_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNOPTIMIZED",
+       format('%s/shared/results/%s_results_incremental_sort.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_INCREMENTAL_SORT",
+       format('%s/shared/results/%s_results_ordered_append.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_ORDERED_APPEND"
+\gset
+SELECT format('\! diff -u --label "Unoptimized results" --label "Incremental Sort results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_INCREMENTAL_SORT') as "DIFF_CMD"
+\gset
+-- get EXPLAIN output for all variations
+\set PREFIX 'EXPLAIN (costs off, timing off, summary off)'
+\set TEST_TABLE 'conditions'
+\set UNOPTIMIZED_OUTPUT ''
+\set INCR_SORT_OUTPUT ''
+\set ORDERED_OUTPUT ''
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Incremental sort feature is available in PG13 and beyond
+-- Disable incremental sort. The query will use sequential scans
+SET enable_incremental_sort = OFF;
+\o :UNOPTIMIZED_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY device, time LIMIT 51;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: _hyper_10_51_chunk.device, _hyper_10_51_chunk."time"
+         ->  Append
+               ->  Seq Scan on _hyper_10_51_chunk
+               ->  Seq Scan on _hyper_10_52_chunk
+(6 rows)
+
+-- Enable incremental sort. The query should use it now
+SET enable_incremental_sort = ON;
+\o :INCR_SORT_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY device, time LIMIT 51;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: _hyper_10_51_chunk.device, _hyper_10_51_chunk."time"
+         Presorted Key: _hyper_10_51_chunk.device
+         ->  Merge Append
+               Sort Key: _hyper_10_51_chunk.device
+               ->  Index Scan using _hyper_10_51_chunk_conditions_device_idx on _hyper_10_51_chunk
+               ->  Index Scan using _hyper_10_52_chunk_conditions_device_idx on _hyper_10_52_chunk
+(8 rows)
+
+-- Use the first column in the query in ORDER BY and also use LIMIT
+-- This should use an "ordered append" plan along with incremental sort
+\o :ORDERED_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY time, device LIMIT 51;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Incremental Sort
+         Sort Key: conditions."time", conditions.device
+         Presorted Key: conditions."time"
+         ->  Custom Scan (ChunkAppend) on conditions
+               Order: conditions."time"
+               ->  Index Scan Backward using _hyper_10_51_chunk_conditions_time_idx on _hyper_10_51_chunk
+               ->  Index Scan Backward using _hyper_10_52_chunk_conditions_time_idx on _hyper_10_52_chunk
+(8 rows)
+
+\set PREFIX ''
+\set TEST_TABLE 'conditions'
+\set UNOPTIMIZED_OUTPUT :TEST_RESULTS_UNOPTIMIZED
+\set INCR_SORT_OUTPUT :TEST_RESULTS_INCREMENTAL_SORT
+\set ORDERED_OUTPUT :TEST_RESULTS_ORDERED_APPEND
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Incremental sort feature is available in PG13 and beyond
+-- Disable incremental sort. The query will use sequential scans
+SET enable_incremental_sort = OFF;
+\o :UNOPTIMIZED_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY device, time LIMIT 51;
+-- Enable incremental sort. The query should use it now
+SET enable_incremental_sort = ON;
+\o :INCR_SORT_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY device, time LIMIT 51;
+-- Use the first column in the query in ORDER BY and also use LIMIT
+-- This should use an "ordered append" plan along with incremental sort
+\o :ORDERED_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY time, device LIMIT 51;
+-- diff results
+:DIFF_CMD

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -5,6 +5,12 @@ set(TEST_FILES_SHARED
   dist_insert.sql
 )
 
+if ((${PG_VERSION_MAJOR} GREATER_EQUAL "13"))
+  list(APPEND TEST_FILES_SHARED
+    incremental_sort.sql
+  )
+endif()
+
 set(TEST_TEMPLATES_SHARED
   constify_timestamptz_op_interval.sql.in
   gapfill.sql.in

--- a/tsl/test/shared/sql/include/incremental_sort.sql
+++ b/tsl/test/shared/sql/include/incremental_sort.sql
@@ -1,0 +1,26 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Incremental sort feature is available in PG13 and beyond
+
+-- Disable incremental sort. The query will use sequential scans
+SET enable_incremental_sort = OFF;
+
+\o :UNOPTIMIZED_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY device, time LIMIT 51;
+
+-- Enable incremental sort. The query should use it now
+SET enable_incremental_sort = ON;
+
+\o :INCR_SORT_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY device, time LIMIT 51;
+
+-- Use the first column in the query in ORDER BY and also use LIMIT
+-- This should use an "ordered append" plan along with incremental sort
+
+\o :ORDERED_OUTPUT
+:PREFIX
+SELECT * FROM :TEST_TABLE ORDER BY time, device LIMIT 51;

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -140,6 +140,7 @@ CREATE TABLE conditions(
     value float
 );
 SELECT * FROM create_hypertable('conditions', 'time');
+CREATE INDEX conditions_device_idx ON conditions (device);
 INSERT INTO conditions VALUES
     ('2017-01-01 06:01', 1, 1.2),
     ('2017-01-01 09:11', 3, 4.3),

--- a/tsl/test/shared/sql/incremental_sort.sql
+++ b/tsl/test/shared/sql/incremental_sort.sql
@@ -1,0 +1,31 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+SELECT
+       format('include/%s.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
+       format('%s/shared/results/%s_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNOPTIMIZED",
+       format('%s/shared/results/%s_results_incremental_sort.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_INCREMENTAL_SORT",
+       format('%s/shared/results/%s_results_ordered_append.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_ORDERED_APPEND"
+\gset
+SELECT format('\! diff -u --label "Unoptimized results" --label "Incremental Sort results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_INCREMENTAL_SORT') as "DIFF_CMD"
+\gset
+
+-- get EXPLAIN output for all variations
+\set PREFIX 'EXPLAIN (costs off, timing off, summary off)'
+\set TEST_TABLE 'conditions'
+\set UNOPTIMIZED_OUTPUT ''
+\set INCR_SORT_OUTPUT ''
+\set ORDERED_OUTPUT ''
+\ir :TEST_QUERY_NAME
+
+\set PREFIX ''
+\set TEST_TABLE 'conditions'
+\set UNOPTIMIZED_OUTPUT :TEST_RESULTS_UNOPTIMIZED
+\set INCR_SORT_OUTPUT :TEST_RESULTS_INCREMENTAL_SORT
+\set ORDERED_OUTPUT :TEST_RESULTS_ORDERED_APPEND
+\ir :TEST_QUERY_NAME
+
+-- diff results
+:DIFF_CMD
+


### PR DESCRIPTION
Starting with PG13, when a relation is already sorted by
(key1, key2) and we need to sort it by (key1, key2, key3) we can simply
split the input rows into groups having equal values in (key1, key2),
and only sort/compare the remaining column key3.

This commit adds a test for hypertables.