### PR TITLE
Bump postgres versions used in CI

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -18,12 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [ "11.10", "12.5" ]
+        pg: [ "11.11", "12.6" ]
         build_type: [ Debug ]
         include:
-          - pg: 11.10
+          - pg: 11.11
             ignores: append-11 chunk_adaptive-11 continuous_aggs_bgw_drop_chunks remote_txn transparent_decompression-11 continuous_aggs_insert continuous_aggs_multi continuous_aggs_concurrent_refresh
-          - pg: 12.5
+          - pg: 12.6
             ignores: append-12 chunk_adaptive-12 continuous_aggs_bgw_drop_chunks remote_txn transparent_decompression-12
 
     steps:

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: ["11.10", "12.5"]
+        pg: ["11.11", "12.6"]
         os: [ubuntu-18.04]
     env:
       PG_SRC_DIR: pgbuild

--- a/.github/workflows/cron-tests.yaml
+++ b/.github/workflows/cron-tests.yaml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      PG_VERSION: 12.5
+      PG_VERSION: 12.6
 
     steps:
     - name: Checkout TimescaleDB

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: 'ubuntu-18.04'
     strategy:
       matrix:
-        pg: ["11.10","12.5"]
+        pg: ["11.11","12.6"]
         opt: ["", "-r"]
         include:
-          - pg: 11.10
+          - pg: 11.11
             pg_major: 11
-          - pg: 12.5
+          - pg: 12.6
             pg_major: 12
           - opt: "-r"
             kind: "with repair test"

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -21,9 +21,9 @@ import sys
 event_type = sys.argv[1]
 
 PG11_EARLIEST = "11.0"
-PG11_LATEST = "11.10"
+PG11_LATEST = "11.11"
 PG12_EARLIEST = "12.0"
-PG12_LATEST = "12.5"
+PG12_LATEST = "12.6"
 PG13_EARLIEST = "13.2"
 PG13_LATEST = "13.2"
 


### PR DESCRIPTION
Run tests on PG 11.11, 12.6 and 13.2