### PR TITLE
Run Travis tests on Ubuntu Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 language: c
 os:
   - linux
+dist:
+  - focal
 services:
   - docker
 notifications:
@@ -81,6 +83,7 @@ jobs:
     - if: (type = cron) OR (branch = prerelease_test)
       name: "Git hook tests"
       before_install:
+        - sudo apt-get -y install python2
       install:
       after_failure:
       after_script:


### PR DESCRIPTION
Some Docker images have issues running on Ubuntu Xenial, which is the
default build environment on Travis. Switching to Ubuntu Focal in
order to use a newer Docker.