### PR TITLE
Adjust eclass_indexes for compressed chunks for PG13

### DIFF
--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -2154,28 +2154,36 @@ FROM :TEST_TABLE
 WHERE device_id_peer IN (
         VALUES (1),
             (2));
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Nested Loop Semi Join (actual rows=0 loops=1)
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=0 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
-   Join Filter: (_hyper_1_1_chunk.device_id_peer = "*VALUES*".column1)
-   Rows Removed by Join Filter: 13680
-   ->  Append (actual rows=6840 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
-               Output: _hyper_1_1_chunk.device_id_peer
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
-               Output: _hyper_1_2_chunk.device_id_peer
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
-               Output: _hyper_1_3_chunk.device_id_peer
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
-   ->  Materialize (actual rows=2 loops=6840)
+   ->  Unique (actual rows=2 loops=1)
          Output: "*VALUES*".column1
-         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Output: "*VALUES*".column1
-(19 rows)
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Append (actual rows=0 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=2)
+               Output: _hyper_1_1_chunk.device_id_peer
+               Filter: ("*VALUES*".column1 = _hyper_1_1_chunk.device_id_peer)
+               ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=2)
+                     Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id_peer
+                     Index Cond: (compress_hyper_5_15_chunk.device_id_peer = "*VALUES*".column1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=2)
+               Output: _hyper_1_2_chunk.device_id_peer
+               Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id_peer)
+               Rows Removed by Filter: 2520
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=2)
+               Output: _hyper_1_3_chunk.device_id_peer
+               Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id_peer)
+               ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id__1 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=2)
+                     Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id_peer
+                     Index Cond: (compress_hyper_5_16_chunk.device_id_peer = "*VALUES*".column1)
+(27 rows)
 
 RESET enable_hashjoin;
 :PREFIX_VERBOSE
@@ -2213,26 +2221,34 @@ WHERE device_id IN (
             (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join (actual rows=2736 loops=1)
+ Nested Loop (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
-   Hash Cond: (_hyper_1_1_chunk.device_id = "*VALUES*".column1)
-   ->  Append (actual rows=6840 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
-               Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
-               Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
-               Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Seq Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
-   ->  Hash (actual rows=2 loops=1)
+   ->  Unique (actual rows=2 loops=1)
          Output: "*VALUES*".column1
-         Buckets: 1024  Batches: 1 
-         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Output: "*VALUES*".column1
-(19 rows)
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Append (actual rows=1368 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
+               Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_1_1_chunk.device_id)
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
+                     Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
+               Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
+               Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id)
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
+                     Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+(27 rows)
 
 SET seq_page_cost = 100;
 -- loop/row counts of this query is different on windows so we run it without analyze
@@ -2306,26 +2322,40 @@ WHERE device_id IN (
             (2));
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join (actual rows=2736 loops=1)
+ Nested Loop (actual rows=2736 loops=1)
    Output: _hyper_1_1_chunk.device_id_peer
-   Hash Cond: (_hyper_1_1_chunk.device_id = "*VALUES*".column1)
-   ->  Append (actual rows=6840 loops=1)
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=1800 loops=1)
-               Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
-         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=2520 loops=1)
-               Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=2520 loops=1)
-               Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=5 loops=1)
-                     Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
-   ->  Hash (actual rows=2 loops=1)
+   ->  Unique (actual rows=2 loops=1)
          Output: "*VALUES*".column1
-         Buckets: 1024  Batches: 1 
-         ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+         ->  Sort (actual rows=2 loops=1)
                Output: "*VALUES*".column1
-(19 rows)
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Append (actual rows=1368 loops=2)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=360 loops=2)
+               Output: _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_1_1_chunk.device_id)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer
+                     Recheck Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
+                     Heap Blocks: exact=2
+                     ->  Bitmap Index Scan on compress_hyper_5_15_chunk_c_index_2 (actual rows=1 loops=2)
+                           Index Cond: (compress_hyper_5_15_chunk.device_id = "*VALUES*".column1)
+         ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk (actual rows=504 loops=2)
+               Output: _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_1_2_chunk.device_id)
+               Rows Removed by Filter: 2016
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=504 loops=2)
+               Output: _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_1_3_chunk.device_id)
+               ->  Bitmap Heap Scan on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=1 loops=2)
+                     Output: compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer
+                     Recheck Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+                     Heap Blocks: exact=2
+                     ->  Bitmap Index Scan on compress_hyper_5_16_chunk_c_index_2 (actual rows=1 loops=2)
+                           Index Cond: (compress_hyper_5_16_chunk.device_id = "*VALUES*".column1)
+(33 rows)
 
 SET enable_indexscan TO TRUE;
 SET enable_seqscan TO TRUE;
@@ -2421,64 +2451,64 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Incremental Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Presorted Key: m1."time"
          Full-sort Groups: 1  Sort Method: quicksort 
          ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m3_1."time" = m1."time")
-               ->  Merge Append (actual rows=3 loops=1)
-                     Sort Key: m3_1."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: m3_1."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
-                           Filter: (device_id = 3)
-                           Rows Removed by Filter: 2
-                     ->  Sort (actual rows=1 loops=1)
-                           Sort Key: m3_3."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                                       Rows Removed by Filter: 4
-               ->  Materialize (actual rows=11 loops=1)
-                     ->  Merge Join (actual rows=11 loops=1)
-                           Merge Cond: (m1."time" = m2."time")
-                           Join Filter: (m1.device_id = m2.device_id)
-                           Rows Removed by Join Filter: 40
-                           ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
-                                 Order: m1."time"
+               Merge Cond: (m1."time" = m3_1."time")
+               ->  Merge Join (actual rows=11 loops=1)
+                     Merge Cond: (m1."time" = m2."time")
+                     Join Filter: (m1.device_id = m2.device_id)
+                     Rows Removed by Join Filter: 40
+                     ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=11 loops=1)
+                           Order: m1."time"
+                           ->  Sort (actual rows=11 loops=1)
+                                 Sort Key: m1_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m1_3."time"
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
+                     ->  Materialize (actual rows=51 loops=1)
+                           ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
+                                 Order: m2."time"
                                  ->  Sort (actual rows=11 loops=1)
-                                       Sort Key: m1_1."time"
+                                       Sort Key: m2_1."time"
                                        Sort Method: quicksort 
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m1_1 (actual rows=1800 loops=1)
-                                             ->  Seq Scan on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m1_2 (never executed)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                             ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                                 ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
                                  ->  Sort (never executed)
-                                       Sort Key: m1_3."time"
-                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (never executed)
-                                             ->  Seq Scan on compress_hyper_5_16_chunk (never executed)
-                           ->  Materialize (actual rows=51 loops=1)
-                                 ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=11 loops=1)
-                                       Order: m2."time"
-                                       ->  Sort (actual rows=11 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                                   ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                                       ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (never executed)
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_3."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
-                                                   ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+                                       Sort Key: m2_3."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (never executed)
+                                             ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (never executed)
+               ->  Materialize (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=3 loops=1)
+                           Sort Key: m3_1."time"
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m3_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m3_1 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m3_2 (actual rows=1 loops=1)
+                                 Filter: (device_id = 3)
+                                 Rows Removed by Filter: 2
+                           ->  Sort (actual rows=1 loops=1)
+                                 Sort Key: m3_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m3_3 (actual rows=504 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                             Rows Removed by Filter: 4
 (56 rows)
 
 :PREFIX
@@ -3121,34 +3151,39 @@ FROM metrics,
 WHERE metrics.time > metrics_space.time
     AND metrics.device_id = metrics_space.device_id
     AND metrics.time < metrics_space.time;
-                                                                                         QUERY PLAN                                                                                         
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
-   Join Filter: ((_hyper_1_1_chunk."time" > _hyper_2_4_chunk."time") AND (_hyper_1_1_chunk."time" < _hyper_2_4_chunk."time") AND (_hyper_1_1_chunk.device_id = _hyper_2_4_chunk.device_id))
-   Rows Removed by Join Filter: 46785600
    ->  Append (actual rows=6840 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-   ->  Materialize (actual rows=6840 loops=6840)
-         ->  Append (actual rows=6840 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
-(25 rows)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+   ->  Append (actual rows=0 loops=6840)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
+               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
+                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
+               Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
+               Filter: (_hyper_2_4_chunk.device_id = device_id)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
+               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
+               Rows Removed by Filter: 504
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
+(30 rows)
 
 SET enable_seqscan = TRUE;
 SET enable_bitmapscan = TRUE;
@@ -6599,45 +6634,61 @@ FROM :TEST_TABLE
 WHERE device_id IN (
         VALUES (1),
             (2));
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join
+                                                                     QUERY PLAN                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
    Output: _hyper_2_4_chunk.device_id_peer
-   Hash Cond: (_hyper_2_4_chunk.device_id = "*VALUES*".column1)
+   ->  Unique
+         Output: "*VALUES*".column1
+         ->  Sort
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               ->  Values Scan on "*VALUES*"
+                     Output: "*VALUES*".column1
    ->  Append
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk
                Output: _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_2_4_chunk.device_id)
                ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_17_chunk
                      Output: compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer
+                     Index Cond: (compress_hyper_6_17_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk
                Output: _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_2_5_chunk.device_id)
                ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_18_chunk
                      Output: compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer
+                     Index Cond: (compress_hyper_6_18_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk
                Output: _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_2_6_chunk.device_id)
                ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_19_chunk
                      Output: compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer
-         ->  Index Only Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
+                     Index Cond: (compress_hyper_6_19_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk
                Output: _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.device_id
-         ->  Index Only Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk
+               Index Cond: (_hyper_2_7_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk
                Output: _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.device_id
-         ->  Index Only Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk
+               Index Cond: (_hyper_2_8_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk
                Output: _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.device_id
+               Index Cond: (_hyper_2_9_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk
                Output: _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_2_10_chunk.device_id)
                ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_20_chunk
                      Output: compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer
+                     Index Cond: (compress_hyper_6_20_chunk.device_id = "*VALUES*".column1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk
                Output: _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.device_id
+               Filter: ("*VALUES*".column1 = _hyper_2_11_chunk.device_id)
                ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on _timescaledb_internal.compress_hyper_6_21_chunk
                      Output: compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer
-         ->  Index Only Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
+                     Index Cond: (compress_hyper_6_21_chunk.device_id = "*VALUES*".column1)
+         ->  Index Only Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk
                Output: _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.device_id
-   ->  Hash
-         Output: "*VALUES*".column1
-         ->  Values Scan on "*VALUES*"
-               Output: "*VALUES*".column1
-(36 rows)
+               Index Cond: (_hyper_2_12_chunk.device_id = "*VALUES*".column1)
+(52 rows)
 
 RESET seq_page_cost;
 -- force a BitmapHeapScan
@@ -7973,34 +8024,39 @@ FROM metrics,
 WHERE metrics.time > metrics_space.time
     AND metrics.device_id = metrics_space.device_id
     AND metrics.time < metrics_space.time;
-                                                                                         QUERY PLAN                                                                                         
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=0 loops=1)
-   Join Filter: ((_hyper_1_1_chunk."time" > _hyper_2_4_chunk."time") AND (_hyper_1_1_chunk."time" < _hyper_2_4_chunk."time") AND (_hyper_1_1_chunk.device_id = _hyper_2_4_chunk.device_id))
-   Rows Removed by Join Filter: 46785600
    ->  Append (actual rows=6840 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=1800 loops=1)
-               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=5 loops=1)
-         ->  Seq Scan on _hyper_1_2_chunk (actual rows=2520 loops=1)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=2520 loops=1)
-               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-   ->  Materialize (actual rows=6840 loops=6840)
-         ->  Append (actual rows=6840 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                     ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
-                     ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
-                     ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                     ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                     ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
-(25 rows)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_17_chunk_c_space_index_2 on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=1080 loops=1)
+               ->  Index Scan using compress_hyper_6_18_chunk_c_space_index_2 on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=360 loops=1)
+               ->  Index Scan using compress_hyper_6_19_chunk_c_space_index_2 on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+         ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=504 loops=1)
+         ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=1512 loops=1)
+         ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=504 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               ->  Index Scan using compress_hyper_6_20_chunk_c_space_index_2 on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               ->  Index Scan using compress_hyper_6_21_chunk_c_space_index_2 on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+         ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=504 loops=1)
+   ->  Append (actual rows=0 loops=6840)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=0 loops=6840)
+               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
+               Rows Removed by Filter: 360
+               ->  Index Scan using compress_hyper_5_15_chunk_c_index_2 on compress_hyper_5_15_chunk (actual rows=1 loops=6840)
+                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
+         ->  Index Scan using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk (actual rows=0 loops=6840)
+               Index Cond: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time"))
+               Filter: (_hyper_2_4_chunk.device_id = device_id)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk (actual rows=0 loops=6840)
+               Filter: (("time" > _hyper_2_4_chunk."time") AND ("time" < _hyper_2_4_chunk."time") AND (_hyper_2_4_chunk.device_id = device_id))
+               Rows Removed by Filter: 504
+               ->  Index Scan using compress_hyper_5_16_chunk_c_index_2 on compress_hyper_5_16_chunk (actual rows=1 loops=6840)
+                     Index Cond: (device_id = _hyper_2_4_chunk.device_id)
+(30 rows)
 
 SET enable_seqscan = TRUE;
 SET enable_bitmapscan = TRUE;

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -451,22 +451,32 @@ ORDER BY time;
    Sort Key: mt_1."time"
    Sort Method: quicksort 
    ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time) AND (mt_1.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
                      ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id__t on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_seqscan = TRUE;
 SET enable_bitmapscan = TRUE;
@@ -568,18 +578,17 @@ FROM metrics_ordered_idx met join lookup
 ON met.device_id = lookup.did and met.v0 = lookup.version
 WHERE met.time > '2000-01-19 19:00:00-05' 
       and met.time < '2000-01-20 20:00:00-05'; 
-                                                                                     QUERY PLAN                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=2 loops=1)
-   Join Filter: ((met.device_id = "*VALUES*".column1) AND (met.v0 = "*VALUES*".column2))
-   Rows Removed by Join Filter: 92
    ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=47 loops=2)
-         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-         Rows Removed by Filter: 1
+   ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk met (actual rows=1 loops=2)
+         Filter: (("time" > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND ("time" < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = v0))
+         Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id__ts on compress_hyper_2_8_chunk (actual rows=1 loops=2)
+               Index Cond: (device_id = "*VALUES*".column1)
                Filter: ((_ts_meta_max_1 > 'Wed Jan 19 16:00:00 2000 PST'::timestamp with time zone) AND (_ts_meta_min_1 < 'Thu Jan 20 17:00:00 2000 PST'::timestamp with time zone))
-(9 rows)
+(8 rows)
 
 --add filter to segment by (device_id) and compressed attr column (v0)
 :PREFIX
@@ -635,21 +644,22 @@ JOIN LATERAL
     WHERE  node = f1.device_id) q
 ON met.device_id = q.node and met.device_id_peer = q.device_id_peer 
    and met.v0 = q.v0 and met.v0 > 2 and time = '2018-01-19 20:00:00-05';
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=1 loops=1)
-   Join Filter: ((nodetime.node = met.device_id) AND ("*VALUES*".column2 = met.device_id_peer) AND ("*VALUES*".column3 = met.v0))
+   Join Filter: (nodetime.node = met.device_id)
    ->  Nested Loop (actual rows=1 loops=1)
          Join Filter: (nodetime.node = "*VALUES*".column1)
          Rows Removed by Join Filter: 1
          ->  Seq Scan on nodetime (actual rows=1 loops=1)
          ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk met (actual rows=1 loops=1)
-         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
+         Filter: ((v0 > 2) AND ("time" = 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id) AND ("*VALUES*".column2 = device_id_peer) AND ("*VALUES*".column3 = v0))
          Rows Removed by Filter: 47
          ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_pee on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone))
-(12 rows)
+               Index Cond: (device_id_peer = "*VALUES*".column2)
+               Filter: ((_ts_meta_min_1 <= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Jan 19 17:00:00 2018 PST'::timestamp with time zone) AND ("*VALUES*".column1 = device_id))
+(13 rows)
 
 -- filter on compressed attr (v0) with seqscan enabled and indexscan 
 -- disabled. filters on compressed attr should be above the seq scan.


### PR DESCRIPTION
    In PG13, eclass_indexes are used to traverse the equivalence classes. This should be set correctly
    for compressed chunks.

Reviewers: There are plan changes due to the filters/join conditions being pushed down (as expected) to the compressed chunk.