### PR TITLE
Refactor update tests to use for smoke testing

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -14,14 +14,11 @@ jobs:
     strategy:
       matrix:
         pg: ["11.11","12.6"]
-        opt: ["", "-r"]
         include:
           - pg: 11.11
             pg_major: 11
           - pg: 12.6
             pg_major: 12
-          - opt: "-r"
-            kind: "with repair test"
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}
@@ -30,9 +27,9 @@ jobs:
     - name: Checkout TimescaleDB
       uses: actions/checkout@v2
 
-    - name: Update tests ${{ matrix.pg }} ${{ matrix.kind }}
+    - name: Update tests ${{ matrix.pg }}
       run: |
-        ./scripts/test_updates_pg${{ matrix.pg_major}}.sh ${{ matrix.opt }}
+        ./scripts/test_updates_pg${{ matrix.pg_major }}.sh
 
     - name: Update diff
       if: failure()

--- a/scripts/test_smoke.sh
+++ b/scripts/test_smoke.sh
@@ -1,0 +1,116 @@
+# Run smoke tests on forge and test that updating between versions
+# work. This is based on our update tests but doing some tweaks to
+# ensure we can run it on forge. In particular, we cannot create new
+# roles and we cannot create new databases.
+#
+# For this version, we focus on single-node update.
+#
+# UPDATE_FROM_TAG is the version to update from.
+# UPDATE_TO_TAG is the version to update to.
+#
+# For connection information, we use the normal environment variables
+# supported by psql:
+# - PGHOST is host to use for the connection.
+# - PGPORT is the port to use for the connection.
+# - PGDATABASE is the database to use for the connection.
+# - PGUSER is the username to use for the connection.
+# - PGPASSWORD is the password to use for the connection
+
+: ${PGUSER:?Please provide the user in PGUSER}
+: ${PGHOST:?Please provide the host in PGHOST}
+: ${PGPORT:?Please provide the port in PGPORT}
+: ${PGDATABASE:?Please provide the database in PGDATABASE}
+: ${PGPASSWORD:?Please provide the password in PGPASSWORD}
+: ${TEST_VERSION:?Please provide a test version in TEST_VERSION}
+SCRIPT_DIR=$(dirname $0)
+BASE_DIR=${PWD}/${SCRIPT_DIR}/..
+SCRATCHDIR=`mktemp -d -t 'smoketest-XXXX'`
+DUMPFILE="$SCRATCHDIR/smoke.dump"
+UPGRADE_OUT="$SCRATCHDIR/upgrade.out"
+CLEAN_OUT="$SCRATCHDIR/clean.out"
+RESTORE_OUT="$SCRATCHDIR/restore.out"
+UPDATE_FROM_TAG=${UPDATE_FROM_TAG:-1.7.4}
+UPDATE_TO_TAG=${UPDATE_TO_TAG:-2.0.1}
+
+# trap cleanup EXIT
+
+# cleanup() {
+#     rm -rf $SCRATCHDIR
+# }
+
+# Extra options to pass to psql
+PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v TEST_REPAIR=false"
+PSQL="psql -X $PGOPTS"
+
+set -o pipefail
+
+echo "**** Output and dumps will be saved in ${SCRATCHDIR} ****"
+echo "**** Moving to directory ${BASE_DIR}/test/sql/updates ****"
+cd ${BASE_DIR}/test/sql/updates
+
+echo "**** Connecting as '$PGUSER' to database $PGDATABASE on $PGHOST:$PGPORT ****"
+
+set -x
+
+# For the comments below, we assume the upgrade is from 1.7.5 to 2.0.2
+
+$PSQL -c "SELECT * FROM pg_available_extensions WHERE name LIKE 'timescaledb%'"
+
+# Create a 1.7.5 version Upgrade
+echo "**** Connecting to ${FORGE_CONNINFO} and running setup ****"
+$PSQL -c "DROP EXTENSION IF EXISTS timescaledb CASCADE"
+$PSQL -f pre.cleanup.sql
+$PSQL -c "\d"
+$PSQL -c "\df"
+$PSQL -c "CREATE EXTENSION timescaledb VERSION '${UPDATE_FROM_TAG}'"
+$PSQL -c "\dx"
+
+# Run setup on Upgrade
+$PSQL -f pre.smoke.sql
+$PSQL -f setup.${TEST_VERSION}.sql
+
+# Run update on Upgrade. You now have a 2.0.2 version in Upgrade.
+$PSQL -c "ALTER EXTENSION timescaledb UPDATE TO '${UPDATE_TO_TAG}'"
+
+# Apply post-update actions
+#$PSQL -f post.repair.sql
+
+# Dump the contents of Upgrade
+pg_dump -Fc -f $DUMPFILE
+
+# Run the post scripts on Upgrade to get UpgradeOut to compare
+# with. We can now discard Upgrade database.
+$PSQL -f post.${TEST_VERSION}.sql >$UPGRADE_OUT
+
+: Create a 2.0.2 version Clean
+$PSQL -c "DROP EXTENSION IF EXISTS timescaledb CASCADE"
+$PSQL -f pre.cleanup.sql
+$PSQL -c "CREATE EXTENSION timescaledb VERSION '${UPDATE_TO_TAG}'"
+
+: Run the setup scripts on Clean, with post-update actions.
+$PSQL -f pre.smoke.sql
+$PSQL -f setup.${TEST_VERSION}.sql
+#$PSQL -f post.repair.sql
+
+: Run the post scripts on Clean to get output CleanOut
+$PSQL -f post.${TEST_VERSION}.sql >$CLEAN_OUT
+
+: Create a 2.0.2 version Restore
+$PSQL -c "DROP EXTENSION IF EXISTS timescaledb CASCADE"
+$PSQL -f pre.cleanup.sql
+$PSQL -c "CREATE EXTENSION timescaledb VERSION '${UPDATE_TO_TAG}'"
+
+: Restore the UpgradeDump into Restore
+$PSQL -c "SELECT timescaledb_pre_restore()"
+pg_restore -d $PGDATABASE $DUMPFILE || true
+$PSQL -c "SELECT timescaledb_post_restore()"
+
+: Run the post scripts on Restore to get a RestoreOut
+$PSQL -f post.${TEST_VERSION}.sql >$RESTORE_OUT
+
+# Compare UpgradeOut with CleanOut and make sure they are identical
+diff -u $UPGRADE_OUT $CLEAN_OUT && echo "No difference between $UPGRADE_OUT and $CLEAN_OUT"
+
+# Compare RestoreOut with CleanOut and make sure they are identical
+diff -u $RESTORE_OUT $CLEAN_OUT && echo "No difference between $RESTORE_OUT and $CLEAN_OUT"
+

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -13,13 +13,9 @@ UPDATE_TO_IMAGE=${UPDATE_TO_IMAGE:-update_test}
 UPDATE_TO_TAG=${UPDATE_TO_TAG:-${GIT_ID}}
 PG_VERSION=${PG_VERSION:-11.0}
 
-# This will propagate to the test_update_from_tags.sh script
-export TEST_REPAIR
-
 FAILED_TEST=
 KEEP_TEMP_DIRS=false
 TEST_UPDATE_FROM_TAGS_EXTRA_ARGS=
-TEST_REPAIR=false
 FAIL_COUNT=0
 
 # Declare a hash table to keep test names keyed by pid
@@ -37,10 +33,6 @@ do
             KEEP_TEMP_DIRS=true
             TEST_UPDATE_FROM_TAGS_EXTRA_ARGS="-d"
             ;;
-	r)
-	    echo "Breaking dimension slices to test repair part"
-	    TEST_REPAIR=true
-	    ;;
     esac
 done
 

--- a/scripts/test_updates_pg11.sh
+++ b/scripts/test_updates_pg11.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$(dirname $0)
 
 TAGS="1.1.0-pg11 1.1.1-pg11 1.2.0-pg11 1.2.1-pg11 1.2.2-pg11"
 TEST_VERSION="v2"
+export TEST_REPAIR=true
 
 TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
 EXIT_CODE=$?
@@ -16,6 +17,7 @@ fi
 
 TAGS="1.3.0-pg11 1.3.1-pg11 1.3.2-pg11 1.4.0-pg11 1.4.1-pg11 1.4.2-pg11"
 TEST_VERSION="v4"
+export TEST_REPAIR=true
 
 TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
 EXIT_CODE=$?
@@ -25,6 +27,7 @@ fi
 
 TAGS="1.5.0-pg11 1.5.1-pg11 1.6.0-pg11 1.6.1-pg11"
 TEST_VERSION="v5"
+export TEST_REPAIR=true
 
 TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
 EXIT_CODE=$?
@@ -32,11 +35,32 @@ if [ $EXIT_CODE -ne 0 ]; then
   exit $EXIT_CODE
 fi
 
-TAGS="1.7.0-pg11 1.7.1-pg11 1.7.2-pg11 1.7.3-pg11 1.7.4-pg11 1.7.5-pg11 2.0.0-rc1-pg11 2.0.0-rc2-pg11 2.0.0-rc3-pg11 2.0.0-rc4-pg11 2.0.0-pg11 2.0.1-pg11 2.0.2-pg11"
+TAGS="1.7.0-pg11 1.7.1-pg11 1.7.2-pg11 1.7.3-pg11 1.7.4-pg11 1.7.5-pg11"
 TEST_VERSION="v6"
+export TEST_REPAIR=true
 
 TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
   exit $EXIT_CODE
+fi
+
+TAGS="2.0.0-rc1-pg11"
+TEST_VERSION="v7"
+export TEST_REPAIR=true
+
+TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+    exit $EXIT_CODE
+fi
+
+TAGS=" 2.0.0-rc1-pg11 2.0.0-rc2-pg11 2.0.0-rc3-pg11 2.0.0-rc4-pg11 2.0.0-pg11 2.0.1-pg11 2.0.2-pg11"
+TEST_VERSION="v7"
+export TEST_REPAIR=false
+
+TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+    exit $EXIT_CODE
 fi

--- a/scripts/test_updates_pg12.sh
+++ b/scripts/test_updates_pg12.sh
@@ -6,11 +6,32 @@ set -o pipefail
 SCRIPT_DIR=$(dirname $0)
 echo $SCRIPT_DIR
 
-TAGS="1.7.0-pg12 1.7.1-pg12 1.7.2-pg12 1.7.3-pg12 1.7.4-pg12 1.7.5-pg12 2.0.0-rc1-pg12 2.0.0-rc2-pg12 2.0.0-rc3-pg12 2.0.0-rc4-pg12 2.0.0-pg12 2.0.1-pg12 2.0.2-pg12"
+TAGS="1.7.0-pg12 1.7.1-pg12 1.7.2-pg12 1.7.3-pg12 1.7.4-pg12 1.7.5-pg12"
 TEST_VERSION="v6"
+export TEST_REPAIR=true
 
 TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
   exit $EXIT_CODE
+fi
+
+TAGS="2.0.0-rc1-pg12"
+TEST_VERSION="v7"
+export TEST_REPAIR=true
+
+TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+    exit $EXIT_CODE
+fi
+
+TAGS="2.0.0-rc1-pg12 2.0.0-rc2-pg12 2.0.0-rc3-pg12 2.0.0-rc4-pg12 2.0.0-pg12 2.0.1-pg12 2.0.2-pg12"
+TEST_VERSION="v7"
+export TEST_REPAIR=false
+
+TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+    exit $EXIT_CODE
 fi

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -10,10 +10,13 @@
 \d+ _timescaledb_catalog.chunk_index
 \d+ _timescaledb_catalog.tablespace
 
-\z _timescaledb_cache.*
-\z _timescaledb_catalog.*
-\z _timescaledb_config.*
-\z _timescaledb_internal.*
+-- List all permissions but sort them to avoid mismatches
+SELECT nspname AS "Schema",
+       relname AS "Name",
+       unnest(relacl)::text AS "Access"
+  FROM pg_class cl JOIN pg_namespace ns ON relnamespace = ns.oid
+ WHERE nspname IN ('_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal')
+ORDER BY nspname, relname, "Access";
 
 \di _timescaledb_catalog.*
 \ds+ _timescaledb_catalog.*;

--- a/test/sql/updates/post.continuous_aggs.sql
+++ b/test/sql/updates/post.continuous_aggs.sql
@@ -18,11 +18,6 @@ CALL refresh_continuous_aggregate('mat_before',NULL,NULL);
 --the max of the temp for the POR should now be 165
 SELECT * FROM mat_before ORDER BY bucket, location;
 
-SET ROLE cagg_user;
---should be able to query as cagg_user
-SELECT * FROM mat_before ORDER BY bucket, location;
-RESET ROLE;
-
 -- Output the ACLs for each internal cagg object
 SELECT cl.oid::regclass::text AS reloid,
        relacl

--- a/test/sql/updates/post.v7.sql
+++ b/test/sql/updates/post.v7.sql
@@ -1,0 +1,13 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\ir post.catalog.sql
+\ir post.insert.sql
+\ir post.integrity_test.sql
+\ir catalog_missing_columns.sql
+\ir post.compression.sql
+\ir post.continuous_aggs.v2.sql
+\ir post.policies.sql
+\ir post.sequences.sql
+\ir post.functions.sql

--- a/test/sql/updates/pre.cleanup.sql
+++ b/test/sql/updates/pre.cleanup.sql
@@ -1,0 +1,64 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Clean up objects that are created by the setup files. Ideally, we
+-- should clean them up in each post.*.sql file after generating the
+-- output, but now we do it here.
+
+SELECT :'TEST_VERSION' >= '2.0.0' AS has_create_mat_view \gset
+
+SET client_min_messages TO WARNING;
+
+\if :has_create_mat_view
+DROP MATERIALIZED VIEW IF EXISTS mat_inval CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_drop CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_before CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_conflict CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_inttime CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_inttime2 CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_ignoreinval CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS cagg.realtime_mat CASCADE;
+\else
+DROP VIEW IF EXISTS mat_inval CASCADE;
+DROP VIEW IF EXISTS mat_drop CASCADE;
+DROP VIEW IF EXISTS mat_before CASCADE;
+DROP VIEW IF EXISTS mat_conflict CASCADE;
+DROP VIEW IF EXISTS mat_inttime CASCADE;
+DROP VIEW IF EXISTS mat_inttime2 CASCADE;
+DROP VIEW IF EXISTS mat_ignoreinval CASCADE;
+DROP VIEW IF EXISTS cagg.realtime_mat CASCADE;
+\endif
+
+DROP TABLE IF EXISTS public.hyper_timestamp;
+DROP TABLE IF EXISTS public."two_Partitions";
+DROP TABLE IF EXISTS conditions_before;
+DROP TABLE IF EXISTS inval_test;
+DROP TABLE IF EXISTS int_time_test;
+DROP TABLE IF EXISTS conflict_test;
+DROP TABLE IF EXISTS drop_test;
+DROP TABLE IF EXISTS repair_test_timestamptz;
+DROP TABLE IF EXISTS repair_test_int;
+DROP TABLE IF EXISTS repair_test_extra;
+DROP TABLE IF EXISTS repair_test_timestamp;
+DROP TABLE IF EXISTS repair_test_date;
+DROP TABLE IF EXISTS compress;
+DROP TABLE IF EXISTS devices;
+DROP TABLE IF EXISTS disthyper;
+DROP TABLE IF EXISTS policy_test_timestamptz;
+
+DROP TYPE IF EXISTS custom_type;
+DROP TYPE IF EXISTS custom_type_for_compression;
+
+DROP PROCEDURE IF EXISTS _timescaledb_testing.restart_dimension_slice_id;
+DROP PROCEDURE IF EXISTS _timescaledb_testing.stop_workers;
+
+DROP FUNCTION IF EXISTS timescaledb_integrity_test;
+DROP FUNCTION IF EXISTS timescaledb_catalog_has_no_missing_columns;
+DROP FUNCTION IF EXISTS integer_now_test;
+
+DROP SCHEMA IF EXISTS cagg;
+DROP SCHEMA IF EXISTS _timescaledb_testing;
+
+
+RESET client_min_messages;

--- a/test/sql/updates/pre.smoke.sql
+++ b/test/sql/updates/pre.smoke.sql
@@ -1,0 +1,12 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- These functions are used when running smoke tests. For smoke tests
+-- we assume that we do not have SUPER privileges.
+
+CREATE SCHEMA IF NOT EXISTS _timescaledb_testing;
+
+CREATE PROCEDURE _timescaledb_testing.restart_dimension_slice_id() LANGUAGE SQL AS '';
+
+CREATE PROCEDURE _timescaledb_testing.stop_workers() LANGUAGE SQL AS '';

--- a/test/sql/updates/pre.testing.sql
+++ b/test/sql/updates/pre.testing.sql
@@ -1,0 +1,20 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- These functions are used when running normal update tests.
+
+CREATE SCHEMA IF NOT EXISTS _timescaledb_testing;
+
+CREATE OR REPLACE PROCEDURE _timescaledb_testing.restart_dimension_slice_id()
+LANGUAGE SQL
+AS $$
+   ALTER SEQUENCE _timescaledb_catalog.dimension_slice_id_seq RESTART WITH 100;
+$$;
+
+CREATE OR REPLACE PROCEDURE _timescaledb_testing.stop_workers()
+LANGUAGE SQL
+AS $$
+   SELECT _timescaledb_internal.stop_background_workers();
+$$;
+

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -18,7 +18,7 @@ SELECT
 
 -- disable background workers to prevent deadlocks between background processes
 -- on timescaledb 1.7.x
-SELECT _timescaledb_internal.stop_background_workers();
+CALL _timescaledb_testing.stop_workers();
 
 CREATE TYPE custom_type AS (high int, low int);
 
@@ -298,7 +298,7 @@ CALL refresh_continuous_aggregate('mat_ignoreinval',NULL,NULL);
 \endif
 
 -- test new data beyond the invalidation threshold is properly handled --
-CREATE TABLE inval_test (time TIMESTAMPTZ, location TEXT, temperature DOUBLE PRECISION);
+CREATE TABLE inval_test (time TIMESTAMPTZ NOT NULL, location TEXT, temperature DOUBLE PRECISION);
 SELECT create_hypertable('inval_test', 'time', chunk_time_interval => INTERVAL '1 week');
  
 INSERT INTO inval_test
@@ -349,7 +349,7 @@ INSERT INTO inval_test
 SELECT generate_series('2118-12-01 00:00'::timestamp, '2118-12-20 00:00'::timestamp, '1 day'), 'NYC', generate_series(131.0, 150.0, 1.0);
 
 -- Add an integer base table to ensure we handle it correctly
-CREATE TABLE int_time_test(timeval integer, col1 integer, col2 integer);
+CREATE TABLE int_time_test(timeval integer not null, col1 integer, col2 integer);
 select create_hypertable('int_time_test', 'timeval', chunk_time_interval=> 2);
 
 CREATE OR REPLACE FUNCTION integer_now_test() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timeval), 0) FROM int_time_test $$;
@@ -415,7 +415,7 @@ CALL refresh_continuous_aggregate('mat_inttime2',NULL,NULL);
 \endif
 
 -- Test that retention policies that conflict with continuous aggs are disabled --
-CREATE TABLE conflict_test (time TIMESTAMPTZ, location TEXT, temperature DOUBLE PRECISION);
+CREATE TABLE conflict_test (time TIMESTAMPTZ NOT NULL, location TEXT, temperature DOUBLE PRECISION);
 SELECT create_hypertable('conflict_test', 'time', chunk_time_interval => INTERVAL '1 week');
 
 DO LANGUAGE PLPGSQL $$
@@ -464,7 +464,7 @@ WITH GRANT OPTION;
 -- here and then drop chunks from the hypertable and make sure that
 -- the update from 1.7 to 2.0 works as expected.
 CREATE TABLE drop_test (
-    time timestamptz,
+    time timestamptz not null,
     location INT,
     temperature double PRECISION
 );

--- a/test/sql/updates/setup.databases.sql
+++ b/test/sql/updates/setup.databases.sql
@@ -1,0 +1,21 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE DATABASE single;
+-- Always pre-create the data node database 'dn1' so that we can dump
+-- and restore it even on TimescaleDB versions that don't support
+-- multinode. Otherwise, we'd have to create version-dependent scripts
+-- to specifically handle multinode tests. We use template0, or
+-- otherwise dn1 will have the same UUID as 'single' since template1
+-- has the extension pre-installed.
+CREATE DATABASE dn1 TEMPLATE template0;
+\c dn1
+-- Make sure the extension is installed so that extension versions
+-- that don't support multinode will still be able to update the
+-- extension with ALTER EXTENSION ... UPDATE.
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+

--- a/test/sql/updates/setup.policies.sql
+++ b/test/sql/updates/setup.policies.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE TABLE policy_test_timestamptz(time timestamptz, device_id int, value float);
+CREATE TABLE policy_test_timestamptz(time timestamptz not null, device_id int, value float);
 SELECT table_name FROM create_hypertable('policy_test_timestamptz','time');
 
 ALTER TABLE policy_test_timestamptz SET (timescaledb.compress);

--- a/test/sql/updates/setup.repair.sql
+++ b/test/sql/updates/setup.repair.sql
@@ -7,7 +7,7 @@
 -- the dimension slice table. The repair script should then repair all
 -- of them and there should be no dimension slices missing.
 
-SELECT extversion < '2.0.0' AS runs_repair_script
+SELECT extversion < '2.0.0' OR extversion = '2.0.0-rc1' AS runs_repair_script
   FROM pg_extension
  WHERE extname = 'timescaledb' \gset
 

--- a/test/sql/updates/setup.timestamp.sql
+++ b/test/sql/updates/setup.timestamp.sql
@@ -13,4 +13,4 @@ SELECT * FROM create_hypertable('hyper_timestamp'::regclass, 'time'::name, 'devi
     chunk_time_interval=> _timescaledb_internal.interval_to_usec('1 minute'));
 
 --some old versions use more slice_ids than newer ones. Make this uniform
-ALTER SEQUENCE _timescaledb_catalog.dimension_slice_id_seq RESTART WITH 100;
+CALL _timescaledb_testing.restart_dimension_slice_id();

--- a/test/sql/updates/setup.v2.sql
+++ b/test/sql/updates/setup.v2.sql
@@ -2,23 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE DATABASE single;
--- Always pre-create the data node database 'dn1' so that we can dump
--- and restore it even on TimescaleDB versions that don't support
--- multinode. Otherwise, we'd have to create version-dependent scripts
--- to specifically handle multinode tests. We use template0, or
--- otherwise dn1 will have the same UUID as 'single' since template1
--- has the extension pre-installed.
-CREATE DATABASE dn1 TEMPLATE template0;
-\c dn1
--- Make sure the extension is installed so that extension versions
--- that don't support multinode will still be able to update the
--- extension with ALTER EXTENSION ... UPDATE.
-CREATE EXTENSION IF NOT EXISTS timescaledb;
-
-\c single
-CREATE EXTENSION IF NOT EXISTS timescaledb;
-
 \ir setup.bigint.sql
 \ir setup.constraints.sql
 \ir setup.insert_bigint.v2.sql

--- a/test/sql/updates/setup.v7.sql
+++ b/test/sql/updates/setup.v7.sql
@@ -2,7 +2,5 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\ir setup.v2.sql
-\ir setup.continuous_aggs.v2.sql
-\ir setup.compression.sql
-\ir setup.policies.sql
+\ir setup.v6.sql
+\ir setup.multinode.sql


### PR DESCRIPTION
Refactor update tests to use for smoke testing

In order to support smoke-testing with a single server, the update
tests are refactored to not require a `postgres` user with full
privileges.

To support both running smoke tests and update tests, the following
changes where made:

- Database creation code was factored out of tests and is only executed
  for update tests.
- Since the default for `docker_pgscript` was to use the `postgres`
  database and the database creation code also switched database to
  `single` as part of the exection, the default of `docker_pgscript` is
  now changed to `single`.
- Parts of tests that changes roles during execution was removed since
  it is more suitable for a regression test.
- Operations that require escalated privileges are factored out into
  support functions that execute the original code for update tests and
  are no-ops for smoke tests.
- All multinode tests are now added to a new version, `v7` which allow
  us to create multinode objects only for versions that support
  multinode.
- Test script `test_updates_pg11` and `test_updates_pg12` are changed
  to use `v6` for updates from versions preceeding 2.0 and `v7` for
  versions 2.0 and later.
- A dedicated `test_smoke` script was added that can run a smoke test
  against a single server.

In addition, the commit contains the following changes:

- All timestamp columns now have `not null` added to avoid spamming the
  output file and help finding the real issue.
- Extension of dump files are changed from `sql` to `dump` since they
  use the custom format and are not SQL files.
- Only run repair tests on versions where a repair actually happens.
