### PR TITLE
Disable strict-overflow for gcc < 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,11 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
     message(STATUS "Compiler does not support -Wimplicit-fallthrough")
   endif()
 
+  # strict overflow check produces false positives on gcc < 8
+  if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8)
+    add_compile_options(-Wno-strict-overflow)
+  endif()
+
   # On UNIX, the compiler needs to support -fvisibility=hidden to hide symbols by default
   check_c_compiler_flag(-fvisibility=hidden CC_SUPPORTS_VISIBILITY_HIDDEN)
 


### PR DESCRIPTION
The strict-overflow check on gcc < 8 produces false positives
leading to build failuren when compiling with -Werror