### PR TITLE
Add string mapping for CONNECTION_CHECK_TARGET

### DIFF
--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -339,6 +339,9 @@ static const char *conn_status_str[] = {
 #if PG12_GE
 	[CONNECTION_GSS_STARTUP] = "GSS STARTUP",
 #endif
+#if PG13_GE
+	[CONNECTION_CHECK_TARGET] = "CHECK TARGET",
+#endif
 };
 
 static const char *conn_txn_status_str[] = {


### PR DESCRIPTION
PG13 adds a new connection status when checking for a proper
target connection.

https://github.com/postgres/postgres/commit/b438e7e7a1c58e0c20b5f46e73cbd713e8033c69