### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,25 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
-## Unreleased
+## 2.1.0 (2021-02-22)
+
+This release adds major new features since the 2.0.2 release.
+We deem it moderate priority for upgrading.
+
+This release adds the long-awaited support for PostgreSQL 13 to TimescaleDB.
+The minimum required PostgreSQL 13 version is 13.2 due to a security vulnerability
+affecting TimescaleDB functionality present in earlier versions of PostgreSQL 13.
+
+This release also relaxes some restrictions for compressed hypertables;
+namely, TimescaleDB now supports adding columns to compressed hypertables
+and renaming columns of compressed hypertables.
+
+**Major Features**
+* #2779 Add support for PostgreSQL 13
 
 **Minor features**
 * #2736 Support adding columns to hypertables with compression enabled
+* #2909 Support renaming columns of hypertables with compression enabled
 
 ## 2.0.2 (2021-02-19)
 
@@ -22,7 +37,6 @@ lot of invalidations.
 
 **Minor features**
 * #2926 Optimize cagg refresh for small invalidations
-* #2909 Support renaming columns of compression enabled hypertables.
 
 **Bugfixes**
 * #2850 Set status for backend in background jobs

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -106,6 +106,7 @@ set(MOD_FILES
   updates/2.0.0-rc4--2.0.0.sql
   updates/2.0.0--2.0.1.sql
   updates/2.0.1--2.0.2.sql
+  updates/2.0.2--2.1.0.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
-version = 2.1.0-dev
-update_from_version = 2.0.2
+version = 2.2.0-dev
+update_from_version = 2.1.0


### PR DESCRIPTION
This release adds major new features since the 2.0.2 release.
We deem it moderate priority for upgrading.

This release adds the long-awaited support for PostgreSQL 13 to TimescaleDB.
The minimum required PostgreSQL 13 version is 13.2 due to a security vulnerability
affecting TimescaleDB functionality present in earlier versions of PostgreSQL 13.

This release also relaxes some restrictions for compressed hypertables;
namely, TimescaleDB now supports adding columns to compressed hypertables
and renaming columns of compressed hypertables.

**Major Features**
* #2779 Add support for PostgreSQL 13

**Minor features**
* #2736 Support adding columns to hypertables with compression enabled
* #2909 Support renaming columns of hypertables with compression enabled