### PR TITLE
Release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,26 @@ accidentally triggering the load of a previous DB version.**
 
 **Minor features**
 * #2736 Support adding columns to hypertables with compression enabled
+
+## 2.0.2 (2021-02-19)
+
+This maintenance release contains bugfixes since the 2.0.1 release. We
+deem it high priority for upgrading.
+
+The bug fixes in this release address issues with joins, the status of
+background jobs, and disabling compression. It also includes
+enhancements to continuous aggregates, including improved validation
+of policies and optimizations for faster refreshes when there are a
+lot of invalidations.
+
+**Minor features**
 * #2926 Optimize cagg refresh for small invalidations
 
 **Bugfixes**
+* #2850 Set status for backend in background jobs
 * #2883 Fix join qual propagation for nested joins
+* #2884 Add GUC to control join qual propagation
+* #2885 Fix compressed chunk check when disabling compression
 * #2908 Fix changing column type of clustered hypertables
 * #2942 Validate continuous aggregate policy
 
@@ -19,6 +35,9 @@ accidentally triggering the load of a previous DB version.**
 * @zeeshanshabbir93 for reporting an issue with joins
 * @Antiarchitect for reporting the issue with slow refreshes of
   continuous aggregates.
+* @diego-hermida for reporting the issue about being unable to disable
+  compression
+* @mtin for reporting the issue about wrong job status
 
 ## 1.7.5 (2021-02-12)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -105,6 +105,7 @@ set(MOD_FILES
   updates/2.0.0-rc3--2.0.0-rc4.sql
   updates/2.0.0-rc4--2.0.0.sql
   updates/2.0.0--2.0.1.sql
+  updates/2.0.1--2.0.2.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/sql/updates/2.0.1--2.0.2.sql
+++ b/sql/updates/2.0.1--2.0.2.sql
@@ -1,0 +1,2 @@
+-- set compressed_chunk_id to NULL for dropped chunks
+UPDATE _timescaledb_catalog.chunk SET compressed_chunk_id = NULL WHERE dropped = true AND compressed_chunk_id IS NOT NULL;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,4 +1,1 @@
 
--- set compressed_chunk_id to NULL for dropped chunks
-UPDATE _timescaledb_catalog.chunk SET compressed_chunk_id = NULL WHERE dropped = true AND compressed_chunk_id IS NOT NULL;
-

--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
-version = 2.0.1
-update_from_version = 2.0.0
+version = 2.0.2
+update_from_version = 2.0.1


### PR DESCRIPTION
This maintenance release contains bugfixes since the 2.0.1 release. We
deem it high priority for upgrading.

The bug fixes in this release address issues with joins, the status of
background jobs, and disabling compression. It also includes
enhancements to continuous aggregates, including improved validation
of policies and optimizations for faster refreshes when there are a
lot of invalidations.

**Minor features**
* #2926 Optimize cagg refresh for small invalidations

**Bugfixes**
* #2850 Set status for backend in background jobs
* #2883 Fix join qual propagation for nested joins
* #2884 Add GUC to control join qual propagation
* #2885 Fix compressed chunk check when disabling compression
* #2908 Fix changing column type of clustered hypertables
* #2942 Validate continuous aggregate policy

**Thanks**
* @zeeshanshabbir93 for reporting the issue with full outer joins
* @Antiarchitect for reporting the issue with slow refreshes of
* @diego-hermida for reporting the issue about being unable to disable
  compression
* @mtin for reporting the issue about wrong job status