### PR TITLE
Fix index creation for hypertables with dropped columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## Unreleased
+
+**Bugfixes**
+* #2974 Fix index creation for hypertables with dropped columns
+
+**Thanks**
+* @jocrau for reporting an issue with index creation
+
 ## 2.1.0 (2021-02-22)
 
 This release adds major new features since the 2.0.2 release.

--- a/test/expected/ddl-11.out
+++ b/test/expected/ddl-11.out
@@ -528,3 +528,19 @@ ALTER TABLE alter_test_bigint
 DROP COLUMN time;
 ERROR:  cannot drop column named in partition key
 \set ON_ERROR_STOP 1
+-- test expression index creation where physical layout of chunks differs from hypertable
+CREATE TABLE i2504(time timestamp NOT NULL, a int, b int, c int, d int);
+select create_hypertable('i2504', 'time');
+  create_hypertable  
+---------------------
+ (11,public,i2504,t)
+(1 row)
+
+INSERT INTO i2504 VALUES (now(), 1, 2, 3, 4);
+ALTER TABLE i2504 DROP COLUMN b;
+INSERT INTO i2504(time, a, c, d) VALUES
+(now() - interval '1 year', 1, 2, 3),
+(now() - interval '2 years', 1, 2, 3);
+CREATE INDEX idx2 ON i2504(a,d) WHERE c IS NOT NULL;
+DROP INDEX idx2;
+CREATE INDEX idx2 ON i2504(a,d) WITH (timescaledb.transaction_per_chunk) WHERE c IS NOT NULL;

--- a/test/expected/ddl-12.out
+++ b/test/expected/ddl-12.out
@@ -528,3 +528,19 @@ ALTER TABLE alter_test_bigint
 DROP COLUMN time;
 ERROR:  cannot drop column named in partition key
 \set ON_ERROR_STOP 1
+-- test expression index creation where physical layout of chunks differs from hypertable
+CREATE TABLE i2504(time timestamp NOT NULL, a int, b int, c int, d int);
+select create_hypertable('i2504', 'time');
+  create_hypertable  
+---------------------
+ (11,public,i2504,t)
+(1 row)
+
+INSERT INTO i2504 VALUES (now(), 1, 2, 3, 4);
+ALTER TABLE i2504 DROP COLUMN b;
+INSERT INTO i2504(time, a, c, d) VALUES
+(now() - interval '1 year', 1, 2, 3),
+(now() - interval '2 years', 1, 2, 3);
+CREATE INDEX idx2 ON i2504(a,d) WHERE c IS NOT NULL;
+DROP INDEX idx2;
+CREATE INDEX idx2 ON i2504(a,d) WITH (timescaledb.transaction_per_chunk) WHERE c IS NOT NULL;

--- a/test/expected/ddl-13.out
+++ b/test/expected/ddl-13.out
@@ -528,3 +528,19 @@ ALTER TABLE alter_test_bigint
 DROP COLUMN time;
 ERROR:  cannot drop column named in partition key
 \set ON_ERROR_STOP 1
+-- test expression index creation where physical layout of chunks differs from hypertable
+CREATE TABLE i2504(time timestamp NOT NULL, a int, b int, c int, d int);
+select create_hypertable('i2504', 'time');
+  create_hypertable  
+---------------------
+ (11,public,i2504,t)
+(1 row)
+
+INSERT INTO i2504 VALUES (now(), 1, 2, 3, 4);
+ALTER TABLE i2504 DROP COLUMN b;
+INSERT INTO i2504(time, a, c, d) VALUES
+(now() - interval '1 year', 1, 2, 3),
+(now() - interval '2 years', 1, 2, 3);
+CREATE INDEX idx2 ON i2504(a,d) WHERE c IS NOT NULL;
+DROP INDEX idx2;
+CREATE INDEX idx2 ON i2504(a,d) WITH (timescaledb.transaction_per_chunk) WHERE c IS NOT NULL;

--- a/test/sql/ddl.sql.in
+++ b/test/sql/ddl.sql.in
@@ -89,3 +89,21 @@ ALTER COLUMN time TYPE TEXT;
 ALTER TABLE alter_test_bigint
 DROP COLUMN time;
 \set ON_ERROR_STOP 1
+
+
+-- test expression index creation where physical layout of chunks differs from hypertable
+CREATE TABLE i2504(time timestamp NOT NULL, a int, b int, c int, d int);
+
+select create_hypertable('i2504', 'time');
+
+INSERT INTO i2504 VALUES (now(), 1, 2, 3, 4);
+ALTER TABLE i2504 DROP COLUMN b;
+
+INSERT INTO i2504(time, a, c, d) VALUES
+(now() - interval '1 year', 1, 2, 3),
+(now() - interval '2 years', 1, 2, 3);
+
+CREATE INDEX idx2 ON i2504(a,d) WHERE c IS NOT NULL;
+DROP INDEX idx2;
+CREATE INDEX idx2 ON i2504(a,d) WITH (timescaledb.transaction_per_chunk) WHERE c IS NOT NULL;
+


### PR DESCRIPTION
The index creation code would take the IndexInfo from the hypertable
and adjust it for the chunk but wouldnt reset IndexInfo for each
individual chunk leading to errors when the hypertable has dropped
columns.

Fixes #2504 