### PR TITLE
Do not notify Slack if in PR

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -83,7 +83,7 @@ jobs:
         path: postgres.log
 
     - name: Slack Notification
-      if: failure()
+      if: failure() && github.event_name != 'pull_request'
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_COLOR: '#ff0000'

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -72,7 +72,7 @@ jobs:
         fi
 
     - name: Slack Notification
-      if: failure()
+      if: failure() && github.event_name != 'pull_request'
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_COLOR: '#ff0000'

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -72,7 +72,7 @@ jobs:
         fi
 
     - name: Slack Notification
-      if: failure()
+      if: failure() && github.event_name != 'pull_request'
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_COLOR: '#ff0000'


### PR DESCRIPTION
Notifying a Slack channel on regression test failures fails in a fork,
which is common for PRs. The failed Slack error is confusing, since it
disturbs from checking actual regression test failure. Furthermore,
notifying Slack is not needed in the case of PRs as developers rely on
GitHub's GUI around PRs. This commit fixes GH Actions workflows to not
notify Slack on PRs.