### PR TITLE
Refactor and harden size and stats functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #2974 Fix index creation for hypertables with dropped columns
+* #2989 Refactor and harden size and stats functions
 * #3042 Commit end transaction for CREATE INDEX
 
 **Thanks**
 * @jocrau for reporting an issue with index creation
+* @pedrokost and @RobAtticus for reporting an issue with size
+  functions on empty hypertables
 
 ## 2.1.0 (2021-02-22)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -27,7 +27,8 @@ set(SOURCE_FILES
   pre_install/fdw_functions.sql
   hypertable.sql
   chunk.sql
-  ddl_internal.sql
+  data_node.sql
+  ddl_internal.sql  
   util_time.sql
   util_internal_table_ddl.sql
   chunk_constraint.sql
@@ -44,7 +45,6 @@ set(SOURCE_FILES
   cache.sql
   bgw_scheduler.sql
   metadata.sql
-  data_node.sql
   dist_internal.sql
   views.sql
   gapfill.sql

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,1 +1,2 @@
-
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -160,20 +160,20 @@ SELECT * FROM test_dt ORDER BY time;
 SELECT * FROM "testSchema0".hypertable_detailed_size('test_ts');
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
-       16384 |       65536 |       16384 |       98304 | 
+       16384 |       81920 |       16384 |      122880 | 
 (1 row)
 
 -- testing hypertable_detailed_size END
 SELECT * FROM "testSchema0".hypertable_index_size('test_ts_time_idx');
  hypertable_index_size 
 -----------------------
-                 32768
+                 40960
 (1 row)
 
 SELECT * FROM "testSchema0".hypertable_index_size('test_ts_device_time_idx');
  hypertable_index_size 
 -----------------------
-                 32768
+                 40960
 (1 row)
 
 CREATE SCHEMA "testSchema";

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -45,49 +45,49 @@ INSERT 0 1
 SELECT * FROM hypertable_detailed_size('"public"."two_Partitions"');
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
-       32768 |      417792 |       32768 |      483328 | 
+       32768 |      475136 |       32768 |      548864 | 
 (1 row)
 
 SELECT * FROM hypertable_index_size('"public"."two_Partitions_device_id_timeCustom_idx"');
  hypertable_index_size 
 -----------------------
-                 65536
+                 73728
 (1 row)
 
 SELECT * FROM hypertable_index_size('"public"."two_Partitions_timeCustom_device_id_idx"');
  hypertable_index_size 
 -----------------------
-                 65536
+                 73728
 (1 row)
 
 SELECT * FROM hypertable_index_size('"public"."two_Partitions_timeCustom_idx"');
  hypertable_index_size 
 -----------------------
-                 65536
+                 73728
 (1 row)
 
 SELECT * FROM hypertable_index_size('"public"."two_Partitions_timeCustom_series_0_idx"');
  hypertable_index_size 
 -----------------------
-                 65536
+                 73728
 (1 row)
 
 SELECT * FROM hypertable_index_size('"public"."two_Partitions_timeCustom_series_1_idx"');
  hypertable_index_size 
 -----------------------
-                 65536
+                 73728
 (1 row)
 
 SELECT * FROM hypertable_index_size('"public"."two_Partitions_timeCustom_series_2_idx"');
  hypertable_index_size 
 -----------------------
-                 40960
+                 49152
 (1 row)
 
 SELECT * FROM hypertable_index_size('"public"."two_Partitions_timeCustom_series_bool_idx"');
  hypertable_index_size 
 -----------------------
-                 49152
+                 57344
 (1 row)
 
 SELECT * FROM chunks_detailed_size('"public"."two_Partitions"') order by chunk_name;
@@ -413,14 +413,96 @@ SELECT * FROM approximate_row_count(NULL);
 (1 row)
 
 \set ON_ERROR_STOP 1
-SELECT * FROM chunks_detailed_size(NULL);
+-- Test size functions with invalid or non-existing OID
+SELECT * FROM hypertable_size(0);
+ hypertable_size 
+-----------------
+                
+(1 row)
+
+SELECT * FROM hypertable_detailed_size(0) ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM chunks_detailed_size(0) ORDER BY node_name;
  chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 --------------+------------+-------------+-------------+-------------+-------------+-----------
 (0 rows)
 
-SELECT * FROM hypertable_detailed_size(NULL);
+SELECT * FROM hypertable_compression_stats(0) ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats(0) ORDER BY node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size(0);
+ hypertable_index_size 
+-----------------------
+                      
+(1 row)
+
+SELECT * FROM hypertable_size(1);
+ hypertable_size 
+-----------------
+                
+(1 row)
+
+SELECT * FROM hypertable_detailed_size(1) ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM chunks_detailed_size(1) ORDER BY node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats(1) ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats(1) ORDER BY node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size(1);
+ hypertable_index_size 
+-----------------------
+                      
+(1 row)
+
+-- Test size functions with NULL input
+SELECT * FROM hypertable_size(NULL);
+ hypertable_size 
+-----------------
+                
+(1 row)
+
+SELECT * FROM hypertable_detailed_size(NULL) ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM chunks_detailed_size(NULL) ORDER BY node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats(NULL) ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats(NULL) ORDER BY node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
 (0 rows)
 
 SELECT * FROM hypertable_index_size(NULL);
@@ -429,8 +511,146 @@ SELECT * FROM hypertable_index_size(NULL);
                       
 (1 row)
 
--- tests with tables that are not hypertables
-CREATE TABLE regtab( a integer, b integer);
-CREATE INDEX regtab_idx ON regtab( a);
-SELECT * FROM hypertable_index_size('regtab_idx');
-ERROR:  query returned no rows
+-- Test size functions on regular table
+CREATE TABLE hypersize(time timestamptz, device int);
+CREATE INDEX hypersize_time_idx ON hypersize (time);
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+\set SHOW_CONTEXT never
+SELECT pg_relation_size('hypersize'), pg_table_size('hypersize'), pg_indexes_size('hypersize'), pg_total_relation_size('hypersize'), pg_relation_size('hypersize_time_idx');
+ pg_relation_size | pg_table_size | pg_indexes_size | pg_total_relation_size | pg_relation_size 
+------------------+---------------+-----------------+------------------------+------------------
+                0 |             0 |            8192 |                   8192 |             8192
+(1 row)
+
+SELECT * FROM hypertable_size('hypersize');
+ hypertable_size 
+-----------------
+                
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('hypersize') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM chunks_detailed_size('hypersize') ORDER BY node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('hypersize') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('hypersize') ORDER BY node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size('hypersize_time_idx');
+ hypertable_index_size 
+-----------------------
+                      
+(1 row)
+
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
+-- Test size functions on empty hypertable
+SELECT * FROM create_hypertable('hypersize', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             6 | public      | hypersize  | t
+(1 row)
+
+SELECT pg_relation_size('hypersize'), pg_table_size('hypersize'), pg_indexes_size('hypersize'), pg_total_relation_size('hypersize'), pg_relation_size('hypersize_time_idx');
+ pg_relation_size | pg_table_size | pg_indexes_size | pg_total_relation_size | pg_relation_size 
+------------------+---------------+-----------------+------------------------+------------------
+                0 |             0 |            8192 |                   8192 |             8192
+(1 row)
+
+SELECT * FROM hypertable_size('hypersize');
+ hypertable_size 
+-----------------
+            8192
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('hypersize') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+           0 |        8192 |           0 |        8192 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size('hypersize') ORDER BY node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('hypersize') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('hypersize') ORDER BY node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size('hypersize_time_idx');
+ hypertable_index_size 
+-----------------------
+                  8192
+(1 row)
+
+-- Test size functions on non-empty hypertable
+INSERT INTO hypersize VALUES('2021-02-25', 1);
+SELECT pg_relation_size('hypersize'), pg_table_size('hypersize'), pg_indexes_size('hypersize'), pg_total_relation_size('hypersize'), pg_relation_size('hypersize_time_idx');
+ pg_relation_size | pg_table_size | pg_indexes_size | pg_total_relation_size | pg_relation_size 
+------------------+---------------+-----------------+------------------------+------------------
+                0 |             0 |            8192 |                   8192 |             8192
+(1 row)
+
+SELECT pg_relation_size(ch), pg_table_size(ch), pg_indexes_size(ch), pg_total_relation_size(ch)
+FROM show_chunks('hypersize') ch
+ORDER BY ch;
+ pg_relation_size | pg_table_size | pg_indexes_size | pg_total_relation_size 
+------------------+---------------+-----------------+------------------------
+             8192 |          8192 |           16384 |                  24576
+(1 row)
+
+SELECT * FROM hypertable_size('hypersize');
+ hypertable_size 
+-----------------
+           32768
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('hypersize') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+        8192 |       24576 |           0 |       32768 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size('hypersize') ORDER BY node_name;
+     chunk_schema      |    chunk_name     | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+-------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_6_11_chunk |        8192 |       16384 |           0 |       24576 | 
+(1 row)
+
+SELECT * FROM hypertable_compression_stats('hypersize') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('hypersize') ORDER BY node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size('hypersize_time_idx');
+ hypertable_index_size 
+-----------------------
+                 24576
+(1 row)
+

--- a/test/isolation/expected/multi_transaction_indexing.out
+++ b/test/isolation/expected/multi_transaction_indexing.out
@@ -9,7 +9,7 @@ step CI: <... completed>
 step P: SELECT * FROM hypertable_index_size('test_index');
 hypertable_index_size
 
-65536          
+73728          
 step Sc: COMMIT;
 
 starting permutation: I1 CI Bc Ic P Sc
@@ -21,7 +21,7 @@ step CI: <... completed>
 step P: SELECT * FROM hypertable_index_size('test_index');
 hypertable_index_size
 
-65536          
+73728          
 step Sc: COMMIT;
 
 starting permutation: S1 CI Bc Sc P Ic
@@ -38,7 +38,7 @@ step Sc: COMMIT;
 step P: SELECT * FROM hypertable_index_size('test_index');
 hypertable_index_size
 
-49152          
+57344          
 step Ic: COMMIT;
 
 starting permutation: F WPE CI DI Bc WPR P Ic Sc
@@ -70,6 +70,6 @@ step RI: <... completed>
 step P: SELECT * FROM hypertable_index_size('test_index');
 hypertable_index_size
 
-49152          
+57344          
 step Ic: COMMIT;
 step Sc: COMMIT;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -440,18 +440,18 @@ pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('foo');
 -[ RECORD 1 ]--+-----------
 pg_size_pretty | 32 kB
-pg_size_pretty | 144 kB
+pg_size_pretty | 160 kB
 pg_size_pretty | 8192 bytes
-pg_size_pretty | 184 kB
+pg_size_pretty | 200 kB
 
 select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
 pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('conditions');
--[ RECORD 1 ]--+------
+-[ RECORD 1 ]--+-------
 pg_size_pretty | 16 kB
-pg_size_pretty | 48 kB
+pg_size_pretty | 56 kB
 pg_size_pretty | 32 kB
-pg_size_pretty | 96 kB
+pg_size_pretty | 112 kB
 
 select * from timescaledb_information.hypertables
 where hypertable_name like 'foo' or hypertable_name like 'conditions'

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -347,10 +347,11 @@ ORDER BY chunk_name, node_name;
 SELECT * FROM hypertable_detailed_size('compressed'::regclass) ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |       node_name       
 -------------+-------------+-------------+-------------+-----------------------
-       16384 |       65536 |           0 |       81920 | db_dist_compression_1
-       16384 |       65536 |           0 |       81920 | db_dist_compression_2
-       16384 |       65536 |           0 |       81920 | db_dist_compression_3
-(3 rows)
+       16384 |       81920 |           0 |       98304 | db_dist_compression_1
+       16384 |       81920 |           0 |       98304 | db_dist_compression_2
+       16384 |       81920 |           0 |       98304 | db_dist_compression_3
+           0 |       16384 |           0 |       16384 | 
+(4 rows)
 
 -- Test compression policy with distributed hypertable
 --

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -380,10 +380,11 @@ SELECT node_name, "options" FROM timescaledb_information.data_nodes ORDER BY nod
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |      node_name       
 -------------+-------------+-------------+-------------+----------------------
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_1
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_2
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_3
-(3 rows)
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_1
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_2
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_3
+           0 |       24576 |           0 |       24576 | 
+(4 rows)
 
 -- Show what some queries would look like on the frontend
 EXPLAIN (VERBOSE, COSTS FALSE)

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -380,10 +380,11 @@ SELECT node_name, "options" FROM timescaledb_information.data_nodes ORDER BY nod
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |      node_name       
 -------------+-------------+-------------+-------------+----------------------
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_1
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_2
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_3
-(3 rows)
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_1
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_2
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_3
+           0 |       24576 |           0 |       24576 | 
+(4 rows)
 
 -- Show what some queries would look like on the frontend
 EXPLAIN (VERBOSE, COSTS FALSE)

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -380,10 +380,11 @@ SELECT node_name, "options" FROM timescaledb_information.data_nodes ORDER BY nod
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |      node_name       
 -------------+-------------+-------------+-------------+----------------------
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_1
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_2
-       81920 |       98304 |           0 |      180224 | db_dist_hypertable_3
-(3 rows)
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_1
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_2
+       81920 |      122880 |           0 |      204800 | db_dist_hypertable_3
+           0 |       24576 |           0 |       24576 | 
+(4 rows)
 
 -- Show what some queries would look like on the frontend
 EXPLAIN (VERBOSE, COSTS FALSE)

--- a/tsl/test/expected/dist_util.out
+++ b/tsl/test/expected/dist_util.out
@@ -207,69 +207,640 @@ SELECT key, value FROM _timescaledb_catalog.metadata WHERE key LIKE 'dist_uuid';
 
 -- Test space reporting functions for distributed and non-distributed tables
 \c frontend_2 :ROLE_CLUSTER_SUPERUSER
-CREATE TABLE nondisttable(time timestamptz PRIMARY KEY, device int CHECK (device > 0), temp float);
-CREATE TABLE disttable(time timestamptz PRIMARY KEY, device int CHECK (device > 0), temp float);
-SELECT * FROM create_hypertable('nondisttable', 'time');
+CREATE TABLE nondisttable(time timestamptz, device int CHECK (device > 0), temp float);
+CREATE TABLE disttable(time timestamptz, device int CHECK (device > 0), temp float);
+SELECT * FROM create_hypertable('nondisttable', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
              1 | public      | nondisttable | t
 (1 row)
 
-SELECT * FROM create_distributed_hypertable('disttable', 'time');
+SELECT * FROM create_distributed_hypertable('disttable', 'time', create_default_indexes => false);
+NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              2 | public      | disttable  | t
 (1 row)
 
+SELECT node_name FROM timescaledb_information.data_nodes
+ORDER BY node_name;
+  node_name  
+-------------
+ data_node_1
+ data_node_2
+(2 rows)
+
+SELECT * FROM timescaledb_information.hypertables
+ORDER BY hypertable_schema, hypertable_name;
+ hypertable_schema | hypertable_name |       owner        | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |        data_nodes         | tablespaces 
+-------------------+-----------------+--------------------+----------------+------------+---------------------+----------------+--------------------+---------------------------+-------------
+ public            | disttable       | cluster_super_user |              1 |          0 | f                   | t              |                  1 | {data_node_1,data_node_2} | 
+ public            | nondisttable    | cluster_super_user |              1 |          0 | f                   | f              |                    |                           | 
+(2 rows)
+
+-- Test size functions on empty distributed hypertable.
+--
+-- First, show the output from standard PG size functions. The
+-- functions are expected to remove 0 table bytes for the distributed
+-- hypertable since it doesn't have local storage.
+SELECT pg_table_size('disttable'), pg_relation_size('disttable'), pg_indexes_size('disttable'), pg_total_relation_size('disttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |               0 |                      0
+(1 row)
+
+SELECT pg_table_size(ch), pg_relation_size(ch), pg_indexes_size(ch), pg_total_relation_size(ch)
+FROM show_chunks('disttable') ch;
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+(0 rows)
+
+SELECT pg_table_size('nondisttable'), pg_relation_size('nondisttable'), pg_indexes_size('nondisttable'), pg_total_relation_size('nondisttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |               0 |                      0
+(1 row)
+
+SELECT pg_table_size(ch), pg_relation_size(ch), pg_indexes_size(ch), pg_total_relation_size(ch)
+FROM show_chunks('nondisttable') ch;
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+(0 rows)
+
+SELECT * FROM hypertable_size('disttable');
+ hypertable_size 
+-----------------
+               0
+(1 row)
+
+SELECT * FROM hypertable_size('nondisttable');
+ hypertable_size 
+-----------------
+               0
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+           0 |           0 |           0 |           0 | data_node_1
+           0 |           0 |           0 |           0 | data_node_2
+           0 |           0 |           0 |           0 | 
+(3 rows)
+
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+           0 |           0 |           0 |           0 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY  chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('nondisttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('nondisttable') ORDER BY  chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+-- Create primary key index and check how it affects the size of the
+-- empty hypertables.
+ALTER TABLE nondisttable ADD CONSTRAINT nondisttable_pkey PRIMARY KEY (time);
+ALTER TABLE disttable ADD CONSTRAINT disttable_pkey PRIMARY KEY (time);
+SELECT pg_table_size('disttable'), pg_relation_size('disttable'), pg_indexes_size('disttable'), pg_total_relation_size('disttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |            8192 |                   8192
+(1 row)
+
+SELECT pg_table_size('nondisttable'), pg_relation_size('nondisttable'), pg_indexes_size('nondisttable'), pg_total_relation_size('nondisttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |            8192 |                   8192
+(1 row)
+
+-- Note that the empty disttable is three times the size of the
+-- nondisttable since it has primary key indexes on two data nodes in
+-- addition to the access node.
+SELECT * FROM hypertable_size('disttable');
+ hypertable_size 
+-----------------
+           24576
+(1 row)
+
+SELECT * FROM hypertable_size('nondisttable');
+ hypertable_size 
+-----------------
+            8192
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+           0 |        8192 |           0 |        8192 | data_node_1
+           0 |        8192 |           0 |        8192 | data_node_2
+           0 |        8192 |           0 |        8192 | 
+(3 rows)
+
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+           0 |        8192 |           0 |        8192 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY  chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+--------------+------------+-------------+-------------+-------------+-------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('nondisttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('nondisttable') ORDER BY  chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size('disttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 24576
+(1 row)
+
+SELECT * FROM hypertable_index_size('nondisttable_pkey');
+ hypertable_index_size 
+-----------------------
+                  8192
+(1 row)
+
+-- Test size functions on tables with an empty chunk
+INSERT INTO nondisttable VALUES ('2017-01-01 06:01', 1, 1.1);
+INSERT INTO disttable SELECT * FROM nondisttable;
+SELECT pg_table_size('disttable'), pg_relation_size('disttable'), pg_indexes_size('disttable'), pg_total_relation_size('disttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |            8192 |                   8192
+(1 row)
+
+SELECT pg_table_size(ch), pg_relation_size(ch), pg_indexes_size(ch), pg_total_relation_size(ch)
+FROM show_chunks('disttable') ch;
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |               0 |                      0
+(1 row)
+
+SELECT pg_table_size('nondisttable'), pg_relation_size('nondisttable'), pg_indexes_size('nondisttable'), pg_total_relation_size('nondisttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |            8192 |                   8192
+(1 row)
+
+SELECT pg_table_size(ch), pg_relation_size(ch), pg_indexes_size(ch), pg_total_relation_size(ch)
+FROM show_chunks('nondisttable') ch;
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+          8192 |             8192 |           16384 |                  24576
+(1 row)
+
+SELECT * FROM hypertable_size('disttable');
+ hypertable_size 
+-----------------
+           49152
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+        8192 |       24576 |           0 |       32768 | data_node_1
+           0 |        8192 |           0 |        8192 | data_node_2
+           0 |        8192 |           0 |        8192 | 
+(3 rows)
+
+SELECT * FROM hypertable_size('nondisttable');
+ hypertable_size 
+-----------------
+           32768
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+        8192 |       24576 |           0 |       32768 | 
+(1 row)
+
+-- Delete all data, but keep chunks
+DELETE FROM nondisttable;
+DELETE FROM disttable;
+VACUUM FULL ANALYZE nondisttable;
+VACUUM FULL ANALYZE disttable;
+SELECT pg_table_size('disttable'), pg_relation_size('disttable'), pg_indexes_size('disttable'), pg_total_relation_size('disttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |            8192 |                   8192
+(1 row)
+
+SELECT pg_table_size(ch), pg_relation_size(ch), pg_indexes_size(ch)
+FROM show_chunks('disttable') ch;
+ pg_table_size | pg_relation_size | pg_indexes_size 
+---------------+------------------+-----------------
+             0 |                0 |               0
+(1 row)
+
+SELECT pg_table_size('nondisttable'), pg_relation_size('nondisttable'), pg_indexes_size('nondisttable'), pg_total_relation_size('nondisttable');
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |            8192 |                   8192
+(1 row)
+
+SELECT pg_table_size(ch), pg_relation_size(ch), pg_indexes_size(ch), pg_total_relation_size(ch)
+FROM show_chunks('nondisttable') ch;
+ pg_table_size | pg_relation_size | pg_indexes_size | pg_total_relation_size 
+---------------+------------------+-----------------+------------------------
+             0 |                0 |            8192 |                   8192
+(1 row)
+
+SELECT * FROM hypertable_size('disttable');
+ hypertable_size 
+-----------------
+           32768
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+           0 |       16384 |           0 |       16384 | data_node_1
+           0 |        8192 |           0 |        8192 | data_node_2
+           0 |        8192 |           0 |        8192 | 
+(3 rows)
+
+SELECT * FROM hypertable_size('nondisttable');
+ hypertable_size 
+-----------------
+           16384
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+           0 |       16384 |           0 |       16384 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_2_2_chunk |           0 |        8192 |           0 |        8192 | data_node_1
+(1 row)
+
+SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk |           0 |        8192 |           0 |        8192 | 
+(1 row)
+
+SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('nondisttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size('disttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 32768
+(1 row)
+
+SELECT * FROM hypertable_index_size('nondisttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 16384
+(1 row)
+
+-- Test size functions on non-empty hypertable
 INSERT INTO nondisttable VALUES
        ('2017-01-01 06:01', 1, 1.1),
        ('2017-01-01 08:01', 1, 1.2),
        ('2018-01-02 08:01', 2, 1.3),
        ('2019-01-01 09:11', 3, 2.1),
        ('2017-01-01 06:05', 1, 1.4);
-INSERT INTO disttable VALUES
-       ('2017-01-01 06:01', 1, 1.1),
-       ('2017-01-01 08:01', 1, 1.2),
-       ('2018-01-02 08:01', 2, 1.3),
-       ('2019-01-01 09:11', 3, 2.1),
-       ('2017-01-01 06:05', 1, 1.4);
-SELECT * FROM timescaledb_information.data_nodes ORDER BY node_name;
-  node_name  |       owner        |                    options                     
--------------+--------------------+------------------------------------------------
- data_node_1 | cluster_super_user | {host=localhost,port=55432,dbname=backend_2_1}
- data_node_2 | cluster_super_user | {host=localhost,port=55432,dbname=backend_x_2}
-(2 rows)
+INSERT INTO disttable SELECT * FROM nondisttable;
+SELECT * FROM hypertable_size('disttable');
+ hypertable_size 
+-----------------
+           98304
+(1 row)
 
-SELECT * FROM timescaledb_information.hypertables ORDER BY hypertable_schema, hypertable_name;
- hypertable_schema | hypertable_name |       owner        | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor |        data_nodes         | tablespaces 
--------------------+-----------------+--------------------+----------------+------------+---------------------+----------------+--------------------+---------------------------+-------------
- public            | disttable       | cluster_super_user |              1 |          3 | f                   | t              |                  1 | {data_node_1,data_node_2} | 
- public            | nondisttable    | cluster_super_user |              1 |          3 | f                   | f              |                    |                           | 
-(2 rows)
+SELECT * FROM hypertable_size('nondisttable');
+ hypertable_size 
+-----------------
+           81920
+(1 row)
 
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
-       16384 |       32768 |           0 |       49152 | data_node_1
-        8192 |       16384 |           0 |       24576 | data_node_2
-(2 rows)
+       16384 |       40960 |           0 |       57344 | data_node_1
+        8192 |       24576 |           0 |       32768 | data_node_2
+           0 |        8192 |           0 |        8192 | 
+(3 rows)
 
 SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
-       24576 |       49152 |           0 |       73728 | 
+       24576 |       57344 |           0 |       81920 | 
 (1 row)
 
-SELECT * FROM hypertable_size('disttable') ;
- hypertable_size 
------------------
-           73728
+SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       16384 |           0 |       24576 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+(3 rows)
+
+SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk |        8192 |       16384 |           0 |       24576 | 
+ _timescaledb_internal | _hyper_1_3_chunk |        8192 |       16384 |           0 |       24576 | 
+ _timescaledb_internal | _hyper_1_4_chunk |        8192 |       16384 |           0 |       24576 | 
+(3 rows)
+
+SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_compression_stats('nondisttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM chunk_compression_stats('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+ chunk_schema | chunk_name | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+(0 rows)
+
+SELECT * FROM hypertable_index_size('disttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 73728
 (1 row)
 
-SELECT * FROM hypertable_size('nondisttable') ;
+SELECT * FROM hypertable_index_size('nondisttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 57344
+(1 row)
+
+-- Enable compression
+ALTER TABLE nondisttable
+SET (timescaledb.compress,
+	 timescaledb.compress_segmentby='device',
+	 timescaledb.compress_orderby = 'time DESC');
+ALTER TABLE disttable
+SET (timescaledb.compress,
+	 timescaledb.compress_segmentby='device',
+	 timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM hypertable_size('disttable');
  hypertable_size 
 -----------------
-           73728
+           98304
+(1 row)
+
+SELECT * FROM hypertable_size('nondisttable');
+ hypertable_size 
+-----------------
+           81920
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+       16384 |       40960 |           0 |       57344 | data_node_1
+        8192 |       24576 |           0 |       32768 | data_node_2
+           0 |        8192 |           0 |        8192 | 
+(3 rows)
+
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+       24576 |       57344 |           0 |       81920 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       16384 |           0 |       24576 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+(3 rows)
+
+SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk |        8192 |       16384 |           0 |       24576 | 
+ _timescaledb_internal | _hyper_1_3_chunk |        8192 |       16384 |           0 |       24576 | 
+ _timescaledb_internal | _hyper_1_4_chunk |        8192 |       16384 |           0 |       24576 | 
+(3 rows)
+
+SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes |  node_name  
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------
+            2 |                        0 |                                |                                |                                |                                |                               |                               |                               |                               | data_node_1
+            1 |                        0 |                                |                                |                                |                                |                               |                               |                               |                               | data_node_2
+(2 rows)
+
+SELECT * FROM hypertable_compression_stats('nondisttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+            3 |                        0 |                                |                                |                                |                                |                               |                               |                               |                               | 
+(1 row)
+
+SELECT * FROM chunk_compression_stats('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |      chunk_name       | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes |  node_name  
+-----------------------+-----------------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------
+ _timescaledb_internal | _dist_hyper_2_2_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | data_node_2
+ _timescaledb_internal | _dist_hyper_2_6_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | data_node_1
+(3 rows)
+
+SELECT * FROM chunk_compression_stats('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |    chunk_name    | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+-----------------------+------------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | 
+ _timescaledb_internal | _hyper_1_3_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | 
+ _timescaledb_internal | _hyper_1_4_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | 
+(3 rows)
+
+SELECT * FROM hypertable_index_size('disttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 73728
+(1 row)
+
+SELECT * FROM hypertable_index_size('nondisttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 57344
+(1 row)
+
+-- Compress two chunks (out of three) to see effect of compression
+SELECT compress_chunk(ch)
+FROM show_chunks('disttable') ch
+LIMIT 2;
+               compress_chunk                
+---------------------------------------------
+ _timescaledb_internal._dist_hyper_2_2_chunk
+ _timescaledb_internal._dist_hyper_2_5_chunk
+(2 rows)
+
+SELECT compress_chunk(ch)
+FROM show_chunks('nondisttable') ch
+LIMIT 2;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+(2 rows)
+
+SELECT * FROM hypertable_size('disttable');
+ hypertable_size 
+-----------------
+          131072
+(1 row)
+
+SELECT * FROM hypertable_size('nondisttable');
+ hypertable_size 
+-----------------
+          114688
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-------------+-------------+-------------+-------------+-------------
+       16384 |       49152 |        8192 |       73728 | data_node_1
+        8192 |       32768 |        8192 |       49152 | data_node_2
+           0 |        8192 |           0 |        8192 | 
+(3 rows)
+
+SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+       24576 |       73728 |       16384 |      114688 | 
+(1 row)
+
+SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
+-----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
+ _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       24576 |        8192 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
+(3 rows)
+
+SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-----------------------+------------------+-------------+-------------+-------------+-------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk |        8192 |       24576 |        8192 |       40960 | 
+ _timescaledb_internal | _hyper_1_3_chunk |        8192 |       24576 |        8192 |       40960 | 
+ _timescaledb_internal | _hyper_1_4_chunk |        8192 |       16384 |           0 |       24576 | 
+(3 rows)
+
+SELECT * FROM hypertable_compression_stats('disttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes |  node_name  
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------
+            2 |                        1 |                           8192 |                          16384 |                              0 |                          24576 |                          8192 |                         16384 |                          8192 |                         32768 | data_node_1
+            1 |                        1 |                           8192 |                          16384 |                              0 |                          24576 |                          8192 |                         16384 |                          8192 |                         32768 | data_node_2
+(2 rows)
+
+SELECT * FROM hypertable_compression_stats('nondisttable') ORDER BY node_name;
+ total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+--------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+            3 |                        2 |                          16384 |                          32768 |                              0 |                          49152 |                         16384 |                         32768 |                         16384 |                         65536 | 
+(1 row)
+
+SELECT * FROM chunk_compression_stats('disttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |      chunk_name       | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes |  node_name  
+-----------------------+-----------------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------
+ _timescaledb_internal | _dist_hyper_2_2_chunk | Compressed         |                           8192 |                          16384 |                              0 |                          24576 |                          8192 |                         16384 |                          8192 |                         32768 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk | Compressed         |                           8192 |                          16384 |                              0 |                          24576 |                          8192 |                         16384 |                          8192 |                         32768 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_6_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | data_node_1
+(3 rows)
+
+SELECT * FROM chunk_compression_stats('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
+     chunk_schema      |    chunk_name    | compression_status | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes | node_name 
+-----------------------+------------------+--------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------
+ _timescaledb_internal | _hyper_1_1_chunk | Compressed         |                           8192 |                          16384 |                              0 |                          24576 |                          8192 |                         16384 |                          8192 |                         32768 | 
+ _timescaledb_internal | _hyper_1_3_chunk | Compressed         |                           8192 |                          16384 |                              0 |                          24576 |                          8192 |                         16384 |                          8192 |                         32768 | 
+ _timescaledb_internal | _hyper_1_4_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | 
+(3 rows)
+
+SELECT * FROM hypertable_index_size('disttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 57344
+(1 row)
+
+SELECT * FROM hypertable_index_size('nondisttable_pkey');
+ hypertable_index_size 
+-----------------------
+                 40960
 (1 row)
 
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -107,10 +107,11 @@ SELECT * FROM hypertable_detailed_size('dist_table'::regclass)
 ORDER BY node_name;;
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
-       16384 |       65536 |        8192 |       90112 | view_node_1
-       16384 |       65536 |        8192 |       90112 | view_node_2
-       16384 |       65536 |           0 |       81920 | view_node_3
-(3 rows)
+       16384 |       81920 |        8192 |      106496 | view_node_1
+       16384 |       81920 |        8192 |      106496 | view_node_2
+       16384 |       81920 |           0 |       98304 | view_node_3
+           0 |       16384 |           0 |       16384 | 
+(4 rows)
 
 ---tables with special characters in the name ----
 CREATE TABLE "quote'tab" ( a timestamp,  b integer);
@@ -133,8 +134,7 @@ SELECT * FROM  chunks_detailed_size( '"quote''tab"') ORDER BY chunk_name, node_n
  _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       32768 |           0 |       40960 | view_node_2
  _timescaledb_internal | _dist_hyper_2_7_chunk |        8192 |       32768 |           0 |       40960 | view_node_1
  _timescaledb_internal | _dist_hyper_2_7_chunk |        8192 |       32768 |           0 |       40960 | view_node_2
-                       |                       |             |             |             |             | view_node_3
-(9 rows)
+(8 rows)
 
 CREATE TABLE "special#tab" ( a timestamp,  b integer);
 SELECT create_hypertable( 'special#tab', 'a', 'b', replication_factor=>2, chunk_time_interval=>INTERVAL '1 day');
@@ -156,12 +156,11 @@ SELECT * FROM  chunks_detailed_size( '"special#tab"') ORDER BY chunk_name, node_
  _timescaledb_internal | _dist_hyper_3_8_chunk  |        8192 |       32768 |           0 |       40960 | view_node_2
  _timescaledb_internal | _dist_hyper_3_9_chunk  |        8192 |       32768 |           0 |       40960 | view_node_1
  _timescaledb_internal | _dist_hyper_3_9_chunk  |        8192 |       32768 |           0 |       40960 | view_node_2
-                       |                        |             |             |             |             | view_node_3
-(9 rows)
+(8 rows)
 
 SELECT * FROM  hypertable_index_size( 'dist_table_time_idx') ;
  hypertable_index_size 
 -----------------------
-                 81920
+                114688
 (1 row)
 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -121,6 +121,7 @@ set(SOLO_TESTS
   continuous_aggs_ddl
   continuous_aggs_dump
   data_fetcher
+  dist_util
   move-11
   move-12
   move-13


### PR DESCRIPTION
Fix a number of issues with size and stats functions:

* Return `0` size instead of `NULL` in several functions when
  hypertables have no chunks (e.g., `hypertable_size`,
  `hypertable_detailed_size`).
* Return `NULL` when functions are called on non-hypertables instead
  of simply failing with generic error `query returned no rows`.
* Include size of "root" hypertable, which can have non-zero size
  indexes and other objects even if the root table holds no data.
* Make `hypertable_detailed_size` include one additional row for
  storage size of objects on the access node. While the access node
  stores no data, the empty hypertable may still take up some disk
  space.
* Improve test coverage for all size utility functions. In particular,
  add tests on regular tables as well as empty and compressed
  hypertables.
* Several size utility functions that were defined as `PL/pgSQL`
  functions have been converted to simple `SQL` functions since they
  ran only a single SQL query.

The `dist_util` test is moved to the solo test group because,
otherwise, it gives different size output when run in parallel vs. in
isolation.

Fixes #2871