### PR TITLE
Add missing ORDER BY to flaky tests

### DIFF
--- a/test/expected/histogram_test.out
+++ b/test/expected/histogram_test.out
@@ -77,7 +77,7 @@ SELECT histogram(key, 1, 3, 1) FROM hitest1;
 (1 row)
 
 -- standard 2 bucket
-SELECT qualify, histogram(score, 0, 10, 2) FROM hitest2 GROUP BY qualify;
+SELECT qualify, histogram(score, 0, 10, 2) FROM hitest2 GROUP BY qualify ORDER BY qualify;
  qualify | histogram 
 ---------+-----------
  f       | {0,2,0,0}
@@ -85,7 +85,7 @@ SELECT qualify, histogram(score, 0, 10, 2) FROM hitest2 GROUP BY qualify;
 (2 rows)
 
 -- standard multi-bucket
-SELECT qualify, histogram(score, 0, 10, 5) FROM hitest2 GROUP BY qualify
+SELECT qualify, histogram(score, 0, 10, 5) FROM hitest2 GROUP BY qualify ORDER BY qualify;
  qualify |    histogram    
 ---------+-----------------
  f       | {0,0,1,1,0,0,0}

--- a/test/sql/histogram_test.sql
+++ b/test/sql/histogram_test.sql
@@ -43,6 +43,6 @@ SELECT histogram(key, 1, 3, 2) FROM hitest1;
 SELECT histogram(key, 1, 3, 1) FROM hitest1;
 
 -- standard 2 bucket
-SELECT qualify, histogram(score, 0, 10, 2) FROM hitest2 GROUP BY qualify;
+SELECT qualify, histogram(score, 0, 10, 2) FROM hitest2 GROUP BY qualify ORDER BY qualify;
 -- standard multi-bucket
-SELECT qualify, histogram(score, 0, 10, 5) FROM hitest2 GROUP BY qualify
+SELECT qualify, histogram(score, 0, 10, 5) FROM hitest2 GROUP BY qualify ORDER BY qualify;

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -330,11 +330,11 @@ where hypertable_name like 'test4';
 
 select location, count(*)
 from test4
-group by location;
+group by location ORDER BY location;
  location | count 
 ----------+-------
- POR      | 18721
  NYC      |    31
+ POR      | 18721
 (2 rows)
 
 SELECT $$ SELECT * FROM test4 ORDER BY timec $$ AS "QUERY" \gset

--- a/tsl/test/expected/continuous_aggs_refresh.out
+++ b/tsl/test/expected/continuous_aggs_refresh.out
@@ -429,15 +429,15 @@ SELECT * FROM weekly_temp_without_data;
 -----+--------+----------
 (0 rows)
 
-SELECT * FROM weekly_temp_with_data;
+SELECT * FROM weekly_temp_with_data ORDER BY 1,2;
              day              | device |     avg_temp     
 ------------------------------+--------+------------------
- Sun Apr 26 17:00:00 2020 PDT |      3 | 21.5631067961165
+ Sun Apr 26 17:00:00 2020 PDT |      0 | 17.8181818181818
  Sun Apr 26 17:00:00 2020 PDT |      1 | 17.2474226804124
+ Sun Apr 26 17:00:00 2020 PDT |      2 | 18.9803921568627
+ Sun Apr 26 17:00:00 2020 PDT |      3 | 21.5631067961165
  Sun May 03 17:00:00 2020 PDT |      0 | 16.7659574468085
  Sun May 03 17:00:00 2020 PDT |      1 | 22.7272727272727
- Sun Apr 26 17:00:00 2020 PDT |      0 | 17.8181818181818
- Sun Apr 26 17:00:00 2020 PDT |      2 | 18.9803921568627
  Sun May 03 17:00:00 2020 PDT |      2 |  15.811320754717
  Sun May 03 17:00:00 2020 PDT |      3 |               19
 (8 rows)

--- a/tsl/test/sql/compression_hypertable.sql
+++ b/tsl/test/sql/compression_hypertable.sql
@@ -144,7 +144,7 @@ where hypertable_name like 'test4';
 
 select location, count(*)
 from test4
-group by location;
+group by location ORDER BY location;
 
 SELECT $$ SELECT * FROM test4 ORDER BY timec $$ AS "QUERY" \gset
 

--- a/tsl/test/sql/continuous_aggs_refresh.sql
+++ b/tsl/test/sql/continuous_aggs_refresh.sql
@@ -260,7 +260,7 @@ FROM conditions
 GROUP BY 1,2 WITH DATA;
 
 SELECT * FROM weekly_temp_without_data;
-SELECT * FROM weekly_temp_with_data;
+SELECT * FROM weekly_temp_with_data ORDER BY 1,2;
 
 \set ON_ERROR_STOP 0
 -- REFRESH MATERIALIZED VIEW is blocked on continuous aggregates


### PR DESCRIPTION
Add missing ORDER BY clause to queries in histogram_test,
compression_hypertable, and continuous_aggs_refresh test.