### PR TITLE
Refactor update tests for smoke testing

### DIFF
--- a/scripts/test_update_from_tag.sh
+++ b/scripts/test_update_from_tag.sh
@@ -229,25 +229,25 @@ if [[ "${TEST_VERSION}" > "v6" ]] || [[ "${TEST_VERSION}" = "v6" ]]; then
     fi
 fi
 
-docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc single > /tmp/single.sql"
-docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc dn1 > /tmp/dn1.sql"
-docker cp ${CONTAINER_UPDATED}:/tmp/single.sql ${TEST_TMPDIR}/single.sql
-docker cp ${CONTAINER_UPDATED}:/tmp/dn1.sql ${TEST_TMPDIR}/dn1.sql
+docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc single > /tmp/single.dump"
+docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc dn1 > /tmp/dn1.dump"
+docker cp ${CONTAINER_UPDATED}:/tmp/single.dump ${TEST_TMPDIR}/single.dump
+docker cp ${CONTAINER_UPDATED}:/tmp/dn1.dump ${TEST_TMPDIR}/dn1.dump
 
 echo "Restoring database on clean version"
-docker cp ${TEST_TMPDIR}/single.sql ${CONTAINER_CLEAN_RESTORE}:/tmp/single.sql
-docker cp ${TEST_TMPDIR}/dn1.sql ${CONTAINER_CLEAN_RESTORE}:/tmp/dn1.sql
+docker cp ${TEST_TMPDIR}/single.dump ${CONTAINER_CLEAN_RESTORE}:/tmp/single.dump
+docker cp ${TEST_TMPDIR}/dn1.dump ${CONTAINER_CLEAN_RESTORE}:/tmp/dn1.dump
 
 # Restore single
 docker_exec ${CONTAINER_CLEAN_RESTORE} "createdb -h localhost -U postgres single"
 docker_pgcmd ${CONTAINER_CLEAN_RESTORE} "ALTER DATABASE single SET timescaledb.restoring='on'"
-docker_exec ${CONTAINER_CLEAN_RESTORE} "pg_restore -h localhost -U postgres -d single /tmp/single.sql"
+docker_exec ${CONTAINER_CLEAN_RESTORE} "pg_restore -h localhost -U postgres -d single /tmp/single.dump"
 docker_pgcmd ${CONTAINER_CLEAN_RESTORE} "ALTER DATABASE single RESET timescaledb.restoring"
 
 # Restore dn1
 docker_exec ${CONTAINER_CLEAN_RESTORE} "createdb -h localhost -U postgres dn1"
 docker_pgcmd ${CONTAINER_CLEAN_RESTORE} "ALTER DATABASE dn1 SET timescaledb.restoring='on'"
-docker_exec ${CONTAINER_CLEAN_RESTORE} "pg_restore -h localhost -U postgres -d dn1 /tmp/dn1.sql"
+docker_exec ${CONTAINER_CLEAN_RESTORE} "pg_restore -h localhost -U postgres -d dn1 /tmp/dn1.dump"
 docker_pgcmd ${CONTAINER_CLEAN_RESTORE} "ALTER DATABASE dn1 RESET timescaledb.restoring"
 
 echo "Comparing upgraded ($UPDATE_FROM_TAG -> $UPDATE_TO_TAG) with clean install ($UPDATE_TO_TAG)"

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -298,7 +298,7 @@ CALL refresh_continuous_aggregate('mat_ignoreinval',NULL,NULL);
 \endif
 
 -- test new data beyond the invalidation threshold is properly handled --
-CREATE TABLE inval_test (time TIMESTAMPTZ, location TEXT, temperature DOUBLE PRECISION);
+CREATE TABLE inval_test (time TIMESTAMPTZ NOT NULL, location TEXT, temperature DOUBLE PRECISION);
 SELECT create_hypertable('inval_test', 'time', chunk_time_interval => INTERVAL '1 week');
  
 INSERT INTO inval_test
@@ -349,7 +349,7 @@ INSERT INTO inval_test
 SELECT generate_series('2118-12-01 00:00'::timestamp, '2118-12-20 00:00'::timestamp, '1 day'), 'NYC', generate_series(131.0, 150.0, 1.0);
 
 -- Add an integer base table to ensure we handle it correctly
-CREATE TABLE int_time_test(timeval integer, col1 integer, col2 integer);
+CREATE TABLE int_time_test(timeval integer not null, col1 integer, col2 integer);
 select create_hypertable('int_time_test', 'timeval', chunk_time_interval=> 2);
 
 CREATE OR REPLACE FUNCTION integer_now_test() returns int LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timeval), 0) FROM int_time_test $$;
@@ -415,7 +415,7 @@ CALL refresh_continuous_aggregate('mat_inttime2',NULL,NULL);
 \endif
 
 -- Test that retention policies that conflict with continuous aggs are disabled --
-CREATE TABLE conflict_test (time TIMESTAMPTZ, location TEXT, temperature DOUBLE PRECISION);
+CREATE TABLE conflict_test (time TIMESTAMPTZ NOT NULL, location TEXT, temperature DOUBLE PRECISION);
 SELECT create_hypertable('conflict_test', 'time', chunk_time_interval => INTERVAL '1 week');
 
 DO LANGUAGE PLPGSQL $$
@@ -464,7 +464,7 @@ WITH GRANT OPTION;
 -- here and then drop chunks from the hypertable and make sure that
 -- the update from 1.7 to 2.0 works as expected.
 CREATE TABLE drop_test (
-    time timestamptz,
+    time timestamptz not null,
     location INT,
     temperature double PRECISION
 );

--- a/test/sql/updates/setup.policies.sql
+++ b/test/sql/updates/setup.policies.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE TABLE policy_test_timestamptz(time timestamptz, device_id int, value float);
+CREATE TABLE policy_test_timestamptz(time timestamptz not null, device_id int, value float);
 SELECT table_name FROM create_hypertable('policy_test_timestamptz','time');
 
 ALTER TABLE policy_test_timestamptz SET (timescaledb.compress);


### PR DESCRIPTION
In order to support smoke-testing with a single server, the update
tests are refactored. This is part of a longer sequence of changes to
support both running smoke tests and update tests and contain the
following changes:

- All timestamp columns now have `not null` added to avoid spamming the
  output file and help finding the real issue.
- Extension of dump files are changed from `sql` to `dump` since they
  use the custom format and are not SQL files.