### PR TITLE
Mark timescaledb as trusted extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,9 @@ if (PG_SOURCE_DIR)
 endif (PG_SOURCE_DIR)
 
 set(EXT_CONTROL_FILE ${PROJECT_NAME}.control)
+if (${PG_VERSION_MAJOR} GREATER "12")
+  set(TRUSTED trusted=true)
+endif()
 configure_file(${EXT_CONTROL_FILE}.in ${EXT_CONTROL_FILE})
 
 install(

--- a/test/expected/trusted_extension.out
+++ b/test/expected/trusted_extension.out
@@ -1,0 +1,51 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE DATABASE trusted_test;
+GRANT CREATE ON DATABASE trusted_test TO test_role_1;
+\c trusted_test test_role_1
+-- user shouldnt have superuser privilege
+SELECT rolsuper FROM pg_roles WHERE rolname=user;
+ rolsuper 
+----------
+ f
+(1 row)
+
+SET client_min_messages TO ERROR;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+CREATE TABLE t(time timestamptz);
+SELECT create_hypertable('t','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ (1,public,t,t)
+(1 row)
+
+INSERT INTO t VALUES ('2000-01-01'), ('2001-01-01');
+SELECT * FROM t ORDER BY 1;
+             time             
+------------------------------
+ Sat Jan 01 00:00:00 2000 PST
+ Mon Jan 01 00:00:00 2001 PST
+(2 rows)
+
+SELECT * FROM timescaledb_information.hypertables;
+ hypertable_schema | hypertable_name |    owner    | num_dimensions | num_chunks | compression_enabled | is_distributed | replication_factor | data_nodes | tablespaces 
+-------------------+-----------------+-------------+----------------+------------+---------------------+----------------+--------------------+------------+-------------
+ public            | t               | test_role_1 |              1 |          2 | f                   | f              |                    |            | 
+(1 row)
+
+\dt+ _timescaledb_internal._hyper_*
+                                            List of relations
+        Schema         |       Name       | Type  |    Owner    | Persistence |    Size    | Description 
+-----------------------+------------------+-------+-------------+-------------+------------+-------------
+ _timescaledb_internal | _hyper_1_1_chunk | table | test_role_1 | permanent   | 8192 bytes | 
+ _timescaledb_internal | _hyper_1_2_chunk | table | test_role_1 | permanent   | 8192 bytes | 
+(2 rows)
+
+DROP EXTENSION timescaledb CASCADE;
+NOTICE:  drop cascades to 3 other objects
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE trusted_test;

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -98,6 +98,9 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
     timestamp_limits.sql
     with_clause_parser.sql
   )
+  list(APPEND TEST_TEMPLATES
+    multi_transaction_index.sql.in
+  )
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 if(${PG_VERSION_MAJOR} EQUAL "11")
@@ -130,13 +133,8 @@ endif()
 
 if ((${PG_VERSION_MAJOR} GREATER_EQUAL "13"))
   list(APPEND TEST_FILES
+    trusted_extension.sql
     vacuum_parallel.sql
-  )
-endif()
-
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-  list(APPEND TEST_TEMPLATES
-    multi_transaction_index.sql.in
   )
 endif()
 

--- a/test/sql/trusted_extension.sql
+++ b/test/sql/trusted_extension.sql
@@ -1,0 +1,30 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE DATABASE trusted_test;
+GRANT CREATE ON DATABASE trusted_test TO test_role_1;
+
+\c trusted_test test_role_1
+-- user shouldnt have superuser privilege
+SELECT rolsuper FROM pg_roles WHERE rolname=user;
+
+SET client_min_messages TO ERROR;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+
+CREATE TABLE t(time timestamptz);
+SELECT create_hypertable('t','time');
+
+INSERT INTO t VALUES ('2000-01-01'), ('2001-01-01');
+
+SELECT * FROM t ORDER BY 1;
+SELECT * FROM timescaledb_information.hypertables;
+\dt+ _timescaledb_internal._hyper_*
+
+DROP EXTENSION timescaledb CASCADE;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE trusted_test;

--- a/timescaledb.control.in
+++ b/timescaledb.control.in
@@ -5,3 +5,4 @@ module_pathname = '$libdir/timescaledb-@PROJECT_VERSION_MOD@'
 #extension cannot be relocatable once installed because it uses multiple schemas and that is forbidden by PG.
 #(though this extension is relocatable during installation).
 relocatable = false
+@TRUSTED@


### PR DESCRIPTION
PG13 adds the trusted attribute to extensions. Extensions marked
as trusted do not require superuser privileges, but can be installed
by a non-superuser with CREATE privilege in the database.
The objects within the extension will be owned by the bootstrap
superuser, but the extension itself will be owned by the calling user.

https://github.com/postgres/postgres/commit/50fc694e