### PR TITLE
SkipScan

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -22,11 +22,11 @@ jobs:
         build_type: [ Debug ]
         include:
           - pg: 11.11
-            ignores: append-11 chunk_adaptive-11 continuous_aggs_bgw_drop_chunks remote_txn transparent_decompression-11 continuous_aggs_insert continuous_aggs_multi continuous_aggs_concurrent_refresh
+            ignores: append-11 chunk_adaptive-11 continuous_aggs_bgw_drop_chunks remote_txn transparent_decompression-11 continuous_aggs_insert continuous_aggs_multi continuous_aggs_concurrent_refresh plan_skip_scan-11
           - pg: 12.6
-            ignores: append-12 chunk_adaptive-12 continuous_aggs_bgw_drop_chunks remote_txn transparent_decompression-12
+            ignores: append-12 chunk_adaptive-12 continuous_aggs_bgw_drop_chunks remote_txn transparent_decompression-12 plan_skip_scan-12
           - pg: 13.2
-            ignores: append-13 chunk_adaptive-13 remote_txn transparent_decompression-13 vacuum_parallel
+            ignores: append-13 chunk_adaptive-13 remote_txn transparent_decompression-13 vacuum_parallel plan_skip_scan-13
 
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Major Features**
+* #3000 SkipScan to speed up SELECT DISTINCT
+
 **Bugfixes**
 * #2989 Refactor and harden size and stats functions
 * #3058 Reduce memory usage for distributed inserts

--- a/src/chunk_append/chunk_append.c
+++ b/src/chunk_append/chunk_append.c
@@ -34,6 +34,13 @@ static CustomPathMethods chunk_append_path_methods = {
 	.PlanCustomPath = ts_chunk_append_plan_create,
 };
 
+bool
+ts_is_chunk_append_path(Path *path)
+{
+	return IsA(path, CustomPath) &&
+		   castNode(CustomPath, path)->methods == &chunk_append_path_methods;
+}
+
 static bool
 has_joins(FromExpr *jointree)
 {

--- a/src/chunk_append/chunk_append.h
+++ b/src/chunk_append/chunk_append.h
@@ -27,5 +27,6 @@ extern Path *ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hyp
 extern bool ts_ordered_append_should_optimize(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht,
 											  List *join_conditions, int *order_attno,
 											  bool *reverse);
+extern TSDLLEXPORT bool ts_is_chunk_append_path(Path *path);
 
 #endif /* TIMESCALEDB_CHUNK_APPEND_H */

--- a/src/compat.h
+++ b/src/compat.h
@@ -371,6 +371,7 @@ get_vacuum_options(const VacuumStmt *stmt)
 #define list_delete_cell_compat(l, lc, prev) list_delete_cell((l), (lc))
 #define list_make5(x1, x2, x3, x4, x5) lappend(list_make4(x1, x2, x3, x4), x5)
 #define list_make5_oid(x1, x2, x3, x4, x5) lappend_oid(list_make4_oid(x1, x2, x3, x4), x5)
+#define list_make5_int(x1, x2, x3, x4, x5) lappend_int(list_make4_int(x1, x2, x3, x4), x5)
 #define for_each_cell_compat(cell, list, initcell) for_each_cell (cell, list, initcell)
 #endif
 

--- a/src/constraint_aware_append.c
+++ b/src/constraint_aware_append.c
@@ -570,6 +570,14 @@ ts_constraint_aware_append_possible(Path *path)
 	}
 	return false;
 }
+
+bool
+ts_is_constraint_aware_append_path(Path *path)
+{
+	return IsA(path, CustomPath) &&
+		   castNode(CustomPath, path)->methods == &constraint_aware_append_path_methods;
+}
+
 void
 _constraint_aware_append_init(void)
 {

--- a/src/constraint_aware_append.h
+++ b/src/constraint_aware_append.h
@@ -24,7 +24,8 @@ typedef struct ConstraintAwareAppendState
 typedef struct Hypertable Hypertable;
 
 extern bool ts_constraint_aware_append_possible(Path *path);
-extern Path *ts_constraint_aware_append_path_create(PlannerInfo *root, Path *subpath);
+extern TSDLLEXPORT Path *ts_constraint_aware_append_path_create(PlannerInfo *root, Path *subpath);
+extern TSDLLEXPORT bool ts_is_constraint_aware_append_path(Path *path);
 extern void _constraint_aware_append_init(void);
 
 #endif /* TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H */

--- a/src/guc.c
+++ b/src/guc.c
@@ -53,6 +53,7 @@ bool ts_guc_enable_cagg_reorder_groupby = true;
 TSDLLEXPORT bool ts_guc_enable_transparent_decompression = true;
 bool ts_guc_enable_per_data_node_queries = true;
 bool ts_guc_enable_async_append = true;
+TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 int ts_guc_max_open_chunks_per_insert = 10;
 int ts_guc_max_cached_chunks_per_hypertable = 10;
 int ts_guc_telemetry_level = TELEMETRY_DEFAULT;
@@ -190,6 +191,17 @@ _guc_init(void)
 							 "Enable transparent decompression",
 							 "Enable transparent decompression when querying hypertable",
 							 &ts_guc_enable_transparent_decompression,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("timescaledb.enable_skipscan",
+							 "Enable SkipScan",
+							 "Enable SkipScan for DISTINCT queries",
+							 &ts_guc_enable_skip_scan,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -23,6 +23,7 @@ extern bool ts_guc_enable_cagg_reorder_groupby;
 extern TSDLLEXPORT bool ts_guc_enable_transparent_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_per_data_node_queries;
 extern TSDLLEXPORT bool ts_guc_enable_async_append;
+extern TSDLLEXPORT bool ts_guc_enable_skip_scan;
 extern bool ts_guc_restoring;
 extern int ts_guc_max_open_chunks_per_insert;
 extern int ts_guc_max_cached_chunks_per_hypertable;

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -36,6 +36,7 @@
 #include "hypertable.h"
 #include "license_guc.h"
 #include "nodes/decompress_chunk/planner.h"
+#include "nodes/skip_scan/skip_scan.h"
 #include "nodes/gapfill/gapfill.h"
 #include "partialize_finalize.h"
 #include "planner.h"
@@ -200,6 +201,7 @@ ts_module_init(PG_FUNCTION_ARGS)
 
 	_continuous_aggs_cache_inval_init();
 	_decompress_chunk_init();
+	_skip_scan_init();
 	_remote_connection_cache_init();
 	_remote_dist_txn_init();
 	_tsl_process_utility_init();

--- a/tsl/src/nodes/CMakeLists.txt
+++ b/tsl/src/nodes/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(compress_dml)
 add_subdirectory(decompress_chunk)
 add_subdirectory(gapfill)
+add_subdirectory(skip_scan)

--- a/tsl/src/nodes/skip_scan/CMakeLists.txt
+++ b/tsl/src/nodes/skip_scan/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/planner.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/exec.c
+)
+target_sources(${TSL_LIBRARY_NAME} PRIVATE ${SOURCES})

--- a/tsl/src/nodes/skip_scan/README.md
+++ b/tsl/src/nodes/skip_scan/README.md
@@ -1,0 +1,89 @@
+# SkipScan #
+
+This module implements SkipScan; an optimization for `SELECT DISTINCT ON`.
+Usually for `SELECT DISTINCT ON` Postgres will plan either a `UNIQUE` over a
+sorted path, or some form of aggregate. In either case, it needs to scan the
+entire table, even in cases where there are only a few unique values.
+
+A skip scan optimizes this case when we have an ordered index. Instead of
+scanning the entire table and deduplicating after, the scan remembers the last
+value returned, and searches the index for the next value after that one. This
+means that for a table with `k` keys, with `u` distinct values, a skip scan runs
+in time `u * log(k)` as opposed to scanning then deduplicating, which takes time
+`k`. We can write the number of unique values `u` as of function of `k` by
+dividing by the number of repeats `r` i.e. `u = k/r` this means that a skip scan
+will be faster if each key is repeated more than a logarithmic number of times,
+i.e. if `r > log(k)` then `u * log(k) < k/log(k) * log(k) < k`.
+
+
+## Implementation ##
+
+We plan our skip scan with a tree something like
+
+```SQL
+Custom Scan (SkipScan) on table
+   ->  Index Scan using table_key_idx on table
+       Index Cond: (key > NULL)
+```
+
+After each iteration through the `SkipScan` we replace the `key > NULL` with
+a `key > [next value we are returning]` and restart the underlying `IndexScan`.
+There are some subtleties around `NULL` handling, see the source file for more
+detail.
+
+
+## Planning Heuristics ##
+
+To plan our SkipScan we look for a compatible plan, for instance
+
+```SQL
+Unique
+   ->  Index Scan
+```
+
+or
+
+```SQL
+Unique
+   ->  Merge Append
+         ->  Index Scan
+         ...
+```
+
+given such a plan, we know the index is sorted in an order with the distinct
+key(s) first, so we can add quals to the `IndexScan` representing the previous
+key returned, and thus skip over the repeated values. The `Unique` node tells us
+which columns are relevant.
+
+We use this to create plans that look like
+
+```SQL
+Unique
+  ->  Custom Scan (SkipScan) on skip_scan
+        ->  Index Scan using skip_scan_dev_name_idx on skip_scan
+```
+
+or
+
+```SQL
+Unique
+  ->  Merge Append
+        Sort Key: _hyper_2_1_chunk.dev_name
+        ->  Custom Scan (SkipScan) on _hyper_2_1_chunk
+              ->  Index Scan using _hyper_2_1_chunk_idx on _hyper_2_1_chunk
+        ->  Custom Scan (SkipScan) on _hyper_2_2_chunk
+              ->  Index Scan using _hyper_2_2_chunk_idx on _hyper_2_2_chunk
+```
+
+respectively. While we could remove the top-level Unique node for the single
+chunk/normal table case we keep it so we don't need to support projection
+as postgres won't modify the SkipScan targetlist that way.
+
+## Postgres-Native Skip Scan ##
+
+Upstream postgres is also working on a skip scan implementation, see e.g.
+https://commitfest.postgresql.org/32/1741/
+As when this document was first written, it is not yet merged. Their strategy
+involves integrating this functionality into the btree searching code,
+and will be available in PG15 at the earliest. The two
+implementations should not interfere with eachother.

--- a/tsl/src/nodes/skip_scan/exec.c
+++ b/tsl/src/nodes/skip_scan/exec.c
@@ -1,0 +1,384 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * SkipScan is an optimized form of SELECT DISTINCT ON (column)
+ * Conceptually, a SkipScan is a regular IndexScan with an additional skip-qual like
+ *     WHERE column > [previous value of column]
+ *
+ * Implementing this qual is complicated by two factors:
+ *   1. The first time through the SkipScan there is no previous value for the
+ *      DISTINCT column.
+ *   2. NULL values don't behave nicely with ordering operators.
+ *
+ * To get around these issues, we have to special case those two cases. All in
+ * all, the SkipScan's state machine evolves according to the following flowchart
+ *
+ *                        start
+ *                          |
+ *          +================================+
+ *          | search for NULL if NULLS FIRST |
+ *          +================================+
+ *                  |
+ *                  v
+ *  +=====================+          +==============================+
+ *  | search for non-NULL |--found-->| search for values after prev |
+ *  +=====================+  value   +==============================+
+ *                  |                   |
+ *                  v                   v
+ *           +================================+
+ *           | search for NULL if NULLS LAST  |
+ *           +================================+
+ *                          |
+ *                          v
+ *                    /===========\
+ *                    |   DONE    |
+ *                    \===========/
+ *
+ */
+
+#include <postgres.h>
+#include <access/genam.h>
+#include <nodes/extensible.h>
+#include <nodes/pg_list.h>
+#include <utils/datum.h>
+
+#include "guc.h"
+#include "nodes/skip_scan/skip_scan.h"
+
+typedef enum SkipScanStage
+{
+	SS_BEGIN = 0,
+	SS_NULLS_FIRST,
+	SS_NOT_NULL,
+	SS_VALUES,
+	SS_NULLS_LAST,
+	SS_END,
+} SkipScanStage;
+
+typedef struct SkipScanState
+{
+	CustomScanState cscan_state;
+	IndexScanDesc *scan_desc;
+	MemoryContext ctx;
+
+	/* Interior Index(Only)Scan the SkipScan runs over */
+	ScanState *idx;
+
+	/* Pointers into the Index(Only)Scan */
+	int *num_scan_keys;
+	ScanKey *scan_keys;
+	ScanKey skip_key;
+
+	Datum prev_datum;
+	bool prev_is_null;
+
+	/* Info about the type we are performing DISTINCT on */
+	bool distinct_by_val;
+	int distinct_col_attnum;
+	int distinct_typ_len;
+	int sk_attno;
+
+	SkipScanStage stage;
+
+	bool nulls_first;
+	/* rescan required before getting next tuple */
+	bool needs_rescan;
+
+	void *idx_scan;
+} SkipScanState;
+
+static bool has_nulls_first(SkipScanState *state);
+static bool has_nulls_last(SkipScanState *state);
+static void skip_scan_rescan_index(SkipScanState *state);
+static void skip_scan_switch_stage(SkipScanState *state, SkipScanStage new_stage);
+
+static void
+skip_scan_begin(CustomScanState *node, EState *estate, int eflags)
+{
+	SkipScanState *state = (SkipScanState *) node;
+	state->ctx = AllocSetContextCreate(estate->es_query_cxt, "skipscan", ALLOCSET_DEFAULT_SIZES);
+
+	state->idx = (ScanState *) ExecInitNode(state->idx_scan, estate, eflags);
+	node->custom_ps = list_make1(state->idx);
+
+	if (IsA(state->idx_scan, IndexScan))
+	{
+		IndexScanState *idx = castNode(IndexScanState, state->idx);
+		state->scan_keys = &idx->iss_ScanKeys;
+		state->num_scan_keys = &idx->iss_NumScanKeys;
+		state->scan_desc = &idx->iss_ScanDesc;
+	}
+	else if (IsA(state->idx_scan, IndexOnlyScan))
+	{
+		IndexOnlyScanState *idx = castNode(IndexOnlyScanState, state->idx);
+		state->scan_keys = &idx->ioss_ScanKeys;
+		state->num_scan_keys = &idx->ioss_NumScanKeys;
+		state->scan_desc = &idx->ioss_ScanDesc;
+	}
+	else
+		elog(ERROR, "unknown subscan type in SkipScan");
+
+	/* scankeys are not setup for explain only */
+	if (eflags & EXEC_FLAG_EXPLAIN_ONLY)
+		return;
+
+	/* find position of our skip key
+	 * skip key is put as first key for the respective column in sort_indexquals
+	 */
+	ScanKey data = *state->scan_keys;
+	for (int i = 0; i < *state->num_scan_keys; i++)
+	{
+		if (data[i].sk_flags == SK_ISNULL && data[i].sk_attno == state->sk_attno)
+		{
+			state->skip_key = &data[i];
+			break;
+		}
+	}
+	if (!state->skip_key)
+		elog(ERROR, "ScanKey for skip qual not found");
+}
+
+static bool
+has_nulls_first(SkipScanState *state)
+{
+	return state->nulls_first;
+}
+
+static bool
+has_nulls_last(SkipScanState *state)
+{
+	return !has_nulls_first(state);
+}
+
+static void
+skip_scan_rescan_index(SkipScanState *state)
+{
+	/* if the scan in the child scan has not been
+	 * setup yet which is true before the first tuple
+	 * has been retrieved from child scan we cannot
+	 * trigger rescan but since the child scan
+	 * has not been initialized it will pick up
+	 * any ScanKey changes we did */
+	if (*state->scan_desc)
+		index_rescan(*state->scan_desc,
+					 *state->scan_keys,
+					 *state->num_scan_keys,
+					 NULL /*orderbys*/,
+					 0 /*norderbys*/);
+	state->needs_rescan = false;
+}
+
+/*
+ * Update skip scankey flags according to stage
+ */
+static void
+skip_scan_switch_stage(SkipScanState *state, SkipScanStage new_stage)
+{
+	Assert(new_stage > state->stage);
+
+	switch (new_stage)
+	{
+		case SS_NOT_NULL:
+			state->skip_key->sk_flags = SK_ISNULL | SK_SEARCHNOTNULL;
+			state->skip_key->sk_argument = 0;
+			state->needs_rescan = true;
+			break;
+
+		case SS_VALUES:
+			state->skip_key->sk_flags = 0;
+			state->needs_rescan = true;
+			break;
+
+		case SS_NULLS_LAST:
+		case SS_NULLS_FIRST:
+			state->skip_key->sk_flags = SK_ISNULL | SK_SEARCHNULL;
+			state->skip_key->sk_argument = 0;
+			state->needs_rescan = true;
+			break;
+
+		case SS_BEGIN:
+		case SS_END:
+			break;
+	}
+
+	state->stage = new_stage;
+}
+
+static void
+skip_scan_update_key(SkipScanState *state, TupleTableSlot *slot)
+{
+	if (!state->prev_is_null && !state->distinct_by_val)
+	{
+		Assert(state->stage == SS_VALUES);
+		pfree(DatumGetPointer(state->prev_datum));
+	}
+
+	MemoryContext old_ctx = MemoryContextSwitchTo(state->ctx);
+	state->prev_datum = slot_getattr(slot, state->distinct_col_attnum, &state->prev_is_null);
+	if (state->prev_is_null)
+	{
+		state->skip_key->sk_flags = SK_ISNULL;
+		state->skip_key->sk_argument = 0;
+	}
+	else
+	{
+		state->prev_datum =
+			datumCopy(state->prev_datum, state->distinct_by_val, state->distinct_typ_len);
+		state->skip_key->sk_argument = state->prev_datum;
+	}
+
+	MemoryContextSwitchTo(old_ctx);
+
+	/* we need to do a rescan whenever we modify the ScanKey */
+	state->needs_rescan = true;
+}
+
+static TupleTableSlot *
+skip_scan_exec(CustomScanState *node)
+{
+	SkipScanState *state = (SkipScanState *) node;
+	TupleTableSlot *result;
+
+	/*
+	 * We are not supporting projection here since no plan
+	 * we generate will need it as our SkipScan node will
+	 * always be below Unique need so our targetlist
+	 * will not get modified by postgres.
+	 */
+	Assert(!node->ss.ps.ps_ProjInfo);
+
+	while (true)
+	{
+		if (state->needs_rescan)
+			skip_scan_rescan_index(state);
+
+		switch (state->stage)
+		{
+			case SS_BEGIN:
+				if (has_nulls_first(state))
+					skip_scan_switch_stage(state, SS_NULLS_FIRST);
+				else
+					skip_scan_switch_stage(state, SS_NOT_NULL);
+
+				break;
+
+			case SS_NULLS_FIRST:
+				result = state->idx->ps.ExecProcNode(&state->idx->ps);
+
+				/*
+				 * if we found a NULL value we return it, otherwise
+				 * we restart the scan looking for non-NULL
+				 */
+				skip_scan_switch_stage(state, SS_NOT_NULL);
+				if (!TupIsNull(result))
+					return result;
+
+				break;
+
+			case SS_NOT_NULL:
+			case SS_VALUES:
+				result = state->idx->ps.ExecProcNode(&state->idx->ps);
+
+				if (!TupIsNull(result))
+				{
+					/*
+					 * if we found a tuple we update the skip scan key
+					 * and look for values greater than the value we just
+					 * found. If this is the first non-NULL value we
+					 * also switch stage to look for values greater than
+					 * that in subsequent calls.
+					 */
+					if (state->stage == SS_NOT_NULL)
+						skip_scan_switch_stage(state, SS_VALUES);
+
+					skip_scan_update_key(state, result);
+					return result;
+				}
+				else
+				{
+					/*
+					 * if there are no more values that satisfy
+					 * the skip constraint we are either done
+					 * for NULLS FIRST ordering or need to check
+					 * for NULLs if we have NULLS LAST ordering
+					 */
+					if (has_nulls_last(state))
+						skip_scan_switch_stage(state, SS_NULLS_LAST);
+					else
+						skip_scan_switch_stage(state, SS_END);
+				}
+				break;
+
+			case SS_NULLS_LAST:
+				result = state->idx->ps.ExecProcNode(&state->idx->ps);
+				skip_scan_switch_stage(state, SS_END);
+				return result;
+				break;
+
+			case SS_END:
+				return NULL;
+				break;
+		}
+	}
+}
+
+static void
+skip_scan_end(CustomScanState *node)
+{
+	SkipScanState *state = (SkipScanState *) node;
+	ExecEndNode(&state->idx->ps);
+}
+
+static void
+skip_scan_rescan(CustomScanState *node)
+{
+	SkipScanState *state = (SkipScanState *) node;
+	/* reset stage so we can assert in skip_scan_switch_stage that stage always moves forward */
+	state->stage = SS_BEGIN;
+
+	/* Switching state here instead of in the main loop
+	 * means we dont have to call skip_scan_rescan_index
+	 * as ExecReScan on the child scan takes care of that. */
+	if (has_nulls_first(state))
+		skip_scan_switch_stage(state, SS_NULLS_FIRST);
+	else
+		skip_scan_switch_stage(state, SS_NOT_NULL);
+
+	state->prev_is_null = true;
+	state->prev_datum = 0;
+
+	state->needs_rescan = false;
+	ExecReScan(&state->idx->ps);
+	MemoryContextReset(state->ctx);
+}
+
+static CustomExecMethods skip_scan_state_methods = {
+	.CustomName = "SkipScanState",
+	.BeginCustomScan = skip_scan_begin,
+	.EndCustomScan = skip_scan_end,
+	.ExecCustomScan = skip_scan_exec,
+	.ReScanCustomScan = skip_scan_rescan,
+};
+
+Node *
+tsl_skip_scan_state_create(CustomScan *cscan)
+{
+	SkipScanState *state = (SkipScanState *) newNode(sizeof(SkipScanState), T_CustomScanState);
+
+	state->idx_scan = linitial(cscan->custom_plans);
+	state->stage = SS_BEGIN;
+
+	state->distinct_col_attnum = linitial_int(cscan->custom_private);
+	state->distinct_by_val = lsecond_int(cscan->custom_private);
+	state->distinct_typ_len = lthird_int(cscan->custom_private);
+	state->nulls_first = lfourth_int(cscan->custom_private);
+	state->sk_attno = list_nth_int(cscan->custom_private, 4);
+
+	state->prev_is_null = true;
+	state->cscan_state.methods = &skip_scan_state_methods;
+	return (Node *) state;
+}

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -1,0 +1,613 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <access/sysattr.h>
+#include <nodes/extensible.h>
+#include <nodes/nodeFuncs.h>
+#include <nodes/makefuncs.h>
+#include <optimizer/clauses.h>
+#include <optimizer/cost.h>
+#include <optimizer/paths.h>
+#include <optimizer/pathnode.h>
+#include <optimizer/planmain.h>
+#include <optimizer/restrictinfo.h>
+#include <optimizer/tlist.h>
+#include <utils/syscache.h>
+#include <utils/typcache.h>
+
+#include <compat.h>
+#if PG11
+#include <optimizer/var.h>
+#elif PG12_GE
+#include <optimizer/optimizer.h>
+#endif
+#include <import/planner.h>
+#include "guc.h"
+#include "nodes/skip_scan/skip_scan.h"
+#include "constraint_aware_append.h"
+#include "chunk_append/chunk_append.h"
+
+#include <math.h>
+
+typedef struct SkipScanPath
+{
+	CustomPath cpath;
+	IndexPath *index_path;
+
+	/* Index clause which we'll use to skip past elements we've already seen */
+	RestrictInfo *skip_clause;
+	/* The column offset, on the index, of the column we are calling DISTINCT on */
+	int distinct_column;
+	int distinct_typ_len;
+	bool distinct_by_val;
+	int sk_attno;
+} SkipScanPath;
+
+static TargetEntry *get_tle_for_pathkey(List *tlist, PathKey *pathkey);
+static EquivalenceMember *find_ec_member_for_tle(EquivalenceClass *ec, TargetEntry *tle,
+												 Relids relids);
+static int get_idx_key(IndexOptInfo *idxinfo, AttrNumber attno);
+static List *sort_indexquals(IndexOptInfo *indexinfo, List *quals);
+static OpExpr *fix_indexqual(IndexOptInfo *index, RestrictInfo *rinfo, AttrNumber distinct_column);
+static bool build_skip_qual(SkipScanPath *skip_scan_path, IndexPath *index_path, Var *var);
+static List *build_subpath(PlannerInfo *root, List *subpaths, double ndistinct);
+static ChunkAppendPath *copy_chunk_append_path(ChunkAppendPath *ca, List *subpaths);
+
+/**************************
+ * SkipScan Plan Creation *
+ **************************/
+
+static CustomScanMethods skip_scan_plan_methods = {
+	.CustomName = "SkipScan",
+	.CreateCustomScanState = tsl_skip_scan_state_create,
+};
+
+void
+_skip_scan_init(void)
+{
+	/*
+	 * Because we reinitialize the tsl stuff when the license
+	 * changes the init function may be called multiple times
+	 * per session so we check if the SkipScan node has been
+	 * registered already here to prevent registering it twice.
+	 */
+	if (GetCustomScanMethods(skip_scan_plan_methods.CustomName, true) == NULL)
+		RegisterCustomScanMethods(&skip_scan_plan_methods);
+}
+
+static Plan *
+skip_scan_plan_create(PlannerInfo *root, RelOptInfo *relopt, CustomPath *best_path, List *tlist,
+					  List *clauses, List *custom_plans)
+{
+	SkipScanPath *path = (SkipScanPath *) best_path;
+	CustomScan *skip_plan = makeNode(CustomScan);
+	IndexPath *index_path = path->index_path;
+
+	OpExpr *op = fix_indexqual(index_path->indexinfo, path->skip_clause, path->distinct_column);
+
+	Plan *plan = linitial(custom_plans);
+	if (IsA(plan, IndexScan))
+	{
+		IndexScan *idx_plan = castNode(IndexScan, plan);
+		skip_plan->scan = idx_plan->scan;
+
+		/* we prepend skip qual here so sort_indexquals will put it as first qual for that column */
+		idx_plan->indexqual =
+			sort_indexquals(index_path->indexinfo, lcons(op, idx_plan->indexqual));
+	}
+	else if (IsA(plan, IndexOnlyScan))
+	{
+		IndexOnlyScan *idx_plan = castNode(IndexOnlyScan, plan);
+		skip_plan->scan = idx_plan->scan;
+		/* we prepend skip qual here so sort_indexquals will put it as first qual for that column */
+		idx_plan->indexqual =
+			sort_indexquals(index_path->indexinfo, lcons(op, idx_plan->indexqual));
+	}
+	else
+		elog(ERROR, "bad subplan type for SkipScan: %d", plan->type);
+
+	skip_plan->scan.plan.targetlist = tlist;
+	skip_plan->custom_scan_tlist = list_copy(tlist);
+	skip_plan->scan.plan.qual = NIL;
+	skip_plan->scan.plan.type = T_CustomScan;
+	skip_plan->methods = &skip_scan_plan_methods;
+	skip_plan->custom_plans = custom_plans;
+	/* get position of skipped column in tuples produced by child scan */
+	PathKey *pk = linitial_node(PathKey, best_path->path.pathkeys);
+	TargetEntry *tle = get_tle_for_pathkey(plan->targetlist, pk);
+
+	skip_plan->custom_private = list_make5_int(tle->resno,
+											   path->distinct_by_val,
+											   path->distinct_typ_len,
+											   pk->pk_nulls_first,
+											   path->sk_attno);
+	return &skip_plan->scan.plan;
+}
+
+/*************************
+ * SkipScanPath Creation *
+ *************************/
+static CustomPathMethods skip_scan_path_methods = {
+	.CustomName = "SkipScanPath",
+	.PlanCustomPath = skip_scan_plan_create,
+};
+
+static SkipScanPath *skip_scan_path_create(PlannerInfo *root, IndexPath *index_path,
+										   double ndistinct);
+
+/*
+ * Create SkipScan paths based on existing Unique paths.
+ * For a Unique path on a simple relation like the following
+ *
+ *  Unique
+ *    ->  Index Scan using skip_scan_dev_name_idx on skip_scan
+ *
+ * a SkipScan path like this will be created:
+ *
+ *  Unique
+ *    ->  Custom Scan (SkipScan) on skip_scan
+ *          ->  Index Scan using skip_scan_dev_name_idx on skip_scan
+ *
+ * For a Unique path on a hypertable with multiple chunks like the following
+ *
+ *  Unique
+ *    ->  Merge Append
+ *          Sort Key: _hyper_2_1_chunk.dev_name
+ *          ->  Index Scan using _hyper_2_1_chunk_idx on _hyper_2_1_chunk
+ *          ->  Index Scan using _hyper_2_2_chunk_idx on _hyper_2_2_chunk
+ *
+ * a SkipScan path like this will be created:
+ *
+ *  Unique
+ *    ->  Merge Append
+ *          Sort Key: _hyper_2_1_chunk.dev_name
+ *          ->  Custom Scan (SkipScan) on _hyper_2_1_chunk
+ *                ->  Index Scan using _hyper_2_1_chunk_idx on _hyper_2_1_chunk
+ *          ->  Custom Scan (SkipScan) on _hyper_2_2_chunk
+ *                ->  Index Scan using _hyper_2_2_chunk_idx on _hyper_2_2_chunk
+ */
+void
+tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo *output_rel)
+{
+	ListCell *lc;
+	UpperUniquePath *unique = NULL;
+
+	if (!ts_guc_enable_skip_scan)
+		return;
+
+	/*
+	 * look for Unique Path so we dont have repeat some of
+	 * the calculations done by postgres and can also assume
+	 * that the DISTINCT clause is elegible for sort based
+	 * DISTINCT
+	 */
+	foreach (lc, output_rel->pathlist)
+	{
+		if (IsA(lfirst(lc), UpperUniquePath))
+		{
+			unique = lfirst_node(UpperUniquePath, lc);
+
+			/* currently we do not handle DISTINCT on more than one key. To do so,
+			 * we would need to break down the SkipScan into subproblems: first
+			 * find the minimal tuple then for each prefix find all unique suffix
+			 * tuples. For instance, if we are searching over (int, int), we would
+			 * first find (0, 0) then find (0, N) for all N in the domain, then
+			 * find (1, N), then (2, N), etc
+			 */
+			if (unique->numkeys > 1)
+				return;
+
+			break;
+		}
+	}
+	/* no UniquePath found so this query might not be
+	 * elegible for sort-based DISTINCT and therefore
+	 * not elegible for SkipScan either */
+	if (!unique)
+		return;
+
+	foreach (lc, input_rel->pathlist)
+	{
+		bool project = false;
+		bool has_caa = false;
+
+		Path *subpath = lfirst(lc);
+
+		if (!pathkeys_contained_in(unique->path.pathkeys, subpath->pathkeys))
+			continue;
+
+		/* If path is a ProjectionPath we strip it off for processing
+		 * but also add a ProjectionPath on top of the SKipScanPaths
+		 * later.
+		 */
+		if (IsA(subpath, ProjectionPath))
+		{
+			ProjectionPath *proj = castNode(ProjectionPath, subpath);
+			subpath = proj->subpath;
+			project = true;
+		}
+
+		/* Path might be wrapped in a ConstraintAwareAppendPath if this
+		 * is a MergeAppend that could benefit from runtime exclusion.
+		 * We treat this similar to ProjectionPath and add it back
+		 * later
+		 */
+		if (ts_is_constraint_aware_append_path(subpath))
+		{
+			subpath = linitial(castNode(CustomPath, subpath)->custom_paths);
+			Assert(IsA(subpath, MergeAppendPath));
+			has_caa = true;
+		}
+
+		if (IsA(subpath, IndexPath))
+		{
+			IndexPath *index_path = castNode(IndexPath, subpath);
+
+			subpath = (Path *) skip_scan_path_create(root, index_path, unique->path.rows);
+			if (!subpath)
+				continue;
+		}
+		else if (IsA(subpath, MergeAppendPath))
+		{
+			MergeAppendPath *merge_path = castNode(MergeAppendPath, subpath);
+			List *new_paths = build_subpath(root, merge_path->subpaths, unique->path.rows);
+
+			/* build_subpath returns NULL when no SkipScanPath was created */
+			if (!new_paths)
+				continue;
+
+			subpath = (Path *) create_merge_append_path(root,
+														merge_path->path.parent,
+														new_paths,
+														merge_path->path.pathkeys,
+														NULL,
+														merge_path->partitioned_rels);
+			subpath->pathtarget = copy_pathtarget(merge_path->path.pathtarget);
+		}
+		else if (ts_is_chunk_append_path(subpath))
+		{
+			ChunkAppendPath *ca = (ChunkAppendPath *) subpath;
+			List *new_paths = build_subpath(root, ca->cpath.custom_paths, unique->path.rows);
+			/* ChunkAppend should never be wrapped in ConstraintAwareAppendPath */
+			Assert(!has_caa);
+
+			/* build_subpath returns NULL when no SkipScanPath was created */
+			if (!new_paths)
+				continue;
+
+			/* We copy the existing ChunkAppendPath here because we don't have all the
+			 * information used for creating the original one and we don't want to
+			 * duplicate all the checks done when creating the original one.
+			 */
+			subpath = (Path *) copy_chunk_append_path(ca, new_paths);
+		}
+		else
+		{
+			continue;
+		}
+
+		/* add ConstraintAwareAppendPath if the original path had one */
+		if (has_caa)
+			subpath = ts_constraint_aware_append_path_create(root, subpath);
+
+		Path *new_unique = (Path *)
+			create_upper_unique_path(root, output_rel, subpath, unique->numkeys, unique->path.rows);
+		new_unique->pathtarget = unique->path.pathtarget;
+
+		if (project)
+			new_unique = (Path *) create_projection_path(root,
+														 output_rel,
+														 new_unique,
+														 copy_pathtarget(new_unique->pathtarget));
+
+		add_path(output_rel, new_unique);
+	}
+}
+
+static ChunkAppendPath *
+copy_chunk_append_path(ChunkAppendPath *ca, List *subpaths)
+{
+	ListCell *lc;
+	double total_cost = 0, rows = 0;
+	ChunkAppendPath *new = palloc(sizeof(ChunkAppendPath));
+	memcpy(new, ca, sizeof(ChunkAppendPath));
+	new->cpath.custom_paths = subpaths;
+
+	foreach (lc, subpaths)
+	{
+		Path *child = lfirst(lc);
+		total_cost += child->total_cost;
+		rows += child->rows;
+	}
+	new->cpath.path.total_cost = total_cost;
+	new->cpath.path.rows = rows;
+
+	return new;
+}
+
+static SkipScanPath *
+skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, double ndistinct)
+{
+	double startup = index_path->path.startup_cost;
+	double total = index_path->path.total_cost;
+	double rows = index_path->path.rows;
+
+	if (index_path->indexinfo->sortopfamily == NULL)
+		return NULL; /* non-orderable index, skip these for now */
+
+	/* orderbyops are not compatible with skipscan */
+	if (index_path->indexorderbys != NIL)
+		return NULL;
+
+	SkipScanPath *skip_scan_path = (SkipScanPath *) newNode(sizeof(SkipScanPath), T_CustomPath);
+
+	skip_scan_path->cpath.path.pathtype = T_CustomScan;
+	skip_scan_path->cpath.path.pathkeys = index_path->path.pathkeys;
+	skip_scan_path->cpath.path.pathtarget = index_path->path.pathtarget;
+	skip_scan_path->cpath.path.param_info = index_path->path.param_info;
+	skip_scan_path->cpath.path.parent = index_path->path.parent;
+	skip_scan_path->cpath.path.rows = ndistinct;
+	skip_scan_path->cpath.custom_paths = list_make1(index_path);
+	skip_scan_path->cpath.methods = &skip_scan_path_methods;
+
+	/* We calculate SkipScan cost as ndistinct * startup_cost + (ndistinct/rows) * total_cost
+	 * ndistinct * startup_cost is to account for the rescans we have to do and since startup
+	 * cost for indexes does not include page access cost we add a fraction of the total cost
+	 * accounting for the number of rows we expect to fetch.
+	 */
+	skip_scan_path->cpath.path.startup_cost = index_path->path.startup_cost;
+	skip_scan_path->cpath.path.total_cost = ndistinct * startup + (ndistinct / rows) * total;
+
+	/* While add_path may pfree paths with higher costs
+	 * it will never free IndexPaths and only ever do a shallow
+	 * free so reusing the IndexPath here is safe. */
+	skip_scan_path->index_path = index_path;
+
+	/* find the ordering operator we'll use to skip around each key column
+	 * Since the DISTINCT columns are required to be prefix of ORDER BY
+	 * and we only support single column DISTINCT the first pathkey
+	 * has to be the distinct column
+	 */
+	PathKey *first_pathkey = linitial(index_path->path.pathkeys);
+	TargetEntry *tle = get_tle_for_pathkey(index_path->indexinfo->indextlist, first_pathkey);
+
+	/* SkipScan on expressions not supported */
+	if (!IsA(tle->expr, Var))
+		return NULL;
+
+	/* build skip qual this may fail if we cannot look up the operator */
+	if (!build_skip_qual(skip_scan_path, index_path, castNode(Var, tle->expr)))
+		return NULL;
+
+	return skip_scan_path;
+}
+
+/*
+ * Creates SkipScanPath for each path of subpaths that is an IndexPath
+ * If no subpath can be changed to SkipScanPath returns NULL
+ * otherwise returns list of new paths
+ */
+static List *
+build_subpath(PlannerInfo *root, List *subpaths, double ndistinct)
+{
+	bool has_skip_path = false;
+	List *new_paths = NIL;
+	ListCell *lc;
+
+	foreach (lc, subpaths)
+	{
+		Path *child = lfirst(lc);
+		if (IsA(child, IndexPath))
+		{
+			SkipScanPath *skip_path =
+				skip_scan_path_create(root, castNode(IndexPath, child), ndistinct);
+
+			if (skip_path)
+			{
+				child = (Path *) skip_path;
+				has_skip_path = true;
+			}
+		}
+
+		new_paths = lappend(new_paths, child);
+	}
+
+	if (!has_skip_path)
+	{
+		pfree(new_paths);
+		return NIL;
+	}
+
+	return new_paths;
+}
+
+static bool
+build_skip_qual(SkipScanPath *skip_scan_path, IndexPath *index_path, Var *var)
+{
+	IndexOptInfo *info = index_path->indexinfo;
+	Oid column_type = exprType((Node *) var);
+	Oid column_collation = get_typcollation(column_type);
+	TypeCacheEntry *tce = lookup_type_cache(column_type, 0);
+	int idx_key = get_idx_key(info, var->varattno);
+
+	skip_scan_path->distinct_column = var->varattno;
+	skip_scan_path->distinct_by_val = tce->typbyval;
+	skip_scan_path->distinct_typ_len = tce->typlen;
+	/* sk_attno of the skip qual */
+	skip_scan_path->sk_attno = idx_key + 1;
+
+	int16 strategy = info->reverse_sort[idx_key] ? BTLessStrategyNumber : BTGreaterStrategyNumber;
+	if (index_path->indexscandir == BackwardScanDirection)
+	{
+		strategy =
+			(strategy == BTLessStrategyNumber) ? BTGreaterStrategyNumber : BTLessStrategyNumber;
+	}
+
+	Oid comparator =
+		get_opfamily_member(info->sortopfamily[idx_key], column_type, column_type, strategy);
+	if (!OidIsValid(comparator))
+		return false; /* cannot use this index */
+
+	Const *prev_val = makeNullConst(column_type, -1, column_collation);
+	Var *current_val = makeVar(info->rel->relid /*varno*/,
+							   var->varattno /*varattno*/,
+							   column_type /*vartype*/,
+							   -1 /*vartypmod*/,
+							   column_collation /*varcollid*/,
+							   0 /*varlevelsup*/);
+
+	Expr *comparison_expr = make_opclause(comparator,
+										  BOOLOID /*opresulttype*/,
+										  false /*opretset*/,
+										  &current_val->xpr /*leftop*/,
+										  &prev_val->xpr /*rightop*/,
+										  InvalidOid /*opcollid*/,
+										  info->indexcollations[idx_key] /*inputcollid*/);
+	set_opfuncid(castNode(OpExpr, comparison_expr));
+
+	skip_scan_path->skip_clause = make_simple_restrictinfo(comparison_expr);
+
+	return true;
+}
+
+static TargetEntry *
+get_tle_for_pathkey(List *tlist, PathKey *pathkey)
+{
+	EquivalenceClass *ec = pathkey->pk_eclass;
+	TargetEntry *tle;
+
+	/* since SkipScan is on top of an index the EquivalenceClass
+	 * should not be volatile */
+	Assert(!ec->ec_has_volatile);
+
+	ListCell *lc;
+	foreach (lc, tlist)
+	{
+		tle = (TargetEntry *) lfirst(lc);
+		if (find_ec_member_for_tle(ec, tle, NULL))
+			return tle;
+	}
+
+	elog(ERROR, "skip column not found in targetlist");
+	pg_unreachable();
+}
+
+static int
+get_idx_key(IndexOptInfo *idxinfo, AttrNumber attno)
+{
+	for (int i = 0; i < idxinfo->nkeycolumns; i++)
+	{
+		if (attno == idxinfo->indexkeys[i])
+			return i;
+	}
+
+	elog(ERROR, "column not present in index: %d", attno);
+	pg_unreachable();
+}
+
+/*
+ * find_ec_member_for_tle
+ *
+ * copied from createplan.c
+ * check for childreen has been removed as targetlist we deal with here
+ * may be for a child since each chunk gets its own skipscan node
+ */
+static EquivalenceMember *
+find_ec_member_for_tle(EquivalenceClass *ec, TargetEntry *tle, Relids relids)
+{
+	Expr *tlexpr;
+	ListCell *lc;
+
+	/* We ignore binary-compatible relabeling on both ends */
+	tlexpr = tle->expr;
+	while (tlexpr && IsA(tlexpr, RelabelType))
+		tlexpr = ((RelabelType *) tlexpr)->arg;
+
+	foreach (lc, ec->ec_members)
+	{
+		EquivalenceMember *em = (EquivalenceMember *) lfirst(lc);
+		Expr *emexpr;
+
+		/*
+		 * We shouldn't be trying to sort by an equivalence class that
+		 * contains a constant, so no need to consider such cases any further.
+		 */
+		if (em->em_is_const)
+			continue;
+
+		/* Match if same expression (after stripping relabel) */
+		emexpr = em->em_expr;
+		while (emexpr && IsA(emexpr, RelabelType))
+			emexpr = ((RelabelType *) emexpr)->arg;
+
+		if (equal(emexpr, tlexpr))
+			return em;
+	}
+
+	return NULL;
+}
+
+/* Sort quals according to index column order.
+ * ScanKeys need to be sorted by the position of the index column
+ * they are referencing but since we don't want to adjust actual
+ * ScanKey array we presort qual list when creating plan.
+ */
+static List *
+sort_indexquals(IndexOptInfo *indexinfo, List *quals)
+{
+	List *indexclauses[INDEX_MAX_KEYS] = { 0 };
+	List *ordered_list = NIL;
+	ListCell *lc;
+	int i;
+
+	foreach (lc, quals)
+	{
+		Bitmapset *bms = NULL;
+		pull_varattnos(lfirst(lc), INDEX_VAR, &bms);
+		Assert(bms_num_members(bms) >= 1);
+
+		i = bms_next_member(bms, -1) + FirstLowInvalidHeapAttributeNumber - 1;
+		indexclauses[i] = lappend(indexclauses[i], lfirst(lc));
+	}
+
+	for (i = 0; i < INDEX_MAX_KEYS; i++)
+	{
+		if (indexclauses[i] != NIL)
+			ordered_list = list_concat(ordered_list, indexclauses[i]);
+	}
+
+	return ordered_list;
+}
+
+static OpExpr *
+fix_indexqual(IndexOptInfo *index, RestrictInfo *rinfo, AttrNumber distinct_column)
+{
+	/* technically our placeholder col > NULL is unsatisfiable, and in some instances
+	 * the planner will realize this and use is as an excuse to remove other quals.
+	 * in order to prevent this, we prepare this qual ourselves.
+	 */
+
+	/* fix_indexqual_references */
+	int indexcol = get_idx_key(index, distinct_column);
+	OpExpr *op = copyObject(castNode(OpExpr, rinfo->clause));
+	Assert(list_length(op->args) == 2);
+	Assert(bms_equal(rinfo->left_relids, index->rel->relids));
+
+	/* fix_indexqual_operand */
+	Assert(index->indexkeys[indexcol] != 0);
+	Var *node = linitial_node(Var, op->args);
+	Assert(((Var *) node)->varno == index->rel->relid &&
+		   ((Var *) node)->varattno == index->indexkeys[indexcol]);
+
+	Var *result = (Var *) copyObject(node);
+	result->varno = INDEX_VAR;
+	result->varattno = indexcol + 1;
+
+	linitial(op->args) = result;
+
+	return op;
+}

--- a/tsl/src/nodes/skip_scan/skip_scan.h
+++ b/tsl/src/nodes/skip_scan/skip_scan.h
@@ -1,0 +1,17 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_TSL_NODES_SKIP_SCAN_H
+#define TIMESCALEDB_TSL_NODES_SKIP_SCAN_H
+
+#include <postgres.h>
+#include <nodes/plannodes.h>
+
+extern void tsl_skip_scan_paths_add(PlannerInfo *root, RelOptInfo *input_rel,
+									RelOptInfo *output_rel);
+extern Node *tsl_skip_scan_state_create(CustomScan *cscan);
+extern void _skip_scan_init(void);
+
+#endif /* TIMESCALEDB_TSL_NODES_SKIP_SCAN_H */

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -9,6 +9,7 @@
 #include <foreign/fdwapi.h>
 
 #include "async_append.h"
+#include "nodes/skip_scan/skip_scan.h"
 #include "chunk.h"
 #include "compat.h"
 #include "debug_guc.h"
@@ -71,6 +72,9 @@ tsl_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptIn
 		case UPPERREL_WINDOW:
 			if (IsA(linitial(input_rel->pathlist), CustomPath))
 				gapfill_adjust_window_targetlist(root, input_rel, output_rel);
+			break;
+		case UPPERREL_DISTINCT:
+			tsl_skip_scan_paths_add(root, input_rel, output_rel);
 			break;
 		case UPPERREL_FINAL:
 			if (ts_guc_enable_async_append && root->parse->resultRelation == 0 &&

--- a/tsl/test/expected/plan_skip_scan-11.out
+++ b/tsl/test/expected/plan_skip_scan-11.out
@@ -1,0 +1,3764 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan;
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+ANALYZE skip_scan_nulls;
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable     
+---------------------------
+ (1,public,skip_scan_ht,t)
+(1 row)
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_ht;
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set TABLE skip_scan
+\ir include/skip_scan_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=12 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=12 loops=1)
+         Group Key: dev
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+               Heap Fetches: 11
+(5 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: dev_name
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: dev_name
+         ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
+               Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               Heap Blocks: exact=64
+               ->  Bitmap Index Scan on skip_scan_idx_hash (actual rows=2000 loops=1)
+                     Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(10 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: ((dev % 3))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: (dev % 3)
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Index Scan using skip_scan_expr_idx on skip_scan (actual rows=10022 loops=1)
+(2 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10022 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10022 loops=1)
+         Group Key: dev, "time", dev_name, val
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10022 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10022 loops=1)
+         Group Key: dev, "time", dev_name, val, 'q1_9'::text
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10021 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10021 loops=1)
+         Group Key: dev, "time", 'q1_10'::text
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, "time"
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+               Heap Fetches: 11
+(5 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Index Scan using skip_scan_time_dev_idx on skip_scan (actual rows=10022 loops=1)
+(1 row)
+
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=1001 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+               Heap Fetches: 1001
+(5 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                           Index Cond: (dev > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+                           Index Cond: ("time" > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                           Index Cond: (dev > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=0 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 12
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(7 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=9 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=9 loops=1)
+                     Index Cond: (dev > 1)
+(5 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=8 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=8 loops=1)
+                     Index Cond: (dev > int_func_stable())
+(5 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=7 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=7 loops=1)
+               Filter: (dev > int_func_volatile())
+               Rows Removed by Filter: 3022
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: (dev = ANY (inta_func_stable()))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+               Filter: (dev = ANY (inta_func_volatile()))
+               Rows Removed by Filter: 7022
+(5 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=6 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=6 loops=1)
+               Index Cond: (ROW(dev, "time") > ROW(5, 100))
+(4 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
+         Index Cond: (dev > 20)
+(3 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+               Heap Fetches: 5
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+               Heap Fetches: 5
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=2 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=2 loops=1)
+               Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=4 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=4 loops=1)
+               Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+               Filter: ((val > 10) AND (val < 10000))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+               Heap Fetches: 1
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+               Heap Fetches: 1
+(5 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ CTE Scan on devices (actual rows=12 loops=1)
+   CTE devices
+     ->  Unique (actual rows=12 loops=1)
+           ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                 ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                       Index Cond: (dev > NULL::integer)
+                       Heap Fetches: 12
+(7 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Sort (actual rows=12 loops=1)
+   Sort Key: devices.dev
+   Sort Method: quicksort 
+   CTE devices
+     ->  Unique (actual rows=12 loops=1)
+           ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                 ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                       Index Cond: (dev > NULL::integer)
+                       Heap Fetches: 12
+   ->  CTE Scan on devices (actual rows=12 loops=1)
+(10 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20022 loops=1)
+               Join Filter: (skip_scan."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 22
+               ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10022 loops=1)
+               ->  Materialize (actual rows=2 loops=10022)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(8 rows)
+
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10 loops=2)
+                           Filter: (dev <> "*VALUES*".column1)
+                           Rows Removed by Filter: 1021
+(8 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
+                           Index Cond: (dev >= "*VALUES*".column1)
+(7 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Result (actual rows=833 loops=12)
+         ->  Unique (actual rows=833 loops=12)
+               ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                           Index Cond: (dev = skip_scan.dev)
+(11 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Unique (actual rows=833 loops=12)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
+                     Heap Fetches: 10001
+(11 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Unique (actual rows=833 loops=12)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
+                     Heap Fetches: 10001
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Unique (actual rows=10001 loops=1)
+   ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
+         Index Cond: (dev IS NOT NULL)
+         Heap Fetches: 10001
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10001 loops=1)
+   ->  Sort (actual rows=20002 loops=1)
+         Sort Key: skip_scan.dev, skip_scan."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=20002 loops=1)
+               ->  Unique (actual rows=10001 loops=1)
+                     ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+                           Heap Fetches: 10001
+               ->  Nested Loop (actual rows=10001 loops=1)
+                     ->  Unique (actual rows=12 loops=1)
+                           ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
+                                 ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=12 loops=1)
+                                       Index Cond: (dev > NULL::integer)
+                                       Heap Fetches: 12
+                     ->  Unique (actual rows=833 loops=12)
+                           ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
+                                 ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
+                                       Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
+                                       Heap Fetches: 10001
+(20 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=12 loops=1)
+         ->  Result (actual rows=12 loops=1)
+               ->  Unique (actual rows=12 loops=1)
+                     ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                           ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(6 rows)
+
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+               Heap Fetches: 1
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+               Heap Fetches: 0
+(5 rows)
+
+\set TABLE skip_scan_ht
+\ir include/skip_scan_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=11 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (("time" = 100) AND (dev > NULL::integer))
+                     Heap Fetches: 11
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=11 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (("time" = 100) AND (dev > NULL::integer))
+                     Heap Fetches: 11
+(7 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev_name
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _hyper_1_1_chunk.dev_name
+         ->  Append (actual rows=2000 loops=1)
+               ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=16
+                     ->  Bitmap Index Scan on _hyper_1_1_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_2_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=16
+                     ->  Bitmap Index Scan on _hyper_1_2_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_3_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=16
+                     ->  Bitmap Index Scan on _hyper_1_3_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_4_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=16
+                     ->  Bitmap Index Scan on _hyper_1_4_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(26 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: ((_hyper_1_1_chunk.dev % 3))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: (_hyper_1_1_chunk.dev % 3)
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: ((_hyper_1_1_chunk.dev % 3))
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_expr_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: ((_hyper_1_2_chunk.dev % 3))
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: ((_hyper_1_3_chunk.dev % 3))
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: ((_hyper_1_4_chunk.dev % 3))
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(16 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_ht
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_ht
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val, 'q1_9'::text
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", 'q1_10'::text
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_ht
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_ht
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+                     Heap Fetches: 11
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=11 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+                     Heap Fetches: 11
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=11 loops=1)
+         Sort Key: _hyper_1_4_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+                     Heap Fetches: 11
+(7 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan_ht
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on skip_scan_ht (actual rows=10020 loops=1)
+   Order: skip_scan_ht."time"
+   ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Merge Append (actual rows=1000 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+(19 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_ht
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=7 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 4
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(15 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+(16 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_ht
+               Chunks left after exclusion: 4
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+(19 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+(22 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+(18 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+(22 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+(15 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: skip_scan_ht.dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+(11 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=5 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+                     Heap Fetches: 5
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+                     Heap Fetches: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+                     Heap Fetches: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+                     Heap Fetches: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+                     Heap Fetches: 5
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+                     Filter: ((val > 10) AND (val < 10000))
+                     Rows Removed by Filter: 396
+(8 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+(19 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ CTE Scan on devices (actual rows=11 loops=1)
+   CTE devices
+     ->  Unique (actual rows=11 loops=1)
+           ->  Merge Append (actual rows=44 loops=1)
+                 Sort Key: _hyper_1_1_chunk.dev
+                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+(21 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: devices.dev
+   Sort Method: quicksort 
+   CTE devices
+     ->  Unique (actual rows=11 loops=1)
+           ->  Merge Append (actual rows=44 loops=1)
+                 Sort Key: _hyper_1_1_chunk.dev
+                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                             Index Cond: (dev > NULL::integer)
+                             Heap Fetches: 11
+   ->  CTE Scan on devices (actual rows=11 loops=1)
+(24 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_1_1_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(13 rows)
+
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+(22 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+(18 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Result (actual rows=909 loops=11)
+         ->  Unique (actual rows=909 loops=11)
+               ->  Merge Append (actual rows=909 loops=11)
+                     Sort Key: _hyper_1_1_chunk_1."time"
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+(36 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Unique (actual rows=909 loops=11)
+         ->  Merge Append (actual rows=909 loops=11)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+(39 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Unique (actual rows=909 loops=11)
+         ->  Merge Append (actual rows=909 loops=11)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+(39 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10000 loops=1)
+   ->  Merge Append (actual rows=10000 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10000 loops=1)
+   ->  Sort (actual rows=20000 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=20000 loops=1)
+               ->  Unique (actual rows=10000 loops=1)
+                     ->  Merge Append (actual rows=10000 loops=1)
+                           Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+                           ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+               ->  Nested Loop (actual rows=10000 loops=1)
+                     ->  Unique (actual rows=11 loops=1)
+                           ->  Merge Append (actual rows=44 loops=1)
+                                 Sort Key: _hyper_1_1_chunk_1.dev
+                                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                     ->  Unique (actual rows=909 loops=11)
+                           ->  Merge Append (actual rows=909 loops=11)
+                                 Sort Key: _hyper_1_1_chunk_2."time"
+                                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+(59 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  Result (actual rows=11 loops=1)
+               ->  Unique (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=44 loops=1)
+                           Sort Key: _hyper_1_1_chunk.dev
+                           ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+               Heap Fetches: 1
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+               Heap Fetches: 0
+(5 rows)
+
+\ir include/skip_scan_query_ht.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(time);
+-- SkipScan with ordered append
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Custom Scan (ChunkAppend) on skip_scan_ht (actual rows=1000 loops=1)
+         Order: skip_scan_ht."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+(19 rows)
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- compression doesnt prevent skipscan
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=2538 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_dev__ts_meta_ on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- partial indexes don't prevent skipscan
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- try one query with EXPLAIN only for coverage
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Unique
+   ->  Custom Scan (SkipScan) on skip_scan
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan
+               Index Cond: (dev_name > NULL::text)
+(4 rows)
+
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan_ht;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Unique
+   ->  Merge Append
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk
+                     Index Cond: (dev_name > NULL::text)
+(15 rows)
+

--- a/tsl/test/expected/plan_skip_scan-12.out
+++ b/tsl/test/expected/plan_skip_scan-12.out
@@ -1,0 +1,3735 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan;
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+ANALYZE skip_scan_nulls;
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable     
+---------------------------
+ (1,public,skip_scan_ht,t)
+(1 row)
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_ht;
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set TABLE skip_scan
+\ir include/skip_scan_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=12 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=12 loops=1)
+         Group Key: dev
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+               Heap Fetches: 11
+(5 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: dev_name
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: dev_name
+         ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
+               Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               Heap Blocks: exact=13
+               ->  Bitmap Index Scan on skip_scan_idx_hash (actual rows=2000 loops=1)
+                     Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(10 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: ((dev % 3))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: (dev % 3)
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Index Scan using skip_scan_expr_idx on skip_scan (actual rows=10022 loops=1)
+(2 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10022 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10022 loops=1)
+         Group Key: dev, "time", dev_name, val
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10022 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10022 loops=1)
+         Group Key: dev, "time", dev_name, val, 'q1_9'::text
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10021 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10021 loops=1)
+         Group Key: dev, "time", 'q1_10'::text
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, "time"
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+               Heap Fetches: 11
+(5 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Index Scan using skip_scan_time_dev_idx on skip_scan (actual rows=10022 loops=1)
+(1 row)
+
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=1001 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+               Heap Fetches: 1001
+(5 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                           Index Cond: (dev > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+                           Index Cond: ("time" > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                           Index Cond: (dev > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=0 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 12
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(7 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=9 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=9 loops=1)
+                     Index Cond: (dev > 1)
+(5 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=8 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=8 loops=1)
+                     Index Cond: (dev > int_func_stable())
+(5 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=7 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=7 loops=1)
+               Filter: (dev > int_func_volatile())
+               Rows Removed by Filter: 3022
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: (dev = ANY (inta_func_stable()))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+               Filter: (dev = ANY (inta_func_volatile()))
+               Rows Removed by Filter: 7022
+(5 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=6 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=6 loops=1)
+               Index Cond: (ROW(dev, "time") > ROW(5, 100))
+(4 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
+         Index Cond: (dev > 20)
+(3 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+               Heap Fetches: 5
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+               Heap Fetches: 5
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=2 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=2 loops=1)
+               Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=4 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=4 loops=1)
+               Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+               Filter: ((val > 10) AND (val < 10000))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+               Heap Fetches: 1
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+               Heap Fetches: 1
+(5 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20022 loops=1)
+               Join Filter: (skip_scan."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 22
+               ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10022 loops=1)
+               ->  Materialize (actual rows=2 loops=10022)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(8 rows)
+
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10 loops=2)
+                           Filter: (dev <> "*VALUES*".column1)
+                           Rows Removed by Filter: 1021
+(8 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
+                           Index Cond: (dev >= "*VALUES*".column1)
+(7 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Result (actual rows=833 loops=12)
+         ->  Unique (actual rows=833 loops=12)
+               ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                           Index Cond: (dev = skip_scan.dev)
+(11 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Unique (actual rows=833 loops=12)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
+                     Heap Fetches: 10001
+(11 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Unique (actual rows=833 loops=12)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
+                     Heap Fetches: 10001
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Unique (actual rows=10001 loops=1)
+   ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
+         Index Cond: (dev IS NOT NULL)
+         Heap Fetches: 10001
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10001 loops=1)
+   ->  Sort (actual rows=20002 loops=1)
+         Sort Key: skip_scan.dev, skip_scan."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=20002 loops=1)
+               ->  Unique (actual rows=10001 loops=1)
+                     ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+                           Heap Fetches: 10001
+               ->  Nested Loop (actual rows=10001 loops=1)
+                     ->  Unique (actual rows=12 loops=1)
+                           ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
+                                 ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=12 loops=1)
+                                       Index Cond: (dev > NULL::integer)
+                                       Heap Fetches: 12
+                     ->  Unique (actual rows=833 loops=12)
+                           ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
+                                 ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
+                                       Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
+                                       Heap Fetches: 10001
+(20 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=12 loops=1)
+         ->  Result (actual rows=12 loops=1)
+               ->  Unique (actual rows=12 loops=1)
+                     ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                           ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(6 rows)
+
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+               Heap Fetches: 1
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+               Heap Fetches: 0
+(5 rows)
+
+\set TABLE skip_scan_ht
+\ir include/skip_scan_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         Index Cond: ("time" = 100)
+         Heap Fetches: 11
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         Index Cond: ("time" = 100)
+         Heap Fetches: 11
+(4 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev_name
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _hyper_1_1_chunk.dev_name
+         ->  Append (actual rows=2000 loops=1)
+               ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_1_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_2_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_2_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_3_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_3_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_4_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_4_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(26 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: ((_hyper_1_1_chunk.dev % 3))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: (_hyper_1_1_chunk.dev % 3)
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: ((_hyper_1_1_chunk.dev % 3))
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_expr_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: ((_hyper_1_2_chunk.dev % 3))
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: ((_hyper_1_3_chunk.dev % 3))
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Sort (actual rows=2505 loops=1)
+               Sort Key: ((_hyper_1_4_chunk.dev % 3))
+               Sort Method: quicksort 
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(16 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_ht
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_ht
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val, 'q1_9'::text
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", 'q1_10'::text
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_ht
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_ht
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+                     Heap Fetches: 11
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+               Heap Fetches: 11
+(5 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan_ht
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on skip_scan_ht (actual rows=10020 loops=1)
+   Order: skip_scan_ht."time"
+   ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Merge Append (actual rows=1000 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+(19 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_ht
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=7 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 4
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(15 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+(16 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_ht
+               Chunks left after exclusion: 4
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+(19 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+(22 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+(18 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+(22 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+(15 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+(11 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+         Index Cond: (("time" = 100) AND (dev > 5))
+         Heap Fetches: 5
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+                     Heap Fetches: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+               Filter: ((val > 10) AND (val < 10000))
+               Rows Removed by Filter: 396
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+(19 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_1_1_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(13 rows)
+
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+(22 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+(18 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Result (actual rows=909 loops=11)
+         ->  Unique (actual rows=909 loops=11)
+               ->  Merge Append (actual rows=909 loops=11)
+                     Sort Key: _hyper_1_1_chunk_1."time"
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+(36 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Unique (actual rows=909 loops=11)
+         ->  Merge Append (actual rows=909 loops=11)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+(39 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Unique (actual rows=909 loops=11)
+         ->  Merge Append (actual rows=909 loops=11)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+(39 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10000 loops=1)
+   ->  Merge Append (actual rows=10000 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10000 loops=1)
+   ->  Sort (actual rows=20000 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=20000 loops=1)
+               ->  Unique (actual rows=10000 loops=1)
+                     ->  Merge Append (actual rows=10000 loops=1)
+                           Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+                           ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+               ->  Nested Loop (actual rows=10000 loops=1)
+                     ->  Unique (actual rows=11 loops=1)
+                           ->  Merge Append (actual rows=44 loops=1)
+                                 Sort Key: _hyper_1_1_chunk_1.dev
+                                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                     ->  Unique (actual rows=909 loops=11)
+                           ->  Merge Append (actual rows=909 loops=11)
+                                 Sort Key: _hyper_1_1_chunk_2."time"
+                                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+(59 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  Result (actual rows=11 loops=1)
+               ->  Unique (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=44 loops=1)
+                           Sort Key: _hyper_1_1_chunk.dev
+                           ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+               Heap Fetches: 1
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+               Heap Fetches: 0
+(5 rows)
+
+\ir include/skip_scan_query_ht.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(time);
+-- SkipScan with ordered append
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Custom Scan (ChunkAppend) on skip_scan_ht (actual rows=1000 loops=1)
+         Order: skip_scan_ht."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+(19 rows)
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- compression doesnt prevent skipscan
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=2538 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_dev__ts_meta_ on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- partial indexes don't prevent skipscan
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- try one query with EXPLAIN only for coverage
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Unique
+   ->  Custom Scan (SkipScan) on skip_scan
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan
+               Index Cond: (dev_name > NULL::text)
+(4 rows)
+
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan_ht;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Unique
+   ->  Merge Append
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk
+                     Index Cond: (dev_name > NULL::text)
+(15 rows)
+

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -1,0 +1,3719 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan;
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+ANALYZE skip_scan_nulls;
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable     
+---------------------------
+ (1,public,skip_scan_ht,t)
+(1 row)
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_ht;
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set TABLE skip_scan
+\ir include/skip_scan_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=12 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=12 loops=1)
+         Group Key: dev
+         Batches: 1 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(7 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_last on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_nulls_first on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan Backward using skip_scan_idx_dev_time_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev < NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_idx_time_dev_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer))
+               Heap Fetches: 11
+(5 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: dev_name
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: dev_name
+         Batches: 1 
+         ->  Bitmap Heap Scan on skip_scan (actual rows=2000 loops=1)
+               Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               Heap Blocks: exact=13
+               ->  Bitmap Index Scan on skip_scan_idx_hash (actual rows=2000 loops=1)
+                     Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(11 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: ((dev % 3))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: (dev % 3)
+         Batches: 1 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(7 rows)
+
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Index Scan using skip_scan_expr_idx on skip_scan (actual rows=10022 loops=1)
+(2 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10022 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10022 loops=1)
+         Group Key: dev, "time", dev_name, val
+         Batches: 1 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(7 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10022 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10022 loops=1)
+         Group Key: dev, "time", dev_name, val, 'q1_9'::text
+         Batches: 1 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(7 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Sort (actual rows=10021 loops=1)
+   Sort Key: dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10021 loops=1)
+         Group Key: dev, "time", 'q1_10'::text
+         Batches: 1 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(7 rows)
+
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: dev_name, "time"
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Result (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=3 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 3
+(6 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+         ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+               Heap Fetches: 11
+(5 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Index Scan using skip_scan_time_dev_idx on skip_scan (actual rows=10022 loops=1)
+(1 row)
+
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Unique (actual rows=1001 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1001 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_idx on skip_scan (actual rows=1001 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+               Heap Fetches: 1001
+(5 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+(6 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(4 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=12 loops=1)
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(5 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                           Index Cond: (dev > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=11 loops=1)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=11 loops=1)
+                           Index Cond: ("time" > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+                           Index Cond: (dev > 5)
+(6 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=0 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 12
+   ->  Result (actual rows=12 loops=1)
+         ->  Unique (actual rows=12 loops=1)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(7 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=9 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=9 loops=1)
+                     Index Cond: (dev > 1)
+(5 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=8 loops=1)
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=8 loops=1)
+                     Index Cond: (dev > int_func_stable())
+(5 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=7 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=7 loops=1)
+               Filter: (dev > int_func_volatile())
+               Rows Removed by Filter: 3022
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Index Cond: (dev = ANY (inta_func_stable()))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=3 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=3 loops=1)
+               Filter: (dev = ANY (inta_func_volatile()))
+               Rows Removed by Filter: 7022
+(5 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=6 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=6 loops=1)
+               Index Cond: (ROW(dev, "time") > ROW(5, 100))
+(4 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
+         Index Cond: (dev > 20)
+(3 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Only Scan using skip_scan_time_dev_val_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: (("time" = 100) AND (dev > NULL::integer) AND (dev > 5))
+               Heap Fetches: 5
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=5 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=5 loops=1)
+               Index Cond: (dev > 5)
+               Filter: ("time" > 200)
+               Rows Removed by Filter: 1000
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=2 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=2 loops=1)
+               Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=4 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=4 loops=1)
+               Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+               Filter: ((val > 10) AND (val < 10000))
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+               Heap Fetches: 1
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+               Heap Fetches: 1
+(5 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+:PREFIX EXECUTE prep;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev_name > NULL::text)
+               Heap Fetches: 12
+(5 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20022 loops=1)
+               Join Filter: (skip_scan."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 22
+               ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10022 loops=1)
+               ->  Materialize (actual rows=2 loops=10022)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(8 rows)
+
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=20 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
+                           Filter: (dev <> "*VALUES*".column1)
+                           Rows Removed by Filter: 1021
+(8 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Custom Scan (SkipScan) on skip_scan (actual rows=10 loops=2)
+                     ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=10 loops=2)
+                           Index Cond: (dev >= "*VALUES*".column1)
+(7 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Result (actual rows=833 loops=12)
+         ->  Unique (actual rows=833 loops=12)
+               ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     ->  Index Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                           Index Cond: (dev = skip_scan.dev)
+(11 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Unique (actual rows=833 loops=12)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
+                     Heap Fetches: 10001
+(11 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10001 loops=1)
+   ->  Unique (actual rows=12 loops=1)
+         ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+               ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 12
+   ->  Unique (actual rows=833 loops=12)
+         ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=833 loops=12)
+               ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_1 (actual rows=833 loops=12)
+                     Index Cond: ((dev = skip_scan.dev) AND ("time" > NULL::integer))
+                     Heap Fetches: 10001
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Unique (actual rows=10001 loops=1)
+   ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
+         Index Cond: (dev IS NOT NULL)
+         Heap Fetches: 10001
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10001 loops=1)
+   ->  Sort (actual rows=20002 loops=1)
+         Sort Key: skip_scan.dev, skip_scan."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=20002 loops=1)
+               ->  Unique (actual rows=10001 loops=1)
+                     ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan (actual rows=10001 loops=1)
+                           Index Cond: (dev IS NOT NULL)
+                           Heap Fetches: 10001
+               ->  Nested Loop (actual rows=10001 loops=1)
+                     ->  Unique (actual rows=12 loops=1)
+                           ->  Custom Scan (SkipScan) on skip_scan skip_scan_1 (actual rows=12 loops=1)
+                                 ->  Index Only Scan using skip_scan_dev_idx on skip_scan skip_scan_1 (actual rows=12 loops=1)
+                                       Index Cond: (dev > NULL::integer)
+                                       Heap Fetches: 12
+                     ->  Unique (actual rows=833 loops=12)
+                           ->  Custom Scan (SkipScan) on skip_scan skip_scan_2 (actual rows=833 loops=12)
+                                 ->  Index Only Scan using skip_scan_dev_time_idx on skip_scan skip_scan_2 (actual rows=833 loops=12)
+                                       Index Cond: ((dev = skip_scan_1.dev) AND ("time" > NULL::integer))
+                                       Heap Fetches: 10001
+(20 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=12 loops=1)
+         ->  Result (actual rows=12 loops=1)
+               ->  Unique (actual rows=12 loops=1)
+                     ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+                           ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(6 rows)
+
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Only Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+               Index Cond: (dev > NULL::integer)
+               Heap Fetches: 12
+(5 rows)
+
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+               Heap Fetches: 1
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+               Heap Fetches: 0
+(5 rows)
+
+\set TABLE skip_scan_ht
+\ir include/skip_scan_query.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+ enable_skipscan 
+-----------------
+ on
+(1 row)
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Sort (actual rows=11 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=11 loops=1)
+         Group Key: _hyper_1_1_chunk.dev
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_last on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev NULLS FIRST
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_nulls_first on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_idx_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_idx_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_idx_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_idx_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev < NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         Index Cond: ("time" = 100)
+         Heap Fetches: 11
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_idx_time_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         Index Cond: ("time" = 100)
+         Heap Fetches: 11
+(4 rows)
+
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev_name
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _hyper_1_1_chunk.dev_name
+         Batches: 1 
+         ->  Append (actual rows=2000 loops=1)
+               ->  Bitmap Heap Scan on _hyper_1_1_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_1_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_2_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_2_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_3_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_3_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+               ->  Bitmap Heap Scan on _hyper_1_4_chunk (actual rows=500 loops=1)
+                     Recheck Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+                     Heap Blocks: exact=4
+                     ->  Bitmap Index Scan on _hyper_1_4_chunk_skip_scan_idx_hash (actual rows=500 loops=1)
+                           Index Cond: (dev_name = ANY ('{device_1,device_2}'::text[]))
+(27 rows)
+
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Sort (actual rows=4 loops=1)
+   Sort Key: ((_hyper_1_1_chunk.dev % 3))
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=4 loops=1)
+         Group Key: (_hyper_1_1_chunk.dev % 3)
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=4 loops=1)
+   ->  Merge Append (actual rows=10020 loops=1)
+         Sort Key: ((_hyper_1_1_chunk.dev % 3))
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_expr_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_2_chunk_skip_scan_expr_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_skip_scan_expr_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_4_chunk_skip_scan_expr_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(7 rows)
+
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+basic DISTINCT queries on skip_scan_ht
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+\qecho stable expression in targetlist on :TABLE
+stable expression in targetlist on skip_scan_ht
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, (length(md5((random())::text)))
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val
+         Batches: 1 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk.val, 'q1_9'::text
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Sort (actual rows=10020 loops=1)
+   Sort Key: _hyper_1_1_chunk.dev
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=10020 loops=1)
+         Group Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time", 'q1_10'::text
+         Batches: 1 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name, _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
+         ->  Result (actual rows=10020 loops=1)
+               ->  Append (actual rows=10020 loops=1)
+                     ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(10 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev_name > NULL::text)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev_name
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+\qecho LIMIT queries on :TABLE
+LIMIT queries on skip_scan_ht
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev < NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=3 loops=1)
+   ->  Unique (actual rows=3 loops=1)
+         ->  Merge Append (actual rows=9 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 3
+(20 rows)
+
+\qecho range queries on :TABLE
+range queries on skip_scan_ht
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=22 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND ("time" >= 100) AND ("time" <= 300))
+                     Heap Fetches: 11
+(11 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" < 200))
+               Heap Fetches: 11
+(5 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+               Index Cond: ((dev > NULL::integer) AND ("time" > 800))
+               Heap Fetches: 11
+(5 rows)
+
+\qecho ordered append on :TABLE
+ordered append on skip_scan_ht
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on skip_scan_ht (actual rows=10020 loops=1)
+   Order: skip_scan_ht."time"
+   ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+   ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Merge Append (actual rows=1000 loops=1)
+         Sort Key: _hyper_1_1_chunk."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_dev_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_dev_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_dev_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: (("time" > NULL::integer) AND ("time" >= 0) AND ("time" <= 5000))
+                     Heap Fetches: 250
+(19 rows)
+
+\qecho SUBSELECTS on :TABLE
+SUBSELECTS on skip_scan_ht
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+(20 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(12 rows)
+
+\qecho ORDER BY
+ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev DESC, _hyper_1_1_chunk."time" DESC
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(13 rows)
+
+\qecho WHERE CLAUSES
+WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 Index Cond: ("time" > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=5 loops=1)
+   ->  Result (actual rows=5 loops=1)
+         ->  Unique (actual rows=5 loops=1)
+               ->  Merge Append (actual rows=20 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                                 Index Cond: (dev > 5)
+(17 rows)
+
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=7 loops=1)
+   Filter: (a."time" > 5)
+   Rows Removed by Filter: 4
+   ->  Result (actual rows=11 loops=1)
+         ->  Unique (actual rows=11 loops=1)
+               ->  Merge Append (actual rows=44 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(15 rows)
+
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=9 loops=1)
+   ->  Unique (actual rows=9 loops=1)
+         ->  Merge Append (actual rows=36 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=1)
+                           Index Cond: (dev > 1)
+(16 rows)
+
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=8 loops=1)
+   ->  Unique (actual rows=8 loops=1)
+         ->  Custom Scan (ConstraintAwareAppend) (actual rows=32 loops=1)
+               Hypertable: skip_scan_ht
+               Chunks left after exclusion: 4
+               ->  Merge Append (actual rows=32 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=8 loops=1)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=8 loops=1)
+                                 Index Cond: (dev > int_func_stable())
+(19 rows)
+
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=7 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=28 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=28 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=7 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=7 loops=1)
+                           Filter: (dev > int_func_volatile())
+                           Rows Removed by Filter: 755
+(22 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Merge Append (actual rows=12 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     Index Cond: (dev = ANY ('{1,2,3}'::integer[]))
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Index Cond: (dev = ANY (inta_func_stable()))
+(18 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=3 loops=1)
+   ->  Custom Scan (ConstraintAwareAppend) (actual rows=12 loops=1)
+         Hypertable: skip_scan_ht
+         Chunks left after exclusion: 4
+         ->  Merge Append (actual rows=12 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=3 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=3 loops=1)
+                           Filter: (dev = ANY (inta_func_volatile()))
+                           Rows Removed by Filter: 1755
+(22 rows)
+
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=6 loops=1)
+   ->  Merge Append (actual rows=24 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=6 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=6 loops=1)
+                     Index Cond: (ROW(dev, "time") > ROW(5, 100))
+(15 rows)
+
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+                  QUERY PLAN                  
+----------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: dev
+         Sort Method: quicksort 
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
+(6 rows)
+
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Merge Append (actual rows=0 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+         ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+(11 rows)
+
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_dev_val_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+         Index Cond: (("time" = 100) AND (dev > 5))
+         Heap Fetches: 5
+(4 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=5 loops=1)
+   ->  Merge Append (actual rows=20 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=5 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=5 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev > 5) AND ("time" > 200))
+                     Heap Fetches: 5
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=5 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=5 loops=1)
+                     Index Cond: (dev > 5)
+                     Filter: ("time" > 200)
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=2 loops=1)
+   ->  Merge Append (actual rows=8 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=2 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2 loops=1)
+                     Index Cond: ((dev >= 5) AND (dev < 7) AND (dev >= 2))
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+               Index Cond: ((dev > 2) AND (dev < 7) AND ("time" > 100) AND ("time" < 200))
+               Filter: ((val > 10) AND (val < 10000))
+               Rows Removed by Filter: 396
+(6 rows)
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev > NULL::integer) AND (dev IS NULL))
+                     Heap Fetches: 1
+(19 rows)
+
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
+                     Heap Fetches: 1
+(19 rows)
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+:PREFIX EXECUTE prep;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev_name > NULL::text)
+                     Heap Fetches: 11
+(19 rows)
+
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a (actual rows=11 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Nested Loop (actual rows=20020 loops=1)
+               Join Filter: (_hyper_1_1_chunk."time" <> "*VALUES*".column1)
+               Rows Removed by Join Filter: 20
+               ->  Merge Append (actual rows=10020 loops=1)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+                     ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+               ->  Materialize (actual rows=2 loops=10020)
+                     ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+(13 rows)
+
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=18 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=9 loops=2)
+         ->  Unique (actual rows=9 loops=2)
+               ->  Merge Append (actual rows=36 loops=2)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=9 loops=2)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=9 loops=2)
+                                 Filter: (dev <> "*VALUES*".column1)
+                                 Rows Removed by Filter: 255
+(22 rows)
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=19 loops=1)
+   ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+   ->  Result (actual rows=10 loops=2)
+         ->  Unique (actual rows=10 loops=2)
+               ->  Merge Append (actual rows=38 loops=2)
+                     Sort Key: _hyper_1_1_chunk.dev
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=10 loops=2)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=10 loops=2)
+                                 Index Cond: (dev >= "*VALUES*".column1)
+(18 rows)
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Result (actual rows=909 loops=11)
+         ->  Unique (actual rows=909 loops=11)
+               ->  Merge Append (actual rows=909 loops=11)
+                     Sort Key: _hyper_1_1_chunk_1."time"
+                     ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+                     ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                                 Index Cond: (dev = _hyper_1_1_chunk.dev)
+(36 rows)
+
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Unique (actual rows=909 loops=11)
+         ->  Merge Append (actual rows=909 loops=11)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+(39 rows)
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=10000 loops=1)
+   ->  Unique (actual rows=11 loops=1)
+         ->  Merge Append (actual rows=44 loops=1)
+               Sort Key: _hyper_1_1_chunk.dev
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                           Index Cond: (dev > NULL::integer)
+                           Heap Fetches: 11
+   ->  Unique (actual rows=909 loops=11)
+         ->  Merge Append (actual rows=909 loops=11)
+               Sort Key: _hyper_1_1_chunk_1."time"
+               ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+               ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                     ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=227 loops=11)
+                           Index Cond: ((dev = _hyper_1_1_chunk.dev) AND ("time" > NULL::integer))
+                           Heap Fetches: 2500
+(39 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10000 loops=1)
+   ->  Merge Append (actual rows=10000 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+         ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+         ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
+               Index Cond: (dev IS NOT NULL)
+               Heap Fetches: 2500
+(15 rows)
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=10000 loops=1)
+   ->  Sort (actual rows=20000 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+         Sort Method: quicksort 
+         ->  Append (actual rows=20000 loops=1)
+               ->  Unique (actual rows=10000 loops=1)
+                     ->  Merge Append (actual rows=10000 loops=1)
+                           Sort Key: _hyper_1_1_chunk.dev, _hyper_1_1_chunk."time"
+                           ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+                           ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=2500 loops=1)
+                                 Index Cond: (dev IS NOT NULL)
+                                 Heap Fetches: 2500
+               ->  Nested Loop (actual rows=10000 loops=1)
+                     ->  Unique (actual rows=11 loops=1)
+                           ->  Merge Append (actual rows=44 loops=1)
+                                 Sort Key: _hyper_1_1_chunk_1.dev
+                                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk _hyper_1_1_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk _hyper_1_2_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk _hyper_1_3_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
+                                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk _hyper_1_4_chunk_1 (actual rows=11 loops=1)
+                                             Index Cond: (dev > NULL::integer)
+                                             Heap Fetches: 11
+                     ->  Unique (actual rows=909 loops=11)
+                           ->  Merge Append (actual rows=909 loops=11)
+                                 Sort Key: _hyper_1_1_chunk_2."time"
+                                 ->  Custom Scan (SkipScan) on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk _hyper_1_1_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk _hyper_1_2_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk _hyper_1_3_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+                                 ->  Custom Scan (SkipScan) on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
+                                       ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk _hyper_1_4_chunk_2 (actual rows=227 loops=11)
+                                             Index Cond: ((dev = _hyper_1_1_chunk_1.dev) AND ("time" > NULL::integer))
+                                             Heap Fetches: 2500
+(59 rows)
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Insert on skip_scan_insert (actual rows=0 loops=1)
+   ->  Subquery Scan on a (actual rows=11 loops=1)
+         ->  Result (actual rows=11 loops=1)
+               ->  Unique (actual rows=11 loops=1)
+                     ->  Merge Append (actual rows=44 loops=1)
+                           Sort Key: _hyper_1_1_chunk.dev
+                           ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                           ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+                                 ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(14 rows)
+
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+                     Index Cond: (dev > NULL::integer)
+                     Heap Fetches: 11
+(19 rows)
+
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=1 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=1 loops=1)
+               Index Cond: ("time" > NULL::integer)
+               Heap Fetches: 1
+(5 rows)
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Unique (actual rows=0 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan_nulls (actual rows=0 loops=1)
+         ->  Index Only Scan using skip_scan_nulls_time_idx on skip_scan_nulls (actual rows=0 loops=1)
+               Index Cond: (("time" > NULL::integer) AND ("time" IS NOT NULL))
+               Heap Fetches: 0
+(5 rows)
+
+\ir include/skip_scan_query_ht.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(time);
+-- SkipScan with ordered append
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1000 loops=1)
+   ->  Custom Scan (ChunkAppend) on skip_scan_ht (actual rows=1000 loops=1)
+         Order: skip_scan_ht."time"
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_time_idx on _hyper_1_1_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_time_idx on _hyper_1_2_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_time_idx on _hyper_1_3_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=250 loops=1)
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_time_idx on _hyper_1_4_chunk (actual rows=250 loops=1)
+                     Index Cond: ("time" > NULL::integer)
+                     Heap Fetches: 250
+(19 rows)
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- compression doesnt prevent skipscan
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=2538 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Index Scan using compress_hyper_2_5_chunk__compressed_hypertable_2_dev__ts_meta_ on compress_hyper_2_5_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- partial indexes don't prevent skipscan
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx1 on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx1 on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx1 on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- try one query with EXPLAIN only for coverage
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Unique
+   ->  Custom Scan (SkipScan) on skip_scan
+         ->  Index Only Scan using skip_scan_dev_name_idx on skip_scan
+               Index Cond: (dev_name > NULL::text)
+(4 rows)
+
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan_ht;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Unique
+   ->  Merge Append
+         Sort Key: _hyper_1_1_chunk.dev_name
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk
+               ->  Index Only Scan using _hyper_1_1_chunk_skip_scan_ht_dev_name_idx on _hyper_1_1_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk
+               ->  Index Only Scan using _hyper_1_2_chunk_skip_scan_ht_dev_name_idx on _hyper_1_2_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk
+               ->  Index Only Scan using _hyper_1_3_chunk_skip_scan_ht_dev_name_idx on _hyper_1_3_chunk
+                     Index Cond: (dev_name > NULL::text)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk
+               ->  Index Only Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk
+                     Index Cond: (dev_name > NULL::text)
+(15 rows)
+

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -1,0 +1,856 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- need superuser to adjust statistics in load script
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\set TEST_BASE_NAME skip_scan
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results_unoptimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_UNOPTIMIZED",
+    format('%s/results/%s_results_optimized.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_OPTIMIZED" \gset
+SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') AS "DIFF_CMD" \gset
+\ir :TEST_LOAD_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan;
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+ANALYZE skip_scan_nulls;
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+     create_hypertable     
+---------------------------
+ (1,public,skip_scan_ht,t)
+(1 row)
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+ANALYZE skip_scan_ht;
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);
+-- run tests on normal table and diff results
+\set TABLE skip_scan
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+\qecho ordered append on :TABLE
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+SET timescaledb.enable_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+\qecho ordered append on :TABLE
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+RESET timescaledb.enable_skipscan;
+-- compare SkipScan results on normal table
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_skipscan 
+ -----------------
+- off
++ on
+ (1 row)
+ 
+  dev 
+-- run tests on hypertable and diff results
+\set TABLE skip_scan_ht
+\set PREFIX ''
+\o :TEST_RESULTS_OPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+\qecho ordered append on :TABLE
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+SET timescaledb.enable_skipscan TO false;
+\o :TEST_RESULTS_UNOPTIMIZED
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+DROP INDEX skip_scan_idx_time_dev_idx;
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+DROP INDEX skip_scan_idx_hash;
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+\qecho basic DISTINCT queries on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+\qecho ordered append on :TABLE
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+RESET force_parallel_mode;
+TRUNCATE skip_scan_insert;
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+\o
+RESET timescaledb.enable_skipscan;
+-- compare SkipScan results on hypertable
+:DIFF_CMD
+--- Unoptimized results
++++ Optimized results
+@@ -1,6 +1,6 @@
+  enable_skipscan 
+ -----------------
+- off
++ on
+ (1 row)
+ 
+  dev 

--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -11,6 +11,7 @@
 /dist_hypertable-*.sql
 /dist_query-*.sql
 /move-*.sql
+/plan_skip_scan-*.sql
 /reorder-*.sql
 /remote_copy-*.sql
 /jit-*.sql

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_FILES
   continuous_aggs_watermark.sql
   dist_views.sql
   partialize_finalize.sql
+  skip_scan.sql
 )
 
 set(TEST_FILES_DEBUG
@@ -67,6 +68,7 @@ set(TEST_TEMPLATES
   compression_qualpushdown.sql.in
   continuous_aggs_union_view.sql.in
   move.sql.in
+  plan_skip_scan.sql.in
   reorder.sql.in
   transparent_decompression.sql.in
   transparent_decompression_ordered_index.sql.in

--- a/tsl/test/sql/include/skip_scan_load.sql
+++ b/tsl/test/sql/include/skip_scan_load.sql
@@ -1,0 +1,51 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE skip_scan(time int, dev int, dev_name text, val int);
+
+INSERT INTO skip_scan SELECT t, d, 'device_' || d::text, t*d FROM generate_series(1, 1000) t, generate_series(1, 10) d;
+INSERT INTO skip_scan VALUES (NULL, 0, -1, NULL), (0, NULL, -1, NULL);
+INSERT INTO skip_scan(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+
+ANALYZE skip_scan;
+
+CREATE TABLE skip_scan_nulls(time int);
+CREATE INDEX ON skip_scan_nulls(time);
+INSERT INTO skip_scan_nulls SELECT NULL FROM generate_series(1,100);
+
+ANALYZE skip_scan_nulls;
+
+-- create hypertable with different physical layouts in the chunks
+CREATE TABLE skip_scan_ht(f1 int, f2 int, f3 int, time int NOT NULL, dev int, dev_name text, val int);
+SELECT create_hypertable('skip_scan_ht', 'time', chunk_time_interval => 250, create_default_indexes => false);
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(0, 249) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f1;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(250, 499) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f2;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(500, 749) t, generate_series(1, 10) d;
+ALTER TABLE skip_scan_ht DROP COLUMN f3;
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, d, 'device_' || d::text, random() FROM generate_series(750, 999) t, generate_series(1, 10) d;
+
+INSERT INTO skip_scan_ht(time,dev,dev_name,val) SELECT t, NULL, NULL, NULL FROM generate_series(0, 999, 50) t;
+
+ANALYZE skip_scan_ht;
+
+ALTER TABLE skip_scan_ht SET (timescaledb.compress,timescaledb.compress_orderby='time desc', timescaledb.compress_segmentby='dev');
+
+CREATE TABLE skip_scan_insert(time int, dev int, dev_name text, val int, query text);
+
+CREATE OR REPLACE FUNCTION int_func_immutable() RETURNS int LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$SELECT 1; $$;
+CREATE OR REPLACE FUNCTION int_func_stable() RETURNS int LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT 2; $$;
+CREATE OR REPLACE FUNCTION int_func_volatile() RETURNS int LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT 3; $$;
+
+CREATE OR REPLACE FUNCTION inta_func_immutable() RETURNS int[] LANGUAGE SQL IMMUTABLE SECURITY DEFINER AS $$ SELECT ARRAY[1,2,3]; $$;
+CREATE OR REPLACE FUNCTION inta_func_stable() RETURNS int[] LANGUAGE SQL STABLE SECURITY DEFINER AS $$ SELECT ARRAY[2,3,4]; $$;
+CREATE OR REPLACE FUNCTION inta_func_volatile() RETURNS int[] LANGUAGE SQL VOLATILE SECURITY DEFINER AS $$ SELECT ARRAY[3,4,5]; $$;
+
+-- adjust statistics so we get skipscan plans
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_nulls'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid='skip_scan_ht'::regclass;
+UPDATE pg_statistic SET stadistinct=1, stanullfrac=0.5 WHERE starelid IN (select inhrelid from pg_inherits where inhparent='skip_scan_ht'::regclass);

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -1,0 +1,228 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- canary for result diff
+SELECT current_setting('timescaledb.enable_skipscan') AS enable_skipscan;
+
+-- test different index configurations
+-- no index so we cant do SkipScan
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+
+-- NULLS LAST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_last ON :TABLE(dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev DESC;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+DROP INDEX skip_scan_idx_dev_nulls_last;
+
+-- NULLS FIRST index on dev
+CREATE INDEX skip_scan_idx_dev_nulls_first ON :TABLE(dev NULLS FIRST);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev NULLS FIRST;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev NULLS FIRST;
+DROP INDEX skip_scan_idx_dev_nulls_first;
+
+-- multicolumn index with dev as leading column
+CREATE INDEX skip_scan_idx_dev_time_idx ON :TABLE(dev, time);
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC;
+DROP INDEX skip_scan_idx_dev_time_idx;
+
+-- multicolumn index with dev as non-leading column
+CREATE INDEX skip_scan_idx_time_dev_idx ON :TABLE(time, dev);
+:PREFIX SELECT DISTINCT dev FROM :TABLE WHERE time = 100 ORDER BY dev;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time = 100;
+DROP INDEX skip_scan_idx_time_dev_idx;
+
+-- hash index is not ordered so can't use skipscan
+CREATE INDEX skip_scan_idx_hash ON :TABLE USING hash(dev_name);
+:PREFIX SELECT DISTINCT dev_name FROM :TABLE WHERE dev_name IN ('device_1','device_2') ORDER BY dev_name;
+DROP INDEX skip_scan_idx_hash;
+
+-- expression indexes
+-- currently not supported by skipscan
+CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
+:PREFIX SELECT DISTINCT dev%3 FROM :TABLE ORDER BY dev%3;
+:PREFIX SELECT DISTINCT ON (dev%3) dev FROM :TABLE ORDER BY dev%3;
+DROP INDEX skip_scan_expr_idx;
+
+CREATE INDEX ON :TABLE(dev_name);
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(dev, time);
+CREATE INDEX ON :TABLE(time,dev);
+CREATE INDEX ON :TABLE(time,dev,val);
+
+\qecho basic DISTINCT queries on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_1' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_2' FROM :TABLE ORDER BY dev_name;
+:PREFIX SELECT DISTINCT dev, 'q1_3', NULL FROM :TABLE ORDER BY dev;
+
+\qecho stable expression in targetlist on :TABLE
+:PREFIX SELECT DISTINCT dev, 'q1_4', length(md5(now()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_5', length(md5(now()::text)) FROM :TABLE ORDER BY dev_name;
+
+-- volatile expression in targetlist
+:PREFIX SELECT DISTINCT dev, 'q1_6', length(md5(random()::text)) FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev_name, 'q1_7', length(md5(random()::text)) FROM :TABLE ORDER BY dev_name;
+
+-- queries without skipscan because distinct is not limited to specific column
+:PREFIX SELECT DISTINCT * FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT *, 'q1_9' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, time, 'q1_10' FROM :TABLE ORDER BY dev;
+:PREFIX SELECT DISTINCT dev, NULL, 'q1_11' FROM :TABLE ORDER BY dev;
+
+-- DISTINCT ON queries
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, 'q2_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) *, 'q2_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, time, 'q2_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, NULL, 'q2_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) time, 'q2_10' FROM :TABLE ORDER by dev, time;
+:PREFIX SELECT DISTINCT ON (dev) dev, tableoid::regclass, 'q2_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_immutable(), 'q2_12' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_stable(), 'q2_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev) dev, int_func_volatile(), 'q2_14' FROM :TABLE;
+
+-- DISTINCT ON queries on TEXT column
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_2' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_3', NULL FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_4', length(md5(now()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, 'q3_5', length(md5(random()::text)) FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) * FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) *, 'q3_7' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, time, 'q3_8' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, NULL, 'q3_9' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) time, 'q3_10' FROM :TABLE ORDER by dev_name, time;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name, tableoid::regclass, 'q3_11' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name::varchar) dev_name::varchar FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
+:PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+
+\qecho LIMIT queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev, time LIMIT 3;
+
+\qecho range queries on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time BETWEEN 100 AND 300;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time < 200;
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE time > 800;
+
+\qecho ordered append on :TABLE
+:PREFIX SELECT * FROM :TABLE ORDER BY time;
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE WHERE time BETWEEN 0 AND 5000;
+
+\qecho SUBSELECTS on :TABLE
+:PREFIX SELECT time, dev, val, 'q4_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+:PREFIX SELECT NULL, dev, NULL, 'q4_3' FROM (SELECT DISTINCT ON (dev) dev FROM :TABLE) a;
+:PREFIX SELECT time, dev, NULL, 'q4_4' FROM (SELECT DISTINCT ON (dev) dev, time FROM :TABLE) a;
+
+\qecho ORDER BY
+:PREFIX SELECT time, dev, val, 'q5_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev, time) a;
+:PREFIX SELECT time, dev, val, 'q5_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE ORDER BY dev DESC, time DESC) a;
+
+\qecho WHERE CLAUSES
+:PREFIX SELECT time, dev, val, 'q6_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_2' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE time > 5) a;
+:PREFIX SELECT time, dev, val, 'q6_3' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE dev > 5;
+:PREFIX SELECT time, dev, val, 'q6_4' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a WHERE time > 5;
+--\qecho immutable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_5' FROM :TABLE WHERE dev > int_func_immutable();
+--\qecho stable func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) *, 'q6_6' FROM :TABLE WHERE dev > int_func_stable();
+--\qecho volatile func in WHERE clause on :TABLE
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > int_func_volatile();
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_immutable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_stable());
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = ANY(inta_func_volatile());
+-- RowCompareExpr
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
+-- always false expr similar to our initial skip qual
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
+-- no tuples matching does not use skipscan due to cost
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
+-- multiple constraints in WHERE clause
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time > 200;
+:PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev >= 5 AND dev < 7 AND dev >= 2;
+:PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
+
+:PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
+:PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+
+-- CTE
+:PREFIX WITH devices AS (
+	SELECT DISTINCT ON (dev) dev FROM :TABLE
+)
+SELECT * FROM devices;
+
+:PREFIX WITH devices AS (
+	SELECT DISTINCT dev FROM :TABLE
+)
+SELECT * FROM devices ORDER BY dev;
+
+-- prepared statements
+PREPARE prep AS SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+:PREFIX EXECUTE prep;
+DEALLOCATE prep;
+
+-- ReScan tests
+:PREFIX SELECT time, dev, val, 'q7_1' FROM (SELECT DISTINCT ON (dev) * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT * FROM :TABLE WHERE time != a.v) b) a;
+
+:PREFIX SELECT time, dev, val, 'q7_2' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev != a.v) b) a;
+
+-- RuntimeKeys
+:PREFIX SELECT time, dev, val, 'q8_1' FROM (SELECT * FROM (
+    VALUES (1), (2)) a(v),
+    LATERAL (SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev >= a.v) b) c;
+
+-- Emulate multi-column DISTINCT using multiple SkipSkans
+:PREFIX SELECT time, dev, val, 'q9_1' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) * FROM :TABLE WHERE dev = a.dev) b) c;
+
+:PREFIX SELECT time, dev, NULL, 'q9_2' FROM (SELECT b.* FROM
+    (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+    LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b) c;
+
+-- Test that the multi-column DISTINCT emulation is equivalent to a real multi-column DISTINCT
+:PREFIX SELECT * FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL;
+
+:PREFIX SELECT DISTINCT ON (dev, time) dev, time FROM :TABLE WHERE dev IS NOT NULL
+UNION SELECT b.* FROM
+   (SELECT DISTINCT ON (dev) dev FROM :TABLE) a,
+   LATERAL (SELECT DISTINCT ON (time) dev, time FROM :TABLE WHERE dev = a.dev) b;
+
+-- SkipScan into INSERT
+:PREFIX INSERT INTO skip_scan_insert(time, dev, val, query) SELECT time, dev, val, 'q10_1' FROM (SELECT DISTINCT ON (dev) * FROM :TABLE) a;
+
+-- parallel query
+SET force_parallel_mode TO true;
+:PREFIX SELECT DISTINCT dev FROM :TABLE ORDER BY dev;
+RESET force_parallel_mode;
+
+TRUNCATE skip_scan_insert;
+
+-- table with only nulls
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls;
+
+-- no tuples in resultset
+:PREFIX SELECT DISTINCT ON (time) time FROM skip_scan_nulls WHERE time IS NOT NULL;
+

--- a/tsl/test/sql/include/skip_scan_query_ht.sql
+++ b/tsl/test/sql/include/skip_scan_query_ht.sql
@@ -1,0 +1,25 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE INDEX ON :TABLE(dev);
+CREATE INDEX ON :TABLE(time);
+
+-- SkipScan with ordered append
+:PREFIX SELECT DISTINCT ON (time) time FROM :TABLE ORDER BY time;
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+
+-- compression doesnt prevent skipscan
+SELECT compress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
+
+--baseline query with skipscan
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+
+-- partial indexes don't prevent skipscan
+DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
+:PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
+

--- a/tsl/test/sql/plan_skip_scan.sql.in
+++ b/tsl/test/sql/plan_skip_scan.sql.in
@@ -1,0 +1,20 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- need superuser to modify statistics
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\ir include/skip_scan_load.sql
+
+-- we want to run with analyze here so we can see counts in the nodes
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set TABLE skip_scan
+\ir include/skip_scan_query.sql
+
+\set TABLE skip_scan_ht
+\ir include/skip_scan_query.sql
+\ir include/skip_scan_query_ht.sql
+
+-- try one query with EXPLAIN only for coverage
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan_ht;


### PR DESCRIPTION
This patch implements a skip-scan; an optimization for `SELECT DISTINCT ON`.
Usually for `SELECT DISTINCT ON` postgres will plan either a `UNIQUE` over a
sorted path, or some form of aggregate. In either case, it needs to scan the
entire table, even in cases where there are only a few unique values.

A skip-scan optimizes this case when we have an ordered index. Instead of
scanning the entire table and deduplicating after, the scan remembers the last
value returned, and searches the index for the next value after that one. This
means that for a table with `k` keys, with `u` distinct values, a skip-scan runs
in time `u * log(k)` as opposed to scanning then deduplicating, which takes time
`k`. We can write the number of unique values `u` as of function of `k` by
dividing by the number of repeats `r` i.e. `u = k/r` this means that a skip-scan
will be faster if each key is repeated more than a logarithmic number of times,
i.e. if `r > log(k)` then `u * log(k) < k/log(k) * log(k) < k`.

Disable-check: commit-count
