### PR TITLE
Break out superuser operations in update tests

### DIFF
--- a/scripts/test_update_smoke.sh
+++ b/scripts/test_update_smoke.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Run smoke tests to test that updating between versions work.
+#
+# This is based on our update tests but doing some tweaks to ensure we
+# can run it on Forge (or any other PostgreSQL server that only permit
+# a single user and single database).
+#
+# In particular, we cannot create new roles and we cannot create new
+# databases.
+#
+# For this version, we focus on single-node update and smoke testing
+# cannot (necessarily) be done with multinode setups. Feel free to try
+# though.
+#
+# The following environment variables can be set: 
+# - UPDATE_FROM_TAG is the version to update from (optional).
+#
+# - UPDATE_TO_TAG is the version to update to (optional).
+#
+# - PGHOST is host to use for the connection (required).
+#
+# - PGPORT is the port to use for the connection (required).
+#
+# - PGDATABASE is the database to use for the connection (required).
+#
+# - PGUSER is the username to use for the connection (required).
+#
+# - PGPASSWORD is the password to use for the connection
+#   (optional). If not set, password from .pgpass will be used (if
+#   available).
+
+while getopts "d" opt;
+do
+    case $opt in
+        d)
+            cleanup=1
+            ;;
+	r)
+	    TEST_REPAIR=true
+	    ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+SCRIPT_DIR=$(dirname $0)
+BASE_DIR=${PWD}/${SCRIPT_DIR}/..
+SCRATCHDIR=`mktemp -d -t 'smoketest-XXXX'`
+DUMPFILE="$SCRATCHDIR/smoke.dump"
+UPGRADE_OUT="$SCRATCHDIR/upgrade.out"
+CLEAN_OUT="$SCRATCHDIR/clean.out"
+RESTORE_OUT="$SCRATCHDIR/restore.out"
+UPDATE_FROM_TAG=${1:-${UPDATE_FROM_TAG:-1.7.4}}
+UPDATE_TO_TAG=${2:-${UPDATE_TO_TAG:-2.0.1}}
+TEST_REPAIR=false
+TEST_VERSION=${TEST_VERSION:-v6}
+
+# We do not have superuser privileges when running tests.
+WITH_SUPERUSER=false
+
+# Extra options to pass to psql
+PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v TEST_REPAIR=${TEST_REPAIR} -v WITH_SUPERUSER=${WITH_SUPERUSER}"
+PSQL="psql -qX $PGOPTS"
+
+cleanup() {
+    rm -rf $SCRATCHDIR
+}
+
+if [[ "x$cleanup" != "x" ]]; then
+    echo "**** Debug mode: $SCRATCHDIR will not be removed"
+    trap cleanup EXIT
+fi
+
+missing_versions() {
+        $PSQL -t <<EOF
+SELECT * FROM (VALUES ('$1'), ('$2')) AS foo
+EXCEPT
+SELECT version FROM pg_available_extension_versions WHERE name = 'timescaledb' AND version IN ('$1', '$2');
+EOF
+}
+
+set -e
+
+echo "**** Scratch directory: ${SCRATCHDIR}"
+echo "**** Update files in directory ${BASE_DIR}/test/sql/updates"
+cd ${BASE_DIR}/test/sql/updates
+
+$PSQL -c '\conninfo'
+
+missing=($(missing_versions $UPDATE_FROM_TAG $UPDATE_TO_TAG))
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "ERROR: Missing version(s) ${missing[@]} of 'timescaledb'"
+    echo "Available versions: " $($PSQL -tc "SELECT version FROM pg_available_extension_versions WHERE name = 'timescaledb'")
+    exit 1
+fi
+
+set -x
+
+# For the comments below, we assume the upgrade is from 1.7.5 to 2.0.2
+# (this is just an example, the real value is given by variables
+# above).
+
+# Create a 1.7.5 version Upgrade
+: ---- Connecting to ${FORGE_CONNINFO} and running setup ----
+$PSQL -c "DROP EXTENSION IF EXISTS timescaledb CASCADE"
+$PSQL -f pre.cleanup.sql
+$PSQL -c "CREATE EXTENSION timescaledb VERSION '${UPDATE_FROM_TAG}'"
+$PSQL -c "\dx"
+
+# Run setup on Upgrade
+$PSQL -f pre.smoke.sql
+$PSQL -f setup.${TEST_VERSION}.sql
+
+# Run update on Upgrade. You now have a 2.0.2 version in Upgrade.
+$PSQL -c "ALTER EXTENSION timescaledb UPDATE TO '${UPDATE_TO_TAG}'"
+
+# Apply post-update actions
+if [[ "x$TEST_REPAIR" = "xtrue" ]]; then
+    $PSQL -f post.repair.sql
+fi
+
+# Dump the contents of Upgrade
+pg_dump -Fc -f $DUMPFILE
+
+# Run the post scripts on Upgrade to get UpgradeOut to compare
+# with.  We can now discard Upgrade database.
+$PSQL -f post.${TEST_VERSION}.sql >$UPGRADE_OUT
+
+: ---- Create a 2.0.2 version Clean ----
+$PSQL -c "DROP EXTENSION IF EXISTS timescaledb CASCADE"
+$PSQL -f pre.cleanup.sql
+$PSQL -c "CREATE EXTENSION timescaledb VERSION '${UPDATE_TO_TAG}'"
+
+: ---- Run the setup scripts on Clean, with post-update actions ----
+$PSQL -f pre.smoke.sql
+$PSQL -f setup.${TEST_VERSION}.sql
+#$PSQL -f post.repair.sql
+
+: ---- Run the post scripts on Clean to get output CleanOut ----
+$PSQL -f post.${TEST_VERSION}.sql >$CLEAN_OUT
+
+: ---- Create a 2.0.2 version Restore ----
+$PSQL -c "DROP EXTENSION IF EXISTS timescaledb CASCADE"
+$PSQL -f pre.cleanup.sql
+$PSQL -c "CREATE EXTENSION timescaledb VERSION '${UPDATE_TO_TAG}'"
+
+: ---- Restore the UpgradeDump into Restore ----
+$PSQL -c "SELECT timescaledb_pre_restore()"
+pg_restore -d $PGDATABASE $DUMPFILE || true
+$PSQL -c "SELECT timescaledb_post_restore()"
+
+: ---- Run the post scripts on Restore to get a RestoreOut ----
+$PSQL -f post.${TEST_VERSION}.sql >$RESTORE_OUT
+
+: ---- Compare UpgradeOut with CleanOut and make sure they are identical ----
+diff -u $UPGRADE_OUT $CLEAN_OUT && echo "No difference between $UPGRADE_OUT and $CLEAN_OUT" | tee $SCRATCHDIR/upgrade-clean.diff
+
+: ---- Compare RestoreOut with CleanOut and make sure they are identical ----
+diff -u $RESTORE_OUT $CLEAN_OUT && echo "No difference between $RESTORE_OUT and $CLEAN_OUT" | tee $SCRATCHDIR/restore-clean.diff
+

--- a/test/sql/updates/post.continuous_aggs.sql
+++ b/test/sql/updates/post.continuous_aggs.sql
@@ -18,11 +18,6 @@ CALL refresh_continuous_aggregate('mat_before',NULL,NULL);
 --the max of the temp for the POR should now be 165
 SELECT * FROM mat_before ORDER BY bucket, location;
 
-SET ROLE cagg_user;
---should be able to query as cagg_user
-SELECT * FROM mat_before ORDER BY bucket, location;
-RESET ROLE;
-
 -- Output the ACLs for each internal cagg object
 SELECT cl.oid::regclass::text AS reloid,
        relacl

--- a/test/sql/updates/pre.cleanup.sql
+++ b/test/sql/updates/pre.cleanup.sql
@@ -1,0 +1,64 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Clean up objects that are created by the setup files. Ideally, we
+-- should clean them up in each post.*.sql file after generating the
+-- output, but now we do it here.
+
+SELECT :'TEST_VERSION' >= '2.0.0' AS has_create_mat_view \gset
+
+SET client_min_messages TO WARNING;
+
+\if :has_create_mat_view
+DROP MATERIALIZED VIEW IF EXISTS mat_inval CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_drop CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_before CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_conflict CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_inttime CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_inttime2 CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS mat_ignoreinval CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS cagg.realtime_mat CASCADE;
+\else
+DROP VIEW IF EXISTS mat_inval CASCADE;
+DROP VIEW IF EXISTS mat_drop CASCADE;
+DROP VIEW IF EXISTS mat_before CASCADE;
+DROP VIEW IF EXISTS mat_conflict CASCADE;
+DROP VIEW IF EXISTS mat_inttime CASCADE;
+DROP VIEW IF EXISTS mat_inttime2 CASCADE;
+DROP VIEW IF EXISTS mat_ignoreinval CASCADE;
+DROP VIEW IF EXISTS cagg.realtime_mat CASCADE;
+\endif
+
+DROP TABLE IF EXISTS public.hyper_timestamp;
+DROP TABLE IF EXISTS public."two_Partitions";
+DROP TABLE IF EXISTS conditions_before;
+DROP TABLE IF EXISTS inval_test;
+DROP TABLE IF EXISTS int_time_test;
+DROP TABLE IF EXISTS conflict_test;
+DROP TABLE IF EXISTS drop_test;
+DROP TABLE IF EXISTS repair_test_timestamptz;
+DROP TABLE IF EXISTS repair_test_int;
+DROP TABLE IF EXISTS repair_test_extra;
+DROP TABLE IF EXISTS repair_test_timestamp;
+DROP TABLE IF EXISTS repair_test_date;
+DROP TABLE IF EXISTS compress;
+DROP TABLE IF EXISTS devices;
+DROP TABLE IF EXISTS disthyper;
+DROP TABLE IF EXISTS policy_test_timestamptz;
+
+DROP TYPE IF EXISTS custom_type;
+DROP TYPE IF EXISTS custom_type_for_compression;
+
+DROP PROCEDURE IF EXISTS _timescaledb_testing.restart_dimension_slice_id;
+DROP PROCEDURE IF EXISTS _timescaledb_testing.stop_workers;
+
+DROP FUNCTION IF EXISTS timescaledb_integrity_test;
+DROP FUNCTION IF EXISTS timescaledb_catalog_has_no_missing_columns;
+DROP FUNCTION IF EXISTS integer_now_test;
+
+DROP SCHEMA IF EXISTS cagg;
+DROP SCHEMA IF EXISTS _timescaledb_testing;
+
+
+RESET client_min_messages;

--- a/test/sql/updates/pre.smoke.sql
+++ b/test/sql/updates/pre.smoke.sql
@@ -1,0 +1,12 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- These functions are used when running smoke tests. For smoke tests
+-- we assume that we do not have SUPER privileges.
+
+CREATE SCHEMA IF NOT EXISTS _timescaledb_testing;
+
+CREATE PROCEDURE _timescaledb_testing.restart_dimension_slice_id() LANGUAGE SQL AS '';
+
+CREATE PROCEDURE _timescaledb_testing.stop_workers() LANGUAGE SQL AS '';

--- a/test/sql/updates/pre.testing.sql
+++ b/test/sql/updates/pre.testing.sql
@@ -1,0 +1,20 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- These functions are used when running normal update tests.
+
+CREATE SCHEMA IF NOT EXISTS _timescaledb_testing;
+
+CREATE OR REPLACE PROCEDURE _timescaledb_testing.restart_dimension_slice_id()
+LANGUAGE SQL
+AS $$
+   ALTER SEQUENCE _timescaledb_catalog.dimension_slice_id_seq RESTART WITH 100;
+$$;
+
+CREATE OR REPLACE PROCEDURE _timescaledb_testing.stop_workers()
+LANGUAGE SQL
+AS $$
+   SELECT _timescaledb_internal.stop_background_workers();
+$$;
+

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -18,7 +18,7 @@ SELECT
 
 -- disable background workers to prevent deadlocks between background processes
 -- on timescaledb 1.7.x
-SELECT _timescaledb_internal.stop_background_workers();
+CALL _timescaledb_testing.stop_workers();
 
 CREATE TYPE custom_type AS (high int, low int);
 
@@ -142,7 +142,9 @@ BEGIN
   END IF;
 END $$;
 
+\if :WITH_SUPERUSER
 GRANT SELECT ON mat_before TO cagg_user WITH GRANT OPTION;
+\endif
 
 \if :has_refresh_mat_view
 REFRESH MATERIALIZED VIEW mat_before;
@@ -252,7 +254,9 @@ BEGIN
   END IF;
 END $$;
 
+\if :WITH_SUPERUSER
 GRANT SELECT ON cagg.realtime_mat TO cagg_user;
+\endif
 
 \if :has_refresh_mat_view
 REFRESH MATERIALIZED VIEW cagg.realtime_mat;
@@ -453,9 +457,11 @@ BEGIN
   END IF;
 END $$;
 
+\if :WITH_SUPERUSER
 GRANT SELECT, TRIGGER, UPDATE
 ON mat_conflict TO cagg_user
 WITH GRANT OPTION;
+\endif
 
 -- Test that calling drop chunks on the hypertable does not break the
 -- update process when chunks are marked as dropped rather than

--- a/test/sql/updates/setup.databases.sql
+++ b/test/sql/updates/setup.databases.sql
@@ -1,0 +1,21 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE DATABASE single;
+-- Always pre-create the data node database 'dn1' so that we can dump
+-- and restore it even on TimescaleDB versions that don't support
+-- multinode. Otherwise, we'd have to create version-dependent scripts
+-- to specifically handle multinode tests. We use template0, or
+-- otherwise dn1 will have the same UUID as 'single' since template1
+-- has the extension pre-installed.
+CREATE DATABASE dn1 TEMPLATE template0;
+\c dn1
+-- Make sure the extension is installed so that extension versions
+-- that don't support multinode will still be able to update the
+-- extension with ALTER EXTENSION ... UPDATE.
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+\c single
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+

--- a/test/sql/updates/setup.repair.sql
+++ b/test/sql/updates/setup.repair.sql
@@ -7,7 +7,7 @@
 -- the dimension slice table. The repair script should then repair all
 -- of them and there should be no dimension slices missing.
 
-SELECT extversion < '2.0.0' AS runs_repair_script
+SELECT extversion < '2.0.0' OR extversion = '2.0.0-rc1' AS runs_repair_script
   FROM pg_extension
  WHERE extname = 'timescaledb' \gset
 

--- a/test/sql/updates/setup.timestamp.sql
+++ b/test/sql/updates/setup.timestamp.sql
@@ -13,4 +13,4 @@ SELECT * FROM create_hypertable('hyper_timestamp'::regclass, 'time'::name, 'devi
     chunk_time_interval=> _timescaledb_internal.interval_to_usec('1 minute'));
 
 --some old versions use more slice_ids than newer ones. Make this uniform
-ALTER SEQUENCE _timescaledb_catalog.dimension_slice_id_seq RESTART WITH 100;
+CALL _timescaledb_testing.restart_dimension_slice_id();

--- a/test/sql/updates/setup.v2.sql
+++ b/test/sql/updates/setup.v2.sql
@@ -2,23 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-CREATE DATABASE single;
--- Always pre-create the data node database 'dn1' so that we can dump
--- and restore it even on TimescaleDB versions that don't support
--- multinode. Otherwise, we'd have to create version-dependent scripts
--- to specifically handle multinode tests. We use template0, or
--- otherwise dn1 will have the same UUID as 'single' since template1
--- has the extension pre-installed.
-CREATE DATABASE dn1 TEMPLATE template0;
-\c dn1
--- Make sure the extension is installed so that extension versions
--- that don't support multinode will still be able to update the
--- extension with ALTER EXTENSION ... UPDATE.
-CREATE EXTENSION IF NOT EXISTS timescaledb;
-
-\c single
-CREATE EXTENSION IF NOT EXISTS timescaledb;
-
 \ir setup.bigint.sql
 \ir setup.constraints.sql
 \ir setup.insert_bigint.v2.sql


### PR DESCRIPTION
In order to support smoke-testing with a single server, the update
tests are refactored to not require a `postgres` user with full
privileges. The following changes where made:

- Database creation code was factored out of tests and is only executed
  for update tests.
- Since the default for `docker_pgscript` was to use the `postgres`
  database and the database creation code also switched database to
  `single` as part of the execution, the default of `docker_pgscript` is
  now changed to `single`.
- Parts of tests that changes roles during execution was removed since
  it is more suitable for a regression test and does not work unless you have superuser privileges.
- Operations that require escalated privileges are factored out into
  support functions that execute the original code for update tests and
  are no-ops for smoke tests.
- A dedicated `test_smoke` script was added that can run a smoke test
  against a single server.