### PR TITLE
Check CMake build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif ()
 
+set(SUPPORTED_BUILD_TYPES Debug Release RelWithDebugInfo MinSizeRel)
+if (NOT CMAKE_BUILD_TYPE IN_LIST SUPPORTED_BUILD_TYPES)
+  message(FATAL_ERROR "Bad CMAKE_BUILD_TYPE. Expected one of ${SUPPORTED_BUILD_TYPES}")
+endif()
+
 message(STATUS "TimescaleDB version ${PROJECT_VERSION_MOD}. Can be updated from version ${UPDATE_FROM_VERSION}")
 message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
 


### PR DESCRIPTION
If an unsupported CMake build type is used, it is accepted but generate
strange builds for the compiler. This commit adds a check that only one
of the standard build types are used.