### PR TITLE
Factor out repair test from update test

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -9,12 +9,11 @@ on:
   pull_request:
 jobs:
   update_test:
-    name: Update test PG${{ matrix.pg }} ${{ matrix.kind }}
+    name: Update test PG${{ matrix.pg }}
     runs-on: 'ubuntu-18.04'
     strategy:
       matrix:
         pg: ["11.11","12.6","13.2"]
-        opt: ["", "-r"]
         include:
           - pg: 11.11
             pg_major: 11
@@ -22,8 +21,6 @@ jobs:
             pg_major: 12
           - pg: 13.2
             pg_major: 13
-          - opt: "-r"
-            kind: "with repair test"
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}
@@ -32,9 +29,9 @@ jobs:
     - name: Checkout TimescaleDB
       uses: actions/checkout@v2
 
-    - name: Update tests ${{ matrix.pg }} ${{ matrix.kind }}
+    - name: Update tests ${{ matrix.pg }}
       run: |
-        ./scripts/test_updates_pg${{ matrix.pg_major}}.sh ${{ matrix.opt }}
+        ./scripts/test_updates_pg${{ matrix.pg_major }}.sh
 
     - name: Update diff
       if: failure()

--- a/scripts/test_functions.inc
+++ b/scripts/test_functions.inc
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname $0)
+
+# Run tests given as arguments.
+#
+# Options:
+#   -r    Run repair tests as a separate pass (optional)
+#   -vN   Use version N of the update tests (required)
+run_tests() (
+    export TEST_VERSION
+    export TEST_REPAIR=false
+
+    OPTIND=1
+    while getopts "v:r" opt;
+    do
+        case $opt in
+             v)
+                 TEST_VERSION=v$OPTARG
+                 ;;
+             r)
+                 TEST_REPAIR=true
+                 ;;
+        esac
+    done
+
+    shift $((OPTIND-1))
+
+    export TAGS="$@"
+    bash ${SCRIPT_DIR}/test_updates.sh
+    if [[ "$TEST_REPAIR" = "true" ]]; then
+        bash ${SCRIPT_DIR}/test_repairs.sh
+    fi
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
+        exit $EXIT_CODE
+    fi
+)
+

--- a/scripts/test_repair_from_tag.sh
+++ b/scripts/test_repair_from_tag.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+SCRIPT_DIR=$(dirname $0)
+BASE_DIR=${PWD}/${SCRIPT_DIR}/..
+
+GIT_ID=$(git -C ${BASE_DIR} describe --dirty --always | sed -e "s|/|_|g")
+WITH_SUPERUSER=true # Update tests have superuser privileges when running tests.
+UPDATE_FROM_IMAGE=${UPDATE_FROM_IMAGE:-timescale/timescaledb}
+UPDATE_FROM_TAG=${UPDATE_FROM_TAG:-0.1.0}
+UPDATE_TO_IMAGE=${UPDATE_TO_IMAGE:-update_test}
+UPDATE_TO_TAG=${UPDATE_TO_TAG:-${GIT_ID}}
+
+# Extra options to pass to psql
+PGOPTS="-v WITH_SUPERUSER=${WITH_SUPERUSER}"
+PSQL="psql -qX $PGOPTS"
+
+DOCKEROPTS="--env TIMESCALEDB_TELEMETRY=off --env POSTGRES_HOST_AUTH_METHOD=trust"
+
+docker_exec() {
+    # Echo to stderr
+    >&2 echo -e "\033[1m$1\033[0m: $2"
+    docker exec $1 /bin/bash -c "$2"
+}
+
+docker_logs() {
+    # Echo to stderr
+    >&2 echo -e "\033[1m$1\033[0m: $2"
+    docker logs $1
+}
+
+docker_pgcmd() {
+    local database=single
+    OPTIND=1
+    while getopts "d:" opt; do
+        case $opt in
+             d)
+                 database=$OPTARG
+                 ;;
+        esac
+    done
+    shift $((OPTIND-1))
+
+    echo "executing pgcmd on database $database with container $1"
+    set +e
+    docker_exec $1 "$PSQL -h localhost -U postgres -d $database -v VERBOSITY=verbose -c \"$2\""
+    if [ $? -ne 0 ]; then
+      docker_logs $1
+      exit 1
+    fi
+    set -e
+}
+
+docker_pgscript() {
+    local database=single
+    OPTIND=1
+    while getopts "d:" opt; do
+        case $opt in
+             d)
+                 database=$OPTARG
+                 ;;
+        esac
+    done
+    shift $((OPTIND-1))
+
+    docker_exec $1 "$PSQL -h localhost -U postgres -d $database -v ON_ERROR_STOP=1 -f $2"
+}
+
+docker_run() {
+    docker run $DOCKEROPTS -d --name $1 -v ${BASE_DIR}:/src $2 -c timezone='US/Eastern' -c max_prepared_transactions=100
+    wait_for_pg $1
+}
+
+docker_run_vol() {
+    docker run $DOCKEROPTS -d --name $1 -v ${BASE_DIR}:/src -v $2 $3 -c timezone='US/Eastern' -c max_prepared_transactions=100
+    wait_for_pg $1
+}
+
+wait_for_pg() {
+    set +e
+    for i in {1..20}; do
+        sleep 1
+
+        docker_exec $1 "pg_isready -U postgres"
+
+        if [[ $? == 0 ]] ; then
+            # this makes the test less flaky, although not
+            # ideal. Apperently, pg_isready is not always a good
+            # indication of whether the DB is actually ready to accept
+            # queries
+            sleep 5
+            set -e
+            return 0
+        fi
+        docker_logs $1
+
+    done
+    exit 1
+}
+
+CONTAINER_ORIG=timescaledb-orig-$$
+CONTAINER_UPDATED=timescaledb-updated-$$
+
+echo "**** Checking repair for update from $UPDATE_FROM_TAG ****"
+
+# Start a container with the correct version
+docker_run ${CONTAINER_ORIG} ${UPDATE_FROM_IMAGE}:${UPDATE_FROM_TAG}
+
+UPDATE_VOLUME=$(docker inspect ${CONTAINER_ORIG} --format='{{range .Mounts }}{{.Name}}{{end}}')
+
+docker_pgcmd -d postgres ${CONTAINER_ORIG} "CREATE DATABASE single"
+docker_pgscript ${CONTAINER_ORIG} /src/test/sql/updates/setup.repair.sql
+
+# Remove container but keep volume
+docker rm -f ${CONTAINER_ORIG}
+
+docker_run_vol ${CONTAINER_UPDATED} ${UPDATE_VOLUME}:/var/lib/postgresql/data ${UPDATE_TO_IMAGE}:${UPDATE_TO_TAG}
+docker_pgcmd ${CONTAINER_UPDATED} "ALTER EXTENSION timescaledb UPDATE"
+docker_pgscript ${CONTAINER_UPDATED} /src/test/sql/updates/post.repair.sql
+
+# Run an integrity check. It will report if any dimension slices are missing.
+docker_pgscript ${CONTAINER_UPDATED} /src/test/sql/updates/post.integrity_test.sql

--- a/scripts/test_repairs.sh
+++ b/scripts/test_repairs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -o pipefail
+
+SCRIPT_DIR=$(dirname $0)
+GIT_ID=$(git -C ${BASE_DIR} describe --dirty --always | sed -e "s|/|_|g")
+TEST_TMPDIR=${TEST_TMPDIR:-$(mktemp -d 2>/dev/null || mktemp -d -t 'timescaledb_repair_test' || mkdir -p /tmp/${RANDOM})}
+UPDATE_TO_IMAGE=${UPDATE_TO_IMAGE:-repair_test}
+UPDATE_TO_TAG=${UPDATE_TO_TAG:-${GIT_ID}}
+
+# Build the docker image with current source here so that the parallel
+# tests don't all compete in trying to build it first
+IMAGE_NAME=${UPDATE_TO_IMAGE} TAG_NAME=${UPDATE_TO_TAG} PG_VERSION=${PG_VERSION} bash ${SCRIPT_DIR}/docker-build.sh
+
+# Run repair tests in parallel
+declare -A tests
+for tag in ${TAGS}; do
+    UPDATE_FROM_TAG=${tag} TEST_VERSION=${TEST_VERSION} bash $SCRIPT_DIR/test_repair_from_tag.sh ${TEST_UPDATE_FROM_TAGS_EXTRA_ARGS} > ${TEST_TMPDIR}/${tag}.log 2>&1 &
+
+    tests[$!]=${tag}
+    echo "Launched test ${tag} with pid $!"
+done
+
+# Need to wait on each pid in a loop to return the exit status of each
+for pid in ${!tests[@]}; do
+    echo "Waiting for test pid $pid"
+    wait $pid
+    exit_code=$?
+    echo "Test ${tests[$pid]} (pid $pid) exited with code $exit_code"
+
+    if [ $exit_code -ne 0 ]; then
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAILED_TEST=${tests[$pid]}
+        if [ -f ${TEST_TMPDIR}/${FAILED_TEST}.log ]; then
+            echo "###### Failed test log below #####"
+            cat ${TEST_TMPDIR}/${FAILED_TEST}.log
+        fi
+    fi
+done
+
+if [ "$KEEP_TEMP_DIRS" = "false" ]; then
+    echo "Cleaning up temporary directory"
+    rm -rf ${TEST_TMPDIR}
+fi
+
+exit $FAIL_COUNT
+

--- a/scripts/test_update_from_tag.sh
+++ b/scripts/test_update_from_tag.sh
@@ -206,13 +206,6 @@ docker_pgcmd ${CONTAINER_UPDATED} "ALTER EXTENSION timescaledb UPDATE" "dn1"
 # which is available in the image.
 docker_pgcmd ${CONTAINER_UPDATED} "ALTER EXTENSION timescaledb UPDATE" "postgres"
 
-if [[ "${TEST_VERSION}" > "v6" ]] || [[ "${TEST_VERSION}" = "v6" ]]; then
-    if [[ "${TEST_REPAIR}" = "true" ]]; then
-	echo "Executing post update repair script"
-	docker_pgscript ${CONTAINER_UPDATED} /src/test/sql/updates/post.repair.sql "single"
-    fi
-fi
-
 # Check that there is nothing wrong before taking a backup
 echo "Checking that there are no missing dimension slices"
 docker_pgscript ${CONTAINER_UPDATED} /src/test/sql/updates/setup.check.sql
@@ -221,15 +214,6 @@ echo "Executing setup script on clean"
 docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/setup.databases.sql "postgres"
 docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/pre.testing.sql
 docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/setup.${TEST_VERSION}.sql
-if [[ "${TEST_VERSION}" > "v6" ]] || [[ "${TEST_VERSION}" = "v6" ]]; then
-    if [[ "${TEST_REPAIR}" = "true" ]]; then
-	# We need to run the post repair script to make sure that the
-	# constraint is on the clean rerun as well since the setup
-	# script can remove it.
-	echo "Executing post update repair script on clean"
-	docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/post.repair.sql "single"
-    fi
-fi
 
 docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc single > /tmp/single.dump"
 docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc dn1 > /tmp/dn1.dump"

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -25,7 +25,7 @@ FAIL_COUNT=0
 # Declare a hash table to keep test names keyed by pid
 declare -A tests
 
-while getopts "cdr" opt;
+while getopts "cd" opt;
 do
     case $opt in
         c)
@@ -37,10 +37,6 @@ do
             KEEP_TEMP_DIRS=true
             TEST_UPDATE_FROM_TAGS_EXTRA_ARGS="-d"
             ;;
-	r)
-	    echo "Breaking dimension slices to test repair part"
-	    TEST_REPAIR=true
-	    ;;
     esac
 done
 

--- a/scripts/test_updates_pg11.sh
+++ b/scripts/test_updates_pg11.sh
@@ -1,51 +1,25 @@
 #!/usr/bin/env bash
 
 set -e
-set -o pipefail
 
 SCRIPT_DIR=$(dirname $0)
 
-TAGS="1.1.0-pg11 1.1.1-pg11 1.2.0-pg11 1.2.1-pg11 1.2.2-pg11"
-TEST_VERSION="v2"
+source ${SCRIPT_DIR}/test_functions.inc
 
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
-
-TAGS="1.3.0-pg11 1.3.1-pg11 1.3.2-pg11 1.4.0-pg11 1.4.1-pg11 1.4.2-pg11"
-TEST_VERSION="v4"
-
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
-
-TAGS="1.5.0-pg11 1.5.1-pg11 1.6.0-pg11 1.6.1-pg11"
-TEST_VERSION="v5"
-
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
-
-TAGS="1.7.0-pg11 1.7.1-pg11 1.7.2-pg11 1.7.3-pg11 1.7.4-pg11 1.7.5-pg11"
-TEST_VERSION="v6"
-
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
-
-TAGS="2.0.0-rc1-pg11 2.0.0-rc2-pg11 2.0.0-rc3-pg11 2.0.0-rc4-pg11 2.0.0-pg11 2.0.1-pg11 2.0.2-pg11 2.1.0-pg11"
-TEST_VERSION="v7"
-
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
+# There are repair steps between:
+#    1.7.1 and 1.7.2
+#    2.0.0-rc1 and 2.0.0-rc2
+#
+# Please extend this list if repairs are needed between more steps.
+run_tests -r -v2 \
+          1.1.0-pg11 1.1.1-pg11 1.2.0-pg11 1.2.1-pg11 1.2.2-pg11
+run_tests -r -v4 \
+          1.3.0-pg11 1.3.1-pg11 1.3.2-pg11 1.4.0-pg11 1.4.1-pg11 1.4.2-pg11
+run_tests -r -v5 \
+          1.5.0-pg11 1.5.1-pg11 1.6.0-pg11 1.6.1-pg11
+run_tests -r -v6 \
+          1.7.0-pg11 1.7.1-pg11 1.7.2-pg11 1.7.3-pg11 1.7.4-pg11 1.7.5-pg11
+run_tests -r -v7 \
+          2.0.0-rc1-pg11 
+run_tests -v7 \
+          2.0.0-rc2-pg11 2.0.0-rc3-pg11 2.0.0-rc4-pg11 2.0.0-pg11 2.0.1-pg11 2.0.2-pg11 2.1.0-pg11

--- a/scripts/test_updates_pg12.sh
+++ b/scripts/test_updates_pg12.sh
@@ -1,25 +1,19 @@
 #!/usr/bin/env bash
 
 set -e
-set -o pipefail
 
 SCRIPT_DIR=$(dirname $0)
-echo $SCRIPT_DIR
 
-TAGS="1.7.0-pg12 1.7.1-pg12 1.7.2-pg12 1.7.3-pg12 1.7.4-pg12 1.7.5-pg12"
-TEST_VERSION="v6"
+source ${SCRIPT_DIR}/test_functions.inc
 
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
-
-TAGS="2.0.0-rc1-pg12 2.0.0-rc2-pg12 2.0.0-rc3-pg12 2.0.0-rc4-pg12 2.0.0-pg12 2.0.1-pg12 2.0.2-pg12 2.1.0-pg12"
-TEST_VERSION="v7"
-
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
+# There are repair steps between:
+#    1.7.1 and 1.7.2
+#    2.0.0-rc1 and 2.0.0-rc2
+#
+# Please extend this list if repairs are needed between more steps.
+run_tests -r -v6 \
+          1.7.0-pg12 1.7.1-pg12 1.7.2-pg12 1.7.3-pg12 1.7.4-pg12 1.7.5-pg12
+run_tests -r -v7 \
+          2.0.0-rc1-pg12 
+run_tests -v7 \
+          2.0.0-rc2-pg12 2.0.0-rc3-pg12 2.0.0-rc4-pg12 2.0.0-pg12 2.0.1-pg12 2.0.2-pg12 2.1.0-pg12

--- a/scripts/test_updates_pg13.sh
+++ b/scripts/test_updates_pg13.sh
@@ -1,16 +1,10 @@
 #!/usr/bin/env bash
 
 set -e
-set -o pipefail
 
 SCRIPT_DIR=$(dirname $0)
-echo $SCRIPT_DIR
 
-TAGS="2.1.0-pg13"
-TEST_VERSION="v7"
+source ${SCRIPT_DIR}/test_functions.inc
 
-TAGS=$TAGS TEST_VERSION=$TEST_VERSION bash ${SCRIPT_DIR}/test_updates.sh "$@"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    exit $EXIT_CODE
-fi
+run_tests -v7 \
+          2.1.0-pg13

--- a/test/sql/updates/post.integrity_test.sql
+++ b/test/sql/updates/post.integrity_test.sql
@@ -2,8 +2,6 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-SELECT * FROM public."two_Partitions";
-
 \d+ _timescaledb_internal.*
 
 CREATE OR REPLACE FUNCTION timescaledb_integrity_test()

--- a/test/sql/updates/setup.repair.sql
+++ b/test/sql/updates/setup.repair.sql
@@ -7,10 +7,6 @@
 -- the dimension slice table. The repair script should then repair all
 -- of them and there should be no dimension slices missing.
 
-SELECT extversion < '2.0.0' OR extversion = '2.0.0-rc1' AS runs_repair_script
-  FROM pg_extension
- WHERE extname = 'timescaledb' \gset
-
 CREATE TABLE repair_test_int(time integer not null, temp float8, tag integer, color integer);
 CREATE TABLE repair_test_timestamptz(time timestamptz not null, temp float8, tag integer, color integer);
 CREATE TABLE repair_test_extra(time timestamptz not null, temp float8, tag integer, color integer);
@@ -84,7 +80,6 @@ CREATE VIEW slices AS (
            ON di.hypertable_id = ch.hypertable_id AND attname = di.column_name
    );
 
-\if :runs_repair_script
 -- Break the first time dimension on each table. These are different
 -- depending on the time type for the table and we need to check all
 -- versions.
@@ -180,6 +175,5 @@ SELECT DISTINCT
        END AS range_end
   FROM unparsed_slices
   WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
-\endif
 
 DROP VIEW slices;

--- a/test/sql/updates/setup.v6.sql
+++ b/test/sql/updates/setup.v6.sql
@@ -6,6 +6,3 @@
 \ir setup.continuous_aggs.v2.sql
 \ir setup.compression.sql
 \ir setup.policies.sql
-\if :TEST_REPAIR
-\ir setup.repair.sql
-\endif


### PR DESCRIPTION
In order to implement repair tests, changes are made to the
`constraint_check` table to simulate a broken dependency, which
requires the constraints on that table to be dropped. This means that
the repair runs without constraints, and a bug in the update test could
potentially not get caught.

This commit fixes this by factoring out the repair tests from the
update tests and run them as a separate pass. This means that the
contraints are not dropped in the update tests and bugs there will be
caught.