### PR TITLE
Fix flaky remote_txn.sql test

### DIFF
--- a/src/debug_wait.h
+++ b/src/debug_wait.h
@@ -33,7 +33,7 @@ typedef struct DebugWait
 } DebugWait;
 
 extern TSDLLEXPORT void ts_debug_waitpoint_init(DebugWait *waitpoint, const char *tagname);
-extern TSDLLEXPORT void ts_debug_waitpoint_wait(DebugWait *waitpoint);
+extern TSDLLEXPORT void ts_debug_waitpoint_wait(DebugWait *waitpoint, bool blocking);
 
 #ifdef TS_DEBUG
 #define DEBUG_WAITPOINT(TAG)                                                                       \
@@ -41,10 +41,21 @@ extern TSDLLEXPORT void ts_debug_waitpoint_wait(DebugWait *waitpoint);
 	{                                                                                              \
 		DebugWait waitpoint;                                                                       \
 		ts_debug_waitpoint_init(&waitpoint, (TAG));                                                \
-		ts_debug_waitpoint_wait(&waitpoint);                                                       \
+		ts_debug_waitpoint_wait(&waitpoint, true);                                                 \
+	} while (0)
+#define DEBUG_RETRY_WAITPOINT(TAG)                                                                 \
+	do                                                                                             \
+	{                                                                                              \
+		DebugWait waitpoint;                                                                       \
+		ts_debug_waitpoint_init(&waitpoint, (TAG));                                                \
+		ts_debug_waitpoint_wait(&waitpoint, false);                                                \
 	} while (0)
 #else
 #define DEBUG_WAITPOINT(TAG)                                                                       \
+	do                                                                                             \
+	{                                                                                              \
+	} while (0)
+#define DEBUG_RETRY_WAITPOINT(TAG)                                                                 \
 	do                                                                                             \
 	{                                                                                              \
 	} while (0)

--- a/tsl/test/expected/remote_txn.out
+++ b/tsl/test/expected/remote_txn.out
@@ -24,6 +24,26 @@ CREATE OR REPLACE FUNCTION test_remote_txn_persistent_record(srv_name name)
 RETURNS VOID
 AS :TSL_MODULE_PATHNAME, 'ts_test_remote_txn_persistent_record'
 LANGUAGE C;
+-- To ensure predictability, we want to kill the remote backend when it's in
+-- the midst of processing the transaction. To ensure that the access node
+-- sets the event handler and then takes an exclusive session lock on the
+-- "remote_conn_xact_end" advisory lock via "debug_waitpoint_enable" function
+--
+-- The "RegisterXactCallback" callback on the remote backend tries to take
+-- this same advisory lock in shared mode and waits. This allows the event
+-- handler enough time to kill this remote backend at the right time
+--
+-- Don't forget to release lock via debug_waitpoint_release on the access node
+-- since it's a session level advisory lock
+--
+CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT)
+RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_debug_waitpoint_enable'
+LANGUAGE C VOLATILE STRICT;
+CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT)
+RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_debug_waitpoint_release'
+LANGUAGE C VOLATILE STRICT;
 CREATE OR REPLACE FUNCTION add_loopback_server(
     server_name            NAME,
     host                   TEXT = 'localhost',
@@ -177,6 +197,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20003,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20003,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -188,6 +214,12 @@ COMMIT;
 WARNING:  kill event: pre-commit
 WARNING:  transaction rollback on data node "loopback" failed
 ERROR:  [loopback]: terminating connection due to administrator command
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 -- Failed connection should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -214,6 +246,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -233,6 +271,12 @@ COMMIT;
 WARNING:  kill event: waiting-commit
 WARNING:  transaction rollback on data node "loopback" failed
 ERROR:  [loopback]: terminating connection due to administrator command
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 --connection failed during commit, so should be cleared from the cache
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -258,6 +302,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -280,6 +330,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (20005,1,'bleh', '2001-01-0
 -- case.
 \echo 'ROLLBACK SQLSTATE' :SQLSTATE
 ROLLBACK SQLSTATE 00000
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 SELECT count(*) FROM "S 1"."T 1" WHERE "C 1" = 20005;
  count 
 -------
@@ -422,6 +478,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10002,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10002,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -434,6 +496,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10002,1,'bleh', '2001-01-0
 -- SQLSTATE should be 08006 connection_failure
 \echo 'COMMIT SQLSTATE' :SQLSTATE
 COMMIT SQLSTATE 08006
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 --the connection was killed, so should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -460,6 +528,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10003,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10003,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -472,6 +546,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10003,1,'bleh', '2001-01-0
 -- SQLSTATE should be 08006 connection_failure
 \echo 'COMMIT SQLSTATE' :SQLSTATE
 COMMIT SQLSTATE 08006
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 --the connection should be cleared from the cache
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -514,6 +594,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10004,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -526,6 +612,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10004,1,'bleh', '2001-01-0
 -- SQLSTATE should be 00000 successful_completion
 \echo 'COMMIT SQLSTATE' :SQLSTATE
 COMMIT SQLSTATE 00000
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 --connection should be cleared
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
@@ -596,6 +688,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10006,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -608,6 +706,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10006,1,'bleh', '2001-01-0
 -- SQLSTATE should be 00000 successful_completion
 \echo 'COMMIT SQLSTATE' :SQLSTATE
 COMMIT SQLSTATE 00000
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 SELECT node_name, connection_status, transaction_status, transaction_depth, processing
 FROM _timescaledb_internal.show_connection_cache() ORDER BY 1,4;
  node_name | connection_status | transaction_status | transaction_depth | processing 
@@ -665,6 +769,12 @@ BEGIN;
  
 (1 row)
 
+    SELECT debug_waitpoint_enable('remote_conn_xact_end');
+ debug_waitpoint_enable 
+------------------------
+ 
+(1 row)
+
     SELECT test.remote_exec('{loopback}', $$ INSERT INTO "S 1"."T 1" VALUES (10005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') $$);
 NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10005,1,'bleh', '2001-01-01', '2001-01-01', 'bleh') 
  remote_exec 
@@ -677,6 +787,12 @@ NOTICE:  [loopback]:  INSERT INTO "S 1"."T 1" VALUES (10005,1,'bleh', '2001-01-0
 -- SQLSTATE should be 00000 successful_completion
 \echo 'COMMIT SQLSTATE' :SQLSTATE
 COMMIT SQLSTATE 00000
+SELECT debug_waitpoint_release('remote_conn_xact_end');
+ debug_waitpoint_release 
+-------------------------
+ 
+(1 row)
+
 --at this point the commit prepared might or might not have been executed before
 --the data node process was killed.
 --but in any case, healing the server will bring it into a known state


### PR DESCRIPTION
The remote_txn.sql test used to be consistently flaky in CI runs.

The RegisterXactCallback function in the test does the following on the
access node:

1) Send an async command to the remote node
2) Invoke the eventcallback, for example:
eventcallback(DTXN_EVENT_WAIT_COMMIT) which kills the remote node
backend
3) Wait for async responses for (1) from remote node and expect it to
fail due to the killing of the remote backend in (2) above.

The above works most of the times but it's possible that (1) completes
successfully and returns successful async response via (3) before the
remote backend gets killed via (2).

To make things more predictable, we now use the DEBUG_WAITPOINT
infrastructure.

To ensure predictability, we want to kill the remote backend when it's
in the midst of processing the transaction. To ensure that the access
node sets the event handler and then takes an exclusive lock on the
"remote_conn_xact_end" advisory lock via "debug_waitpoint_enable"
function

The "RegisterXactCallback" callback on the remote backend tries to take
this same advisory lock in shared mode and waits. This allows the event
handler enough time to kill this remote backend at the right time.

The DEBUG_WAITPOINT infrastructure was modified to provide a "blocking"
and "retry loop" based implementation to take the advisory lock. This
is needed in cases where this function gets called from deep down
inside a transaction where interrupts are not being served currently.
    
The "retry loop" part also returns with a WARNING if the "retry_count"
is exhausted. We could provide an implementation later which decides to
retry indefinitely but the present implementation is good enough for
the current requirements.