### PR TITLE
Add declaration before code to guidelines

### DIFF
--- a/docs/StyleGuide.md
+++ b/docs/StyleGuide.md
@@ -37,6 +37,21 @@ elaborates on the situation. Instead, we've tried our best to develop
 a consistent style that roughly follows the style of the PostgreSQL
 source code.
 
+### Declarations before code
+
+C99 supports having code before a declaration, similar to C++, and we
+also support this in the code. For instance, the following code
+follows the guidelines:
+
+```C
+void some_function()
+{
+    prepare();
+	int result = fetch();
+	...
+}
+```
+
 ### Function and variable names
 
 For clarity and consistency, we've chosen to go with lowercase


### PR DESCRIPTION
Declarations before code has been informally supported and we have
several examples in the code. This commit adds that guideline to the
coding guidelines.