### PR TITLE
Fix typo in DecompressChunk comment

### DIFF
--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -52,10 +52,10 @@ _decompress_chunk_init(void)
 	/*
 	 * Because we reinitialize the tsl stuff when the license
 	 * changes the init function may be called multiple times
-	 * per session so we check if ChunkDecompress node has been
+	 * per session so we check if DecompressChunk node has been
 	 * registered already here to prevent registering it twice.
 	 */
-	if (GetCustomScanMethods("DecompressChunk", true) == NULL)
+	if (GetCustomScanMethods(decompress_chunk_plan_methods.CustomName, true) == NULL)
 	{
 		RegisterCustomScanMethods(&decompress_chunk_plan_methods);
 	}


### PR DESCRIPTION
This patch fixes a typo in DecompressChunk comment and also changes
the initialization function to use the node name from the
CustomScanMethods struct instead of hardcoding it.