### PR TITLE
Commit end transaction for CREATE INDEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #2974 Fix index creation for hypertables with dropped columns
+* #3042 Commit end transaction for CREATE INDEX
 
 **Thanks**
 * @jocrau for reporting an issue with index creation

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2391,6 +2391,9 @@ process_index_start(ProcessUtilityArgs *args)
 		CacheInvalidateRelcacheByRelid(info.obj.objectId);
 	}
 
+	CommitTransactionCommand();
+	StartTransactionCommand();
+
 	UnlockRelationIdForSession(&main_table_index_lock_relid, AccessShareLock);
 
 	DEBUG_WAITPOINT("indexing_done");

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2396,7 +2396,7 @@ process_index_start(ProcessUtilityArgs *args)
 
 	UnlockRelationIdForSession(&main_table_index_lock_relid, AccessShareLock);
 
-	DEBUG_WAITPOINT("indexing_done");
+	DEBUG_WAITPOINT("process_index_start_indexing_done");
 
 	return DDL_DONE;
 }

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -66,6 +66,7 @@
 #include "continuous_agg.h"
 #include "compression_with_clause.h"
 #include "partitioning.h"
+#include "debug_wait.h"
 
 #include "cross_module_fn.h"
 
@@ -2391,6 +2392,8 @@ process_index_start(ProcessUtilityArgs *args)
 	}
 
 	UnlockRelationIdForSession(&main_table_index_lock_relid, AccessShareLock);
+
+	DEBUG_WAITPOINT("indexing_done");
 
 	return DDL_DONE;
 }

--- a/test/isolation/expected/multi_transaction_indexing.out
+++ b/test/isolation/expected/multi_transaction_indexing.out
@@ -43,7 +43,7 @@ step Ic: COMMIT;
 
 starting permutation: F WPE CI DI Bc WPR P Ic Sc
 step F: SET client_min_messages TO 'error';
-step WPE: SELECT debug_waitpoint_enable('indexing_done');
+step WPE: SELECT debug_waitpoint_enable('process_index_start_indexing_done');
 debug_waitpoint_enable
 
                
@@ -51,7 +51,7 @@ step CI: CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.tr
 step DI: DROP INDEX test_index; <waiting ...>
 step Bc: ROLLBACK;
 step DI: <... completed>
-step WPR: SELECT debug_waitpoint_release('indexing_done');
+step WPR: SELECT debug_waitpoint_release('process_index_start_indexing_done');
 debug_waitpoint_release
 
                

--- a/test/isolation/expected/multi_transaction_indexing.out
+++ b/test/isolation/expected/multi_transaction_indexing.out
@@ -1,4 +1,4 @@
-Parsed test spec with 6 sessions
+Parsed test spec with 8 sessions
 
 starting permutation: CI I1 Ic Bc P Sc
 step CI: CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.transaction_per_chunk, timescaledb.barrier_table='barrier'); <waiting ...>
@@ -40,6 +40,29 @@ hypertable_index_size
 
 49152          
 step Ic: COMMIT;
+
+starting permutation: F WPE CI DI Bc WPR P Ic Sc
+step F: SET client_min_messages TO 'error';
+step WPE: SELECT debug_waitpoint_enable('indexing_done');
+debug_waitpoint_enable
+
+               
+step CI: CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.transaction_per_chunk, timescaledb.barrier_table='barrier'); <waiting ...>
+step DI: DROP INDEX test_index; <waiting ...>
+step Bc: ROLLBACK;
+step WPR: SELECT debug_waitpoint_release('indexing_done');
+debug_waitpoint_release
+
+               
+step CI: <... completed>
+step DI: <... completed>
+error in steps WPR CI DI: ERROR:  tuple concurrently updated
+step P: SELECT * FROM hypertable_index_size('test_index');
+hypertable_index_size
+
+49152          
+step Ic: COMMIT;
+step Sc: COMMIT;
 
 starting permutation: CI RI Bc P Ic Sc
 step CI: CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.transaction_per_chunk, timescaledb.barrier_table='barrier'); <waiting ...>

--- a/test/isolation/expected/multi_transaction_indexing.out
+++ b/test/isolation/expected/multi_transaction_indexing.out
@@ -50,17 +50,14 @@ debug_waitpoint_enable
 step CI: CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.transaction_per_chunk, timescaledb.barrier_table='barrier'); <waiting ...>
 step DI: DROP INDEX test_index; <waiting ...>
 step Bc: ROLLBACK;
+step DI: <... completed>
 step WPR: SELECT debug_waitpoint_release('indexing_done');
 debug_waitpoint_release
 
                
 step CI: <... completed>
-step DI: <... completed>
-error in steps WPR CI DI: ERROR:  tuple concurrently updated
 step P: SELECT * FROM hypertable_index_size('test_index');
-hypertable_index_size
-
-49152          
+ERROR:  relation "test_index" does not exist
 step Ic: COMMIT;
 step Sc: COMMIT;
 

--- a/test/isolation/specs/CMakeLists.txt
+++ b/test/isolation/specs/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_TEMPLATES
 
 set(TEST_TEMPLATES_DEBUG
   dropchunks_race.spec.in
+  multi_transaction_indexing.spec.in
 )
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
@@ -28,11 +29,6 @@ foreach(TEMPLATE_FILE ${TEST_TEMPLATES})
   configure_file(${TEMPLATE_FILE} ${TEST_FILE})
   list(APPEND TEST_FILES "${TEST_FILE}")
 endforeach(TEMPLATE_FILE)
-
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-  list(APPEND TEST_FILES
-    multi_transaction_indexing.spec)
-endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 foreach(TEST_FILE ${TEST_FILES})
     string(REGEX REPLACE "(.+)\.spec" "\\1" TESTS_TO_RUN ${TEST_FILE})

--- a/test/isolation/specs/multi_transaction_indexing.spec.in
+++ b/test/isolation/specs/multi_transaction_indexing.spec.in
@@ -10,6 +10,12 @@ setup {
         (21, 19.5, 3);
 
     CREATE TABLE barrier(i INTEGER);
+
+    CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+    AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_enable';
+
+    CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+    AS '@TS_MODULE_PATHNAME@', 'ts_debug_waitpoint_release';
 }
 
 teardown {
@@ -17,8 +23,12 @@ teardown {
     DROP TABLE barrier;
 }
 
+session "Waitpoints"
+step "WPE"      { SELECT debug_waitpoint_enable('indexing_done'); }
+step "WPR"      { SELECT debug_waitpoint_release('indexing_done'); }
+
 session "CREATE INDEX"
-#step "F" { SET client_min_messages TO 'error'; }
+step "F" { SET client_min_messages TO 'error'; }
 step "CI"	{ CREATE INDEX test_index ON ts_index_test(location) WITH (timescaledb.transaction_per_chunk, timescaledb.barrier_table='barrier'); }
 
 session "RELEASE BARRIER"
@@ -35,8 +45,8 @@ setup		{ BEGIN; SET LOCAL lock_timeout = '500ms'; SET LOCAL deadlock_timeout = '
 step "I1"	{ INSERT INTO ts_index_test VALUES (31, 6.4, 1); }
 step "Ic"	{ COMMIT; }
 
-#session "DROP INDEX"
-#step "DI"	{ DROP INDEX test_index; }
+session "DROP INDEX"
+step "DI"	{ DROP INDEX test_index; }
 
 session "RENAME COLUMN"
 step "RI"	{ ALTER TABLE test_index RENAME COLUMN location TO height; }
@@ -55,11 +65,7 @@ permutation "I1" "CI" "Bc" "Ic" "P" "Sc"
 permutation "S1" "CI" "Bc" "Sc" "P" "Ic"
 
 # drop works (the error message outputs an OID, remove the "F" to see the error)
-#
-# TODO(3021): Disabled since a race condition between CREATE INDEX
-# and DROP INDEX cause a flake. Enable when race condition is fixed.
-#
-#permutation "F" "CI" "DI" "Bc" "P" "Ic" "Sc"
+permutation "F" "WPE" "CI" "DI" "Bc" "WPR" "P" "Ic" "Sc"
 
 # rename should block
 permutation "CI" "RI" "Bc" "P" "Ic" "Sc"

--- a/test/isolation/specs/multi_transaction_indexing.spec.in
+++ b/test/isolation/specs/multi_transaction_indexing.spec.in
@@ -24,8 +24,8 @@ teardown {
 }
 
 session "Waitpoints"
-step "WPE"      { SELECT debug_waitpoint_enable('indexing_done'); }
-step "WPR"      { SELECT debug_waitpoint_release('indexing_done'); }
+step "WPE"      { SELECT debug_waitpoint_enable('process_index_start_indexing_done'); }
+step "WPR"      { SELECT debug_waitpoint_release('process_index_start_indexing_done'); }
 
 session "CREATE INDEX"
 step "F" { SET client_min_messages TO 'error'; }


### PR DESCRIPTION
When executing `CREATE INDEX` with `transaction_per_chunk` one
transaction is created at the start to mark the index as invalid, a
session lock is taken to prevent competing `DROP INDEX` from modifying
the indexes, then each chunk is updated inside a separate transaction,
one transaction is created to mark the index as valid, and lastly the
session lock is released.

However, the last transaction was not committed and left open, so a
competing `DROP INDEX` would try to read index status after the session
lock was released, resulting in a concurrent access of the index row
from the `CREATE INDEX`.

This commit fixes that by committing the transaction before releasing
the session lock (and starting another transaction to match the
end-of-statement commit that is done later).

Fixes #3021

NOTE: This commit consists of several commits to demonstrate the original problem but these commits will be squashed before merging.