### PR TITLE
Add error detail for failed refresh policy

### DIFF
--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -493,7 +493,11 @@ policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
 					 errmsg("continuous aggregate policy already exists for \"%s\"",
-							get_rel_name(cagg_oid))));
+							get_rel_name(cagg_oid)),
+					 errdetail("Only one continuous aggregate policy can be created per continuous "
+							   "aggregate and a policy with job id %d already exists for \"%s\".",
+							   ((BgwJob *) linitial(jobs))->fd.id,
+							   get_rel_name(cagg_oid))));
 		BgwJob *existing = linitial(jobs);
 
 		if (policy_config_check_hypertable_lag_equality(existing->fd.config,

--- a/tsl/test/expected/continuous_aggs_policy.out
+++ b/tsl/test/expected/continuous_aggs_policy.out
@@ -73,6 +73,7 @@ SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval) as job_
 --adding again should warn/error
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 10, '1h'::interval, if_not_exists=>false);
 ERROR:  continuous aggregate policy already exists for "mat_m1"
+DETAIL:  Only one continuous aggregate policy can be created per continuous aggregate and a policy with job id 1000 already exists for "mat_m1".
 SELECT add_continuous_aggregate_policy('mat_m1', 20, 15, '1h'::interval, if_not_exists=>true);
 WARNING:  continuous aggregate policy already exists for "mat_m1"
 DETAIL:  A policy already exists with different arguments.


### PR DESCRIPTION
Adds an error detail, which clarifies that only one continuous
aggregate policy can be created per a continuous aggregate. It also
reports the job id of the continuous aggregate policy, which already
exists.