### PR TITLE
Make data_fetcher solo test to fix failing tests

### DIFF
--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -120,6 +120,7 @@ set(SOLO_TESTS
   continuous_aggs_bgw
   continuous_aggs_ddl
   continuous_aggs_dump
+  data_fetcher
   move-11
   move-12
   move-13


### PR DESCRIPTION
The `data_fetcher` test currently causes tests to fail regularly when
run in parallel. Therefore, this change moves `data_fetcher` to solo
tests.