### PR TITLE
Add GitHub action to ensure a single commit

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,60 @@
+name: Pull Request Validation
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [master]
+jobs:
+  # Count the number of commits in a pull request. This can be
+  # disabled by adding a trailer line of the following form to the
+  # pull request message:
+  #
+  #    Disable-Check: commit-count
+  #
+  # The check is case-insensitive and ignores other contents on the
+  # line as well, so it is possible to add several different checks if
+  # that is necessary.
+  #
+  # It is assumed that the trailer is following RFC2822 conventions,
+  # but this is currently not enforced.
+  count_commits:
+    name: Enforce single commit pull request
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Dump GitHub context (for debugging)
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      run: |
+        echo "GITHUB_CONTEXT: $GITHUB_CONTEXT"
+    - name: Check number of commits
+      shell: bash --norc --noprofile {0}
+      # If this becomes more advanced, we might be better of using,
+      # e.g., Perl.
+      run: |
+        cat <<EOF | egrep -qsi '^disable-check:.*\<commit-count\>'
+        ${{ github.event.pull_request.body }}
+        EOF
+        if [[ $? -ne 0 ]]; then
+          base=${{ github.event.pull_request.base.sha }}
+          head=${{ github.event.pull_request.head.sha }}
+          count=`git rev-list --count $base..$head`
+          if [[ "$count" -ne 1 ]]; then
+            echo "Found $count commits in pull request (there should be only one):"
+            git log --format=format:'- %h %s' $base..$head
+            echo
+            echo "To disable commit count, add this trailer to pull request message:"
+            echo
+            echo "Disable-check: commit-count"
+            echo
+            echo "Trailers follow RFC2822 conventions, so no whitespace"
+            echo "before field name and the check is case-insensitive for"
+            echo "both the field name and the field body."
+            exit 1
+          fi
+        fi
+
+


### PR DESCRIPTION
This commit adds a GitHub action that will check that there is only a
single commit in the pull request and trigger an error if that is not
the case.

The check can be disabled by adding the following line as a trailer to
the pull request message (case-insensitive check). Note that only the
pull request body is checked. Trailers are assumed to follow RFC2822
conventions, even though this is not formally enforced right now.

    Disable-Check: commit-count
