### PR TITLE
Fix gapfill/hashagg planner interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ accidentally triggering the load of a previous DB version.**
 * #2974 Fix index creation for hypertables with dropped columns
 * #2989 Refactor and harden size and stats functions
 * #3042 Commit end transaction for CREATE INDEX
+* #3053 Fix gapfill/hashagg planner interaction
 * #3059 Fix UPSERT on hypertables with columns with defaults
 
 **Thanks**
 * @eloyekunle and @kitwestneat for reporting an issue with UPSERT
 * @jocrau for reporting an issue with index creation
+* @majozv and @pehlert for reporting an issue with time_bucket_gapfill
 * @pedrokost and @RobAtticus for reporting an issue with size
   functions on empty hypertables
 

--- a/tsl/test/shared/expected/gapfill-11.out
+++ b/tsl/test/shared/expected/gapfill-11.out
@@ -3115,3 +3115,24 @@ ORDER BY 1 DESC, 2;
  Mon Jan 01 05:00:00 2018 PST |         3 | 0.9 | 30
 (6 rows)
 
+-- issue #3048
+-- test gapfill/hashagg planner interaction
+-- this used to produce a plan without gapfill node
+EXPLAIN (costs off) SELECT time_bucket_gapfill('52w', time, '2000-01-01', '2000-01-10') AS time,
+       sum(v1) AS v1_sum
+FROM metrics
+GROUP BY 1;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  Sort
+         Sort Key: (time_bucket_gapfill('@ 364 days'::interval, _hyper_1_1_chunk."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  HashAggregate
+               Group Key: time_bucket_gapfill('@ 364 days'::interval, _hyper_1_1_chunk."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Result
+                     ->  Append
+                           ->  Seq Scan on _hyper_1_1_chunk
+                           ->  Seq Scan on _hyper_1_2_chunk
+                           ->  Seq Scan on _hyper_1_3_chunk
+(10 rows)
+

--- a/tsl/test/shared/expected/gapfill-12.out
+++ b/tsl/test/shared/expected/gapfill-12.out
@@ -3115,3 +3115,24 @@ ORDER BY 1 DESC, 2;
  Mon Jan 01 05:00:00 2018 PST |         3 | 0.9 | 30
 (6 rows)
 
+-- issue #3048
+-- test gapfill/hashagg planner interaction
+-- this used to produce a plan without gapfill node
+EXPLAIN (costs off) SELECT time_bucket_gapfill('52w', time, '2000-01-01', '2000-01-10') AS time,
+       sum(v1) AS v1_sum
+FROM metrics
+GROUP BY 1;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  Sort
+         Sort Key: (time_bucket_gapfill('@ 364 days'::interval, _hyper_1_1_chunk."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  HashAggregate
+               Group Key: time_bucket_gapfill('@ 364 days'::interval, _hyper_1_1_chunk."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Result
+                     ->  Append
+                           ->  Seq Scan on _hyper_1_1_chunk
+                           ->  Seq Scan on _hyper_1_2_chunk
+                           ->  Seq Scan on _hyper_1_3_chunk
+(10 rows)
+

--- a/tsl/test/shared/expected/gapfill-13.out
+++ b/tsl/test/shared/expected/gapfill-13.out
@@ -3122,3 +3122,24 @@ ORDER BY 1 DESC, 2;
  Mon Jan 01 05:00:00 2018 PST |         3 | 0.9 | 30
 (6 rows)
 
+-- issue #3048
+-- test gapfill/hashagg planner interaction
+-- this used to produce a plan without gapfill node
+EXPLAIN (costs off) SELECT time_bucket_gapfill('52w', time, '2000-01-01', '2000-01-10') AS time,
+       sum(v1) AS v1_sum
+FROM metrics
+GROUP BY 1;
+                                                                                                    QUERY PLAN                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (GapFill)
+   ->  Sort
+         Sort Key: (time_bucket_gapfill('@ 364 days'::interval, _hyper_1_1_chunk."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+         ->  HashAggregate
+               Group Key: time_bucket_gapfill('@ 364 days'::interval, _hyper_1_1_chunk."time", 'Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone, 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Result
+                     ->  Append
+                           ->  Seq Scan on _hyper_1_1_chunk
+                           ->  Seq Scan on _hyper_1_2_chunk
+                           ->  Seq Scan on _hyper_1_3_chunk
+(10 rows)
+

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -1412,3 +1412,12 @@ ORDER BY 1 DESC;
 SELECT * FROM metrics_tstz
 WHERE time >= '2018-01-01 04:00' AND time < '2018-01-01 08:00'
 ORDER BY 1 DESC, 2;
+
+-- issue #3048
+-- test gapfill/hashagg planner interaction
+-- this used to produce a plan without gapfill node
+EXPLAIN (costs off) SELECT time_bucket_gapfill('52w', time, '2000-01-01', '2000-01-10') AS time,
+       sum(v1) AS v1_sum
+FROM metrics
+GROUP BY 1;
+


### PR DESCRIPTION
The hashagg optimization adds a hashagg plan with modified costs
to the list of paths. This happens after gapfill pathes have been
created so those newly created pathes would miss the GapFill node.
If those created pathes would turn out to be cheaper than other
pathes GapFill would fail to work as no GapFill node would be
executed.
This patch changes hashagg path creation to skip adding pathes
when there is a GapFill path.

Fixes #3048