### PR TITLE
Reduce memory usage for distributed inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #2989 Refactor and harden size and stats functions
+* #3058 Reduce memory usage for distributed inserts
 
 **Thanks**
 * @pedrokost and @RobAtticus for reporting an issue with size
   functions on empty hypertables
+* @stephane-moreau for reporting an issue with high memory usage during
+  single-transaction inserts on a distributed hypertable.
 
 ## 2.1.1 (2021-03-29)
 


### PR DESCRIPTION
The data node dispatcher used a per-tuple memory context that wasn't
automatically reset as part of each iteration of the execution
loop. This lead to linearly growing memory usage over a transaction
that inserted a lot of data.

This change switches to using the right per-tuple memory context and
also introduces a new "batch" memory context that maintains the batch
data until it is fully processed and the next batch is read. These
changes mean that memory usage never grows higher than what is needed
for one batch, which will avoid out-of-memory situations.

Fixes #3049