### PR TITLE
Fix UPSERT on hypertables with columns with defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ accidentally triggering the load of a previous DB version.**
 * #2974 Fix index creation for hypertables with dropped columns
 * #2989 Refactor and harden size and stats functions
 * #3042 Commit end transaction for CREATE INDEX
+* #3059 Fix UPSERT on hypertables with columns with defaults
 
 **Thanks**
+* @eloyekunle and @kitwestneat for reporting an issue with UPSERT
 * @jocrau for reporting an issue with index creation
 * @pedrokost and @RobAtticus for reporting an issue with size
   functions on empty hypertables

--- a/test/expected/insert-11.out
+++ b/test/expected/insert-11.out
@@ -659,3 +659,15 @@ ERROR:  duplicate key value violates unique constraint "27_1_sample_table_sequen
 INSERT INTO sample_table (sequence,time,value) VALUES
        (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
 DROP TABLE sample_table;
+-- test on conflict clause on columns with default value
+-- issue #3037
+CREATE TABLE i3037(time timestamptz PRIMARY KEY);
+SELECT create_hypertable('i3037','time');
+  create_hypertable  
+---------------------
+ (13,public,i3037,t)
+(1 row)
+
+ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
+INSERT INTO i3037 VALUES ('2000-01-01');
+INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -659,3 +659,15 @@ ERROR:  duplicate key value violates unique constraint "27_1_sample_table_sequen
 INSERT INTO sample_table (sequence,time,value) VALUES
        (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
 DROP TABLE sample_table;
+-- test on conflict clause on columns with default value
+-- issue #3037
+CREATE TABLE i3037(time timestamptz PRIMARY KEY);
+SELECT create_hypertable('i3037','time');
+  create_hypertable  
+---------------------
+ (13,public,i3037,t)
+(1 row)
+
+ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
+INSERT INTO i3037 VALUES ('2000-01-01');
+INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;

--- a/test/expected/insert-13.out
+++ b/test/expected/insert-13.out
@@ -659,3 +659,15 @@ ERROR:  duplicate key value violates unique constraint "27_1_sample_table_sequen
 INSERT INTO sample_table (sequence,time,value) VALUES
        (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
 DROP TABLE sample_table;
+-- test on conflict clause on columns with default value
+-- issue #3037
+CREATE TABLE i3037(time timestamptz PRIMARY KEY);
+SELECT create_hypertable('i3037','time');
+  create_hypertable  
+---------------------
+ (13,public,i3037,t)
+(1 row)
+
+ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
+INSERT INTO i3037 VALUES ('2000-01-01');
+INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;

--- a/test/sql/insert.sql.in
+++ b/test/sql/insert.sql.in
@@ -198,3 +198,13 @@ INSERT INTO sample_table (sequence,time,value) VALUES
        (7,generate_series(TIMESTAMP '2019-01-01', TIMESTAMP '2019-07-01', '10 minutes'), ROUND(RANDOM()*10)::int);
 
 DROP TABLE sample_table;
+
+-- test on conflict clause on columns with default value
+-- issue #3037
+CREATE TABLE i3037(time timestamptz PRIMARY KEY);
+SELECT create_hypertable('i3037','time');
+ALTER TABLE i3037 ADD COLUMN value float DEFAULT 0;
+
+INSERT INTO i3037 VALUES ('2000-01-01');
+INSERT INTO i3037 VALUES ('2000-01-01') ON CONFLICT(time) DO UPDATE SET value = EXCLUDED.value;
+


### PR DESCRIPTION
When a column with a DEFAULT was added to a hypertable after
hypertable creation this column would have atthasmissing true
for the hypertable itself but not for chunks created after.
This lead to the attribute mapping from the hypertable to
the chunk being non-NULL but the chunk -> hypertable map being
NULL leading to a segfault because the code assumed both maps
would either be NULL or non-NULL.

Fixes #3036 
Fixes #3037 