### PR TITLE
Remove Hypertable argument from ts_constraint_aware_append_path_create

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -33,6 +33,7 @@ jobs:
     - name: Check code formatting
       if: always()
       run: |
+        sudo apt install clang-format-8
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 100
         sudo update-alternatives --set clang-format /usr/bin/clang-format-8
         ./scripts/clang_format_all.sh

--- a/src/constraint_aware_append.c
+++ b/src/constraint_aware_append.c
@@ -34,9 +34,9 @@
 #endif
 
 #include "constraint_aware_append.h"
-#include "hypertable.h"
 #include "chunk_append/transform.h"
 #include "guc.h"
+#include "utils.h"
 
 /*
  * Exclude child relations (chunks) at execution time based on constraints.
@@ -482,7 +482,7 @@ static CustomPathMethods constraint_aware_append_path_methods = {
 };
 
 Path *
-ts_constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht, Path *subpath)
+ts_constraint_aware_append_path_create(PlannerInfo *root, Path *subpath)
 {
 	ConstraintAwareAppendPath *path;
 

--- a/src/constraint_aware_append.h
+++ b/src/constraint_aware_append.h
@@ -24,8 +24,7 @@ typedef struct ConstraintAwareAppendState
 typedef struct Hypertable Hypertable;
 
 extern bool ts_constraint_aware_append_possible(Path *path);
-extern Path *ts_constraint_aware_append_path_create(PlannerInfo *root, Hypertable *ht,
-													Path *subpath);
+extern Path *ts_constraint_aware_append_path_create(PlannerInfo *root, Path *subpath);
 extern void _constraint_aware_append_init(void);
 
 #endif /* TIMESCALEDB_CONSTRAINT_AWARE_APPEND_H */

--- a/src/planner.c
+++ b/src/planner.c
@@ -719,7 +719,7 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 															   ordered,
 															   nested_oids);
 					else if (should_constraint_aware_append(ht, *pathptr))
-						*pathptr = ts_constraint_aware_append_path_create(root, ht, *pathptr);
+						*pathptr = ts_constraint_aware_append_path_create(root, *pathptr);
 					break;
 				default:
 					break;
@@ -738,7 +738,7 @@ apply_optimizations(PlannerInfo *root, TsRelType reltype, RelOptInfo *rel, Range
 						*pathptr =
 							ts_chunk_append_path_create(root, rel, ht, *pathptr, true, false, NIL);
 					else if (should_constraint_aware_append(ht, *pathptr))
-						*pathptr = ts_constraint_aware_append_path_create(root, ht, *pathptr);
+						*pathptr = ts_constraint_aware_append_path_create(root, *pathptr);
 					break;
 				default:
 					break;


### PR DESCRIPTION
The hypertable argument to ts_constraint_aware_append_path_create was
never actually used in the function so this patch removes it.

Disable-check: commit-count
