### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,31 @@ accidentally triggering the load of a previous DB version.**
 ## Unreleased
 
 **Bugfixes**
-* #2974 Fix index creation for hypertables with dropped columns
 * #2989 Refactor and harden size and stats functions
+
+**Thanks**
+* @pedrokost and @RobAtticus for reporting an issue with size
+  functions on empty hypertables
+
+## 2.1.1 (2021-03-29)
+
+This maintenance release contains bugfixes since the 2.1.0 release. We
+deem it high priority for upgrading.
+
+The bug fixes in this release address issues with CREATE INDEX and 
+UPSERT for hypertables, custom jobs, and gapfill queries.
+
+This release marks TimescaleDB as a trusted extension in PG13, so that 
+superuser privileges are not required anymore to install the extension.
+
+**Minor features**
+* #2998 Mark timescaledb as trusted extension
+
+**Bugfixes**
+* #2948 Fix off by 4 error in histogram deserialize
+* #2974 Fix index creation for hypertables with dropped columns
+* #2990 Fix segfault in job_config_check for cagg
+* #2987 Fix crash due to txns in emit_log_hook_callback
 * #3042 Commit end transaction for CREATE INDEX
 * #3053 Fix gapfill/hashagg planner interaction
 * #3059 Fix UPSERT on hypertables with columns with defaults
@@ -16,9 +39,8 @@ accidentally triggering the load of a previous DB version.**
 **Thanks**
 * @eloyekunle and @kitwestneat for reporting an issue with UPSERT
 * @jocrau for reporting an issue with index creation
+* @kev009 for fixing a compilation issue
 * @majozv and @pehlert for reporting an issue with time_bucket_gapfill
-* @pedrokost and @RobAtticus for reporting an issue with size
-  functions on empty hypertables
 
 ## 2.1.0 (2021-02-22)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -107,6 +107,7 @@ set(MOD_FILES
   updates/2.0.0--2.0.1.sql
   updates/2.0.1--2.0.2.sql
   updates/2.0.2--2.1.0.sql
+  updates/2.1.0--2.1.1.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
 version = 2.2.0-dev
-update_from_version = 2.1.0
+update_from_version = 2.1.1


### PR DESCRIPTION
This maintenance release contains bugfixes since the 2.1.0 release. We
deem it high priority for upgrading.

The bug fixes in this release address issues with CREATE INDEX and
UPSERT for hypertables, custom jobs, and gapfill queries.

This release marks TimescaleDB as a trusted extension in PG13, so that 
superuser privileges are not required anymore to install the extension.

**Minor features**
* #2998 Mark timescaledb as trusted extension

**Bugfixes**
* #2948 Fix off by 4 error in histogram deserialize
* #2974 Fix index creation for hypertables with dropped columns
* #2990 Fix segfault in job_config_check for cagg
* #2987 Fix crash due to txns in emit_log_hook_callback
* #3042 Commit end transaction for CREATE INDEX
* #3053 Fix gapfill/hashagg planner interaction
* #3059 Fix UPSERT on hypertables with columns with defaults

**Thanks**
* @eloyekunle and @kitwestneat for reporting an issue with UPSERT
* @jocrau for reporting an issue with index creation
* @kev009 for fixing a compilation issue
* @majozv and @pehlert for reporting an issue with time_bucket_gapfill