### PR TITLE
Refactor chunk creation for future extension

### DIFF
--- a/src/catalog.c
+++ b/src/catalog.c
@@ -514,7 +514,7 @@ catalog_get_table(Catalog *catalog, Oid relid)
  * Get the next serial ID for a catalog table, if one exists for the given table.
  */
 TSDLLEXPORT int64
-ts_catalog_table_next_seq_id(Catalog *catalog, CatalogTable table)
+ts_catalog_table_next_seq_id(const Catalog *catalog, CatalogTable table)
 {
 	Oid relid = catalog->tables[table].serial_relid;
 

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -1244,7 +1244,7 @@ catalog_get_index(Catalog *catalog, CatalogTable tableid, int indexid)
 	return (indexid == INVALID_INDEXID) ? InvalidOid : catalog->tables[tableid].index_ids[indexid];
 }
 
-extern TSDLLEXPORT int64 ts_catalog_table_next_seq_id(Catalog *catalog, CatalogTable table);
+extern TSDLLEXPORT int64 ts_catalog_table_next_seq_id(const Catalog *catalog, CatalogTable table);
 extern Oid ts_catalog_get_cache_proxy_id(Catalog *catalog, CacheType type);
 
 /* Functions that modify the actual catalog table on disk */

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -119,7 +119,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_by_name_with_memory_context(const char *s
 																   const char *table_name,
 																   MemoryContext mctx,
 																   bool fail_if_not_found);
-extern TSDLLEXPORT void ts_chunk_insert_lock(Chunk *chunk, LOCKMODE lock);
+extern TSDLLEXPORT void ts_chunk_insert_lock(const Chunk *chunk, LOCKMODE lock);
 
 extern TSDLLEXPORT Oid ts_chunk_create_table(Chunk *chunk, Hypertable *ht,
 											 const char *tablespacename);

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -80,31 +80,29 @@ chunk_constraints_expand(ChunkConstraints *ccs, int16 new_capacity)
 }
 
 static void
-chunk_constraint_choose_name(Name dst, bool is_dimension, int32 dimension_slice_id,
-							 const char *hypertable_constraint_name, int32 chunk_id)
+chunk_constraint_dimension_choose_name(Name dst, int32 dimension_slice_id)
 {
-	if (is_dimension)
-	{
-		snprintf(NameStr(*dst), NAMEDATALEN, "constraint_%d", dimension_slice_id);
-	}
-	else
-	{
-		char constrname[100];
-		CatalogSecurityContext sec_ctx;
+	snprintf(NameStr(*dst), NAMEDATALEN, "constraint_%d", dimension_slice_id);
+}
 
-		Assert(hypertable_constraint_name != NULL);
+static void
+chunk_constraint_choose_name(Name dst, const char *hypertable_constraint_name, int32 chunk_id)
+{
+	char constrname[NAMEDATALEN];
+	CatalogSecurityContext sec_ctx;
 
-		ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-		snprintf(constrname,
-				 100,
-				 "%d_" INT64_FORMAT "_%s",
-				 chunk_id,
-				 ts_catalog_table_next_seq_id(ts_catalog_get(), CHUNK_CONSTRAINT),
-				 hypertable_constraint_name);
-		ts_catalog_restore_user(&sec_ctx);
+	Assert(hypertable_constraint_name != NULL);
 
-		namestrcpy(dst, constrname);
-	}
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	snprintf(constrname,
+			 NAMEDATALEN,
+			 "%d_" INT64_FORMAT "_%s",
+			 chunk_id,
+			 ts_catalog_table_next_seq_id(ts_catalog_get(), CHUNK_CONSTRAINT),
+			 hypertable_constraint_name);
+	ts_catalog_restore_user(&sec_ctx);
+
+	namestrcpy(dst, constrname);
 }
 
 static ChunkConstraint *
@@ -120,14 +118,16 @@ chunk_constraints_add(ChunkConstraints *ccs, int32 chunk_id, int32 dimension_sli
 
 	if (NULL == constraint_name)
 	{
-		chunk_constraint_choose_name(&cc->fd.constraint_name,
-									 is_dimension_constraint(cc),
-									 cc->fd.dimension_slice_id,
-									 hypertable_constraint_name,
-									 cc->fd.chunk_id);
-
 		if (is_dimension_constraint(cc))
+		{
+			chunk_constraint_dimension_choose_name(&cc->fd.constraint_name,
+												   cc->fd.dimension_slice_id);
 			namestrcpy(&cc->fd.hypertable_constraint_name, "");
+		}
+		else
+			chunk_constraint_choose_name(&cc->fd.constraint_name,
+										 hypertable_constraint_name,
+										 cc->fd.chunk_id);
 	}
 	else
 		namestrcpy(&cc->fd.constraint_name, constraint_name);
@@ -837,7 +837,7 @@ chunk_constraint_rename_hypertable_from_tuple(TupleInfo *ti, const char *newname
 
 	chunk_id = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_constraint_chunk_id)]);
 	namestrcpy(&new_hypertable_constraint_name, newname);
-	chunk_constraint_choose_name(&new_chunk_constraint_name, false, 0, newname, chunk_id);
+	chunk_constraint_choose_name(&new_chunk_constraint_name, newname, chunk_id);
 
 	values[AttrNumberGetAttrOffset(Anum_chunk_constraint_hypertable_constraint_name)] =
 		NameGetDatum(&new_hypertable_constraint_name);

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -46,7 +46,7 @@ ts_hypercube_free(Hypercube *hc)
 
 #if defined(USE_ASSERT_CHECKING)
 static inline bool
-hypercube_is_sorted(Hypercube *hc)
+hypercube_is_sorted(const Hypercube *hc)
 {
 	int i;
 
@@ -131,7 +131,7 @@ ts_hypercube_slice_sort(Hypercube *hc)
 }
 
 DimensionSlice *
-ts_hypercube_get_slice_by_dimension_id(Hypercube *hc, int32 dimension_id)
+ts_hypercube_get_slice_by_dimension_id(const Hypercube *hc, int32 dimension_id)
 {
 	DimensionSlice slice = {
 		.fd.dimension_id = dimension_id,

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -33,7 +33,7 @@ extern Hypercube *ts_hypercube_from_constraints(ChunkConstraints *constraints, M
 extern int ts_hypercube_find_existing_slices(Hypercube *cube, ScanTupLock *tuplock);
 extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p, ScanTupLock *tuplock);
 extern bool ts_hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
-extern TSDLLEXPORT DimensionSlice *ts_hypercube_get_slice_by_dimension_id(Hypercube *hc,
+extern TSDLLEXPORT DimensionSlice *ts_hypercube_get_slice_by_dimension_id(const Hypercube *hc,
 																		  int32 dimension_id);
 extern Hypercube *ts_hypercube_copy(Hypercube *hc);
 extern bool ts_hypercube_equal(Hypercube *hc1, Hypercube *hc2);

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1194,7 +1194,7 @@ ts_hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid)
 }
 
 static int
-hypertable_get_chunk_slice_ordinal(Hypertable *ht, Hypercube *hc)
+hypertable_get_chunk_slice_ordinal(const Hypertable *ht, const Hypercube *hc)
 {
 	Dimension *dim;
 	DimensionSlice *slice;
@@ -2568,7 +2568,7 @@ assert_chunk_data_nodes_is_a_set(List *chunk_data_nodes)
  * happens similar to tablespaces, i.e., based on dimension type.
  */
 List *
-ts_hypertable_assign_chunk_data_nodes(Hypertable *ht, Hypercube *cube)
+ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cube)
 {
 	List *chunk_data_nodes = NIL;
 	List *available_nodes = ts_hypertable_get_available_data_nodes(ht, true);
@@ -2624,7 +2624,8 @@ get_hypertable_data_node(HypertableDataNode *node)
 }
 
 static List *
-get_hypertable_data_node_values(Hypertable *ht, hypertable_data_node_filter filter, get_value value)
+get_hypertable_data_node_values(const Hypertable *ht, hypertable_data_node_filter filter,
+								get_value value)
 {
 	List *list = NULL;
 	ListCell *cell;
@@ -2646,7 +2647,7 @@ ts_hypertable_get_data_node_name_list(Hypertable *ht)
 }
 
 List *
-ts_hypertable_get_available_data_nodes(Hypertable *ht, bool error_if_missing)
+ts_hypertable_get_available_data_nodes(const Hypertable *ht, bool error_if_missing)
 {
 	List *available_nodes = get_hypertable_data_node_values(ht,
 															filter_non_blocked_data_nodes,

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -158,10 +158,10 @@ extern TSDLLEXPORT bool ts_hypertable_set_compressed(Hypertable *ht,
 extern TSDLLEXPORT bool ts_hypertable_unset_compressed(Hypertable *ht);
 extern TSDLLEXPORT void ts_hypertable_clone_constraints_to_compressed(Hypertable *ht,
 																	  List *constraint_list);
-extern List *ts_hypertable_assign_chunk_data_nodes(Hypertable *ht, Hypercube *cube);
+extern List *ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cube);
 extern TSDLLEXPORT List *ts_hypertable_get_data_node_name_list(Hypertable *ht);
 extern TSDLLEXPORT List *ts_hypertable_get_data_node_serverids_list(Hypertable *ht);
-extern TSDLLEXPORT List *ts_hypertable_get_available_data_nodes(Hypertable *ht,
+extern TSDLLEXPORT List *ts_hypertable_get_available_data_nodes(const Hypertable *ht,
 																bool error_if_missing);
 extern TSDLLEXPORT List *ts_hypertable_get_available_data_node_server_oids(Hypertable *ht);
 extern TSDLLEXPORT HypertableType ts_hypertable_get_type(Hypertable *ht);


### PR DESCRIPTION
Separates chunk preparation and metadata update. Separates preparation
of constraints names, since there is no overlap between preparing
names for dimension constraints and other constraints. Factors out 
creation of json string describing dimension slices of a chunk.

This refactoring is preparation for implementing new functionalities.