### PR TITLE
Fix chunk index column name mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ accidentally triggering the load of a previous DB version.**
 * #2989 Refactor and harden size and stats functions
 * #3058 Reduce memory usage for distributed inserts
 * #3067 Fix extremely slow multi-node order by queries
+* #3082 Fix chunk index column name mapping
 * #3083 Keep Append pathkeys in ChunkAppend
 
 **Thanks**
+* @BowenGG for reporting an issue with indexes with INCLUDE
 * @fvannee for reporting an issue with ChunkAppend pathkeys
 * @pedrokost and @RobAtticus for reporting an issue with size
   functions on empty hypertables

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -29,8 +29,7 @@ typedef struct ChunkIndexMapping
 extern void ts_chunk_index_create(Relation hypertable_rel, int32 hypertable_id,
 								  Relation hypertable_idxrel, int32 chunk_id, Relation chunkrel);
 
-void ts_adjust_indexinfo_attnos(IndexInfo *indexinfo, Oid ht_relid, Relation template_indexrel,
-								Relation chunkrel);
+void ts_adjust_indexinfo_attnos(IndexInfo *indexinfo, Oid ht_relid, Relation chunkrel);
 extern void ts_chunk_index_create_from_adjusted_index_info(int32 hypertable_id,
 														   Relation hypertable_idxrel,
 														   int32 chunk_id, Relation chunkrel,

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2041,10 +2041,7 @@ process_index_chunk(Hypertable *ht, Oid chunk_relid, void *arg)
 	if (chunk_index_columns_changed(info->extended_options.n_ht_atts,
 									info->extended_options.ht_hasoid,
 									RelationGetDescr(chunk_rel)))
-		ts_adjust_indexinfo_attnos(indexinfo,
-								   info->main_table_relid,
-								   hypertable_index_rel,
-								   chunk_rel);
+		ts_adjust_indexinfo_attnos(indexinfo, info->main_table_relid, chunk_rel);
 
 	ts_chunk_index_create_from_adjusted_index_info(ht->fd.id,
 												   hypertable_index_rel,
@@ -2133,10 +2130,7 @@ process_index_chunk_multitransaction(int32 hypertable_id, Oid chunk_relid, void 
 	if (chunk_index_columns_changed(info->extended_options.n_ht_atts,
 									info->extended_options.ht_hasoid,
 									RelationGetDescr(chunk_rel)))
-		ts_adjust_indexinfo_attnos(indexinfo,
-								   info->main_table_relid,
-								   hypertable_index_rel,
-								   chunk_rel);
+		ts_adjust_indexinfo_attnos(indexinfo, info->main_table_relid, chunk_rel);
 
 	ts_chunk_index_create_from_adjusted_index_info(hypertable_id,
 												   hypertable_index_rel,

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -710,3 +710,15 @@ ORDER BY
  _timescaledb_internal._hyper_13_19_chunk | _timescaledb_internal._hyper_13_19_chunk_ht_dropped_c0_c1_c2_idx1 | {c0,c1,c2} |      | f      | f       | f         | 
 (9 rows)
 
+-- #3056 check chunk index column name mapping
+CREATE TABLE i3056(c int, order_number int NOT NULL, date_created timestamptz NOT NULL);
+CREATE INDEX ON i3056(order_number) INCLUDE(order_number);
+CREATE INDEX ON i3056(date_created, (order_number % 5)) INCLUDE(order_number);
+SELECT table_name FROM create_hypertable('i3056', 'date_created');
+ table_name 
+------------
+ i3056
+(1 row)
+
+ALTER TABLE i3056 DROP COLUMN c;
+INSERT INTO i3056(order_number,date_created) VALUES (1, '2000-01-01');

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -24,12 +24,13 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testtablespace)
 
 # Tests to ignore
 set(PG_IGNORE_TESTS
+  advisory_lock
+  foreign_data
   identity
+  opr_sanity
   rolenames
   rules
-  opr_sanity
   sanity_check
-  foreign_data
   security_label
 )
 

--- a/test/sql/index.sql
+++ b/test/sql/index.sql
@@ -330,3 +330,12 @@ FROM
 ORDER BY
   1, 2;
 
+-- #3056 check chunk index column name mapping
+CREATE TABLE i3056(c int, order_number int NOT NULL, date_created timestamptz NOT NULL);
+CREATE INDEX ON i3056(order_number) INCLUDE(order_number);
+CREATE INDEX ON i3056(date_created, (order_number % 5)) INCLUDE(order_number);
+SELECT table_name FROM create_hypertable('i3056', 'date_created');
+ALTER TABLE i3056 DROP COLUMN c;
+INSERT INTO i3056(order_number,date_created) VALUES (1, '2000-01-01');
+
+


### PR DESCRIPTION
When mapping index columns references from the hypertable index
to the chunk index the name of the index column was used instead
of the column name of the hypertables. While those names are
identical most of time unless modified this is not true for indexes
with INCLUDE on a column that is also a key column.

Fixes #3056

Disable-check: commit-count
