### PR TITLE
Keep Append pathkeys in ChunkAppend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ accidentally triggering the load of a previous DB version.**
 * #2989 Refactor and harden size and stats functions
 * #3058 Reduce memory usage for distributed inserts
 * #3067 Fix extremely slow multi-node order by queries
+* #3083 Keep Append pathkeys in ChunkAppend
 
 **Thanks**
+* @fvannee for reporting an issue with ChunkAppend pathkeys
 * @pedrokost and @RobAtticus for reporting an issue with size
   functions on empty hypertables
 * @stephane-moreau for reporting an issue with high memory usage during

--- a/test/expected/append-11.out
+++ b/test/expected/append-11.out
@@ -2230,6 +2230,31 @@ LEFT JOIN i2661 ht ON
                      Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
 (19 rows)
 
+-- #3030 test chunkappend keeps pathkeys when subpath is append
+-- on PG11 this will not use ChunkAppend but MergeAppend
+SET enable_seqscan TO FALSE;
+CREATE TABLE i3030(time timestamptz NOT NULL, a int, b int);
+SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes=>false);
+ table_name 
+------------
+ i3030
+(1 row)
+
+CREATE INDEX ON i3030(a,time);
+INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
+ANALYZE i3030;
+:PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=1 loops=1)
+         Sort Key: _hyper_9_38_chunk.a, _hyper_9_38_chunk."time"
+         ->  Index Scan using _hyper_9_38_chunk_i3030_a_time_idx on _hyper_9_38_chunk (actual rows=1 loops=1)
+               Index Cond: (("time" >= ('2000-01-01'::cstring)::timestamp with time zone) AND ("time" <= ('2000-01-03'::cstring)::timestamp with time zone))
+(5 rows)
+
+DROP TABLE i3030;
+RESET enable_seqscan;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-12.out
+++ b/test/expected/append-12.out
@@ -2225,6 +2225,32 @@ LEFT JOIN i2661 ht ON
                      Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
 (19 rows)
 
+-- #3030 test chunkappend keeps pathkeys when subpath is append
+-- on PG11 this will not use ChunkAppend but MergeAppend
+SET enable_seqscan TO FALSE;
+CREATE TABLE i3030(time timestamptz NOT NULL, a int, b int);
+SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes=>false);
+ table_name 
+------------
+ i3030
+(1 row)
+
+CREATE INDEX ON i3030(a,time);
+INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
+ANALYZE i3030;
+:PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on i3030 (actual rows=1 loops=1)
+         Order: i3030.a, i3030."time"
+         Chunks excluded during startup: 0
+         ->  Index Scan using _hyper_9_38_chunk_i3030_a_time_idx on _hyper_9_38_chunk (actual rows=1 loops=1)
+               Index Cond: (("time" >= ('2000-01-01'::cstring)::timestamp with time zone) AND ("time" <= ('2000-01-03'::cstring)::timestamp with time zone))
+(6 rows)
+
+DROP TABLE i3030;
+RESET enable_seqscan;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/append-13.out
+++ b/test/expected/append-13.out
@@ -2226,6 +2226,32 @@ LEFT JOIN i2661 ht ON
                      Filter: ("timestamp" > 'Mon Dec 30 00:00:00 2019'::timestamp without time zone)
 (19 rows)
 
+-- #3030 test chunkappend keeps pathkeys when subpath is append
+-- on PG11 this will not use ChunkAppend but MergeAppend
+SET enable_seqscan TO FALSE;
+CREATE TABLE i3030(time timestamptz NOT NULL, a int, b int);
+SELECT table_name FROM create_hypertable('i3030', 'time', create_default_indexes=>false);
+ table_name 
+------------
+ i3030
+(1 row)
+
+CREATE INDEX ON i3030(a,time);
+INSERT INTO i3030 (time,a) SELECT time, a FROM generate_series('2000-01-01'::timestamptz,'2000-01-01 3:00:00'::timestamptz,'1min'::interval) time, generate_series(1,30) a;
+ANALYZE i3030;
+:PREFIX SELECT * FROM i3030 where time BETWEEN '2000-01-01'::text::timestamptz AND '2000-01-03'::text::timestamptz ORDER BY a,time LIMIT 1;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   ->  Custom Scan (ChunkAppend) on i3030 (actual rows=1 loops=1)
+         Order: i3030.a, i3030."time"
+         Chunks excluded during startup: 0
+         ->  Index Scan using _hyper_9_38_chunk_i3030_a_time_idx on _hyper_9_38_chunk (actual rows=1 loops=1)
+               Index Cond: (("time" >= ('2000-01-01'::cstring)::timestamp with time zone) AND ("time" <= ('2000-01-03'::cstring)::timestamp with time zone))
+(6 rows)
+
+DROP TABLE i3030;
+RESET enable_seqscan;
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results

--- a/test/expected/query-12.out
+++ b/test/expected/query-12.out
@@ -206,18 +206,17 @@ WHERE time < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
-         ->  HashAggregate
-               Group Key: date_trunc('minute'::text, hyper_1."time")
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Chunks excluded during startup: 0
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-                           Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(9 rows)
+   ->  GroupAggregate
+         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('minute'::text, hyper_1."time") DESC
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+                     Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(8 rows)
 
 --test on table with time partitioning function. Currently not
 --optimized to use index for ordering since the index is an expression

--- a/test/expected/query-13.out
+++ b/test/expected/query-13.out
@@ -206,18 +206,17 @@ WHERE time < to_timestamp(900)
 GROUP BY t
 ORDER BY t DESC
 LIMIT 2;
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: (date_trunc('minute'::text, hyper_1."time")) DESC
-         ->  HashAggregate
-               Group Key: date_trunc('minute'::text, hyper_1."time")
-               ->  Custom Scan (ChunkAppend) on hyper_1
-                     Chunks excluded during startup: 0
-                     ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
-                           Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
-(9 rows)
+   ->  GroupAggregate
+         Group Key: (date_trunc('minute'::text, hyper_1."time"))
+         ->  Custom Scan (ChunkAppend) on hyper_1
+               Order: date_trunc('minute'::text, hyper_1."time") DESC
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_1_1_chunk_time_plain on _hyper_1_1_chunk
+                     Index Cond: ("time" < 'Wed Dec 31 16:15:00 1969 PST'::timestamp with time zone)
+(8 rows)
 
 --test on table with time partitioning function. Currently not
 --optimized to use index for ordering since the index is an expression

--- a/tsl/test/expected/continuous_aggs_query-13.out
+++ b/tsl/test/expected/continuous_aggs_query-13.out
@@ -288,6 +288,7 @@ select * from mat_m1 where timec > '2018-10-01' order by timec desc;
                      Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
                      ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
                            Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                           Order: _materialized_hypertable_2.timec
                            Startup Exclusion: true
                            Runtime Exclusion: false
                            Chunks excluded during startup: 0
@@ -309,7 +310,7 @@ select * from mat_m1 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(33 rows)
+(34 rows)
 
 -- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
 :EXPLAIN
@@ -335,6 +336,7 @@ select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01'
                                  Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
                                  ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
                                        Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Order: _materialized_hypertable_2.timec
                                        Startup Exclusion: true
                                        Runtime Exclusion: false
                                        Chunks excluded during startup: 0
@@ -356,7 +358,7 @@ select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01'
                                              Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                              Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(40 rows)
+(41 rows)
 
 :EXPLAIN
 select * from mat_m2 where timec > '2018-10-01' order by timec desc;
@@ -374,6 +376,7 @@ select * from mat_m2 where timec > '2018-10-01' order by timec desc;
                      Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
                      ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
                            Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Order: _materialized_hypertable_3.timec
                            Startup Exclusion: true
                            Runtime Exclusion: false
                            Chunks excluded during startup: 0
@@ -395,7 +398,7 @@ select * from mat_m2 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(33 rows)
+(34 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
@@ -415,6 +418,7 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                            Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
                            ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
                                  Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Order: _materialized_hypertable_3.timec
                                  Startup Exclusion: true
                                  Runtime Exclusion: false
                                  Chunks excluded during startup: 0
@@ -436,7 +440,7 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(35 rows)
+(36 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
@@ -456,6 +460,7 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                            Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
                            ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
                                  Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                                 Order: _materialized_hypertable_3.timec
                                  Startup Exclusion: true
                                  Runtime Exclusion: false
                                  Chunks excluded during startup: 0
@@ -477,7 +482,7 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(35 rows)
+(36 rows)
 
 --plans with CTE
 :EXPLAIN
@@ -498,6 +503,7 @@ select * from m1;
                      Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
                      ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
                            Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
+                           Order: _materialized_hypertable_3.timec
                            Startup Exclusion: true
                            Runtime Exclusion: false
                            Chunks excluded during startup: 0
@@ -519,7 +525,7 @@ select * from m1;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(33 rows)
+(34 rows)
 
 -- should reorder mat_m1 group by only based on mat_m1 order-by
 :EXPLAIN
@@ -575,6 +581,7 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                  Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
                                  ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
                                        Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Order: _materialized_hypertable_2.timec
                                        Startup Exclusion: true
                                        Runtime Exclusion: false
                                        Chunks excluded during startup: 0
@@ -596,7 +603,7 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(70 rows)
+(71 rows)
 
 --should reorder only for mat_m1.
 :EXPLAIN
@@ -633,6 +640,7 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                  Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
                                  ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
                                        Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
+                                       Order: _materialized_hypertable_2.timec
                                        Startup Exclusion: true
                                        Runtime Exclusion: false
                                        Chunks excluded during startup: 0
@@ -654,7 +662,7 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(51 rows)
+(52 rows)
 
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
  locid | location |            timec             | minl | sumt | sumh 

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -408,9 +408,10 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
-   ->  HashAggregate (actual rows=2 loops=1)
+   ->  GroupAggregate (actual rows=2 loops=1)
          Group Key: _materialized_hypertable_6.time_bucket
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
+               Order: _materialized_hypertable_6.time_bucket
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
                      Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
@@ -422,7 +423,7 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-(15 rows)
+(16 rows)
 
 -- result should have 4 rows
 SELECT * FROM boundary_view ORDER BY time_bucket;
@@ -601,13 +602,11 @@ ORDER by 1;
          ->  GroupAggregate (actual rows=1 loops=1)
                Group Key: _materialized_hypertable_9.time_bucket
                Filter: ((_timescaledb_internal.finalize_agg('sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_3, NULL::bigint) > 50) AND ((_timescaledb_internal.finalize_agg('avg(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_4, NULL::numeric))::integer > 12))
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _materialized_hypertable_9.time_bucket
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
-                                 Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
+               ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
+                     Order: _materialized_hypertable_9.time_bucket
+                     Chunks excluded during startup: 0
+                     ->  Index Scan Backward using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
+                           Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
          ->  HashAggregate (actual rows=2 loops=1)
                Group Key: time_bucket(5, ht_intdata.a)
                Filter: ((sum(ht_intdata.c) > 50) AND ((avg(ht_intdata.b))::integer > 12))
@@ -624,7 +623,7 @@ ORDER by 1;
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                            Rows Removed by Filter: 2
-(30 rows)
+(28 rows)
 
 -- Test caggs with different time types
 CREATE TABLE smallint_table (time smallint, value int);

--- a/tsl/test/expected/continuous_aggs_union_view-13.out
+++ b/tsl/test/expected/continuous_aggs_union_view-13.out
@@ -410,10 +410,10 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
-   ->  HashAggregate (actual rows=2 loops=1)
+   ->  GroupAggregate (actual rows=2 loops=1)
          Group Key: _materialized_hypertable_6.time_bucket
-         Batches: 1 
          ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
+               Order: _materialized_hypertable_6.time_bucket
                Chunks excluded during startup: 0
                ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
                      Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
@@ -605,13 +605,11 @@ ORDER by 1;
          ->  GroupAggregate (actual rows=1 loops=1)
                Group Key: _materialized_hypertable_9.time_bucket
                Filter: ((_timescaledb_internal.finalize_agg('sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_3, NULL::bigint) > 50) AND ((_timescaledb_internal.finalize_agg('avg(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_4, NULL::numeric))::integer > 12))
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: _materialized_hypertable_9.time_bucket
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
-                                 Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
+               ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
+                     Order: _materialized_hypertable_9.time_bucket
+                     Chunks excluded during startup: 0
+                     ->  Index Scan Backward using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
+                           Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
          ->  HashAggregate (actual rows=2 loops=1)
                Group Key: time_bucket(5, ht_intdata.a)
                Filter: ((sum(ht_intdata.c) > 50) AND ((avg(ht_intdata.b))::integer > 12))
@@ -629,7 +627,7 @@ ORDER by 1;
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                            Rows Removed by Filter: 2
-(31 rows)
+(29 rows)
 
 -- Test caggs with different time types
 CREATE TABLE smallint_table (time smallint, value int);

--- a/tsl/test/expected/jit-13.out
+++ b/tsl/test/expected/jit-13.out
@@ -195,11 +195,13 @@ SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC
                      Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _timescaledb_internal.finalize_agg('avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision), (_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision))
                      Group Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
                      Filter: ((_timescaledb_internal.finalize_agg('max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)) = '1800'::double precision)
-                     ->  Sort
+                     ->  Incremental Sort
                            Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
                            Sort Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
+                           Presorted Key: _materialized_hypertable_4.bucket
                            ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_4
                                  Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
+                                 Order: _materialized_hypertable_4.bucket
                                  Startup Exclusion: true
                                  Runtime Exclusion: false
                                  Chunks excluded during startup: 0
@@ -218,7 +220,7 @@ SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC
                            ->  Index Scan using _hyper_3_5_chunk_jit_test_contagg_observation_time_idx on _timescaledb_internal._hyper_3_5_chunk
                                  Output: _hyper_3_5_chunk.observation_time, _hyper_3_5_chunk.device_id, _hyper_3_5_chunk.metric
                                  Index Cond: (_hyper_3_5_chunk.observation_time >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
-(33 rows)
+(35 rows)
 
 -- generate the results into two different files
 \set ECHO errors

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -158,23 +158,21 @@ ORDER BY c.id;
 
 :PREFIX SELECT d.device_id, m.time,  m.time
  FROM metrics_ordered_idx2 d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx2 m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=4291 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk d (actual rows=4291 loops=1)
          ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk (actual rows=5 loops=1)
    ->  Subquery Scan on m (actual rows=1 loops=4291)
          Filter: (d.device_id_peer = m.device_id_peer)
          ->  Limit (actual rows=1 loops=4291)
-               ->  Sort (actual rows=1 loops=4291)
-                     Sort Key: m_1."time" DESC
-                     Sort Method: top-N heapsort 
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=4291 loops=4291)
-                           ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=4291 loops=4291)
-                                 ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=5 loops=4291)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-(14 rows)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
+                     Order: m_1."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=1 loops=4291)
+                           ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=1 loops=4291)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+(12 rows)
 
 SET enable_seqscan = FALSE;
 \ir include/transparent_decompression_ordered_index.sql

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -158,23 +158,21 @@ ORDER BY c.id;
 
 :PREFIX SELECT d.device_id, m.time,  m.time
  FROM metrics_ordered_idx2 d INNER JOIN LATERAL (SELECT * FROM metrics_ordered_idx2 m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON m.device_id_peer = d.device_id_peer;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop (actual rows=4291 loops=1)
    ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk d (actual rows=4291 loops=1)
          ->  Index Scan using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk (actual rows=5 loops=1)
    ->  Subquery Scan on m (actual rows=1 loops=4291)
          Filter: (d.device_id_peer = m.device_id_peer)
          ->  Limit (actual rows=1 loops=4291)
-               ->  Sort (actual rows=1 loops=4291)
-                     Sort Key: m_1."time" DESC
-                     Sort Method: top-N heapsort 
-                     ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=4291 loops=4291)
-                           ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=4291 loops=4291)
-                                 ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=5 loops=4291)
-                                       Index Cond: (device_id_peer = 3)
-                                       Filter: (device_id = d.device_id)
-(14 rows)
+               ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
+                     Order: m_1."time" DESC
+                     ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=1 loops=4291)
+                           ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_pe on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=1 loops=4291)
+                                 Index Cond: (device_id_peer = 3)
+                                 Filter: (device_id = d.device_id)
+(12 rows)
 
 SET enable_seqscan = FALSE;
 \ir include/transparent_decompression_ordered_index.sql


### PR DESCRIPTION
This changes ChunkAppend to always keep the pathkeys from the original
path because the original path was either a MergeAppendPath and this
will become an ordered append or the original path is an AppendPath
and since we do not reorder children the order will be kept intact.
For the AppendPath case with pathkeys it was most likely an Append
with only a single child. We could skip the ChunkAppend path creation
if there is only a single child but we decided earlier that ChunkAppend
would be beneficial for this query so we treat it the same as if it
had multiple children.

Fixes #3030