### PR TITLE
Install clang-8 for PG11.0 CI test

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -123,7 +123,7 @@ if event_type != "pull_request":
     "pg": PG11_EARLIEST,
     "llvm_config": "/usr/bin/llvm-config-8",
     "clang": "clang-8",
-    "extra_packages": "llvm-8 llvm-8-dev llvm-8-tools",
+    "extra_packages": "clang-8 llvm-8 llvm-8-dev llvm-8-tools",
     "installcheck_args": "IGNORES='cluster-11 continuous_aggs_insert continuous_aggs_multi continuous_aggs_concurrent_refresh'"
   }
   m["include"].append(build_debug_config(pg11_debug_earliest))


### PR DESCRIPTION
clang-8 is no longer installed by default in the ubuntu images so
we have to explicitly install it for any actions that require it.

https://github.com/actions/virtual-environments/issues/2950