### PR TITLE
Do not notify Slack for MacOS test

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -162,7 +162,7 @@ jobs:
         path: coredumps
 
     - name: Slack Notification
-      if: failure() && github.event_name != 'pull_request'
+      if: failure() && github.event_name != 'pull_request' && runner.os != 'macOS'
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SLACK_COLOR: '#ff0000'


### PR DESCRIPTION
Slack notification only works on Linux and produces error if it is
called during MacOS test. This fix avoids notifying Slack if a
regression test is run on MacOS.

PR comment:
[This build](https://github.com/timescale/timescaledb/runs/2272609163?check_suite_focus=true#step:20:15) contains the error:
```
Run rtCamp/action-slack-notify@v2.0.2
Error: Container action is only supported on Linux
```