### PR TITLE
Fix dist_restore_point test on PG11.0

### DIFF
--- a/tsl/test/isolation/expected/dist_restore_point.out
+++ b/tsl/test/isolation/expected/dist_restore_point.out
@@ -323,8 +323,6 @@ debug_waitpoint_enable
 
                
 step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
-s2: NOTICE:  the number of partitions in dimension "device" was decreased to 3
-DETAIL:  To make efficient use of all attached data nodes, the number of space partitions was set to match the number of data nodes.
 step s2_del_dn: SELECT * FROM delete_data_node('data_node_4'); <waiting ...>
 step s3_lock_count: 
 	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 

--- a/tsl/test/isolation/specs/dist_restore_point.spec.in
+++ b/tsl/test/isolation/specs/dist_restore_point.spec.in
@@ -57,6 +57,7 @@ setup
 {
 	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 	SET application_name = 's2';
+	SET client_min_messages TO warning;
 }
 step "s2_create_dist_rp" { SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s2_test'); }
 step "s2_insert"         { INSERT INTO disttable VALUES ('2019-08-02 10:45', 0, 0.0); }


### PR DESCRIPTION
The test fails on PG11.0 since there is no notice during data node deletion. Reduce client notice level to warning, to make it compatible with other versions.

Fixes https://github.com/timescale/timescaledb/issues/3093