### PR TITLE
Fix command execution in pr-validation

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -35,7 +35,7 @@ jobs:
       # If this becomes more advanced, we might be better of using,
       # e.g., Perl.
       run: |
-        cat <<EOF | egrep -qsi '^disable-check:.*\<commit-count\>'
+        cat << "EOF" | egrep -qsi '^disable-check:.*\<commit-count\>'
         ${{ github.event.pull_request.body }}
         EOF
         if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
The github action to check for multiple commits would check the
pullrequest message for a command to disable the check.
While processing the message any commands enclosed in backticks
would be executed as shell commands.