### PR TITLE
Use commit date in get_git_commit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Bugfixes**
+* #3101 Use commit date in get_git_commit()
+
 ## 2.2.0 (2021-04-13)
 
 This release adds major new features since the 2.1.1 release.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ if(GIT_FOUND)
 
   # Fetch the date of the head commit
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} log -1 --format=%aI
+    COMMAND ${GIT_EXECUTABLE} log -1 --format=%cI
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE EXT_GIT_COMMIT_TIME
     RESULT_VARIABLE _log_RESULT


### PR DESCRIPTION
get_git_commit used the author date instead of the commit date
when showing information about the commit. For the purpose of
the function the author date is not that significant and when
the commit to the branch actually happened is much more relevant.