### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,36 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+## 2.2.0 (2021-04-13)
+
+This release adds major new features since the 2.1.1 release.
+We deem it moderate priority for upgrading.
+
+This release adds the Skip Scan optimization, which significantly 
+improves the performance of queries with DISTINCT ON. This 
+optimization is not yet available for queries on distributed 
+hypertables.
+
+This release also adds a function to create a distributed 
+restore point, which allows performing a consistent restore of a 
+multi-node cluster from a backup.
+
+The bug fixes in this release address issues with size and stats 
+functions, high memory usage in distributed inserts, slow distributed 
+ORDER BY queries, indexes involving INCLUDE, and single chunk query 
+planning.
+
+**PostgreSQL 11 deprecation announcement**
+
+Timescale is working hard on our next exciting features. To make that 
+possible, we require functionality that is unfortunately absent on 
+PostgreSQL 11. For this reason, we will continue supporting PostgreSQL 
+11 until mid-June 2021. Sooner to that time, we will announce the 
+specific version of TimescaleDB in which PostgreSQL 11 support will 
+not be included going forward.
+
 **Major Features**
+* #2843 Add distributed restore point functionality
 * #3000 SkipScan to speed up SELECT DISTINCT
 
 **Bugfixes**
@@ -21,10 +50,10 @@ accidentally triggering the load of a previous DB version.**
 * @fvannee for reporting an issue with ChunkAppend pathkeys
 * @pedrokost and @RobAtticus for reporting an issue with size
   functions on empty hypertables
-* @stephane-moreau for reporting an issue with high memory usage during
-  single-transaction inserts on a distributed hypertable.
 * @phemmer and @ryanbooz for reporting issues with slow
   multi-node order by queries
+* @stephane-moreau for reporting an issue with high memory usage during
+  single-transaction inserts on a distributed hypertable.
 
 ## 2.1.1 (2021-03-29)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -108,6 +108,7 @@ set(MOD_FILES
   updates/2.0.1--2.0.2.sql
   updates/2.0.2--2.1.0.sql
   updates/2.1.0--2.1.1.sql
+  updates/2.1.1--2.2.0.sql
 )
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/sql/updates/2.1.1--2.2.0.sql
+++ b/sql/updates/2.1.1--2.2.0.sql
@@ -1,0 +1,2 @@
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,2 +1,0 @@
-DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
-DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;

--- a/version.config
+++ b/version.config
@@ -1,2 +1,2 @@
-version = 2.2.0-dev
-update_from_version = 2.1.1
+version = 2.3.0-dev
+update_from_version = 2.2.0


### PR DESCRIPTION
This release adds major new features since the 2.1.1 release.
We deem it moderate priority for upgrading.

This release adds the Skip Scan optimization, which significantly 
improves the performance of queries with DISTINCT ON. This 
optimization is not yet available for queries on distributed 
hypertables.

This release also adds a function to create a distributed 
restore point, which allows performing a consistent restore of a 
multi-node cluster from a backup.

The bug fixes in this release address issues with size and stats 
functions, high memory usage in distributed inserts, slow distributed 
ORDER BY queries, indexes involving INCLUDE, and single chunk query 
planning.

**PostgreSQL 11 deprecation announcement**

Timescale is working hard on our next exciting features. To make that 
possible, we require functionality that is unfortunately absent on 
PostgreSQL 11. For this reason, we will continue supporting PostgreSQL 
11 until mid-June 2021. Sooner to that time, we will announce the 
specific version of TimescaleDB in which PostgreSQL 11 support will 
not be included going forward.

**Major Features**
* #2843 Add distributed restore point functionality
* #3000 SkipScan to speed up SELECT DISTINCT

**Bugfixes**
* #2989 Refactor and harden size and stats functions
* #3058 Reduce memory usage for distributed inserts
* #3067 Fix extremely slow multi-node order by queries
* #3082 Fix chunk index column name mapping
* #3083 Keep Append pathkeys in ChunkAppend

**Thanks**
* @BowenGG for reporting an issue with indexes with INCLUDE
* @fvannee for reporting an issue with ChunkAppend pathkeys
* @pedrokost and @RobAtticus for reporting an issue with size
  functions on empty hypertables
* @phemmer and @ryanbooz for reporting issues with slow
  multi-node order by queries
* @stephane-moreau for reporting an issue with high memory usage during
  single-transaction inserts on a distributed hypertable.