### PR TITLE
Fix use after free in add_reorder_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #3101 Use commit date in get_git_commit()
+* #3104 Fix use after free in add_reorder_policy
 
 ## 2.2.0 (2021-04-13)
 


### PR DESCRIPTION
The hypertable object in policy_reorder_add was still used after
releasing the cache leading to occasional segfaults in CI.

https://github.com/timescale/timescaledb/pull/3100/checks?check_run_id=2321566721
Fixes https://github.com/timescale/timescaledb-private/issues/906