### PR TITLE
Fix Skip Scan cost calculation for queries with excluded chunks

### DIFF
--- a/tsl/test/expected/plan_skip_scan-11.out
+++ b/tsl/test/expected/plan_skip_scan-11.out
@@ -922,14 +922,15 @@ WHERE CLAUSES
                One-Time Filter: false
 (6 rows)
 
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
-   ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
-         Index Cond: (dev > 20)
-(3 rows)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=0 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+(4 rows)
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
@@ -2978,22 +2979,26 @@ WHERE CLAUSES
                One-Time Filter: false
 (6 rows)
 
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_1_1_chunk.dev
-         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-(11 rows)
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+(15 rows)
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;

--- a/tsl/test/expected/plan_skip_scan-12.out
+++ b/tsl/test/expected/plan_skip_scan-12.out
@@ -922,14 +922,15 @@ WHERE CLAUSES
                One-Time Filter: false
 (6 rows)
 
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
-   ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
-         Index Cond: (dev > 20)
-(3 rows)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=0 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+(4 rows)
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
@@ -2961,22 +2962,26 @@ WHERE CLAUSES
                One-Time Filter: false
 (6 rows)
 
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_1_1_chunk.dev
-         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-(11 rows)
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+(15 rows)
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -924,14 +924,15 @@ WHERE CLAUSES
                One-Time Filter: false
 (6 rows)
 
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
-                                  QUERY PLAN                                   
--------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
-   ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
-         Index Cond: (dev > 20)
-(3 rows)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=0 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=0 loops=1)
+               Index Cond: (dev > 20)
+(4 rows)
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
@@ -2945,22 +2946,26 @@ WHERE CLAUSES
                One-Time Filter: false
 (6 rows)
 
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Merge Append (actual rows=0 loops=1)
          Sort Key: _hyper_1_1_chunk.dev
-         ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-         ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
-               Index Cond: (dev > 20)
-(11 rows)
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=0 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=0 loops=1)
+                     Index Cond: (dev > 20)
+(15 rows)
 
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -184,7 +184,7 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
 -- always false expr similar to our initial skip qual
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
@@ -377,7 +377,7 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
 -- always false expr similar to our initial skip qual
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
@@ -585,7 +585,7 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
 -- always false expr similar to our initial skip qual
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;
@@ -778,7 +778,7 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
 -- always false expr similar to our initial skip qual
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -146,7 +146,7 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE (dev, time) > (5,100);
 -- always false expr similar to our initial skip qual
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > NULL;
--- no tuples matching does not use skipscan due to cost
+-- no tuples matching
 :PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev > 20;
 -- multiple constraints in WHERE clause
 :PREFIX SELECT DISTINCT ON (dev) dev,time FROM :TABLE WHERE dev > 5 AND time = 100;


### PR DESCRIPTION
If the row estimate for the scan below Skip Scan is 1 we assume that the
estimate got clamped to 1 and no rows would be returned by this scan and
this chunk will most likely be excluded by runtime exclusion.
Otherwise the cost for this path would be highly inflated due to
(ndistinct / rows) * total leading to SkipScan not being chosen for
queries on hypertables with a lot of excluded chunks.