### PR TITLE
Add "SELECT DISTINCT" pushdown in multi-node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Features**
+* #3113 Pushdown "SELECT DISTINCT" in multi-node to allow use of Skip Scan
+
 **Bugfixes**
 * #3101 Use commit date in get_git_commit()
 * #3104 Fix use after free in add_reorder_policy

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,7 +70,7 @@ extern int64 ts_date_trunc_interval_period_approx(text *units);
  */
 extern TSDLLEXPORT int64 ts_get_interval_period_approx(Interval *interval);
 
-extern Oid ts_inheritance_parent_relid(Oid relid);
+extern TSDLLEXPORT Oid ts_inheritance_parent_relid(Oid relid);
 
 extern Oid ts_lookup_proc_filtered(const char *schema, const char *funcname, Oid *rettype,
 								   proc_filter filter, void *filter_arg);

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -2380,33 +2380,33 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
            ->  HashAggregate (actual rows=7 loops=1)
                  Output: disttable_replicated_1.device
                  Group Key: disttable_replicated_1.device
-                 ->  Append (actual rows=8 loops=1)
+                 ->  Append (actual rows=7 loops=1)
                        ->  Seq Scan on public.disttable_replicated disttable_replicated_1 (actual rows=0 loops=1)
                              Output: disttable_replicated_1.device
-                       ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk _dist_hyper_6_12_chunk_1 (actual rows=2 loops=1)
+                       ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk _dist_hyper_6_12_chunk_1 (actual rows=1 loops=1)
                              Output: _dist_hyper_6_12_chunk_1.device
                              Data node: db_dist_hypertable_1
-                             Remote SQL: SELECT device FROM _timescaledb_internal._dist_hyper_6_12_chunk
+                             Remote SQL: SELECT DISTINCT device FROM _timescaledb_internal._dist_hyper_6_12_chunk
                        ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_13_chunk _dist_hyper_6_13_chunk_1 (actual rows=1 loops=1)
                              Output: _dist_hyper_6_13_chunk_1.device
                              Data node: db_dist_hypertable_2
-                             Remote SQL: SELECT device FROM _timescaledb_internal._dist_hyper_6_13_chunk
+                             Remote SQL: SELECT DISTINCT device FROM _timescaledb_internal._dist_hyper_6_13_chunk
                        ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_14_chunk _dist_hyper_6_14_chunk_1 (actual rows=1 loops=1)
                              Output: _dist_hyper_6_14_chunk_1.device
                              Data node: db_dist_hypertable_3
-                             Remote SQL: SELECT device FROM _timescaledb_internal._dist_hyper_6_14_chunk
+                             Remote SQL: SELECT DISTINCT device FROM _timescaledb_internal._dist_hyper_6_14_chunk
                        ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_15_chunk _dist_hyper_6_15_chunk_1 (actual rows=2 loops=1)
                              Output: _dist_hyper_6_15_chunk_1.device
                              Data node: db_dist_hypertable_1
-                             Remote SQL: SELECT device FROM _timescaledb_internal._dist_hyper_6_15_chunk
+                             Remote SQL: SELECT DISTINCT device FROM _timescaledb_internal._dist_hyper_6_15_chunk
                        ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_16_chunk _dist_hyper_6_16_chunk_1 (actual rows=1 loops=1)
                              Output: _dist_hyper_6_16_chunk_1.device
                              Data node: db_dist_hypertable_2
-                             Remote SQL: SELECT device FROM _timescaledb_internal._dist_hyper_6_16_chunk
+                             Remote SQL: SELECT DISTINCT device FROM _timescaledb_internal._dist_hyper_6_16_chunk
                        ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_17_chunk _dist_hyper_6_17_chunk_1 (actual rows=1 loops=1)
                              Output: _dist_hyper_6_17_chunk_1.device
                              Data node: db_dist_hypertable_3
-                             Remote SQL: SELECT device FROM _timescaledb_internal._dist_hyper_6_17_chunk
+                             Remote SQL: SELECT DISTINCT device FROM _timescaledb_internal._dist_hyper_6_17_chunk
    InitPlan 2 (returns $1)
      ->  Limit (actual rows=1 loops=1)
            Output: devices.device

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -2353,8 +2353,8 @@ WITH devices AS (
      SELECT DISTINCT device FROM disttable_replicated ORDER BY device
 )
 UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM devices LIMIT 1);
-                                                                                                  QUERY PLAN                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.disttable_replicated (actual rows=0 loops=1)
    Update on public.disttable_replicated
    Foreign Update on _timescaledb_internal._dist_hyper_6_12_chunk
@@ -2382,17 +2382,17 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
                                    Output: disttable_replicated_2.device
                                    Data node: db_dist_hypertable_1
                                    Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
-                                   Remote SQL: SELECT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
+                                   Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=1 loops=1)
                                    Output: disttable_replicated_3.device
                                    Data node: db_dist_hypertable_2
                                    Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
-                                   Remote SQL: SELECT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
+                                   Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_4 (actual rows=1 loops=1)
                                    Output: disttable_replicated_4.device
                                    Data node: db_dist_hypertable_3
                                    Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
-                                   Remote SQL: SELECT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
+                                   Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
    ->  Seq Scan on public.disttable_replicated (actual rows=0 loops=1)
          Output: disttable_replicated."time", 2, disttable_replicated.temp, disttable_replicated."Color", disttable_replicated.ctid
          Filter: (disttable_replicated.device = $0)

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -2352,8 +2352,8 @@ WITH devices AS (
      SELECT DISTINCT device FROM disttable_replicated ORDER BY device
 )
 UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM devices LIMIT 1);
-                                                                                                  QUERY PLAN                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on public.disttable_replicated (actual rows=0 loops=1)
    Update on public.disttable_replicated
    Foreign Update on _timescaledb_internal._dist_hyper_6_12_chunk disttable_replicated_1
@@ -2381,17 +2381,17 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
                                    Output: disttable_replicated_8.device
                                    Data node: db_dist_hypertable_1
                                    Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
-                                   Remote SQL: SELECT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
+                                   Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_9 (actual rows=1 loops=1)
                                    Output: disttable_replicated_9.device
                                    Data node: db_dist_hypertable_2
                                    Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
-                                   Remote SQL: SELECT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
+                                   Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_10 (actual rows=1 loops=1)
                                    Output: disttable_replicated_10.device
                                    Data node: db_dist_hypertable_3
                                    Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
-                                   Remote SQL: SELECT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
+                                   Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
    ->  Seq Scan on public.disttable_replicated (actual rows=0 loops=1)
          Output: disttable_replicated."time", 2, disttable_replicated.temp, disttable_replicated."Color", disttable_replicated.ctid
          Filter: (disttable_replicated.device = $0)

--- a/tsl/test/expected/dist_query-11.out
+++ b/tsl/test/expected/dist_query-11.out
@@ -930,8 +930,8 @@ SELECT DISTINCT device, time
 FROM hyper
 
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -944,17 +944,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -965,8 +965,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 
 LIMIT 10
-                                                                                              QUERY PLAN                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -979,17 +979,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
 
@@ -1926,8 +1926,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -1940,17 +1940,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -1961,8 +1961,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -1975,17 +1975,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -2702,8 +2702,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -2716,17 +2716,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -2737,8 +2737,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -2751,17 +2751,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -3678,8 +3678,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -3692,17 +3692,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -3713,8 +3713,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -3727,17 +3727,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -4696,8 +4696,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -4710,17 +4710,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -4731,8 +4731,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -4745,17 +4745,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -5705,8 +5705,8 @@ SELECT DISTINCT device, time
 FROM hyper1d
 
 LIMIT 10
-                                                                                               QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper1d.device, hyper1d."time"
    ->  Unique
@@ -5719,17 +5719,17 @@ LIMIT 10
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_2_19_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_2_20_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_2_21_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -5740,8 +5740,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper1d
 
 LIMIT 10
-                                                                                    QUERY PLAN                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper1d.device, hyper1d."time"
    ->  Unique
@@ -5754,17 +5754,17 @@ LIMIT 10
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_2_19_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_2_20_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_2_21_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
 

--- a/tsl/test/expected/dist_query-12.out
+++ b/tsl/test/expected/dist_query-12.out
@@ -930,8 +930,8 @@ SELECT DISTINCT device, time
 FROM hyper
 
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -944,17 +944,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -965,8 +965,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 
 LIMIT 10
-                                                                                              QUERY PLAN                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -979,17 +979,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
 
@@ -1924,8 +1924,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -1938,17 +1938,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -1959,8 +1959,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -1973,17 +1973,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -2670,8 +2670,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -2684,17 +2684,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -2705,8 +2705,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -2719,17 +2719,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -3641,8 +3641,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -3655,17 +3655,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -3676,8 +3676,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -3690,17 +3690,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -4657,8 +4657,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -4671,17 +4671,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -4692,8 +4692,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -4706,17 +4706,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -5664,8 +5664,8 @@ SELECT DISTINCT device, time
 FROM hyper1d
 
 LIMIT 10
-                                                                                               QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper1d.device, hyper1d."time"
    ->  Unique
@@ -5678,17 +5678,17 @@ LIMIT 10
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_2_19_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_2_20_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_2_21_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -5699,8 +5699,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper1d
 
 LIMIT 10
-                                                                                    QUERY PLAN                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper1d.device, hyper1d."time"
    ->  Unique
@@ -5713,17 +5713,17 @@ LIMIT 10
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_2_19_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_2_20_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_2_21_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
 

--- a/tsl/test/expected/dist_query-13.out
+++ b/tsl/test/expected/dist_query-13.out
@@ -930,8 +930,8 @@ SELECT DISTINCT device, time
 FROM hyper
 
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -944,17 +944,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -965,8 +965,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 
 LIMIT 10
-                                                                                              QUERY PLAN                                                                                               
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -979,17 +979,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
 
@@ -1924,8 +1924,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -1938,17 +1938,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -1959,8 +1959,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -1973,17 +1973,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -2670,8 +2670,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -2684,17 +2684,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -2705,8 +2705,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -2719,17 +2719,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -3641,8 +3641,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -3655,17 +3655,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -3676,8 +3676,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -3690,17 +3690,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -4657,8 +4657,8 @@ SELECT DISTINCT device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -4671,17 +4671,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -4692,8 +4692,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper
 ORDER BY 1,2
 LIMIT 10
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                 QUERY PLAN                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper.device, hyper."time"
    ->  Unique
@@ -4706,17 +4706,17 @@ LIMIT 10
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -5664,8 +5664,8 @@ SELECT DISTINCT device, time
 FROM hyper1d
 
 LIMIT 10
-                                                                                               QUERY PLAN                                                                                                
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper1d.device, hyper1d."time"
    ->  Unique
@@ -5678,17 +5678,17 @@ LIMIT 10
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_2_19_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_2_20_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_2_21_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
 
@@ -5699,8 +5699,8 @@ SELECT DISTINCT ON (device) device, time
 FROM hyper1d
 
 LIMIT 10
-                                                                                    QUERY PLAN                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: hyper1d.device, hyper1d."time"
    ->  Unique
@@ -5713,17 +5713,17 @@ LIMIT 10
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
                            Chunks: _dist_hyper_2_19_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
                            Chunks: _dist_hyper_2_20_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
                            Chunks: _dist_hyper_2_21_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
+                           Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
 

--- a/tsl/test/shared/expected/dist_distinct.out
+++ b/tsl/test/shared/expected/dist_distinct.out
@@ -1,0 +1,904 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set TEST_BASE_NAME dist_distinct
+-- Run
+SELECT format('include/%s_run.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+       format('%s/shared/results/%s_results_reference.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_REFERENCE",
+       format('%s/shared/results/%s_results_distributed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_DIST"
+\gset
+SELECT format('\! diff -u --label "Distributed results" --label "Local results" %s %s', :'TEST_RESULTS_DIST', :'TEST_RESULTS_REFERENCE') AS "DIFF_CMD_DIST"
+\gset
+\set PREFIX 'EXPLAIN (verbose, costs off)'
+\set ORDER_BY_1 'ORDER BY 1'
+\set ORDER_BY_1_2 'ORDER BY 1,2'
+\set ECHO queries 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% RUNNING TESTS on table: metrics_dist
+%%% PREFIX: EXPLAIN (verbose, costs off)
+%%% ORDER_BY_1: ORDER BY 1
+%%% ORDER_BY_1_2: ORDER BY 1,2
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+SET enable_hashagg TO false;
+Unique plan on access node for SELECT DISTINCT
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id
+FROM metrics_dist
+ORDER BY 1
+LIMIT 10;
+                                                                                               QUERY PLAN                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist.device_id
+   ->  Unique
+         Output: metrics_dist.device_id
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist.device_id
+               ->  Merge Append
+                     Sort Key: metrics_dist_1.device_id
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1.device_id
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2.device_id
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3.device_id
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+(23 rows)
+
+RESET enable_hashagg;
+SET timescaledb.enable_per_data_node_queries = true;
+SELECT DISTINCT on expressions is not pushed down
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id*v1
+FROM metrics_dist
+ORDER BY 1
+LIMIT 10;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: ((metrics_dist.device_id * metrics_dist.v1))
+   ->  Unique
+         Output: ((metrics_dist.device_id * metrics_dist.v1))
+         ->  Custom Scan (AsyncAppend)
+               Output: ((metrics_dist.device_id * metrics_dist.v1))
+               ->  Merge Append
+                     Sort Key: ((metrics_dist_1.device_id * metrics_dist_1.v1))
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: (metrics_dist_1.device_id * metrics_dist_1.v1)
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: (metrics_dist_2.device_id * metrics_dist_2.v1)
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: (metrics_dist_3.device_id * metrics_dist_3.v1)
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
+(23 rows)
+
+SET timescaledb.enable_remote_explain = ON;
+SELECT DISTINCT on column with index uses SkipScan
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id
+FROM metrics_dist
+ORDER BY 1
+LIMIT 10;
+                                                                                               QUERY PLAN                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist.device_id
+   ->  Unique
+         Output: metrics_dist.device_id
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist.device_id
+               ->  Merge Append
+                     Sort Key: metrics_dist_1.device_id
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1.device_id
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_37_chunk.device_id
+                               ->  Merge Append
+                                     Sort Key: _dist_hyper_7_37_chunk.device_id
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_37_chunk
+                                           Output: _dist_hyper_7_37_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_37_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_37_chunk
+                                                 Output: _dist_hyper_7_37_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_37_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_40_chunk
+                                           Output: _dist_hyper_7_40_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_40_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_40_chunk
+                                                 Output: _dist_hyper_7_40_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_40_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_43_chunk
+                                           Output: _dist_hyper_7_43_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_43_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_43_chunk
+                                                 Output: _dist_hyper_7_43_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_43_chunk.device_id > NULL::integer)
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2.device_id
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_38_chunk.device_id
+                               ->  Merge Append
+                                     Sort Key: _dist_hyper_7_38_chunk.device_id
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_38_chunk
+                                           Output: _dist_hyper_7_38_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_38_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_38_chunk
+                                                 Output: _dist_hyper_7_38_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_38_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_41_chunk
+                                           Output: _dist_hyper_7_41_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_41_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_41_chunk
+                                                 Output: _dist_hyper_7_41_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_41_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_44_chunk
+                                           Output: _dist_hyper_7_44_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_44_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_44_chunk
+                                                 Output: _dist_hyper_7_44_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_44_chunk.device_id > NULL::integer)
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3.device_id
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_39_chunk.device_id
+                               ->  Merge Append
+                                     Sort Key: _dist_hyper_7_39_chunk.device_id
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_39_chunk
+                                           Output: _dist_hyper_7_39_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_39_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_39_chunk
+                                                 Output: _dist_hyper_7_39_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_39_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_42_chunk
+                                           Output: _dist_hyper_7_42_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_42_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_42_chunk
+                                                 Output: _dist_hyper_7_42_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_42_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_45_chunk
+                                           Output: _dist_hyper_7_45_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_45_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_45_chunk
+                                                 Output: _dist_hyper_7_45_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_45_chunk.device_id > NULL::integer)
+ 
+(86 rows)
+
+SELECT DISTINCT with constants and NULLs in targetlist uses SkipScan
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id, NULL, 'const1'
+FROM metrics_dist
+ORDER BY 1
+LIMIT 10;
+                                                                                               QUERY PLAN                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist.device_id, NULL::text, 'const1'::text
+   ->  Unique
+         Output: metrics_dist.device_id, NULL::text, 'const1'::text
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist.device_id, NULL::text, 'const1'::text
+               ->  Merge Append
+                     Sort Key: metrics_dist_1.device_id
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1.device_id, NULL::text, 'const1'::text
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_37_chunk.device_id
+                               ->  Merge Append
+                                     Sort Key: _dist_hyper_7_37_chunk.device_id
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_37_chunk
+                                           Output: _dist_hyper_7_37_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_37_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_37_chunk
+                                                 Output: _dist_hyper_7_37_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_37_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_40_chunk
+                                           Output: _dist_hyper_7_40_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_40_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_40_chunk
+                                                 Output: _dist_hyper_7_40_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_40_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_43_chunk
+                                           Output: _dist_hyper_7_43_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_43_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_43_chunk
+                                                 Output: _dist_hyper_7_43_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_43_chunk.device_id > NULL::integer)
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2.device_id, NULL::text, 'const1'::text
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_38_chunk.device_id
+                               ->  Merge Append
+                                     Sort Key: _dist_hyper_7_38_chunk.device_id
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_38_chunk
+                                           Output: _dist_hyper_7_38_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_38_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_38_chunk
+                                                 Output: _dist_hyper_7_38_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_38_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_41_chunk
+                                           Output: _dist_hyper_7_41_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_41_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_41_chunk
+                                                 Output: _dist_hyper_7_41_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_41_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_44_chunk
+                                           Output: _dist_hyper_7_44_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_44_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_44_chunk
+                                                 Output: _dist_hyper_7_44_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_44_chunk.device_id > NULL::integer)
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3.device_id, NULL::text, 'const1'::text
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_39_chunk.device_id
+                               ->  Merge Append
+                                     Sort Key: _dist_hyper_7_39_chunk.device_id
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_39_chunk
+                                           Output: _dist_hyper_7_39_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_39_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_39_chunk
+                                                 Output: _dist_hyper_7_39_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_39_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_42_chunk
+                                           Output: _dist_hyper_7_42_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_42_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_42_chunk
+                                                 Output: _dist_hyper_7_42_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_42_chunk.device_id > NULL::integer)
+                                     ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_45_chunk
+                                           Output: _dist_hyper_7_45_chunk.device_id
+                                           ->  Index Only Scan using _dist_hyper_7_45_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_45_chunk
+                                                 Output: _dist_hyper_7_45_chunk.device_id
+                                                 Index Cond: (_dist_hyper_7_45_chunk.device_id > NULL::integer)
+ 
+(86 rows)
+
+SELECT DISTINCT only sends columns to the data nodes
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id, time, NULL, 'const1'
+FROM metrics_dist
+ORDER BY 1,2
+LIMIT 10;
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist.device_id, metrics_dist."time", NULL::text, 'const1'::text
+   ->  Unique
+         Output: metrics_dist.device_id, metrics_dist."time", NULL::text, 'const1'::text
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist.device_id, metrics_dist."time", NULL::text, 'const1'::text
+               ->  Merge Append
+                     Sort Key: metrics_dist_1.device_id, metrics_dist_1."time"
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1.device_id, metrics_dist_1."time", NULL::text, 'const1'::text
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                               ->  Sort
+                                     Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                     Sort Key: _dist_hyper_7_37_chunk.device_id, _dist_hyper_7_37_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_37_chunk
+                                                 Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_40_chunk
+                                                 Output: _dist_hyper_7_40_chunk."time", _dist_hyper_7_40_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_43_chunk
+                                                 Output: _dist_hyper_7_43_chunk."time", _dist_hyper_7_43_chunk.device_id
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2.device_id, metrics_dist_2."time", NULL::text, 'const1'::text
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Sort
+                               Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                               Sort Key: _dist_hyper_7_38_chunk.device_id, _dist_hyper_7_38_chunk."time"
+                               ->  HashAggregate
+                                     Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                     Group Key: _dist_hyper_7_38_chunk.device_id, _dist_hyper_7_38_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_38_chunk
+                                                 Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_41_chunk
+                                                 Output: _dist_hyper_7_41_chunk."time", _dist_hyper_7_41_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_44_chunk
+                                                 Output: _dist_hyper_7_44_chunk."time", _dist_hyper_7_44_chunk.device_id
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3.device_id, metrics_dist_3."time", NULL::text, 'const1'::text
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                               ->  Sort
+                                     Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                     Sort Key: _dist_hyper_7_39_chunk.device_id, _dist_hyper_7_39_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_39_chunk
+                                                 Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_42_chunk
+                                                 Output: _dist_hyper_7_42_chunk."time", _dist_hyper_7_42_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_45_chunk
+                                                 Output: _dist_hyper_7_45_chunk."time", _dist_hyper_7_45_chunk.device_id
+ 
+(66 rows)
+
+SELECT DISTINCE is pushed down in attribute attno order
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id, time
+FROM metrics_dist
+ORDER BY 1,2
+LIMIT 10;
+                                                                                                               QUERY PLAN                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist.device_id, metrics_dist."time"
+   ->  Unique
+         Output: metrics_dist.device_id, metrics_dist."time"
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist.device_id, metrics_dist."time"
+               ->  Merge Append
+                     Sort Key: metrics_dist_1.device_id, metrics_dist_1."time"
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1.device_id, metrics_dist_1."time"
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                               ->  Sort
+                                     Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                     Sort Key: _dist_hyper_7_37_chunk.device_id, _dist_hyper_7_37_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_37_chunk
+                                                 Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_40_chunk
+                                                 Output: _dist_hyper_7_40_chunk."time", _dist_hyper_7_40_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_43_chunk
+                                                 Output: _dist_hyper_7_43_chunk."time", _dist_hyper_7_43_chunk.device_id
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2.device_id, metrics_dist_2."time"
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Sort
+                               Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                               Sort Key: _dist_hyper_7_38_chunk.device_id, _dist_hyper_7_38_chunk."time"
+                               ->  HashAggregate
+                                     Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                     Group Key: _dist_hyper_7_38_chunk.device_id, _dist_hyper_7_38_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_38_chunk
+                                                 Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_41_chunk
+                                                 Output: _dist_hyper_7_41_chunk."time", _dist_hyper_7_41_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_44_chunk
+                                                 Output: _dist_hyper_7_44_chunk."time", _dist_hyper_7_44_chunk.device_id
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3.device_id, metrics_dist_3."time"
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                               ->  Sort
+                                     Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                     Sort Key: _dist_hyper_7_39_chunk.device_id, _dist_hyper_7_39_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_39_chunk
+                                                 Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_42_chunk
+                                                 Output: _dist_hyper_7_42_chunk."time", _dist_hyper_7_42_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_45_chunk
+                                                 Output: _dist_hyper_7_45_chunk."time", _dist_hyper_7_45_chunk.device_id
+ 
+(66 rows)
+
+SELECT DISTINCT ON multiple columns is pushed to data nodes
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT ON (device_id, time) device_id, time
+FROM metrics_dist
+ORDER BY 1,2
+LIMIT 10;
+                                                                                                                          QUERY PLAN                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist.device_id, metrics_dist."time"
+   ->  Unique
+         Output: metrics_dist.device_id, metrics_dist."time"
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist.device_id, metrics_dist."time"
+               ->  Merge Append
+                     Sort Key: metrics_dist_1.device_id, metrics_dist_1."time"
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1.device_id, metrics_dist_1."time"
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                               ->  Sort
+                                     Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                     Sort Key: _dist_hyper_7_37_chunk.device_id, _dist_hyper_7_37_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_37_chunk
+                                                 Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_40_chunk
+                                                 Output: _dist_hyper_7_40_chunk."time", _dist_hyper_7_40_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_43_chunk
+                                                 Output: _dist_hyper_7_43_chunk."time", _dist_hyper_7_43_chunk.device_id
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2.device_id, metrics_dist_2."time"
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                               ->  Sort
+                                     Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                     Sort Key: _dist_hyper_7_38_chunk.device_id, _dist_hyper_7_38_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_38_chunk
+                                                 Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_41_chunk
+                                                 Output: _dist_hyper_7_41_chunk."time", _dist_hyper_7_41_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_44_chunk
+                                                 Output: _dist_hyper_7_44_chunk."time", _dist_hyper_7_44_chunk.device_id
+ 
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3.device_id, metrics_dist_3."time"
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                           Remote EXPLAIN: 
+                             Unique
+                               Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                               ->  Sort
+                                     Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                     Sort Key: _dist_hyper_7_39_chunk.device_id, _dist_hyper_7_39_chunk."time"
+                                     ->  Append
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_39_chunk
+                                                 Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_42_chunk
+                                                 Output: _dist_hyper_7_42_chunk."time", _dist_hyper_7_42_chunk.device_id
+                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_7_45_chunk
+                                                 Output: _dist_hyper_7_45_chunk."time", _dist_hyper_7_45_chunk.device_id
+ 
+(65 rows)
+
+SELECT DISTINCT within a sub-select
+EXPLAIN (verbose, costs off)
+SELECT device_id, time, 'const1' FROM (SELECT DISTINCT ON (device_id) device_id, time
+FROM metrics_dist
+ORDER BY 1,2
+LIMIT 10) a;
+                                                                                                                         QUERY PLAN                                                                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on a
+   Output: a.device_id, a."time", 'const1'::text
+   ->  Limit
+         Output: metrics_dist.device_id, metrics_dist."time"
+         ->  Unique
+               Output: metrics_dist.device_id, metrics_dist."time"
+               ->  Custom Scan (AsyncAppend)
+                     Output: metrics_dist.device_id, metrics_dist."time"
+                     ->  Merge Append
+                           Sort Key: metrics_dist_1.device_id, metrics_dist_1."time"
+                           ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                                 Output: metrics_dist_1.device_id, metrics_dist_1."time"
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                                 Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                                 Remote EXPLAIN: 
+                                   Unique
+                                     Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                     ->  Sort
+                                           Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                           Sort Key: _dist_hyper_7_37_chunk.device_id, _dist_hyper_7_37_chunk."time"
+                                           ->  Append
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_37_chunk
+                                                       Output: _dist_hyper_7_37_chunk."time", _dist_hyper_7_37_chunk.device_id
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_40_chunk
+                                                       Output: _dist_hyper_7_40_chunk."time", _dist_hyper_7_40_chunk.device_id
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_43_chunk
+                                                       Output: _dist_hyper_7_43_chunk."time", _dist_hyper_7_43_chunk.device_id
+ 
+                           ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                                 Output: metrics_dist_2.device_id, metrics_dist_2."time"
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                                 Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                                 Remote EXPLAIN: 
+                                   Unique
+                                     Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                     ->  Sort
+                                           Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                           Sort Key: _dist_hyper_7_38_chunk.device_id, _dist_hyper_7_38_chunk."time"
+                                           ->  Append
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_38_chunk
+                                                       Output: _dist_hyper_7_38_chunk."time", _dist_hyper_7_38_chunk.device_id
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_41_chunk
+                                                       Output: _dist_hyper_7_41_chunk."time", _dist_hyper_7_41_chunk.device_id
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_44_chunk
+                                                       Output: _dist_hyper_7_44_chunk."time", _dist_hyper_7_44_chunk.device_id
+ 
+                           ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                                 Output: metrics_dist_3.device_id, metrics_dist_3."time"
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                                 Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                                 Remote EXPLAIN: 
+                                   Unique
+                                     Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                     ->  Sort
+                                           Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                           Sort Key: _dist_hyper_7_39_chunk.device_id, _dist_hyper_7_39_chunk."time"
+                                           ->  Append
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_39_chunk
+                                                       Output: _dist_hyper_7_39_chunk."time", _dist_hyper_7_39_chunk.device_id
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_42_chunk
+                                                       Output: _dist_hyper_7_42_chunk."time", _dist_hyper_7_42_chunk.device_id
+                                                 ->  Seq Scan on _timescaledb_internal._dist_hyper_7_45_chunk
+                                                       Output: _dist_hyper_7_45_chunk."time", _dist_hyper_7_45_chunk.device_id
+ 
+(67 rows)
+
+SET timescaledb.enable_per_data_node_queries = false;
+SELECT DISTINCT works with enable_per_data_node_queries disabled
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id
+FROM metrics_dist
+ORDER BY 1
+LIMIT 10;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: _dist_hyper_7_37_chunk.device_id
+   ->  Unique
+         Output: _dist_hyper_7_37_chunk.device_id
+         ->  Merge Append
+               Sort Key: _dist_hyper_7_37_chunk.device_id
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_37_chunk
+                     Output: _dist_hyper_7_37_chunk.device_id
+                     Data node: data_node_1
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_37_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_37_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_37_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_37_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_37_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_38_chunk
+                     Output: _dist_hyper_7_38_chunk.device_id
+                     Data node: data_node_2
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_38_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_38_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_38_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_38_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_38_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_39_chunk
+                     Output: _dist_hyper_7_39_chunk.device_id
+                     Data node: data_node_3
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_39_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_39_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_39_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_39_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_39_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_40_chunk
+                     Output: _dist_hyper_7_40_chunk.device_id
+                     Data node: data_node_1
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_40_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_40_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_40_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_40_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_40_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_41_chunk
+                     Output: _dist_hyper_7_41_chunk.device_id
+                     Data node: data_node_2
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_41_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_41_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_41_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_41_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_41_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_42_chunk
+                     Output: _dist_hyper_7_42_chunk.device_id
+                     Data node: data_node_3
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_42_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_42_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_42_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_42_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_42_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_43_chunk
+                     Output: _dist_hyper_7_43_chunk.device_id
+                     Data node: data_node_1
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_43_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_43_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_43_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_43_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_43_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_44_chunk
+                     Output: _dist_hyper_7_44_chunk.device_id
+                     Data node: data_node_2
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_44_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_44_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_44_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_44_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_44_chunk.device_id > NULL::integer)
+ 
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_7_45_chunk
+                     Output: _dist_hyper_7_45_chunk.device_id
+                     Data node: data_node_3
+                     Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_7_45_chunk ORDER BY device_id ASC NULLS LAST
+                     Remote EXPLAIN: 
+                       Unique
+                         Output: device_id
+                         ->  Custom Scan (SkipScan) on _timescaledb_internal._dist_hyper_7_45_chunk
+                               Output: device_id
+                               ->  Index Only Scan using _dist_hyper_7_45_chunk_metrics_dist_device_id_time_idx on _timescaledb_internal._dist_hyper_7_45_chunk
+                                     Output: device_id
+                                     Index Cond: (_dist_hyper_7_45_chunk.device_id > NULL::integer)
+ 
+(123 rows)
+
+SET timescaledb.enable_per_data_node_queries = true;
+SET timescaledb.enable_remote_explain = OFF;
+SELECT DISTINCT should not have duplicate columns
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT device_id, device_id
+FROM metrics_dist
+ORDER BY 1;
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: metrics_dist.device_id, metrics_dist.device_id
+   Sort Key: metrics_dist.device_id
+   ->  HashAggregate
+         Output: metrics_dist.device_id, metrics_dist.device_id
+         Group Key: metrics_dist.device_id, metrics_dist.device_id
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist.device_id, metrics_dist.device_id
+               ->  Append
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1.device_id, metrics_dist_1.device_id
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2.device_id, metrics_dist_2.device_id
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3.device_id, metrics_dist_3.device_id
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
+(24 rows)
+
+SELECT DISTINCT handles whole row correctly
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT *
+FROM metrics_dist
+ORDER BY 1,2
+LIMIT 10;
+                                                                                                                                                             QUERY PLAN                                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist."time", metrics_dist.device_id, metrics_dist.v0, metrics_dist.v1, metrics_dist.v2, metrics_dist.v3
+   ->  Unique
+         Output: metrics_dist."time", metrics_dist.device_id, metrics_dist.v0, metrics_dist.v1, metrics_dist.v2, metrics_dist.v3
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist."time", metrics_dist.device_id, metrics_dist.v0, metrics_dist.v1, metrics_dist.v2, metrics_dist.v3
+               ->  Merge Append
+                     Sort Key: metrics_dist_1."time", metrics_dist_1.device_id, metrics_dist_1.v0, metrics_dist_1.v1, metrics_dist_1.v2, metrics_dist_1.v3
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1."time", metrics_dist_1.device_id, metrics_dist_1.v0, metrics_dist_1.v1, metrics_dist_1.v2, metrics_dist_1.v3
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2."time", metrics_dist_2.device_id, metrics_dist_2.v0, metrics_dist_2.v1, metrics_dist_2.v2, metrics_dist_2.v3
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3."time", metrics_dist_3.device_id, metrics_dist_3.v0, metrics_dist_3.v1, metrics_dist_3.v2, metrics_dist_3.v3
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
+(23 rows)
+
+SELECT DISTINCT ON (expr) handles whole row correctly
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT ON (device_id) *
+FROM metrics_dist
+ORDER BY device_id, time
+LIMIT 10;
+                                                                                                                              QUERY PLAN                                                                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist."time", metrics_dist.device_id, metrics_dist.v0, metrics_dist.v1, metrics_dist.v2, metrics_dist.v3
+   ->  Unique
+         Output: metrics_dist."time", metrics_dist.device_id, metrics_dist.v0, metrics_dist.v1, metrics_dist.v2, metrics_dist.v3
+         ->  Custom Scan (AsyncAppend)
+               Output: metrics_dist."time", metrics_dist.device_id, metrics_dist.v0, metrics_dist.v1, metrics_dist.v2, metrics_dist.v3
+               ->  Merge Append
+                     Sort Key: metrics_dist_1.device_id, metrics_dist_1."time"
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: metrics_dist_1."time", metrics_dist_1.device_id, metrics_dist_1.v0, metrics_dist_1.v1, metrics_dist_1.v2, metrics_dist_1.v3
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: metrics_dist_2."time", metrics_dist_2.device_id, metrics_dist_2.v0, metrics_dist_2.v1, metrics_dist_2.v2, metrics_dist_2.v3
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: metrics_dist_3."time", metrics_dist_3.device_id, metrics_dist_3.v0, metrics_dist_3.v1, metrics_dist_3.v2, metrics_dist_3.v3
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
+(23 rows)
+
+SELECT DISTINCT RECORD works correctly
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT metrics_dist r
+FROM metrics_dist
+ORDER BY r
+LIMIT 10;
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: metrics_dist.*
+   ->  Unique
+         Output: metrics_dist.*
+         ->  Sort
+               Output: metrics_dist.*
+               Sort Key: metrics_dist.*
+               ->  Custom Scan (AsyncAppend)
+                     Output: metrics_dist.*
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                                 Output: metrics_dist_1.*
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                                 Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
+                           ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                                 Output: metrics_dist_2.*
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                                 Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
+                           ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                                 Output: metrics_dist_3.*
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                                 Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
+(25 rows)
+
+SELECT DISTINCT FUNCTION_EXPR not pushed down currently
+EXPLAIN (verbose, costs off)
+SELECT DISTINCT time_bucket('1h',time) col1
+FROM metrics_dist
+ORDER BY col1
+LIMIT 10;
+                                                                                                             QUERY PLAN                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: (time_bucket('@ 1 hour'::interval, metrics_dist."time"))
+   ->  Unique
+         Output: (time_bucket('@ 1 hour'::interval, metrics_dist."time"))
+         ->  Custom Scan (AsyncAppend)
+               Output: (time_bucket('@ 1 hour'::interval, metrics_dist."time"))
+               ->  Merge Append
+                     Sort Key: (time_bucket('@ 1 hour'::interval, metrics_dist_1."time"))
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
+                           Output: time_bucket('@ 1 hour'::interval, metrics_dist_1."time")
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_7_37_chunk, _dist_hyper_7_40_chunk, _dist_hyper_7_43_chunk
+                           Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
+                           Output: time_bucket('@ 1 hour'::interval, metrics_dist_2."time")
+                           Data node: data_node_2
+                           Chunks: _dist_hyper_7_38_chunk, _dist_hyper_7_41_chunk, _dist_hyper_7_44_chunk
+                           Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
+                     ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
+                           Output: time_bucket('@ 1 hour'::interval, metrics_dist_3."time")
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_7_39_chunk, _dist_hyper_7_42_chunk, _dist_hyper_7_45_chunk
+                           Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
+(23 rows)
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% RUNNING TESTS on table: metrics
+%%% PREFIX: 
+%%% ORDER_BY_1: ORDER BY 1
+%%% ORDER_BY_1_2: ORDER BY 1,2
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% RUNNING TESTS on table: metrics_dist
+%%% PREFIX: 
+%%% ORDER_BY_1: ORDER BY 1
+%%% ORDER_BY_1_2: ORDER BY 1,2
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-- diff distributed and reference results (should be exactly same)
+:DIFF_CMD_DIST

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_FILES_SHARED
   decompress_placeholdervar.sql
   dist_gapfill.sql
   dist_insert.sql
+  dist_distinct.sql
 )
 
 set(TEST_TEMPLATES_SHARED

--- a/tsl/test/shared/sql/dist_distinct.sql
+++ b/tsl/test/shared/sql/dist_distinct.sql
@@ -1,0 +1,43 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set TEST_BASE_NAME dist_distinct
+-- Run
+SELECT format('include/%s_run.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+       format('%s/shared/results/%s_results_reference.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_REFERENCE",
+       format('%s/shared/results/%s_results_distributed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_DIST"
+\gset
+SELECT format('\! diff -u --label "Distributed results" --label "Local results" %s %s', :'TEST_RESULTS_DIST', :'TEST_RESULTS_REFERENCE') AS "DIFF_CMD_DIST"
+\gset
+
+\set PREFIX 'EXPLAIN (verbose, costs off)'
+\set ORDER_BY_1 'ORDER BY 1'
+\set ORDER_BY_1_2 'ORDER BY 1,2'
+
+\set ECHO queries 
+-- Get EXPLAIN output for the multi-node environment
+\set TABLE_NAME 'metrics_dist'                                                       
+\ir :TEST_QUERY_NAME 
+
+-- get results for all the queries                                              
+-- run queries on single node hypertable and store result                      
+-- then run queries on multinode hypertable and store result
+\set PREFIX ''                                                                  
+\set ECHO none                                                                  
+SET client_min_messages TO error; 
+
+-- run queries on single node hypertable and store reference result
+\set TABLE_NAME 'metrics'
+\o :TEST_RESULTS_REFERENCE
+\ir :TEST_QUERY_NAME
+
+-- run queries on multinode hypertable and store result
+\set TABLE_NAME 'metrics_dist'
+\o :TEST_RESULTS_DIST
+\ir :TEST_QUERY_NAME
+\o
+\set ECHO all                                                                  
+
+-- diff distributed and reference results (should be exactly same)
+:DIFF_CMD_DIST

--- a/tsl/test/shared/sql/include/dist_distinct_run.sql
+++ b/tsl/test/shared/sql/include/dist_distinct_run.sql
@@ -1,0 +1,135 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
+\echo '%%% RUNNING TESTS on table:' :TABLE_NAME
+\echo '%%% PREFIX:' :PREFIX
+\echo '%%% ORDER_BY_1:' :ORDER_BY_1
+\echo '%%% ORDER_BY_1_2:' :ORDER_BY_1_2
+\echo '%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%'
+
+-- Test SkipScan with SELECT DISTINCT in multi-node environment
+-- Ensure that a Unique plan gets chosen on the access node
+SET enable_hashagg TO false;
+\qecho Unique plan on access node for SELECT DISTINCT
+:PREFIX
+SELECT DISTINCT device_id
+FROM :TABLE_NAME
+:ORDER_BY_1
+LIMIT 10;
+RESET enable_hashagg;
+
+SET timescaledb.enable_per_data_node_queries = true;
+-- SELECT DISTINCT on expressions won't be pushed down
+\qecho SELECT DISTINCT on expressions is not pushed down
+:PREFIX
+SELECT DISTINCT device_id*v1
+FROM :TABLE_NAME
+:ORDER_BY_1
+LIMIT 10;
+
+SET timescaledb.enable_remote_explain = ON;
+-- SELECT DISTINCT on column with index should use SkipScan
+\qecho SELECT DISTINCT on column with index uses SkipScan
+:PREFIX
+SELECT DISTINCT device_id
+FROM :TABLE_NAME
+:ORDER_BY_1
+LIMIT 10;
+
+-- SELECT DISTINCT with constants and NULLs in targetlist should use SkipScan
+\qecho SELECT DISTINCT with constants and NULLs in targetlist uses SkipScan
+:PREFIX
+SELECT DISTINCT device_id, NULL, 'const1'
+FROM :TABLE_NAME
+:ORDER_BY_1
+LIMIT 10;
+
+-- SELECT DISTINCT with a mix of constants and columns should send only
+-- the columns to the remote side. However SkipScan won't be used because
+-- right now only single column is supported in SkipScans
+\qecho SELECT DISTINCT only sends columns to the data nodes
+:PREFIX
+SELECT DISTINCT device_id, time, NULL, 'const1'
+FROM :TABLE_NAME
+:ORDER_BY_1_2
+LIMIT 10;
+
+-- SELECT DISTINCT will be pushed down in the attribute attno order. This
+-- is ok because "DISTINCT SELECT col1, col2" returns the same values
+-- (subject to ORDER BY clauses) as "DISTINCE SELECT col2, col1"
+\qecho SELECT DISTINCE is pushed down in attribute attno order
+:PREFIX
+SELECT DISTINCT device_id, time
+FROM :TABLE_NAME
+:ORDER_BY_1_2
+LIMIT 10;
+
+-- SELECT DISTINCT ON on multiple columns will be pushed to the remote side.
+-- However SkipScan won't be used since only one column is supported
+\qecho SELECT DISTINCT ON multiple columns is pushed to data nodes
+:PREFIX
+SELECT DISTINCT ON (device_id, time) device_id, time
+FROM :TABLE_NAME
+:ORDER_BY_1_2
+LIMIT 10;
+
+-- Another variation with SELECT DISTINCT
+\qecho SELECT DISTINCT within a sub-select
+:PREFIX
+SELECT device_id, time, 'const1' FROM (SELECT DISTINCT ON (device_id) device_id, time
+FROM :TABLE_NAME
+:ORDER_BY_1_2
+LIMIT 10) a;
+
+-- Ensure that SELECT DISTINCT pushdown happens even with below disabled
+SET timescaledb.enable_per_data_node_queries = false;
+\qecho SELECT DISTINCT works with enable_per_data_node_queries disabled
+:PREFIX
+SELECT DISTINCT device_id
+FROM :TABLE_NAME
+:ORDER_BY_1
+LIMIT 10;
+
+SET timescaledb.enable_per_data_node_queries = true;
+SET timescaledb.enable_remote_explain = OFF;
+
+-- SELECT DISTINCT should not have duplicate columns
+\qecho SELECT DISTINCT should not have duplicate columns
+:PREFIX
+SELECT DISTINCT device_id, device_id
+FROM :TABLE_NAME
+:ORDER_BY_1;
+
+-- SELECT DISTINCT handles whole row correctly
+\qecho SELECT DISTINCT handles whole row correctly
+:PREFIX
+SELECT DISTINCT *
+FROM :TABLE_NAME
+:ORDER_BY_1_2
+LIMIT 10;
+
+-- SELECT DISTINCT ON handles whole row correctly
+\qecho SELECT DISTINCT ON (expr) handles whole row correctly
+:PREFIX
+SELECT DISTINCT ON (device_id) *
+FROM :TABLE_NAME
+ORDER BY device_id, time
+LIMIT 10;
+
+-- SELECT DISTINCT RECORD works correctly
+\qecho SELECT DISTINCT RECORD works correctly
+:PREFIX
+SELECT DISTINCT :TABLE_NAME r
+FROM :TABLE_NAME
+ORDER BY r
+LIMIT 10;
+
+-- SELECT DISTINCT function is not pushed down
+\qecho SELECT DISTINCT FUNCTION_EXPR not pushed down currently
+:PREFIX
+SELECT DISTINCT time_bucket('1h',time) col1
+FROM :TABLE_NAME
+ORDER BY col1
+LIMIT 10;


### PR DESCRIPTION
Construct "SELECT DISTINCT target_list" or "SELECT DISTINCT ON (col1,
col..) target_list" statement to push down the DISTINCT clause to the
remote side.

We only allow references to basic "Vars" or constants in the DISTINCT
exprs

So, "SELECT DISTINCT col1" is fine but "SELECT DISTINCT 2*col1" is not.

"SELECT DISTINCT col1, 'const1', NULL, col2" which is a mix of column
references and constants is also supported. Everything else is not
supported.

This pushdown also needs to work when
timescaledb.enable_per_data_node_queries is disabled.

All existing test cases in which "SELECT DISTINCT" is now being pushed
down have been modified. New test cases have been added to check that
the remote side uses "Skip Scans" as is suitable in some cases.