### PR TITLE
Support for inserts into compressed chunks

### DIFF
--- a/src/indexing.h
+++ b/src/indexing.h
@@ -24,5 +24,6 @@ extern TSDLLEXPORT Oid ts_indexing_find_clustered_index(Oid table_relid);
 
 extern void ts_indexing_mark_as_valid(Oid index_id);
 extern bool ts_indexing_mark_as_invalid(Oid index_id);
+extern bool ts_relation_has_primary_or_unique_index(Relation htrel);
 
 #endif /* TIMESCALEDB_INDEXING_H */

--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -40,6 +40,7 @@
 #include "chunk_dispatch_state.h"
 #include "chunk_index.h"
 #include "compat/tupconvert.h"
+#include "indexing.h"
 
 /* Just like ExecPrepareExpr except that it doesn't switch to the query memory context */
 static inline ExprState *
@@ -115,6 +116,32 @@ create_chunk_result_relation_info(ChunkDispatch *dispatch, Relation rel)
 
 	create_chunk_rri_constraint_expr(rri, rel);
 
+	return rri;
+}
+
+static inline ResultRelInfo *
+create_compress_chunk_result_relation_info(ChunkDispatch *dispatch, Relation compress_rel)
+{
+	ResultRelInfo *rri, *rri_orig;
+	Index hyper_rti = dispatch->hypertable_result_rel_info->ri_RangeTableIndex;
+	rri = makeNode(ResultRelInfo);
+
+	InitResultRelInfo(rri, compress_rel, hyper_rti, NULL, dispatch->estate->es_instrument);
+
+	rri_orig = dispatch->hypertable_result_rel_info;
+	if (rri_orig->ri_WithCheckOptions || rri_orig->ri_WithCheckOptionExprs ||
+		rri_orig->ri_junkFilter || rri_orig->ri_projectReturning)
+	{
+		elog(ERROR, "CHECK options, RETURNING clause are not supported");
+	}
+	rri->ri_junkFilter = rri_orig->ri_junkFilter; // TODO does this need any translation
+
+	/* compressed rel chunk is on data node. Does not need any FDW access on AN */
+	rri->ri_FdwState = NULL;
+	rri->ri_usesFdwDirectModify = false;
+	rri->ri_FdwRoutine = NULL;
+	// TODO revisit this
+	// create_chunk_rri_constraint_expr(rri, compress_rel);
 	return rri;
 }
 
@@ -562,19 +589,30 @@ extern ChunkInsertState *
 ts_chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 {
 	ChunkInsertState *state;
-	Relation rel, parent_rel;
+	Relation rel, parent_rel, compress_rel;
 	MemoryContext old_mcxt;
 	MemoryContext cis_context = AllocSetContextCreate(dispatch->estate->es_query_cxt,
 													  "chunk insert state memory context",
 													  ALLOCSET_DEFAULT_SIZES);
 	OnConflictAction onconflict_action = ts_chunk_dispatch_get_on_conflict_action(dispatch);
-	ResultRelInfo *resrelinfo;
+	ResultRelInfo *resrelinfo, *relinfo;
+	bool is_compressed = (chunk->fd.compressed_chunk_id != 0);
 
 	/* permissions NOT checked here; were checked at hypertable level */
 	if (check_enable_rls(chunk->table_id, InvalidOid, false) == RLS_ENABLED)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("hypertables do not support row-level security")));
+
+	if (chunk->relkind != RELKIND_RELATION && chunk->relkind != RELKIND_FOREIGN_TABLE)
+		elog(ERROR, "insert is not on a table");
+
+	if (is_compressed &&
+		(onconflict_action != ONCONFLICT_NONE || ts_chunk_dispatch_has_returning(dispatch)))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("insert with ON CONFLICT and RETURNING clause is not supported on "
+						"compressed chunks")));
 
 	/*
 	 * We must allocate the range table entry on the executor's per-query
@@ -583,12 +621,29 @@ ts_chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 	old_mcxt = MemoryContextSwitchTo(dispatch->estate->es_query_cxt);
 
 	rel = table_open(chunk->table_id, RowExclusiveLock);
-
-	if (chunk->relkind != RELKIND_RELATION && chunk->relkind != RELKIND_FOREIGN_TABLE)
-		elog(ERROR, "insert is not on a table");
+	if (is_compressed)
+	{
+		Oid compress_chunk_relid = ts_chunk_get_relid(chunk->fd.compressed_chunk_id, false);
+		if (ts_relation_has_primary_or_unique_index(rel))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg(
+						 "insert into a compressed chunk that has primary or unique constraint is "
+						 "not supported")));
+		}
+		compress_rel = table_open(compress_chunk_relid, RowExclusiveLock);
+	}
 
 	MemoryContextSwitchTo(cis_context);
-	resrelinfo = create_chunk_result_relation_info(dispatch, rel);
+	relinfo = create_chunk_result_relation_info(dispatch, rel);
+	if (!is_compressed)
+		resrelinfo = relinfo;
+	else
+	{
+		/* insert the tuple into the compressed chunk instead */
+		resrelinfo = create_compress_chunk_result_relation_info(dispatch, compress_rel);
+	}
 	CheckValidResultRel(resrelinfo, ts_chunk_dispatch_get_cmd_type(dispatch));
 
 	state = palloc0(sizeof(ChunkInsertState));
@@ -626,6 +681,25 @@ ts_chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 
 	adjust_projections(state, dispatch, RelationGetForm(rel)->reltype);
 
+	if (is_compressed)
+	{
+		int32 htid = ts_hypertable_relid_to_id(chunk->hypertable_relid);
+		/* this is true as compressed chunks are not created on access node */
+		Assert(chunk->relkind != RELKIND_FOREIGN_TABLE);
+		state->compress_rel = compress_rel;
+		Assert(ts_cm_functions->compress_row_init != NULL);
+		/* need a way to convert from chunk tuple to compressed chunk tuple */
+		state->compress_state = ts_cm_functions->compress_row_init(htid, rel, compress_rel);
+		state->compress_slot =
+			MakeSingleTupleTableSlotCompat(RelationGetDescr(resrelinfo->ri_RelationDesc),
+										   table_slot_callbacks(resrelinfo->ri_RelationDesc));
+		state->orig_result_relation_info = relinfo;
+	}
+	else
+	{
+		state->compress_state = NULL;
+	}
+
 	/* Need a tuple table slot to store tuples going into this chunk. We don't
 	 * want this slot tied to the executor's tuple table, since that would tie
 	 * the slot's lifetime to the entire length of the execution and we want
@@ -633,8 +707,8 @@ ts_chunk_insert_state_create(Chunk *chunk, ChunkDispatch *dispatch)
 	 * state. Otherwise, memory might blow up when there are many chunks being
 	 * inserted into. This also means that the slot needs to be destroyed with
 	 * the chunk insert state. */
-	state->slot = MakeSingleTupleTableSlotCompat(RelationGetDescr(resrelinfo->ri_RelationDesc),
-												 table_slot_callbacks(resrelinfo->ri_RelationDesc));
+	state->slot = MakeSingleTupleTableSlotCompat(RelationGetDescr(relinfo->ri_RelationDesc),
+												 table_slot_callbacks(relinfo->ri_RelationDesc));
 	table_close(parent_rel, AccessShareLock);
 
 	if (chunk->relkind == RELKIND_FOREIGN_TABLE)
@@ -705,6 +779,16 @@ ts_chunk_insert_state_destroy(ChunkInsertState *state)
 	destroy_on_conflict_state(state);
 	ExecCloseIndices(state->result_relation_info);
 	table_close(state->rel, NoLock);
+
+	/* TODO check if we nee to keep rel open for this case. Is compress_rel
+	 * sufficient?
+	 */
+	if (state->compress_rel)
+	{
+		table_close(state->compress_rel, NoLock);
+		ts_cm_functions->compress_row_destroy(state->compress_state);
+		ExecDropSingleTupleTableSlot(state->compress_slot);
+	}
 
 	if (NULL != state->slot)
 		ExecDropSingleTupleTableSlot(state->slot);

--- a/src/nodes/chunk_insert_state.h
+++ b/src/nodes/chunk_insert_state.h
@@ -13,6 +13,7 @@
 
 #include "chunk.h"
 #include "cache.h"
+#include "cross_module_fn.h"
 
 typedef struct ChunkInsertState
 {
@@ -48,12 +49,18 @@ typedef struct ChunkInsertState
 
 	/* Slot for inserted/new tuples going into the chunk */
 	TupleTableSlot *slot;
+	TupleTableSlot *compress_slot;
 	/* Map for converting tuple from hypertable (root table) format to chunk format */
 	TupleConversionMap *hyper_to_chunk_map;
 	MemoryContext mctx;
 	EState *estate;
 	List *server_id_list; /* foreign server ids of data nodes used for remote inserts */
 	Oid user_id;
+
+	/* for tracking compressed chunks */
+	Relation compress_rel;
+	ResultRelInfo *orig_result_relation_info;
+	CompressSingleRowState *compress_state;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/tsl/src/compression/segment_meta.c
+++ b/tsl/src/compression/segment_meta.c
@@ -144,3 +144,11 @@ segment_meta_min_max_builder_empty(SegmentMetaMinMaxBuilder *builder)
 {
 	return builder->empty;
 }
+
+void
+segment_meta_min_max_builder_gettype_info(SegmentMetaMinMaxBuilder *builder, int16 *typ_len,
+										  bool *typ_val)
+{
+	*typ_len = builder->type_len;
+	*typ_val = builder->type_by_val;
+}

--- a/tsl/src/compression/segment_meta.h
+++ b/tsl/src/compression/segment_meta.h
@@ -21,4 +21,6 @@ Datum segment_meta_min_max_builder_max(SegmentMetaMinMaxBuilder *builder);
 bool segment_meta_min_max_builder_empty(SegmentMetaMinMaxBuilder *builder);
 
 void segment_meta_min_max_builder_reset(SegmentMetaMinMaxBuilder *builder);
+void segment_meta_min_max_builder_gettype_info(SegmentMetaMinMaxBuilder *builder, int16 *typ_len,
+											   bool *typ_val);
 #endif

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -165,7 +165,7 @@ select compress_chunk( '_timescaledb_internal._hyper_1_2_chunk');
 ERROR:  chunk "_hyper_1_2_chunk" is already compressed
 --TEST2a try DML on a compressed chunk
 insert into foo values( 11 , 10 , 20, 120);
-ERROR:  insert/update/delete not permitted on chunk "_hyper_1_2_chunk"
+ERROR:  insert into a compressed chunk that has primary or unique constraint is not supported
 update foo set b =20 where a = 10;
 ERROR:  cannot update/delete rows from chunk "_hyper_1_2_chunk" as it is compressed
 delete from foo where a = 10;
@@ -208,7 +208,7 @@ ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compres
 insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
 do update set b = excluded.b;
-ERROR:  insert/update/delete not permitted on chunk "_hyper_1_2_chunk"
+ERROR:  insert with ON CONFLICT and RETURNING clause is not supported on compressed chunks
 --TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12);
 ERROR:  insert/update/delete not permitted on chunk "_hyper_1_2_chunk"

--- a/tsl/test/expected/compression_insert.out
+++ b/tsl/test/expected/compression_insert.out
@@ -1,0 +1,152 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE test1 (timec timestamptz , i integer ,
+      b bigint, t text);
+SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
+NOTICE:  adding not-null constraint to column "timec"
+ table_name 
+------------
+ test1
+(1 row)
+
+INSERT INTO test1 select q, 10, 11, 'hello' FROM generate_series( '2020-01-03 10:00:00-05', '2020-01-03 12:00:00-05' , '5 min'::interval) q;
+ALTER TABLE test1 set (timescaledb.compress, 
+timescaledb.compress_segmentby = 'b', 
+timescaledb.compress_orderby = 'timec DESC');
+SELECT compress_chunk(c)
+FROM show_chunks('test1') c;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT count(*) FROM  test1;
+ count 
+-------
+    25
+(1 row)
+
+--we have 1 compressed row --
+SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+ count 
+-------
+     1
+(1 row)
+
+-- single and multi row insert into the compressed chunk --
+INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , 11, 16, 'new' ;
+SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+ count 
+-------
+     2
+(1 row)
+
+INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , i, i +5, 'NEW'
+FROM (Select generate_series(10, 20, 1) i ) q;
+SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+ count 
+-------
+    13
+(1 row)
+
+SELECT count(*) from test1;
+ count 
+-------
+    37
+(1 row)
+
+--Verify that all the data went into the initial chunk
+SELECT count(*)
+FROM show_chunks('test1') c;
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM test1 WHERE b = 11 order by i, timec ;
+            timec             | i  | b  |   t   
+------------------------------+----+----+-------
+ Fri Jan 03 07:00:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:05:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:10:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:15:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:20:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:25:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:30:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:35:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:40:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:45:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:50:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 07:55:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:00:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:05:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:10:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:15:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:20:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:25:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:30:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:35:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:40:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:45:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:50:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 08:55:00 2020 PST | 10 | 11 | hello
+ Fri Jan 03 09:00:00 2020 PST | 10 | 11 | hello
+(25 rows)
+
+SELECT * FROM test1 WHERE i = 11;
+            timec             | i  | b  |  t  
+------------------------------+----+----+-----
+ Thu Jan 02 08:16:00 2020 PST | 11 | 16 | new
+ Thu Jan 02 08:16:00 2020 PST | 11 | 16 | NEW
+(2 rows)
+
+DROP TABLE test1;
+-- TEST 3 add tests with dropped columns on hypertable
+-- also tests defaults
+CREATE TABLE test2 ( itime integer, b bigint, t text);
+SELECT table_name from create_hypertable('test2', 'itime', chunk_time_interval=> 10::integer);
+NOTICE:  adding not-null constraint to column "itime"
+ table_name 
+------------
+ test2
+(1 row)
+
+--create a chunk 
+INSERT INTO test2 SELECT t, 10,  'first'::text FROM generate_series(1, 7, 1) t;
+ALTER TABLE test2 DROP COLUMN b;
+-- TODO fix defaults ---
+ALTER TABLE test2 ADD COLUMN c INT DEFAULT -15;
+ALTER TABLE test2 ADD COLUMN d INT;
+--create a new chunk
+INSERT INTO test2 SELECT t, 'second'::text, 120, 1 FROM generate_series(11, 15, 1) t;
+ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'c, itime DESC');
+SELECT count(*) from ( select compress_chunk(c)
+FROM show_chunks('test2') c ) q;
+ count 
+-------
+     2
+(1 row)
+
+--write to both old chunks and new chunks 
+INSERT INTO test2(itime ,t , d)  SELECT 9, '9', 90 ;
+INSERT INTO test2(itime ,t , d)  SELECT 17, '17', 1700 ;
+SELECT count(*) FROM show_chunks('test2') q;
+ count 
+-------
+     2
+(1 row)
+
+SELECT * from test2 WHERE itime >= 9 and itime <= 17 
+ORDER BY itime;
+ itime |   t    |  c  |  d   
+-------+--------+-----+------
+     9 | 9      | -15 |   90
+    11 | second | 120 |    1
+    12 | second | 120 |    1
+    13 | second | 120 |    1
+    14 | second | 120 |    1
+    15 | second | 120 |    1
+    17 | 17     | -15 | 1700
+(7 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_FILES
   bgw_custom.sql
   bgw_policy.sql
   compression_bgw.sql
+  compression_insert.sql
   compression_permissions.sql
   continuous_aggs_errors.sql
   continuous_aggs_invalidation.sql

--- a/tsl/test/sql/compression_insert.sql
+++ b/tsl/test/sql/compression_insert.sql
@@ -1,0 +1,69 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE test1 (timec timestamptz , i integer ,
+      b bigint, t text);
+SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
+
+INSERT INTO test1 select q, 10, 11, 'hello' FROM generate_series( '2020-01-03 10:00:00-05', '2020-01-03 12:00:00-05' , '5 min'::interval) q;
+ALTER TABLE test1 set (timescaledb.compress, 
+timescaledb.compress_segmentby = 'b', 
+timescaledb.compress_orderby = 'timec DESC');
+
+SELECT compress_chunk(c)
+FROM show_chunks('test1') c;
+
+SELECT count(*) FROM  test1;
+
+--we have 1 compressed row --
+SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+
+-- single and multi row insert into the compressed chunk --
+INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , 11, 16, 'new' ;
+SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+
+INSERT INTO test1 SELECT '2020-01-02 11:16:00-05' , i, i +5, 'NEW'
+FROM (Select generate_series(10, 20, 1) i ) q;
+SELECT COUNT(*) from _timescaledb_internal.compress_hyper_2_2_chunk;
+
+SELECT count(*) from test1;
+
+--Verify that all the data went into the initial chunk
+SELECT count(*)
+FROM show_chunks('test1') c;
+
+SELECT * FROM test1 WHERE b = 11 order by i, timec ;
+
+SELECT * FROM test1 WHERE i = 11;
+
+DROP TABLE test1;
+
+-- TEST 3 add tests with dropped columns on hypertable
+-- also tests defaults
+CREATE TABLE test2 ( itime integer, b bigint, t text);
+SELECT table_name from create_hypertable('test2', 'itime', chunk_time_interval=> 10::integer);
+
+--create a chunk 
+INSERT INTO test2 SELECT t, 10,  'first'::text FROM generate_series(1, 7, 1) t;
+
+ALTER TABLE test2 DROP COLUMN b;
+-- TODO fix defaults ---
+ALTER TABLE test2 ADD COLUMN c INT DEFAULT -15;
+ALTER TABLE test2 ADD COLUMN d INT;
+
+--create a new chunk
+INSERT INTO test2 SELECT t, 'second'::text, 120, 1 FROM generate_series(11, 15, 1) t;
+ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'c, itime DESC');
+
+SELECT count(*) from ( select compress_chunk(c)
+FROM show_chunks('test2') c ) q;
+
+--write to both old chunks and new chunks 
+INSERT INTO test2(itime ,t , d)  SELECT 9, '9', 90 ;
+INSERT INTO test2(itime ,t , d)  SELECT 17, '17', 1700 ;
+
+SELECT count(*) FROM show_chunks('test2') q;
+
+SELECT * from test2 WHERE itime >= 9 and itime <= 17 
+ORDER BY itime;


### PR DESCRIPTION
This  is the 2nd PR and builds on the initial framework.

Inserts are supported by making calls to CompressRowSingleState

(1st PR is : https://github.com/timescale/timescaledb/pull/3105 )