### PR TITLE
Add GitHub action for posting daily CI summary

### DIFF
--- a/.github/workflows/alpine-32bit-build-and-test.yaml
+++ b/.github/workflows/alpine-32bit-build-and-test.yaml
@@ -81,13 +81,3 @@ jobs:
       with:
         name: PostgreSQL log ${{ matrix.pg }}
         path: postgres.log
-
-    - name: Slack Notification
-      if: failure() && github.event_name != 'pull_request'
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_COLOR: '#ff0000'
-        SLACK_USERNAME: GitHub Action
-        SLACK_TITLE: Regression 32-bit PG${{ matrix.pg }} ${{ job.status }}
-        SLACK_MESSAGE: ${{ github.event.head_commit.message }}
-      uses: rtCamp/action-slack-notify@v2.0.2

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -70,13 +70,3 @@ jobs:
         if [ "$version" != "$installed_version" ];then
           false
         fi
-
-    - name: Slack Notification
-      if: failure() && github.event_name != 'pull_request'
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_COLOR: '#ff0000'
-        SLACK_USERNAME: GitHub Action
-        SLACK_TITLE: APT Package ${{ matrix.image }} PG${{ matrix.pg }} ${{ job.status }}
-        SLACK_MESSAGE: ${{ github.event.head_commit.message }}
-      uses: rtCamp/action-slack-notify@v2.0.2

--- a/.github/workflows/ci_summary.yaml
+++ b/.github/workflows/ci_summary.yaml
@@ -1,0 +1,23 @@
+name: CI Summary
+on:
+  schedule:
+    # run daily 8:00 CET on master branch
+    - cron: '0 7 * * *'
+jobs:
+  ci_summary:
+    if: github.repository == 'timescale/timescaledb'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: "Build message"
+      env:
+        SLACK_CHANNEL: "CEKV5LMK3"
+      run: python scripts/gh_ci_summary.py > message.json
+
+    - name: "Notify Slack"
+      uses: krider2010/slack-bot-action@1.0.1
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        MESSAGE_FILE: message.json
+

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -160,13 +160,3 @@ jobs:
       with:
         name: Coredumps ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: coredumps
-
-    - name: Slack Notification
-      if: failure() && github.event_name != 'pull_request' && runner.os != 'macOS'
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_COLOR: '#ff0000'
-        SLACK_USERNAME: GitHub Action
-        SLACK_TITLE: Regression ${{ matrix.os }} PG${{ matrix.pg }} ${{ matrix.name }} ${{ job.status }}
-        SLACK_MESSAGE: ${{ github.event.head_commit.message }}
-      uses: rtCamp/action-slack-notify@v2.0.2

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -70,13 +70,3 @@ jobs:
         if [ "$version" != "$installed_version" ];then
           false
         fi
-
-    - name: Slack Notification
-      if: failure() && github.event_name != 'pull_request'
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_COLOR: '#ff0000'
-        SLACK_USERNAME: GitHub Action
-        SLACK_TITLE: RPM Package ${{ matrix.image }} PG${{ matrix.pg }} ${{ job.status }}
-        SLACK_MESSAGE: ${{ github.event.head_commit.message }}
-      uses: rtCamp/action-slack-notify@v2.0.2

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -44,13 +44,3 @@ jobs:
       with:
         name: Extension update diff ${{ matrix.pg }}
         path: update_test.*.diff.*
-
-    - name: Slack Notification
-      if: failure() && github.event_name != 'pull_request'
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_COLOR: '#ff0000'
-        SLACK_USERNAME: GitHub Action
-        SLACK_TITLE: Update test PG${{ matrix.pg }} ${{ job.status }}
-        SLACK_MESSAGE: ${{ github.event.head_commit.message }}
-      uses: rtCamp/action-slack-notify@v2.0.2

--- a/scripts/gh_ci_summary.py
+++ b/scripts/gh_ci_summary.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+
+from datetime import datetime
+import requests
+import json
+import os
+
+# API reference: https://docs.github.com/en/rest/reference/actions#workflow-runs
+# Slack message formatting: https://api.slack.com/reference/surfaces/formatting
+url = 'https://api.github.com/repos/timescale/timescaledb/actions/runs?event=schedule&status=completed'
+
+message=list()
+
+def get_json(url):
+  response = requests.get(url)
+  return response.json()
+
+# get runs from last 24 hours
+def process_runs(runs):
+  failed=list()
+
+  for run in runs:
+    start = datetime.strptime(run['created_at'], "%Y-%m-%dT%H:%M:%SZ")
+    delta = datetime.now() - start
+
+    if delta.days >= 1:
+      break
+
+    if run['conclusion'] != 'success':
+      failed.append(run)
+
+  return failed
+
+def print_run_details(run):
+  job_data = get_json(run['jobs_url'])
+  for job in job_data['jobs']:
+    if job['conclusion'] != 'success':
+      message.append("<{html_url}|{workflow_name} {name}>".format(workflow_name=run['name'], **job))
+
+def print_summary(failed):
+  if len(failed) > 0:
+    message.append("Failed scheduled CI runs in last 24 hours:")
+    for run in failed:
+      print_run_details(run)
+  else:
+    message.append("No failed scheduled CI runs in last 24 hours :tada:")
+
+try:
+  data = get_json(url)
+  failed = process_runs(data['workflow_runs'])
+  print_summary(failed)
+except json.decoder.JSONDecodeError:
+  message.append("Error processing GitHub response")
+
+slack_msg=dict()
+slack_msg['channel'] = os.environ['SLACK_CHANNEL']
+slack_msg['text'] = "\n".join(message)
+
+print(json.dumps(slack_msg))


### PR DESCRIPTION
This patch adds a GitHub action that posts all failed CI jobs in
the last 24 hours with link to the failed job.


Disable-check: commit-count
