### PR TITLE
Add chunk_status column to catalog chunk table

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -133,23 +133,27 @@ SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_
 -- the chunk's hypercube. Tuples that fall within the chunk's
 -- hypercube are stored in the chunk's data table, as given by
 -- 'schema_name' and 'table_name'.
+CREATE SEQUENCE IF NOT EXISTS _timescaledb_catalog.chunk_id_seq MINVALUE 1;
+
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.chunk (
-  id serial NOT NULL PRIMARY KEY,
+  id integer PRIMARY KEY DEFAULT nextval('_timescaledb_catalog.chunk_id_seq'),
   hypertable_id int NOT NULL REFERENCES _timescaledb_catalog.hypertable (id),
+  compressed_chunk_id integer REFERENCES _timescaledb_catalog.chunk (id),
+  chunk_status smallint NOT NULL DEFAULT 0,
+  dropped boolean NOT NULL DEFAULT FALSE,
   schema_name name NOT NULL,
   table_name name NOT NULL,
-  compressed_chunk_id integer REFERENCES _timescaledb_catalog.chunk (id),
-  dropped boolean NOT NULL DEFAULT FALSE,
   UNIQUE (schema_name, table_name)
 );
+ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
 
 CREATE INDEX IF NOT EXISTS chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
 
 CREATE INDEX IF NOT EXISTS chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
 
-SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.chunk', 'id'), '');
 
 -- A chunk constraint maps a dimension slice to a chunk. Each
 -- constraint associated with a chunk will also be a table constraint

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,93 @@
+
+-- Recreate _timescaledb_catalog.chunk table --
+CREATE TABLE _timescaledb_catalog.chunk_tmp
+AS SELECT * from _timescaledb_catalog.chunk;
+
+CREATE TABLE tmp_chunk_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.chunk_id_seq;
+
+--drop foreign keys on chunk table
+ALTER TABLE _timescaledb_catalog.chunk_constraint DROP CONSTRAINT 
+chunk_constraint_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_index DROP CONSTRAINT 
+chunk_index_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_data_node DROP CONSTRAINT 
+chunk_data_node_chunk_id_fkey;
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats DROP CONSTRAINT 
+bgw_policy_chunk_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT 
+compression_chunk_size_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT 
+compression_chunk_size_compressed_chunk_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.chunk_id_seq;
+DROP TABLE _timescaledb_catalog.chunk;
+
+CREATE SEQUENCE IF NOT EXISTS _timescaledb_catalog.chunk_id_seq MINVALUE 1;
+
+-- now create table without self referential foreign key
+CREATE TABLE IF NOT EXISTS _timescaledb_catalog.chunk (
+  id integer PRIMARY KEY DEFAULT nextval('_timescaledb_catalog.chunk_id_seq'),
+  hypertable_id int NOT NULL REFERENCES _timescaledb_catalog.hypertable (id),
+  compressed_chunk_id integer, 
+  chunk_status smallint NOT NULL DEFAULT 0,
+  dropped boolean NOT NULL DEFAULT FALSE,
+  schema_name name NOT NULL,
+  table_name name NOT NULL,
+  UNIQUE (schema_name, table_name)
+);
+
+INSERT INTO _timescaledb_catalog.chunk
+( id, hypertable_id, compressed_chunk_id, dropped, chunk_status,
+      schema_name, table_name ) 
+SELECT id, hypertable_id, compressed_chunk_id, dropped,
+       0,
+       schema_name, table_name
+FROM _timescaledb_catalog.chunk_tmp;
+
+--add indexes to the chunk table
+CREATE INDEX IF NOT EXISTS chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
+CREATE INDEX IF NOT EXISTS chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+
+ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
+SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM tmp_chunk_seq_value;
+
+-- add self referential foreign key
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY ( compressed_chunk_id )
+ REFERENCES _timescaledb_catalog.chunk( id );
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.chunk_constraint ADD CONSTRAINT 
+chunk_constraint_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id); 
+ALTER TABLE _timescaledb_catalog.chunk_index ADD CONSTRAINT
+chunk_index_chunk_id_fkey FOREIGN KEY (chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.chunk_data_node ADD CONSTRAINT
+chunk_data_node_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);  
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats ADD CONSTRAINT
+bgw_policy_chunk_stats_chunk_id_fkey FOREIGN KEY (chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_chunk_id_fkey FOREIGN KEY (chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE; 
+
+--cleanup
+DROP TABLE _timescaledb_catalog.chunk_tmp;
+DROP TABLE tmp_chunk_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
+
+-- end recreate _timescaledb_catalog.chunk table --

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -353,10 +353,11 @@ enum Anum_chunk
 {
 	Anum_chunk_id = 1,
 	Anum_chunk_hypertable_id,
+	Anum_chunk_compressed_chunk_id,
+	Anum_chunk_chunk_status,
+	Anum_chunk_dropped,
 	Anum_chunk_schema_name,
 	Anum_chunk_table_name,
-	Anum_chunk_compressed_chunk_id,
-	Anum_chunk_dropped,
 	_Anum_chunk_max,
 };
 
@@ -366,10 +367,11 @@ typedef struct FormData_chunk
 {
 	int32 id;
 	int32 hypertable_id;
+	int32 compressed_chunk_id;
+	int16 chunk_status;
+	bool dropped;
 	NameData schema_name;
 	NameData table_name;
-	int32 compressed_chunk_id;
-	bool dropped;
 } FormData_chunk;
 
 typedef FormData_chunk *Form_chunk;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -134,6 +134,8 @@ static Chunk *get_chunks_in_time_range(Hypertable *ht, int64 older_than, int64 n
 
 #define ASSERT_IS_NULL_OR_VALID_CHUNK(chunk) Assert(chunk == NULL || IS_VALID_CHUNK(chunk))
 
+#define CHUNK_STATUS_DEFAULT (int16) 0
+
 static HeapTuple
 chunk_formdata_make_tuple(const FormData_chunk *fd, TupleDesc desc)
 {
@@ -155,6 +157,7 @@ chunk_formdata_make_tuple(const FormData_chunk *fd, TupleDesc desc)
 			Int32GetDatum(fd->compressed_chunk_id);
 	}
 	values[AttrNumberGetAttrOffset(Anum_chunk_dropped)] = BoolGetDatum(fd->dropped);
+	values[AttrNumberGetAttrOffset(Anum_chunk_chunk_status)] = Int16GetDatum(CHUNK_STATUS_DEFAULT);
 
 	return heap_form_tuple(desc, values, nulls);
 }
@@ -175,6 +178,7 @@ chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti)
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_schema_name)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_table_name)]);
 	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_dropped)]);
+	Assert(!nulls[AttrNumberGetAttrOffset(Anum_chunk_chunk_status)]);
 
 	fd->id = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_id)]);
 	fd->hypertable_id = DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_hypertable_id)]);
@@ -192,6 +196,7 @@ chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti)
 			DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_chunk_compressed_chunk_id)]);
 
 	fd->dropped = DatumGetBool(values[AttrNumberGetAttrOffset(Anum_chunk_dropped)]);
+	fd->chunk_status = DatumGetInt16(values[AttrNumberGetAttrOffset(Anum_chunk_chunk_status)]);
 
 	if (should_free)
 		heap_freetuple(tuple);

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -185,25 +185,25 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  2 |             2 |                     |            0 | f       | _timescaledb_internal | _hyper_2_2_chunk
 (1 row)
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
 SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |   table_name   | compressed_chunk_id | dropped 
-----+---------------+-----------------------+----------------+---------------------+---------
-  2 |             2 | _timescaledb_internal | new_chunk_name |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |   table_name   
+----+---------------+---------------------+--------------+---------+-----------------------+----------------
+  2 |             2 |                     |            0 | f       | _timescaledb_internal | new_chunk_name
 (1 row)
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
 SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id | schema_name |   table_name   | compressed_chunk_id | dropped 
-----+---------------+-------------+----------------+---------------------+---------
-  2 |             2 | public      | new_chunk_name |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name |   table_name   
+----+---------------+---------------------+--------------+---------+-------------+----------------
+  2 |             2 |                     |            0 | f       | public      | new_chunk_name
 (1 row)
 
 -- Test that we cannot rename chunk columns
@@ -679,10 +679,10 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped 
-----+---------------+-----------------------+--------------------+---------------------+---------
- 24 |            12 | new_associated_schema | _hyper_12_24_chunk |                     | f
- 25 |            12 | new_associated_schema | _hyper_12_25_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |     table_name     
+----+---------------+---------------------+--------------+---------+-----------------------+--------------------
+ 24 |            12 |                     |            0 | f       | new_associated_schema | _hyper_12_24_chunk
+ 25 |            12 |                     |            0 | f       | new_associated_schema | _hyper_12_25_chunk
 (2 rows)
 
 DROP TABLE my_table;

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -409,13 +409,13 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
 (1 row)
 
 select * from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f
-  2 |             2 | chunk_schema          | _hyper_2_2_chunk |                     | f
-  3 |             5 | _timescaledb_internal | _hyper_5_3_chunk |                     | f
-  4 |             8 | _timescaledb_internal | _hyper_8_4_chunk |                     | f
-  5 |             8 | _timescaledb_internal | _hyper_8_5_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  1 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             2 |                     |            0 | f       | chunk_schema          | _hyper_2_2_chunk
+  3 |             5 |                     |            0 | f       | _timescaledb_internal | _hyper_5_3_chunk
+  4 |             8 |                     |            0 | f       | _timescaledb_internal | _hyper_8_4_chunk
+  5 |             8 |                     |            0 | f       | _timescaledb_internal | _hyper_8_5_chunk
 (5 rows)
 
 select * from test_schema.test_migrate;

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -32,10 +32,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  1 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             2 |                     |            0 | f       | _timescaledb_internal | _hyper_2_2_chunk
 (2 rows)
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
@@ -46,9 +46,9 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  2 |             2 |                     |            0 | f       | _timescaledb_internal | _hyper_2_2_chunk
 (1 row)
 
 DROP TABLE  hypertable_schema.superuser;
@@ -59,8 +59,8 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -37,10 +37,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped 
-----+---------------+---------------+------------------+---------------------+---------
-  1 |             1 | chunk_schema1 | _hyper_1_1_chunk |                     | f
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |  schema_name  |    table_name    
+----+---------------+---------------------+--------------+---------+---------------+------------------
+  1 |             1 |                     |            0 | f       | chunk_schema1 | _hyper_1_1_chunk
+  2 |             2 |                     |            0 | f       | chunk_schema2 | _hyper_2_2_chunk
 (2 rows)
 
 RESET ROLE;
@@ -60,18 +60,18 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped 
-----+---------------+---------------+------------------+---------------------+---------
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |  schema_name  |    table_name    
+----+---------------+---------------------+--------------+---------+---------------+------------------
+  2 |             2 |                     |            0 | f       | chunk_schema2 | _hyper_2_2_chunk
 (1 row)
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  2 |             2 | chunk_schema2         | _hyper_2_2_chunk |                     | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  2 |             2 |                     |            0 | f       | chunk_schema2         | _hyper_2_2_chunk
+  3 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_3_chunk
 (2 rows)
 
 RESET ROLE;
@@ -91,8 +91,8 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;

--- a/test/expected/insert-11.out
+++ b/test/expected/insert-11.out
@@ -157,12 +157,12 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
 (28 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  1 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_2_chunk
+  3 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_3_chunk
+  4 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_4_chunk
 (4 rows)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -157,12 +157,12 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
 (28 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  1 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_2_chunk
+  3 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_3_chunk
+  4 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_4_chunk
 (4 rows)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/expected/insert-13.out
+++ b/test/expected/insert-13.out
@@ -157,12 +157,12 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
 (28 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  1 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_2_chunk
+  3 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_3_chunk
+  4 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_4_chunk
 (4 rows)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -242,22 +242,22 @@ SELECT * FROM "1dim_neg";
 (7 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name     | compressed_chunk_id | dropped 
-----+---------------+-----------------------+-------------------+---------------------+---------
-  1 |             1 | one_Partition         | _hyper_1_1_chunk  |                     | f
-  2 |             1 | one_Partition         | _hyper_1_2_chunk  |                     | f
-  3 |             1 | one_Partition         | _hyper_1_3_chunk  |                     | f
-  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk  |                     | f
-  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk  |                     | f
-  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk  |                     | f
-  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk  |                     | f
-  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk  |                     | f
- 10 |             5 | _timescaledb_internal | _hyper_5_10_chunk |                     | f
- 11 |             6 | _timescaledb_internal | _hyper_6_11_chunk |                     | f
- 12 |             6 | _timescaledb_internal | _hyper_6_12_chunk |                     | f
- 13 |             6 | _timescaledb_internal | _hyper_6_13_chunk |                     | f
- 14 |             6 | _timescaledb_internal | _hyper_6_14_chunk |                     | f
- 15 |             6 | _timescaledb_internal | _hyper_6_15_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name     
+----+---------------+---------------------+--------------+---------+-----------------------+-------------------
+  1 |             1 |                     |            0 | f       | one_Partition         | _hyper_1_1_chunk
+  2 |             1 |                     |            0 | f       | one_Partition         | _hyper_1_2_chunk
+  3 |             1 |                     |            0 | f       | one_Partition         | _hyper_1_3_chunk
+  4 |             2 |                     |            0 | f       | _timescaledb_internal | _hyper_2_4_chunk
+  5 |             3 |                     |            0 | f       | _timescaledb_internal | _hyper_3_5_chunk
+  6 |             3 |                     |            0 | f       | _timescaledb_internal | _hyper_3_6_chunk
+  7 |             3 |                     |            0 | f       | _timescaledb_internal | _hyper_3_7_chunk
+  8 |             3 |                     |            0 | f       | _timescaledb_internal | _hyper_3_8_chunk
+ 10 |             5 |                     |            0 | f       | _timescaledb_internal | _hyper_5_10_chunk
+ 11 |             6 |                     |            0 | f       | _timescaledb_internal | _hyper_6_11_chunk
+ 12 |             6 |                     |            0 | f       | _timescaledb_internal | _hyper_6_12_chunk
+ 13 |             6 |                     |            0 | f       | _timescaledb_internal | _hyper_6_13_chunk
+ 14 |             6 |                     |            0 | f       | _timescaledb_internal | _hyper_6_14_chunk
+ 15 |             6 |                     |            0 | f       | _timescaledb_internal | _hyper_6_15_chunk
 (14 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -41,12 +41,12 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  1 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_1_chunk
+  2 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_2_chunk
+  3 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_3_chunk
+  4 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_4_chunk
 (4 rows)
 
 SELECT * FROM test.show_subtables('"two_Partitions"');
@@ -84,8 +84,8 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 -- should be empty
@@ -105,11 +105,11 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped 
-----+---------------+-----------------------+------------------+---------------------+---------
-  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f
-  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f
-  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |    table_name    
+----+---------------+---------------------+--------------+---------+-----------------------+------------------
+  5 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_5_chunk
+  6 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_6_chunk
+  7 |             1 |                     |            0 | f       | _timescaledb_internal | _hyper_1_7_chunk
 (3 rows)
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_5_chunk;

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -596,11 +596,11 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 --we see the chunks row with the dropped flags set;
 SELECT * FROM _timescaledb_catalog.chunk where dropped;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped 
-----+---------------+-----------------------+--------------------+---------------------+---------
- 13 |            10 | _timescaledb_internal | _hyper_10_13_chunk |                     | t
- 14 |            10 | _timescaledb_internal | _hyper_10_14_chunk |                     | t
- 15 |            10 | _timescaledb_internal | _hyper_10_15_chunk |                     | t
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |     table_name     
+----+---------------+---------------------+--------------+---------+-----------------------+--------------------
+ 13 |            10 |                     |            0 | t       | _timescaledb_internal | _hyper_10_13_chunk
+ 14 |            10 |                     |            0 | t       | _timescaledb_internal | _hyper_10_14_chunk
+ 15 |            10 |                     |            0 | t       | _timescaledb_internal | _hyper_10_15_chunk
 (3 rows)
 
 --still see data in the view

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -379,11 +379,11 @@ SELECT * FROM test.show_subtables('disttable');
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped 
-----+---------------+-----------------------+-----------------------+---------------------+---------
-  2 |             3 | _timescaledb_internal | _dist_hyper_3_2_chunk |                     | f
-  3 |             3 | _timescaledb_internal | _dist_hyper_3_3_chunk |                     | f
-  4 |             3 | _timescaledb_internal | _dist_hyper_3_4_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |      table_name       
+----+---------------+---------------------+--------------+---------+-----------------------+-----------------------
+  2 |             3 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_3_2_chunk
+  3 |             3 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_3_3_chunk
+  4 |             3 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_3_4_chunk
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
@@ -518,10 +518,10 @@ ORDER BY foreign_table_name;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped 
-----+---------------+-----------------------+-----------------------+---------------------+---------
-  3 |             3 | _timescaledb_internal | _dist_hyper_3_3_chunk |                     | f
-  4 |             3 | _timescaledb_internal | _dist_hyper_3_4_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |      table_name       
+----+---------------+---------------------+--------------+---------+-----------------------+-----------------------
+  3 |             3 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_3_3_chunk
+  4 |             3 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_3_4_chunk
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
@@ -568,8 +568,8 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 -- Attach data node should now succeed
@@ -733,8 +733,8 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 \set ON_ERROR_STOP 0
@@ -803,11 +803,11 @@ SELECT * FROM test.show_subtables('disttable');
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped 
-----+---------------+-----------------------+-----------------------+---------------------+---------
-  5 |             5 | _timescaledb_internal | _dist_hyper_5_5_chunk |                     | f
-  6 |             5 | _timescaledb_internal | _dist_hyper_5_6_chunk |                     | f
-  7 |             5 | _timescaledb_internal | _dist_hyper_5_7_chunk |                     | f
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped |      schema_name      |      table_name       
+----+---------------+---------------------+--------------+---------+-----------------------+-----------------------
+  5 |             5 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_5_5_chunk
+  6 |             5 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_5_6_chunk
+  7 |             5 |                     |            0 | f       | _timescaledb_internal | _dist_hyper_5_7_chunk
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -1388,8 +1388,8 @@ SELECT * FROM disttable;
 
 -- Metadata and tables cleaned up
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 SELECT * FROM show_chunks('disttable');
@@ -1406,8 +1406,8 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 
@@ -1430,8 +1430,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 
@@ -1454,8 +1454,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -1388,8 +1388,8 @@ SELECT * FROM disttable;
 
 -- Metadata and tables cleaned up
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 SELECT * FROM show_chunks('disttable');
@@ -1406,8 +1406,8 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 
@@ -1430,8 +1430,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 
@@ -1454,8 +1454,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -1387,8 +1387,8 @@ SELECT * FROM disttable;
 
 -- Metadata and tables cleaned up
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped 
-----+---------------+-------------+------------+---------------------+---------
+ id | hypertable_id | compressed_chunk_id | chunk_status | dropped | schema_name | table_name 
+----+---------------+---------------------+--------------+---------+-------------+------------
 (0 rows)
 
 SELECT * FROM show_chunks('disttable');
@@ -1405,8 +1405,8 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 
@@ -1429,8 +1429,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 
@@ -1453,8 +1453,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped
---+-------------+-----------+----------+-------------------+-------
+id|hypertable_id|compressed_chunk_id|chunk_status|dropped|schema_name|table_name
+--+-------------+-------------------+------------+-------+-----------+----------
 (0 rows)
 
 

--- a/tsl/test/expected/remote_copy-11.out
+++ b/tsl/test/expected/remote_copy-11.out
@@ -99,7 +99,8 @@ SELECT * FROM "+ri(k33_')";
     3420 |                 4324 | "empties"              |    40 | \N
 (18 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name ,table_name, compressed_chunk_id, dropped 
+FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped 
 ----+---------------+-----------------------+------------------------+---------------------+---------
   1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f

--- a/tsl/test/expected/remote_copy-12.out
+++ b/tsl/test/expected/remote_copy-12.out
@@ -99,7 +99,8 @@ SELECT * FROM "+ri(k33_')";
     3420 |                 4324 | "empties"              |    40 | \N
 (18 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name ,table_name, compressed_chunk_id, dropped 
+FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped 
 ----+---------------+-----------------------+------------------------+---------------------+---------
   1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f

--- a/tsl/test/expected/remote_copy-13.out
+++ b/tsl/test/expected/remote_copy-13.out
@@ -99,7 +99,8 @@ SELECT * FROM "+ri(k33_')";
     3420 |                 4324 | "empties"              |    40 | \N
 (18 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name ,table_name, compressed_chunk_id, dropped 
+FROM _timescaledb_catalog.chunk;
  id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped 
 ----+---------------+-----------------------+------------------------+---------------------+---------
   1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f

--- a/tsl/test/sql/remote_copy.sql.in
+++ b/tsl/test/sql/remote_copy.sql.in
@@ -114,7 +114,8 @@ COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FOR
 \.
 
 SELECT * FROM "+ri(k33_')";
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT id, hypertable_id, schema_name ,table_name, compressed_chunk_id, dropped 
+FROM _timescaledb_catalog.chunk;
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 select * from show_chunks('"+ri(k33_'')"');


### PR DESCRIPTION
    
    Add a new column chunk_status to _timescaledb_catalog.chunk.
    Since we rewrite the catalog table on upgrade, use this
    opportunity to reorder the columns and move variable length
    columns to the end of the table

Note to reviewers: The new column is required by some projects related to compression. I have multiple commits to make the review easier.  I'll squash the commits into a single commit.