### PR TITLE
Create an empty chunk table

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -67,3 +67,10 @@ RETURNS TABLE(chunk_id INTEGER, hypertable_id INTEGER, att_num INTEGER, nullfrac
 slot1numbers FLOAT4[], slot2numbers FLOAT4[], slot3numbers FLOAT4[], slot4numbers FLOAT4[], slot5numbers FLOAT4[],
 slotvaluetypetrings CSTRING[], slot1values CSTRING[], slot2values CSTRING[], slot3values CSTRING[], slot4values CSTRING[], slot5values CSTRING[])
 AS '@MODULE_PATHNAME@', 'ts_chunk_get_colstats' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.create_chunk_table(
+       hypertable REGCLASS,
+       slices JSONB,
+       schema_name NAME,
+       table_name NAME)
+RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_chunk_create_empty_table' LANGUAGE C VOLATILE STRICT;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -925,6 +925,20 @@ ts_chunk_get_data_node_name_list(const Chunk *chunk)
 	return datanodes;
 }
 
+static int32
+get_next_chunk_id()
+{
+	int32 chunk_id;
+	CatalogSecurityContext sec_ctx;
+	const Catalog *catalog = ts_catalog_get();
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	chunk_id = ts_catalog_table_next_seq_id(catalog, CHUNK);
+	ts_catalog_restore_user(&sec_ctx);
+
+	return chunk_id;
+}
+
 /*
  * Create a chunk object from the dimensional constraints in the given hypercube.
  *
@@ -939,11 +953,9 @@ ts_chunk_get_data_node_name_list(const Chunk *chunk)
  */
 static Chunk *
 chunk_create_object(const Hypertable *ht, Hypercube *cube, const char *schema_name,
-					const char *table_name, const char *prefix)
+					const char *table_name, const char *prefix, int32 chunk_id)
 {
 	const Hyperspace *hs = ht->space;
-	const Catalog *catalog = ts_catalog_get();
-	CatalogSecurityContext sec_ctx;
 	Chunk *chunk;
 	const char relkind = hypertable_chunk_relkind(ht);
 
@@ -951,12 +963,7 @@ chunk_create_object(const Hypertable *ht, Hypercube *cube, const char *schema_na
 		schema_name = NameStr(ht->fd.associated_schema_name);
 
 	/* Create a new chunk based on the hypercube */
-	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-	chunk = ts_chunk_create_base(ts_catalog_table_next_seq_id(catalog, CHUNK),
-								 hs->num_dimensions,
-								 relkind);
-
-	ts_catalog_restore_user(&sec_ctx);
+	chunk = ts_chunk_create_base(chunk_id, hs->num_dimensions, relkind);
 
 	chunk->fd.hypertable_id = hs->hypertable_id;
 	chunk->cube = cube;
@@ -1038,19 +1045,80 @@ init_scan_by_chunk_id(ScanIterator *iterator, int32 chunk_id)
 								   Int32GetDatum(chunk_id));
 }
 
+/*
+ * Creates only a table for a chunk.
+ * Either table name or chunk id needs to be provided.
+ */
+static Chunk *
+chunk_create_only_table_after_lock(Hypertable *ht, Hypercube *cube, const char *schema_name,
+								   const char *table_name, const char *prefix, int32 chunk_id)
+{
+	Chunk *chunk;
+
+	Assert(table_name != NULL || chunk_id != INVALID_CHUNK_ID);
+
+	chunk = chunk_create_object(ht, cube, schema_name, table_name, prefix, chunk_id);
+	Assert(chunk != NULL);
+
+	chunk_create_table(chunk, ht);
+
+	return chunk;
+}
+
+/*
+ * Checks that given hypercube does not collide with existing chunks and
+ * creates an empty table for a chunk without any metadata modifications.
+ */
+Chunk *
+ts_chunk_create_only_table(Hypertable *ht, Hypercube *cube, const char *schema_name,
+						   const char *table_name)
+{
+	ChunkStub *stub;
+	ScanTupLock tuplock = {
+		.lockmode = LockTupleKeyShare,
+		.waitpolicy = LockWaitBlock,
+	};
+
+	/*
+	 * Chunk table can be created if no chunk collides with the dimension slices.
+	 */
+	stub = chunk_collides(ht, cube);
+	if (stub != NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_TS_CHUNK_COLLISION),
+				 errmsg("chunk table creation failed due to dimension slice collision")));
+
+	/*
+	 * Serialize chunk creation around a lock on the "main table" to avoid
+	 * multiple processes trying to create the same chunk. We use a
+	 * ShareUpdateExclusiveLock, which is the weakest lock possible that
+	 * conflicts with itself. The lock needs to be held until transaction end.
+	 */
+	LockRelationOid(ht->main_table_relid, ShareUpdateExclusiveLock);
+
+	ts_hypercube_find_existing_slices(cube, &tuplock);
+
+	return chunk_create_only_table_after_lock(ht,
+											  cube,
+											  schema_name,
+											  table_name,
+											  NULL,
+											  INVALID_CHUNK_ID);
+}
+
 static Chunk *
 chunk_create_from_hypercube_after_lock(Hypertable *ht, Hypercube *cube, const char *schema_name,
 									   const char *table_name, const char *prefix)
 {
-	Chunk *chunk;
-
 	/* Insert any new dimension slices into metadata */
 	ts_dimension_slice_insert_multi(cube->slices, cube->num_slices);
 
-	chunk = chunk_create_object(ht, cube, schema_name, table_name, prefix);
-	Assert(chunk != NULL);
-
-	chunk_create_table(chunk, ht);
+	Chunk *chunk = chunk_create_only_table_after_lock(ht,
+													  cube,
+													  schema_name,
+													  table_name,
+													  prefix,
+													  get_next_chunk_id());
 
 	chunk_add_constraints(chunk);
 	chunk_insert_into_metadata_after_lock(chunk);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -161,6 +161,9 @@ extern TSDLLEXPORT Datum ts_chunk_id_from_relid(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT List *ts_chunk_get_chunk_ids_by_hypertable_id(int32 hypertable_id);
 extern TSDLLEXPORT List *ts_chunk_get_data_node_name_list(const Chunk *chunk);
 extern List *ts_chunk_data_nodes_copy(const Chunk *chunk);
+extern TSDLLEXPORT Chunk *ts_chunk_create_only_table(Hypertable *ht, Hypercube *cube,
+													 const char *schema_name,
+													 const char *table_name);
 
 extern TSDLLEXPORT int64 ts_chunk_primary_dimension_start(const Chunk *chunk);
 

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -81,6 +81,7 @@ CROSSMODULE_WRAPPER(data_node_detach);
 CROSSMODULE_WRAPPER(chunk_set_default_data_node);
 CROSSMODULE_WRAPPER(chunk_get_relstats);
 CROSSMODULE_WRAPPER(chunk_get_colstats);
+CROSSMODULE_WRAPPER(chunk_create_empty_table);
 
 CROSSMODULE_WRAPPER(timescaledb_fdw_handler);
 CROSSMODULE_WRAPPER(timescaledb_fdw_validator);
@@ -392,6 +393,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.func_call_on_data_nodes = func_call_on_data_nodes_default,
 	.chunk_get_relstats = error_no_default_fn_pg_community,
 	.chunk_get_colstats = error_no_default_fn_pg_community,
+	.chunk_create_empty_table = error_no_default_fn_pg_community,
 	.hypertable_distributed_set_replication_factor = error_no_default_fn_pg_community,
 	.update_compressed_chunk_relstats = update_compressed_chunk_relstats_default,
 };

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -157,6 +157,7 @@ typedef struct CrossModuleFunctions
 	PGFunction chunk_get_relstats;
 	PGFunction chunk_get_colstats;
 	PGFunction hypertable_distributed_set_replication_factor;
+	PGFunction chunk_create_empty_table;
 	void (*update_compressed_chunk_relstats)(Oid uncompressed_relid, Oid compressed_relid);
 } CrossModuleFunctions;
 

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -381,9 +381,19 @@ ts_dimension_get_open_slice_ordinal(Dimension *dim, DimensionSlice *slice)
 	/* Find the index (ordinal) of the chunk's slice in the open dimension */
 	i = ts_dimension_vec_find_slice_index(vec, slice->fd.id);
 
-	Assert(i >= 0);
-
-	return i;
+	if (i >= 0)
+		return i;
+	else
+	{
+		/*
+		 * Returns the number of slices if the slice not found, i.e., i = -1.
+		 * Dimension slice might not exist if a chunk table is created without
+		 * modifying metadata. It happens only during copy/move chunk for distributed
+		 * hypertable, thus this code, which is used when no space dimension exists,
+		 * is unlikely to be used.
+		 */
+		return vec->num_slices;
+	}
 }
 
 /*

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -1627,3 +1627,45 @@ chunk_api_get_chunk_relstats(PG_FUNCTION_ARGS)
 {
 	return chunk_api_get_chunk_stats(fcinfo, false);
 }
+
+Datum
+chunk_create_empty_table(PG_FUNCTION_ARGS)
+{
+	const Oid hypertable_relid = PG_GETARG_OID(0);
+	Jsonb *const slices = PG_GETARG_JSONB_P(1);
+	const char *const schema_name = PG_GETARG_CSTRING(2);
+	const char *const table_name = PG_GETARG_CSTRING(3);
+	Cache *const hcache = ts_hypertable_cache_pin();
+	Hypertable *const ht = ts_hypertable_cache_get_entry(hcache, hypertable_relid, CACHE_FLAG_NONE);
+	Hypercube *hc;
+	const char *parse_err;
+	AclResult acl_result;
+
+	Assert(!PG_ARGISNULL(0));
+	Assert(!PG_ARGISNULL(1));
+	Assert(!PG_ARGISNULL(2));
+	Assert(!PG_ARGISNULL(3));
+	Assert(ht != NULL);
+
+	acl_result = pg_class_aclcheck(hypertable_relid, GetUserId(), ACL_INSERT);
+	if (acl_result != ACLCHECK_OK)
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("permission denied for table \"%s\"", get_rel_name(hypertable_relid)),
+				 errdetail("Insert privileges required on \"%s\" to create chunks.",
+						   get_rel_name(hypertable_relid))));
+
+	hc = hypercube_from_jsonb(slices, ht->space, &parse_err);
+
+	if (hc == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid hypercube for hypertable \"%s\"", get_rel_name(hypertable_relid)),
+				 errdetail("%s", parse_err)));
+
+	ts_chunk_create_only_table(ht, hc, schema_name, table_name);
+
+	ts_cache_release(hcache);
+
+	PG_RETURN_BOOL(true);
+}

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -14,5 +14,6 @@ extern void chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht);
 extern Datum chunk_api_get_chunk_relstats(PG_FUNCTION_ARGS);
 extern Datum chunk_api_get_chunk_colstats(PG_FUNCTION_ARGS);
 extern void chunk_api_update_distributed_hypertable_stats(Oid relid);
+extern Datum chunk_create_empty_table(PG_FUNCTION_ARGS);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_API_H */

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -185,6 +185,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.func_call_on_data_nodes = ts_dist_cmd_func_call_on_data_nodes,
 	.chunk_get_relstats = chunk_api_get_chunk_relstats,
 	.chunk_get_colstats = chunk_api_get_chunk_colstats,
+	.chunk_create_empty_table = chunk_create_empty_table,
 	.hypertable_distributed_set_replication_factor = hypertable_set_replication_factor,
 	.cache_syscache_invalidate = cache_syscache_invalidate,
 	.update_compressed_chunk_relstats = update_compressed_chunk_relstats,

--- a/tsl/test/expected/chunk_api-11.out
+++ b/tsl/test/expected/chunk_api-11.out
@@ -85,6 +85,56 @@ SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [15150240
 ERROR:  permission denied for table "chunkapi"
 DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Test create_chunk_table is STRICT
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+ create_chunk_table 
+--------------------
+ 
+(1 row)
+
+-- Test create_chunk_table for errors
+\set ON_ERROR_STOP 0
+-- Modified time constraint should fail with collision
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  chunk table creation failed due to dimension slice collision
+-- Missing dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Extra dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "device": [-9223372036854775808, 1073741823], "time2": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Bad dimension name
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "dev": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  dimension "dev" does not exist in hypertable
+-- Same dimension twice
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Bad bounds format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": ["1514419200000000", 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  constraint for dimension "time" is not numeric
+-- Bad slices format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  unexpected number of dimensional bounds for dimension "time"
+-- Bad slices json
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time: [1515024000000000] "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid input syntax for type json
+LINE 1: ...imescaledb_internal.create_chunk_table('chunkapi',' {"time: ...
+                                                             ^
+DETAIL:  Token "device" is invalid.
+CONTEXT:  JSON data, line 1:  {"time: [1515024000000000] "device...
+-- Valid chunk, but no permissions
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  permission denied for table "chunkapi"
+DETAIL:  Insert privileges required on "chunkapi" to create chunks.
+\set ON_ERROR_STOP 1
 -- Test that granting insert on tables allow create_chunk to be
 -- called. This will also create a chunk that does not collide and has
 -- a custom schema and name.
@@ -517,3 +567,248 @@ WARNING:  insufficient number of data nodes for distributed hypertable "disttabl
 
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;
+-- Test create_chunk_table to recreate the chunk table and show dimension slices
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SELECT * FROM chunkapi ORDER BY time;
+             time             | device | temp 
+------------------------------+--------+------
+ Mon Jan 01 05:00:00 2018 PST |      1 | 23.4
+(1 row)
+
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  1 |            1 |     1514419200000000 | 1515024000000000
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(3 rows)
+
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(2 rows)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(2 rows)
+
+-- Test that creat_chunk fails since chunk table already exists
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ERROR:  relation "_hyper_1_1_chunk" already exists
+\set ON_ERROR_STOP 1
+-- Test create_chunk_table on a hypertable where the chunk didn't exist before
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+-- Demonstrate that current settings for dimensions don't affect create_chunk_table
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             4 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             5 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+-- Test create_chunk_table if a colliding chunk exists
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             6 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ERROR:  chunk table creation failed due to dimension slice collision
+\set ON_ERROR_STOP 1
+-- Test create_chunk_table when a chunk exists in different space partition and thus doesn't collide
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             7 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 2, 23.4);
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ create_chunk_table 
+--------------------
+ t
+(1 row)
+
+-- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             8 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-02-01 05:00:00-8', 1, 23.4);
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ create_chunk_table 
+--------------------
+ t
+(1 row)
+
+-- Test create_chunk_table with tablespaces
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+DROP TABLESPACE IF EXISTS tablespace2;
+SET client_min_messages = NOTICE;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE2_PATH;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Use the space partition to calculate the tablespace id to use
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             9 | public      | chunkapi   | t
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+ tablespace  
+-------------
+ tablespace1
+(1 row)
+
+DROP TABLE chunkapi;
+-- Use the time partition to calculate the tablespace id to use
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            10 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_10_10_chunk
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+ tablespace  
+-------------
+ tablespace1
+(1 row)
+
+DROP TABLE chunkapi;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE tablespace1;
+DROP TABLESPACE tablespace2;
+SET client_min_messages = NOTICE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/chunk_api-12.out
+++ b/tsl/test/expected/chunk_api-12.out
@@ -85,6 +85,56 @@ SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [15150240
 ERROR:  permission denied for table "chunkapi"
 DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Test create_chunk_table is STRICT
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+ create_chunk_table 
+--------------------
+ 
+(1 row)
+
+-- Test create_chunk_table for errors
+\set ON_ERROR_STOP 0
+-- Modified time constraint should fail with collision
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  chunk table creation failed due to dimension slice collision
+-- Missing dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Extra dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "device": [-9223372036854775808, 1073741823], "time2": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Bad dimension name
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "dev": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  dimension "dev" does not exist in hypertable
+-- Same dimension twice
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Bad bounds format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": ["1514419200000000", 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  constraint for dimension "time" is not numeric
+-- Bad slices format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  unexpected number of dimensional bounds for dimension "time"
+-- Bad slices json
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time: [1515024000000000] "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid input syntax for type json
+LINE 1: ...imescaledb_internal.create_chunk_table('chunkapi',' {"time: ...
+                                                             ^
+DETAIL:  Token "device" is invalid.
+CONTEXT:  JSON data, line 1:  {"time: [1515024000000000] "device...
+-- Valid chunk, but no permissions
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  permission denied for table "chunkapi"
+DETAIL:  Insert privileges required on "chunkapi" to create chunks.
+\set ON_ERROR_STOP 1
 -- Test that granting insert on tables allow create_chunk to be
 -- called. This will also create a chunk that does not collide and has
 -- a custom schema and name.
@@ -517,3 +567,248 @@ WARNING:  insufficient number of data nodes for distributed hypertable "disttabl
 
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;
+-- Test create_chunk_table to recreate the chunk table and show dimension slices
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SELECT * FROM chunkapi ORDER BY time;
+             time             | device | temp 
+------------------------------+--------+------
+ Mon Jan 01 05:00:00 2018 PST |      1 | 23.4
+(1 row)
+
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  1 |            1 |     1514419200000000 | 1515024000000000
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(3 rows)
+
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(2 rows)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(2 rows)
+
+-- Test that creat_chunk fails since chunk table already exists
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ERROR:  relation "_hyper_1_1_chunk" already exists
+\set ON_ERROR_STOP 1
+-- Test create_chunk_table on a hypertable where the chunk didn't exist before
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+-- Demonstrate that current settings for dimensions don't affect create_chunk_table
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             4 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             5 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+-- Test create_chunk_table if a colliding chunk exists
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             6 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ERROR:  chunk table creation failed due to dimension slice collision
+\set ON_ERROR_STOP 1
+-- Test create_chunk_table when a chunk exists in different space partition and thus doesn't collide
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             7 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 2, 23.4);
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ create_chunk_table 
+--------------------
+ t
+(1 row)
+
+-- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             8 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-02-01 05:00:00-8', 1, 23.4);
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ create_chunk_table 
+--------------------
+ t
+(1 row)
+
+-- Test create_chunk_table with tablespaces
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+DROP TABLESPACE IF EXISTS tablespace2;
+SET client_min_messages = NOTICE;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE2_PATH;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Use the space partition to calculate the tablespace id to use
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             9 | public      | chunkapi   | t
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+ tablespace  
+-------------
+ tablespace1
+(1 row)
+
+DROP TABLE chunkapi;
+-- Use the time partition to calculate the tablespace id to use
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            10 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_10_10_chunk
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+ tablespace  
+-------------
+ tablespace1
+(1 row)
+
+DROP TABLE chunkapi;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE tablespace1;
+DROP TABLESPACE tablespace2;
+SET client_min_messages = NOTICE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/chunk_api-13.out
+++ b/tsl/test/expected/chunk_api-13.out
@@ -85,6 +85,56 @@ SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [15150240
 ERROR:  permission denied for table "chunkapi"
 DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Test create_chunk_table is STRICT
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+ create_chunk_table 
+--------------------
+ 
+(1 row)
+
+-- Test create_chunk_table for errors
+\set ON_ERROR_STOP 0
+-- Modified time constraint should fail with collision
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  chunk table creation failed due to dimension slice collision
+-- Missing dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Extra dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "device": [-9223372036854775808, 1073741823], "time2": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Bad dimension name
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "dev": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  dimension "dev" does not exist in hypertable
+-- Same dimension twice
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  invalid number of hypercube dimensions
+-- Bad bounds format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": ["1514419200000000", 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  constraint for dimension "time" is not numeric
+-- Bad slices format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid hypercube for hypertable "chunkapi"
+DETAIL:  unexpected number of dimensional bounds for dimension "time"
+-- Bad slices json
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time: [1515024000000000] "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  invalid input syntax for type json
+LINE 1: ...imescaledb_internal.create_chunk_table('chunkapi',' {"time: ...
+                                                             ^
+DETAIL:  Token "device" is invalid.
+CONTEXT:  JSON data, line 1:  {"time: [1515024000000000] "device...
+-- Valid chunk, but no permissions
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  permission denied for table "chunkapi"
+DETAIL:  Insert privileges required on "chunkapi" to create chunks.
+\set ON_ERROR_STOP 1
 -- Test that granting insert on tables allow create_chunk to be
 -- called. This will also create a chunk that does not collide and has
 -- a custom schema and name.
@@ -517,3 +567,248 @@ WARNING:  insufficient number of data nodes for distributed hypertable "disttabl
 
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;
+-- Test create_chunk_table to recreate the chunk table and show dimension slices
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+SELECT * FROM chunkapi ORDER BY time;
+             time             | device | temp 
+------------------------------+--------+------
+ Mon Jan 01 05:00:00 2018 PST |      1 | 23.4
+(1 row)
+
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  1 |            1 |     1514419200000000 | 1515024000000000
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(3 rows)
+
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+              drop_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(2 rows)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+ id | dimension_id |     range_start      |    range_end     
+----+--------------+----------------------+------------------
+  2 |            2 | -9223372036854775808 |       1073741823
+  3 |            1 |     1515024000000000 | 1519024000000000
+(2 rows)
+
+-- Test that creat_chunk fails since chunk table already exists
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ERROR:  relation "_hyper_1_1_chunk" already exists
+\set ON_ERROR_STOP 1
+-- Test create_chunk_table on a hypertable where the chunk didn't exist before
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             3 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+-- Demonstrate that current settings for dimensions don't affect create_chunk_table
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             4 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             5 | public      | chunkapi   | t
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+-- Test create_chunk_table if a colliding chunk exists
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             6 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ERROR:  chunk table creation failed due to dimension slice collision
+\set ON_ERROR_STOP 1
+-- Test create_chunk_table when a chunk exists in different space partition and thus doesn't collide
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             7 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 2, 23.4);
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ create_chunk_table 
+--------------------
+ t
+(1 row)
+
+-- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             8 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-02-01 05:00:00-8', 1, 23.4);
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ create_chunk_table 
+--------------------
+ t
+(1 row)
+
+-- Test create_chunk_table with tablespaces
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+DROP TABLESPACE IF EXISTS tablespace2;
+SET client_min_messages = NOTICE;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE2_PATH;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+-- Use the space partition to calculate the tablespace id to use
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             9 | public      | chunkapi   | t
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+ tablespace  
+-------------
+ tablespace1
+(1 row)
+
+DROP TABLE chunkapi;
+-- Use the time partition to calculate the tablespace id to use
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time');
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            10 | public      | chunkapi   | t
+(1 row)
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_10_10_chunk
+(1 row)
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+ attach_tablespace 
+-------------------
+ 
+(1 row)
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+ count 
+-------
+     1
+(1 row)
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+ tablespace  
+-------------
+ tablespace1
+(1 row)
+
+DROP TABLE chunkapi;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE tablespace1;
+DROP TABLESPACE tablespace2;
+SET client_min_messages = NOTICE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/sql/chunk_api.sql.in
+++ b/tsl/test/sql/chunk_api.sql.in
@@ -48,6 +48,32 @@ SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', 'ChunkSchema', 'My_chunk_Table_name');
 \set ON_ERROR_STOP 1
 
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+-- Test create_chunk_table is STRICT
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+-- Test create_chunk_table for errors
+\set ON_ERROR_STOP 0
+-- Modified time constraint should fail with collision
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Missing dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Extra dimension
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "device": [-9223372036854775808, 1073741823], "time2": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Bad dimension name
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000],  "dev": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Same dimension twice
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "time": [1514419600000000, 1515024000000000]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Bad bounds format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": ["1514419200000000", 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Bad slices format
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Bad slices json
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time: [1515024000000000] "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+-- Valid chunk, but no permissions
+SET ROLE :ROLE_DEFAULT_PERM_USER_2;
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+\set ON_ERROR_STOP 1
+
 -- Test that granting insert on tables allow create_chunk to be
 -- called. This will also create a chunk that does not collide and has
 -- a custom schema and name.
@@ -229,3 +255,149 @@ SELECT * FROM delete_data_node('data_node_1', force => true);
 SELECT * FROM delete_data_node('data_node_2', force => true);
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;
+
+-- Test create_chunk_table to recreate the chunk table and show dimension slices
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+SELECT * FROM chunkapi ORDER BY time;
+
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+
+-- Test that creat_chunk fails since chunk table already exists
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+\set ON_ERROR_STOP 1
+
+-- Test create_chunk_table on a hypertable where the chunk didn't exist before
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+-- Demonstrate that current settings for dimensions don't affect create_chunk_table
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+-- Test create_chunk_table if a colliding chunk exists
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+\set ON_ERROR_STOP 1
+
+-- Test create_chunk_table when a chunk exists in different space partition and thus doesn't collide
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 2, 23.4);
+
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+-- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
+
+INSERT INTO chunkapi VALUES ('2018-02-01 05:00:00-8', 1, 23.4);
+
+SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+-- Test create_chunk_table with tablespaces
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE IF EXISTS tablespace1;
+DROP TABLESPACE IF EXISTS tablespace2;
+SET client_min_messages = NOTICE;
+CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE1_PATH;
+CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLESPACE2_PATH;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+-- Use the space partition to calculate the tablespace id to use
+
+DROP TABLE chunkapi;
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+
+DROP TABLE chunkapi;
+
+-- Use the time partition to calculate the tablespace id to use
+
+CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
+SELECT * FROM create_hypertable('chunkapi', 'time');
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+
+SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"
+FROM timescaledb_information.chunks c
+ORDER BY chunk_name DESC
+LIMIT 1 \gset
+
+SELECT slices AS "SLICES"
+FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+
+SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+
+SELECT attach_tablespace('tablespace1', 'chunkapi');
+SELECT attach_tablespace('tablespace2', 'chunkapi');
+
+SELECT count(*) FROM 
+   _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
+
+SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
+
+DROP TABLE chunkapi;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+DROP TABLESPACE tablespace1;
+DROP TABLESPACE tablespace2;
+SET client_min_messages = NOTICE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER


### PR DESCRIPTION
Adds an internal API function to create an empty chunk table according 
the given hypertable for the given chunk table name and dimension 
slices. This functions creates a chunk table inheriting from the 
hypertable, so it guarantees the same schema. No TimescaleDB's 
metadata is updated.

To be able to create the chunk table in a tablespace attached to the 
hyeprtable, this commit allows calculating the tablespace id without 
the dimension slice to exist in the catalog.

If there is already a chunk, which collides on dimension slices, the 
function fails to create the chunk table.

The function will be used internally in multi-node to be able to 
replicate a chunk from one data node to another.
