### PR TITLE
Improve INSERT performance on distributed hypertables

### DIFF
--- a/tsl/src/fdw/deparse.h
+++ b/tsl/src/fdw/deparse.h
@@ -14,6 +14,9 @@ typedef struct DeparsedInsertStmt
 	const char *target; /* INSERT INTO (...) */
 	unsigned int num_target_attrs;
 	const char *target_attrs;
+	const char *unnest_attrs;
+	const char *select_tlist;
+	const char *output_attrs;
 	bool do_nothing;
 	const char *returning;
 	List *retrieved_attrs;

--- a/tsl/src/remote/stmt_params.h
+++ b/tsl/src/remote/stmt_params.h
@@ -21,6 +21,8 @@ extern StmtParams *stmt_params_create(List *target_attr_nums, bool ctid, TupleDe
 extern StmtParams *stmt_params_create_from_values(const char **param_values, int n_params);
 extern void stmt_params_convert_values(StmtParams *params, TupleTableSlot *slot,
 									   ItemPointer tupleid);
+extern void stmt_params_convert_datums(StmtParams *params, Datum *values, bool *isnull,
+									   ItemPointer tupleid);
 extern const int *stmt_params_formats(StmtParams *stmt_params);
 extern const int *stmt_params_lengths(StmtParams *stmt_params);
 extern const char *const *stmt_params_values(StmtParams *stmt_params);

--- a/tsl/test/expected/dist_hypertable-11.out
+++ b/tsl/test/expected/dist_hypertable-11.out
@@ -172,8 +172,8 @@ INSERT INTO disttable VALUES
 EXPLAIN (VERBOSE, COSTS FALSE)
 INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -181,7 +181,7 @@ INSERT INTO disttable VALUES
          ->  Custom Scan (DataNodeDispatch)
                Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                Batch size: 1000
-               Remote SQL: INSERT INTO public.disttable("time", device, temp) VALUES ($1, $2, $3), ..., ($2998, $2999, $3000)
+               Remote SQL: INSERT INTO public.disttable("time", device, temp) SELECT "time", device, temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", device, temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                      ->  Result
@@ -2516,8 +2516,8 @@ WITH result AS (
 SET timescaledb.max_insert_batch_size=1;
 EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim DEFAULT VALUES;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -2525,7 +2525,7 @@ INSERT INTO twodim DEFAULT VALUES;
          ->  Custom Scan (DataNodeDispatch)
                Output: 'Sun Feb 10 10:11:00 2019 PST'::timestamp with time zone, 11, '22.1'::double precision
                Batch size: 1
-               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3)
+               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) SELECT "time", "Color", temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", "Color", temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Feb 10 10:11:00 2019 PST'::timestamp with time zone, 11, '22.1'::double precision
                      ->  Result
@@ -2548,8 +2548,8 @@ EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim VALUES
        ('2019-02-10 16:23', 5, 7.1),
        ('2019-02-10 17:11', 7, 3.2);
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -2557,7 +2557,7 @@ INSERT INTO twodim VALUES
          ->  Custom Scan (DataNodeDispatch)
                Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
                Batch size: 4
-               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3), ..., ($10, $11, $12)
+               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) SELECT "time", "Color", temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", "Color", temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
                      ->  Values Scan on "*VALUES*"

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -172,8 +172,8 @@ INSERT INTO disttable VALUES
 EXPLAIN (VERBOSE, COSTS FALSE)
 INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -181,7 +181,7 @@ INSERT INTO disttable VALUES
          ->  Custom Scan (DataNodeDispatch)
                Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                Batch size: 1000
-               Remote SQL: INSERT INTO public.disttable("time", device, temp) VALUES ($1, $2, $3), ..., ($2998, $2999, $3000)
+               Remote SQL: INSERT INTO public.disttable("time", device, temp) SELECT "time", device, temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", device, temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                      ->  Result
@@ -2497,8 +2497,8 @@ WITH result AS (
 SET timescaledb.max_insert_batch_size=1;
 EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim DEFAULT VALUES;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -2506,7 +2506,7 @@ INSERT INTO twodim DEFAULT VALUES;
          ->  Custom Scan (DataNodeDispatch)
                Output: 'Sun Feb 10 10:11:00 2019 PST'::timestamp with time zone, 11, '22.1'::double precision
                Batch size: 1
-               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3)
+               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) SELECT "time", "Color", temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", "Color", temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Feb 10 10:11:00 2019 PST'::timestamp with time zone, 11, '22.1'::double precision
                      ->  Result
@@ -2529,8 +2529,8 @@ EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim VALUES
        ('2019-02-10 16:23', 5, 7.1),
        ('2019-02-10 17:11', 7, 3.2);
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -2538,7 +2538,7 @@ INSERT INTO twodim VALUES
          ->  Custom Scan (DataNodeDispatch)
                Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
                Batch size: 4
-               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3), ..., ($10, $11, $12)
+               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) SELECT "time", "Color", temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", "Color", temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
                      ->  Values Scan on "*VALUES*"

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -172,8 +172,8 @@ INSERT INTO disttable VALUES
 EXPLAIN (VERBOSE, COSTS FALSE)
 INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -181,7 +181,7 @@ INSERT INTO disttable VALUES
          ->  Custom Scan (DataNodeDispatch)
                Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                Batch size: 1000
-               Remote SQL: INSERT INTO public.disttable("time", device, temp) VALUES ($1, $2, $3), ..., ($2998, $2999, $3000)
+               Remote SQL: INSERT INTO public.disttable("time", device, temp) SELECT "time", device, temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", device, temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                      ->  Result
@@ -2496,8 +2496,8 @@ WITH result AS (
 SET timescaledb.max_insert_batch_size=1;
 EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim DEFAULT VALUES;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -2505,7 +2505,7 @@ INSERT INTO twodim DEFAULT VALUES;
          ->  Custom Scan (DataNodeDispatch)
                Output: 'Sun Feb 10 10:11:00 2019 PST'::timestamp with time zone, 11, '22.1'::double precision
                Batch size: 1
-               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3)
+               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) SELECT "time", "Color", temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", "Color", temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Feb 10 10:11:00 2019 PST'::timestamp with time zone, 11, '22.1'::double precision
                      ->  Result
@@ -2528,8 +2528,8 @@ EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim VALUES
        ('2019-02-10 16:23', 5, 7.1),
        ('2019-02-10 17:11', 7, 3.2);
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (HypertableInsert)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -2537,7 +2537,7 @@ INSERT INTO twodim VALUES
          ->  Custom Scan (DataNodeDispatch)
                Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
                Batch size: 4
-               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3), ..., ($10, $11, $12)
+               Remote SQL: INSERT INTO public.twodim("time", "Color", temp) SELECT "time", "Color", temp FROM unnest($1::timestamp with time zone[], $2::integer[], $3::double precision[]) a("time", "Color", temp)
                ->  Custom Scan (ChunkDispatch)
                      Output: "*VALUES*".column1, "*VALUES*".column2, "*VALUES*".column3
                      ->  Values Scan on "*VALUES*"

--- a/tsl/test/expected/dist_partial_agg.out
+++ b/tsl/test/expected/dist_partial_agg.out
@@ -87,7 +87,7 @@ SELECT table_name FROM create_distributed_hypertable( 'conditions', 'timec', 'lo
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
--- This files assumes the existence of some table with definition as seen in the aggregate_table.sql file.
+-- This file assumes the existence of the same table with definition as seen in the aggregate_table.sql file.
 INSERT INTO :TEST_TABLE
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-04 08:00'::timestamp, '5 minute'), 'POR', 'west', generate_series(25, 85, 0.0625), 75, 40, 70, NULL, (1,2)::custom_type, 2, true;
 INSERT INTO :TEST_TABLE

--- a/tsl/test/sql/include/aggregate_table_populate.sql
+++ b/tsl/test/sql/include/aggregate_table_populate.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
--- This files assumes the existence of some table with definition as seen in the aggregate_table.sql file.
+-- This file assumes the existence of the same table with definition as seen in the aggregate_table.sql file.
 INSERT INTO :TEST_TABLE
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-04 08:00'::timestamp, '5 minute'), 'POR', 'west', generate_series(25, 85, 0.0625), 75, 40, 70, NULL, (1,2)::custom_type, 2, true;
 INSERT INTO :TEST_TABLE


### PR DESCRIPTION
Refactor the data node dispatch node to send batches of tuples to data
nodes in columnar format. The columnar format is implemented by
rolling up multiple rows of values into one row of arrays of
values. So, an insert like

```
INSERT INTO hypertable (time, value)
VALUES ('2021-04-19', 1), (2021-04-20, 2);
```
is deparsed to

```
INSERT INTO hypertable (time, value)
SELECT * FROM unnest(ARRAY['2021-04-19', '2021-04-20'], ARRAY[1, 2]) a(t,v);
```

when sent to data nodes. This approach allows sending an arbitrary
number of rows using the same prepared statement:

```
INSERT INTO hypertable (time, value)
SELECT * FROM unnest($1::timestamptz[], $2::integer[]) a(t,v)
```

Previously, the number of rows that could be sent in a batch was
limited by the number of parameters allowed in a prepared statement.

Special care has been taken to handle custom types (e.g., composite)
as the internal fields of such types are unnested along with the
array. For such cases, the deparsed insert statement must look like:

```
INSERT INTO hypertable (time, value)
SELECT time, (high, low)::customtype
FROM unnest($1::timestamptz[], $2::custom_type[]) a(t,high,low);
```

Array columns present another challange. In such cases we must deparse
into an array of arrays. This puts a limit on the number of dimensions
we can support, as rolling up an array adds an extra dimension.