### PR TITLE
Ignore generated SQL test files from templates

### DIFF
--- a/test/sql/.gitignore
+++ b/test/sql/.gitignore
@@ -8,6 +8,7 @@
 /custom_type-*.sql
 /ddl-*.sql
 /delete-*.sql
+/index-*.sql
 /insert-*.sql
 /insert_many-*.sql
 /multi_transaction_index-*.sql

--- a/tsl/test/shared/sql/.gitignore
+++ b/tsl/test/shared/sql/.gitignore
@@ -1,4 +1,5 @@
 /constify_timestamptz_op_interval-*.sql
 /gapfill-*.sql
+/generated_columns-*.sql
 /ordered_append-*.sql
 /ordered_append_join-*.sql


### PR DESCRIPTION
`index` test was moved into SQL test template in #3123 and
`generated_columns` - in #2927. They are added to relevant gitignore.