### PR TITLE
Run code style regression test on all PRs

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -3,12 +3,10 @@ on:
   schedule:
     # run daily 20:00 on master branch
     - cron: '0 20 * * *'
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - prerelease_test
+  pull_request:
 jobs:
   misc_checks:
     name: Check formatting, license and git hooks


### PR DESCRIPTION
Checking code formatting and other simple code style test is good to
perform on PRs to feature branches, not only the master branch. This
commit removes the limitation to perform tests only on PR to the
master.