### PR TITLE
Fix SkipScan for IndexPaths without pathkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ accidentally triggering the load of a previous DB version.**
 * #3106 Fix use after free in chunk_api_get_chunk_stats
 * #3123 Fix crash while using REINDEX TABLE CONCURRENTLY
 * #3135 Fix SkipScan path generation in DISTINCT queries with expressions
+* #3146 Fix SkipScan for IndexPaths without pathkeys
+
+**Thanks**
+* @hperez75 for reporting an issue with Skip Scan
 
 ## 2.2.0 (2021-04-13)
 

--- a/tsl/test/expected/plan_skip_scan-11.out
+++ b/tsl/test/expected/plan_skip_scan-11.out
@@ -3823,6 +3823,14 @@ DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
                ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
 (11 rows)
 
+-- IndexPath without pathkeys doesnt use SkipScan
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Unique
+   ->  Index Only Scan using pg_rewrite_rel_rulename_index on pg_rewrite
+(2 rows)
+
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
                               QUERY PLAN                               

--- a/tsl/test/expected/plan_skip_scan-12.out
+++ b/tsl/test/expected/plan_skip_scan-12.out
@@ -3794,6 +3794,14 @@ DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
                ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
 (11 rows)
 
+-- IndexPath without pathkeys doesnt use SkipScan
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Unique
+   ->  Index Only Scan using pg_rewrite_rel_rulename_index on pg_rewrite
+(2 rows)
+
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
                               QUERY PLAN                               

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -3786,6 +3786,14 @@ DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
                ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx1 on _hyper_1_4_chunk (actual rows=11 loops=1)
 (11 rows)
 
+-- IndexPath without pathkeys doesnt use SkipScan
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Unique
+   ->  Index Only Scan using pg_rewrite_rel_rulename_index on pg_rewrite
+(2 rows)
+
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
                               QUERY PLAN                               

--- a/tsl/test/sql/include/skip_scan_query_ht.sql
+++ b/tsl/test/sql/include/skip_scan_query_ht.sql
@@ -23,3 +23,5 @@ SELECT decompress_chunk('_timescaledb_internal._hyper_1_1_chunk');
 DROP INDEX _timescaledb_internal._hyper_1_1_chunk_skip_scan_ht_dev_idx;
 :PREFIX SELECT DISTINCT ON (dev) dev, dev_name FROM :TABLE;
 
+-- IndexPath without pathkeys doesnt use SkipScan
+EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT 1 FROM pg_rewrite;


### PR DESCRIPTION
The SkipScan code assumed IndexPaths on ordered indexes always
have pathkeys which is not true when the pathkeys are not useful
for the query, leading to a segfault for those queries.