### PR TITLE
Skip ChunkAppend if AppendPath has no children

### DIFF
--- a/src/planner.c
+++ b/src/planner.c
@@ -483,7 +483,12 @@ should_chunk_append(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel, Path *pa
 			 * Params this Path might benefit from startup or runtime exclusion
 			 */
 			{
+				AppendPath *append = castNode(AppendPath, path);
 				ListCell *lc;
+
+				/* Don't create ChunkAppend with no children */
+				if (list_length(append->subpaths) == 0)
+					return false;
 
 				foreach (lc, rel->baserestrictinfo)
 				{
@@ -501,10 +506,11 @@ should_chunk_append(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel, Path *pa
 			 * Can we do ordered append
 			 */
 			{
+				MergeAppendPath *merge = castNode(MergeAppendPath, path);
 				PathKey *pk;
 				ListCell *lc;
 
-				if (!ordered || path->pathkeys == NIL)
+				if (!ordered || path->pathkeys == NIL || list_length(merge->subpaths) == 0)
 					return false;
 
 				pk = linitial_node(PathKey, path->pathkeys);

--- a/test/expected/append-12.out
+++ b/test/expected/append-12.out
@@ -328,15 +328,15 @@ WHERE time < '2016-03-22'
 AND date_part('dow', time) between 1 and 5
 GROUP BY t
 ORDER BY t DESC;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  GroupAggregate (actual rows=0 loops=1)
    Group Key: (date_trunc('year'::text, "time"))
    ->  Sort (actual rows=0 loops=1)
          Sort Key: (date_trunc('year'::text, "time")) DESC
          Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
-               Chunks excluded during startup: 0
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
 (7 rows)
 
 -- a parameterized query can safely constify params, so won't be

--- a/test/expected/append-13.out
+++ b/test/expected/append-13.out
@@ -328,15 +328,15 @@ WHERE time < '2016-03-22'
 AND date_part('dow', time) between 1 and 5
 GROUP BY t
 ORDER BY t DESC;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                        QUERY PLAN                         
+-----------------------------------------------------------
  GroupAggregate (actual rows=0 loops=1)
    Group Key: (date_trunc('year'::text, "time"))
    ->  Sort (actual rows=0 loops=1)
          Sort Key: (date_trunc('year'::text, "time")) DESC
          Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on append_test (actual rows=0 loops=1)
-               Chunks excluded during startup: 0
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
 (7 rows)
 
 -- a parameterized query can safely constify params, so won't be

--- a/tsl/test/expected/continuous_aggs_union_view-12.out
+++ b/tsl/test/expected/continuous_aggs_union_view-12.out
@@ -366,9 +366,9 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 ----------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
    ->  HashAggregate (actual rows=0 loops=1)
-         Group Key: _materialized_hypertable_6.time_bucket
-         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=0 loops=1)
-               Chunks excluded during startup: 0
+         Group Key: time_bucket
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: time_bucket(10, boundary_test."time")
          ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)

--- a/tsl/test/expected/continuous_aggs_union_view-13.out
+++ b/tsl/test/expected/continuous_aggs_union_view-13.out
@@ -366,10 +366,10 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 ----------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
    ->  HashAggregate (actual rows=0 loops=1)
-         Group Key: _materialized_hypertable_6.time_bucket
+         Group Key: time_bucket
          Batches: 1 
-         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=0 loops=1)
-               Chunks excluded during startup: 0
+         ->  Result (actual rows=0 loops=1)
+               One-Time Filter: false
    ->  HashAggregate (actual rows=4 loops=1)
          Group Key: time_bucket(10, boundary_test."time")
          Batches: 1 


### PR DESCRIPTION
Since postgres has optimizations for Append paths without children
we do not replace those paths with ChunkAppend. While this will
prevent ChunkAppendPaths without children during planning, in the
executor it is still possible for ChunkAppend to have no children
as run-time exclusion may remove all of them.