### PR TITLE
Return error for NULL input to create_chunk_table

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -73,4 +73,4 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.create_chunk_table(
        slices JSONB,
        schema_name NAME,
        table_name NAME)
-RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_chunk_create_empty_table' LANGUAGE C VOLATILE STRICT;
+RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_chunk_create_empty_table' LANGUAGE C VOLATILE;

--- a/src/error_utils.h
+++ b/src/error_utils.h
@@ -1,0 +1,27 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_ERROR_UTILS_H
+#define TIMESCALEDB_ERROR_UTILS_H
+
+#define GETARG_NOTNULL_OID(var, arg, name)                                                         \
+	{                                                                                              \
+		var = PG_ARGISNULL(arg) ? InvalidOid : PG_GETARG_OID(arg);                                 \
+		if (!OidIsValid(var))                                                                      \
+			ereport(ERROR,                                                                         \
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),                                     \
+					 errmsg("%s cannot be NULL", name)));                                          \
+	}
+
+#define GETARG_NOTNULL_NULLABLE(var, arg, name, type)                                              \
+	{                                                                                              \
+		if (PG_ARGISNULL(arg))                                                                     \
+			ereport(ERROR,                                                                         \
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),                                     \
+					 errmsg("%s cannot be NULL", name)));                                          \
+		var = PG_GETARG_##type(arg);                                                               \
+	}
+
+#endif /* TIMESCALEDB_ERROR_UTILS_H */

--- a/tsl/test/expected/chunk_api-11.out
+++ b/tsl/test/expected/chunk_api-11.out
@@ -86,15 +86,17 @@ ERROR:  permission denied for table "chunkapi"
 DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
 SET ROLE :ROLE_DEFAULT_PERM_USER;
--- Test create_chunk_table is STRICT
-SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
- create_chunk_table 
---------------------
- 
-(1 row)
-
 -- Test create_chunk_table for errors
 \set ON_ERROR_STOP 0
+-- Test create_chunk_table for NULL input
+SELECT * FROM _timescaledb_internal.create_chunk_table(NULL,' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  hypertable cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  slices cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', NULL,'_hyper_1_1_chunk');
+ERROR:  chunk schema name cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal',NULL);
+ERROR:  chunk table name cannot be NULL
 -- Modified time constraint should fail with collision
 SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
 ERROR:  chunk table creation failed due to dimension slice collision

--- a/tsl/test/expected/chunk_api-12.out
+++ b/tsl/test/expected/chunk_api-12.out
@@ -86,15 +86,17 @@ ERROR:  permission denied for table "chunkapi"
 DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
 SET ROLE :ROLE_DEFAULT_PERM_USER;
--- Test create_chunk_table is STRICT
-SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
- create_chunk_table 
---------------------
- 
-(1 row)
-
 -- Test create_chunk_table for errors
 \set ON_ERROR_STOP 0
+-- Test create_chunk_table for NULL input
+SELECT * FROM _timescaledb_internal.create_chunk_table(NULL,' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  hypertable cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  slices cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', NULL,'_hyper_1_1_chunk');
+ERROR:  chunk schema name cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal',NULL);
+ERROR:  chunk table name cannot be NULL
 -- Modified time constraint should fail with collision
 SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
 ERROR:  chunk table creation failed due to dimension slice collision

--- a/tsl/test/expected/chunk_api-13.out
+++ b/tsl/test/expected/chunk_api-13.out
@@ -86,15 +86,17 @@ ERROR:  permission denied for table "chunkapi"
 DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
 SET ROLE :ROLE_DEFAULT_PERM_USER;
--- Test create_chunk_table is STRICT
-SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
- create_chunk_table 
---------------------
- 
-(1 row)
-
 -- Test create_chunk_table for errors
 \set ON_ERROR_STOP 0
+-- Test create_chunk_table for NULL input
+SELECT * FROM _timescaledb_internal.create_chunk_table(NULL,' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  hypertable cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+ERROR:  slices cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', NULL,'_hyper_1_1_chunk');
+ERROR:  chunk schema name cannot be NULL
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal',NULL);
+ERROR:  chunk table name cannot be NULL
 -- Modified time constraint should fail with collision
 SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
 ERROR:  chunk table creation failed due to dimension slice collision

--- a/tsl/test/sql/chunk_api.sql.in
+++ b/tsl/test/sql/chunk_api.sql.in
@@ -49,10 +49,13 @@ SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [15150240
 \set ON_ERROR_STOP 1
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
--- Test create_chunk_table is STRICT
-SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
 -- Test create_chunk_table for errors
 \set ON_ERROR_STOP 0
+-- Test create_chunk_table for NULL input
+SELECT * FROM _timescaledb_internal.create_chunk_table(NULL,' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi', NULL, '_timescaledb_internal','_hyper_1_1_chunk');
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', NULL,'_hyper_1_1_chunk');
+SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal',NULL);
 -- Modified time constraint should fail with collision
 SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1514419600000000, 1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
 -- Missing dimension


### PR DESCRIPTION
Gives errors if any argument of create_chunk_table is NULL instead of 
being STRICT. Utilizes newly added macros for this.

PR notes:
This PR addresses comments from @erimatnor @pmwkaa @nikkhils about #3137 