### PR TITLE
First steps toward PostgreSQL 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,7 @@ message(STATUS "Compiling against PostgreSQL version ${PG_VERSION}")
 # Ensure that PostgreSQL version is supported and consistent
 # with src/compat.h version check
 if ((${PG_VERSION_MAJOR} LESS "11") OR
-    (${PG_VERSION_MAJOR} GREATER "13"))
+    (${PG_VERSION_MAJOR} GREATER "14"))
   message(FATAL_ERROR "TimescaleDB only supports PostgreSQL 11, 12 and 13")
 endif()
 

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -341,7 +341,7 @@ static void
 catalog_database_info_init(CatalogDatabaseInfo *info)
 {
 	info->database_id = MyDatabaseId;
-	StrNCpy(info->database_name, get_database_name(MyDatabaseId), NAMEDATALEN);
+	strlcpy(info->database_name, get_database_name(MyDatabaseId), NAMEDATALEN);
 	info->schema_id = get_namespace_oid(CATALOG_SCHEMA_NAME, false);
 	info->owner_uid = catalog_owner();
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2933,8 +2933,8 @@ chunk_tuple_update_schema_and_table(TupleInfo *ti, void *data)
 
 	chunk_formdata_fill(&form, ti);
 
-	namecpy(&form.schema_name, &update->schema_name);
-	namecpy(&form.table_name, &update->table_name);
+	strlcpy(NameStr(form.schema_name), NameStr(update->schema_name), NAMEDATALEN);
+	strlcpy(NameStr(form.table_name), NameStr(update->table_name), NAMEDATALEN);
 
 	new_tuple = chunk_formdata_make_tuple(&form, ts_scanner_get_tupledesc(ti));
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -25,19 +25,22 @@
 #define is_supported_pg_version_11(version) ((version >= 110000) && (version < 120000))
 #define is_supported_pg_version_12(version) ((version >= 120000) && (version < 130000))
 #define is_supported_pg_version_13(version) ((version >= 130002) && (version < 140000))
+#define is_supported_pg_version_14(version) ((version >= 140000) && (version < 140001))
 
 #define is_supported_pg_version(version)                                                           \
 	(is_supported_pg_version_11(version) || is_supported_pg_version_12(version) ||                 \
-	 is_supported_pg_version_13(version))
+	 is_supported_pg_version_13(version) || is_supported_pg_version_14(version))
 
 #define PG11 is_supported_pg_version_11(PG_VERSION_NUM)
 #define PG12 is_supported_pg_version_12(PG_VERSION_NUM)
 #define PG13 is_supported_pg_version_13(PG_VERSION_NUM)
+#define PG14 is_supported_pg_version_14(PG_VERSION_NUM)
 
 #define PG12_LT PG11
 #define PG12_GE !(PG12_LT)
-#define PG13_LT !(PG13)
-#define PG13_GE PG13
+#define PG13_GE ((PG13) || (PG14))
+#define PG13_LT ((PG11) || (PG12))
+#define PG14_GE (PG14)
 
 #if !(is_supported_pg_version(PG_VERSION_NUM))
 #error "Unsupported PostgreSQL version"
@@ -367,6 +370,9 @@ get_vacuum_options(const VacuumStmt *stmt)
 #define list_delete_cell_compat(l, lc, prev) list_delete_cell((l), (lc), (prev))
 #define for_each_cell_compat(cell, list, initcell) for_each_cell ((cell), (initcell))
 #else
+#undef list_make5
+#undef list_make5_oid
+#undef list_make5_int
 #define lnext_compat(l, lc) lnext((l), (lc))
 #define list_delete_cell_compat(l, lc, prev) list_delete_cell((l), (lc))
 #define list_make5(x1, x2, x3, x4, x5) lappend(list_make4(x1, x2, x3, x4), x5)


### PR DESCRIPTION
`StrNCpy` and `namecpy` are gone in PostgreSQL 14. Apparently, the community uses `strlcpy` instead. Plus minor changes to get rid of warnings about redefining macros when using MacOS and Clang.