### PR TITLE
Introduce function to copy chunk data between data nodes

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -59,6 +59,12 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.create_chunk(
 RETURNS TABLE(chunk_id INTEGER, hypertable_id INTEGER, schema_name NAME, table_name NAME, relkind "char", slices JSONB, created BOOLEAN)
 AS '@MODULE_PATHNAME@', 'ts_chunk_create' LANGUAGE C VOLATILE;
 
+-- Copy chunk data from the source data node to the destination data node
+CREATE OR REPLACE FUNCTION _timescaledb_internal.copy_chunk_data(chunk REGCLASS, src_node_name NAME, dst_node_name NAME)
+RETURNS VOID
+AS '@MODULE_PATHNAME@', 'ts_chunk_copy_data'
+LANGUAGE C VOLATILE;
+
 -- change default data node for a chunk
 CREATE OR REPLACE FUNCTION _timescaledb_internal.set_chunk_default_data_node(chunk REGCLASS, node_name NAME) RETURNS BOOLEAN
 AS '@MODULE_PATHNAME@', 'ts_chunk_set_default_data_node' LANGUAGE C VOLATILE;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -72,6 +72,7 @@ TS_FUNCTION_INFO_V1(ts_chunk_id_from_relid);
 TS_FUNCTION_INFO_V1(ts_chunk_dml_blocker);
 TS_FUNCTION_INFO_V1(ts_chunk_show);
 TS_FUNCTION_INFO_V1(ts_chunk_create);
+TS_FUNCTION_INFO_V1(ts_chunk_copy_data);
 
 /* Used when processing scanned chunks */
 typedef enum ChunkResult
@@ -3992,4 +3993,10 @@ Datum
 ts_chunk_create(PG_FUNCTION_ARGS)
 {
 	return ts_cm_functions->create_chunk(fcinfo);
+}
+
+Datum
+ts_chunk_copy_data(PG_FUNCTION_ARGS)
+{
+	return ts_cm_functions->copy_chunk_data(fcinfo);
 }

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -371,6 +371,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.chunk_set_default_data_node = error_no_default_fn_pg_community,
 	.show_chunk = error_no_default_fn_pg_community,
 	.create_chunk = error_no_default_fn_pg_community,
+	.copy_chunk_data = error_no_default_fn_pg_community,
 	.create_chunk_on_data_nodes = create_chunk_on_data_nodes_default,
 	.chunk_drop_replica = error_no_default_fn_pg_community,
 	.hypertable_make_distributed = hypertable_make_distributed_default_fn,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -129,6 +129,7 @@ typedef struct CrossModuleFunctions
 	PGFunction chunk_set_default_data_node;
 	PGFunction create_chunk;
 	PGFunction show_chunk;
+	PGFunction copy_chunk_data;
 
 	List *(*get_and_validate_data_node_list)(ArrayType *nodearr);
 	void (*hypertable_make_distributed)(Hypertable *ht, List *data_node_names);

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -16,5 +16,6 @@ extern Datum chunk_set_default_data_node(PG_FUNCTION_ARGS);
 extern Datum chunk_drop_replica(PG_FUNCTION_ARGS);
 extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type);
 extern Datum chunk_create_replica_table(PG_FUNCTION_ARGS);
+extern Datum chunk_copy_data(PG_FUNCTION_ARGS);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_H */

--- a/tsl/src/hypertable.c
+++ b/tsl/src/hypertable.c
@@ -65,7 +65,7 @@ hypertable_create_backend_tables(int32 hypertable_id, List *data_nodes)
 	DeparsedHypertableCommands *commands = deparse_get_distributed_hypertable_create_command(ht);
 
 	foreach (cell, deparse_get_tabledef_commands(ht->main_table_relid))
-		ts_dist_cmd_run_on_data_nodes(lfirst(cell), data_nodes);
+		ts_dist_cmd_run_on_data_nodes(lfirst(cell), data_nodes, true);
 
 	dist_res = ts_dist_cmd_invoke_on_data_nodes(commands->table_create_command, data_nodes, true);
 	foreach (cell, data_nodes)
@@ -82,10 +82,10 @@ hypertable_create_backend_tables(int32 hypertable_id, List *data_nodes)
 	ts_dist_cmd_close_response(dist_res);
 
 	foreach (cell, commands->dimension_add_commands)
-		ts_dist_cmd_run_on_data_nodes(lfirst(cell), data_nodes);
+		ts_dist_cmd_run_on_data_nodes(lfirst(cell), data_nodes, true);
 
 	foreach (cell, commands->grant_commands)
-		ts_dist_cmd_run_on_data_nodes(lfirst(cell), data_nodes);
+		ts_dist_cmd_run_on_data_nodes(lfirst(cell), data_nodes, true);
 
 	return remote_ids;
 }

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -158,6 +158,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.create_chunk = chunk_create,
 	.create_chunk_on_data_nodes = chunk_api_create_on_data_nodes,
 	.chunk_drop_replica = chunk_drop_replica,
+	.copy_chunk_data = chunk_copy_data,
 	.hypertable_make_distributed = hypertable_make_distributed,
 	.get_and_validate_data_node_list = hypertable_get_and_validate_data_nodes,
 	.timescaledb_fdw_handler = timescaledb_fdw_handler,

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -93,6 +93,7 @@ extern unsigned int remote_connection_get_prep_stmt_number(void);
 extern bool remote_connection_configure(TSConnection *conn);
 extern bool remote_connection_check_extension(TSConnection *conn);
 extern void remote_validate_extension_version(TSConnection *conn, const char *data_node_version);
+extern char *remote_connection_get_connstr(const char *node_name);
 
 typedef enum TSConnectionResult
 {

--- a/tsl/src/remote/dist_commands.h
+++ b/tsl/src/remote/dist_commands.h
@@ -37,8 +37,8 @@ extern Size ts_dist_cmd_response_count(DistCmdResult *result);
 extern long ts_dist_cmd_total_row_count(DistCmdResult *result);
 extern void ts_dist_cmd_close_response(DistCmdResult *response);
 
-#define ts_dist_cmd_run_on_data_nodes(command, nodes)                                              \
-	ts_dist_cmd_close_response(ts_dist_cmd_invoke_on_data_nodes(command, nodes, true));
+#define ts_dist_cmd_run_on_data_nodes(command, nodes, transactional)                               \
+	ts_dist_cmd_close_response(ts_dist_cmd_invoke_on_data_nodes(command, nodes, transactional));
 
 extern PreparedDistCmd *ts_dist_cmd_prepare_command(const char *sql, size_t n_params,
 													List *node_names);

--- a/tsl/test/t/002_copy_chunk_data.pl
+++ b/tsl/test/t/002_copy_chunk_data.pl
@@ -1,0 +1,93 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+#
+# Test copy_chunk_data(): using logical replication to copy chunk data
+# between data nodes
+#
+
+use strict;
+use warnings;
+use AccessNode;
+use DataNode;
+use TestLib;
+use Test::More tests => 18;
+
+# initialize multi-node cluster
+my $an  = AccessNode->create('an');
+my $dn1 = DataNode->create('dn1', allows_streaming => 'logical');
+my $dn2 = DataNode->create('dn2', allows_streaming => 'logical');
+
+# add the data nodes from the access node
+$an->add_data_node($dn1);
+$an->add_data_node($dn2);
+
+# create a distributed hypertable and insert a few rows
+$an->safe_psql(
+	'postgres', qq[
+CREATE TABLE test(time timestamp NOT NULL, device int, temp float);
+SELECT create_distributed_hypertable('test', 'time', 'device', 3);
+INSERT INTO test SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, 0.10 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-08 1:00', '1 hour') t;
+]
+);
+
+# check that chunks are shown appropriately on all nodes of the multi-node setup
+my $query = q[SELECT * from show_chunks('test');];
+
+# data node 1 chunks
+$dn1->psql_is(
+	'postgres', $query, q[_timescaledb_internal._dist_hyper_1_1_chunk
+_timescaledb_internal._dist_hyper_1_3_chunk
+_timescaledb_internal._dist_hyper_1_4_chunk],
+	'DN1 shows correct set of chunks');
+
+# data node 2 chunks
+$dn2->psql_is(
+	'postgres', $query,
+	"_timescaledb_internal._dist_hyper_1_2_chunk",
+	'DN2 shows correct set of chunks');
+
+# check rows consistency on data node 1
+my $_dist_hyper_1_1_chunk = 58;
+my $_dist_hyper_1_4_chunk = 2;
+
+$dn1->psql_is(
+	'postgres',
+	"SELECT count(*) FROM _timescaledb_internal._dist_hyper_1_1_chunk",
+	"$_dist_hyper_1_1_chunk",
+	'DN1 shows correct number of rows for _dist_hyper_1_1_chunk');
+
+$dn1->psql_is(
+	'postgres',
+	"SELECT count(*) FROM _timescaledb_internal._dist_hyper_1_4_chunk",
+	"$_dist_hyper_1_4_chunk",
+	'DN1 shows correct number of rows _dist_hyper_1_4_chunk');
+
+# copy chunks {1,4} from data node 1 to data node 2
+$an->safe_psql(
+	'postgres', qq[
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_1_1_chunk'::regclass, 'dn2');
+SELECT _timescaledb_internal.copy_chunk_data('_timescaledb_internal._dist_hyper_1_1_chunk'::regclass, 'dn1', 'dn2');
+
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_1_4_chunk'::regclass, 'dn2');
+SELECT _timescaledb_internal.copy_chunk_data('_timescaledb_internal._dist_hyper_1_4_chunk'::regclass, 'dn1', 'dn2');
+]
+);
+
+# check that data node 2 now has chunks with the data data node 1 chunks
+$dn2->psql_is(
+	'postgres',
+	"SELECT count(*) FROM _timescaledb_internal._dist_hyper_1_1_chunk",
+	"$_dist_hyper_1_1_chunk",
+	'DN2 shows correct number of rows _dist_hyper_1_1_chunk');
+
+$dn2->psql_is(
+	'postgres',
+	"SELECT count(*) FROM _timescaledb_internal._dist_hyper_1_4_chunk",
+	"$_dist_hyper_1_4_chunk",
+	'DN2 shows correct number of rows _dist_hyper_1_4_chunk');
+
+done_testing();
+
+1;

--- a/tsl/test/t/CMakeLists.txt
+++ b/tsl/test/t/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(PROVE_TEST_FILES
     001_simple_multinode.pl
+    002_copy_chunk_data.pl
 )
 
 foreach(P_FILE ${PROVE_TEST_FILES})


### PR DESCRIPTION
Add internal copy_chunk_data() function which implements a way
to copy chunk data between data nodes using logical
replication.

Some moments to consider

* this functionality needs to be tested using separate instances,  `test_copy_chunk_data.sh` been introduced for that purpose
* no chunk locking been made during the copy operation
* no tests for corner cases such as connection failure during the copy or operation retry after failure
* there is no undo/clean procedure in case if operation fails during its operation