### PR TITLE
Implement drop_chunk_replica API

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -30,3 +30,10 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.create_chunk_replica_table(
     chunk REGCLASS,
     data_node_name NAME
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_chunk_create_replica_table' LANGUAGE C VOLATILE;
+
+-- Drop the specified chunk replica on the specified data node
+CREATE OR REPLACE FUNCTION  _timescaledb_internal.chunk_drop_replica(
+    chunk                   REGCLASS,
+    node_name               NAME
+) RETURNS VOID
+AS '@MODULE_PATHNAME@', 'ts_chunk_drop_replica' LANGUAGE C VOLATILE;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -925,6 +925,30 @@ ts_chunk_get_data_node_name_list(const Chunk *chunk)
 	return datanodes;
 }
 
+bool
+ts_chunk_has_data_node(const Chunk *chunk, const char *node_name)
+{
+	ListCell *lc;
+	ChunkDataNode *cdn;
+	bool found = false;
+
+	if (chunk == NULL || node_name == NULL)
+		return false;
+
+	/* check that the chunk is indeed present on the specified data node */
+	foreach (lc, chunk->data_nodes)
+	{
+		cdn = lfirst(lc);
+		if (namestrcmp(&cdn->fd.node_name, node_name) == 0)
+		{
+			found = true;
+			break;
+		}
+	}
+
+	return found;
+}
+
 static int32
 get_next_chunk_id()
 {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -162,6 +162,7 @@ extern TSDLLEXPORT bool ts_chunk_can_be_compressed(int32 chunk_id);
 extern TSDLLEXPORT Datum ts_chunk_id_from_relid(PG_FUNCTION_ARGS);
 extern TSDLLEXPORT List *ts_chunk_get_chunk_ids_by_hypertable_id(int32 hypertable_id);
 extern TSDLLEXPORT List *ts_chunk_get_data_node_name_list(const Chunk *chunk);
+extern bool TSDLLEXPORT ts_chunk_has_data_node(const Chunk *chunk, const char *node_name);
 extern List *ts_chunk_data_nodes_copy(const Chunk *chunk);
 extern TSDLLEXPORT Chunk *ts_chunk_create_only_table(Hypertable *ht, Hypercube *cube,
 													 const char *schema_name,

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -77,6 +77,7 @@ CROSSMODULE_WRAPPER(data_node_add);
 CROSSMODULE_WRAPPER(data_node_delete);
 CROSSMODULE_WRAPPER(data_node_attach);
 CROSSMODULE_WRAPPER(data_node_detach);
+CROSSMODULE_WRAPPER(chunk_drop_replica);
 
 CROSSMODULE_WRAPPER(chunk_set_default_data_node);
 CROSSMODULE_WRAPPER(chunk_get_relstats);
@@ -371,6 +372,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.show_chunk = error_no_default_fn_pg_community,
 	.create_chunk = error_no_default_fn_pg_community,
 	.create_chunk_on_data_nodes = create_chunk_on_data_nodes_default,
+	.chunk_drop_replica = error_no_default_fn_pg_community,
 	.hypertable_make_distributed = hypertable_make_distributed_default_fn,
 	.get_and_validate_data_node_list = get_and_validate_data_node_list_default_fn,
 	.timescaledb_fdw_handler = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -129,6 +129,7 @@ typedef struct CrossModuleFunctions
 	Datum (*chunk_set_default_data_node)(PG_FUNCTION_ARGS);
 	Datum (*create_chunk)(PG_FUNCTION_ARGS);
 	Datum (*show_chunk)(PG_FUNCTION_ARGS);
+
 	List *(*get_and_validate_data_node_list)(ArrayType *nodearr);
 	void (*hypertable_make_distributed)(Hypertable *ht, List *data_node_names);
 	Datum (*timescaledb_fdw_handler)(PG_FUNCTION_ARGS);
@@ -159,6 +160,7 @@ typedef struct CrossModuleFunctions
 	PGFunction hypertable_distributed_set_replication_factor;
 	PGFunction chunk_create_empty_table;
 	PGFunction chunk_create_replica_table;
+	PGFunction chunk_drop_replica;
 	void (*update_compressed_chunk_relstats)(Oid uncompressed_relid, Oid compressed_relid);
 } CrossModuleFunctions;
 

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -13,6 +13,7 @@
 
 extern void chunk_update_foreign_server_if_needed(int32 chunk_id, Oid existing_server_id);
 extern Datum chunk_set_default_data_node(PG_FUNCTION_ARGS);
+extern Datum chunk_drop_replica(PG_FUNCTION_ARGS);
 extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type);
 extern Datum chunk_create_replica_table(PG_FUNCTION_ARGS);
 

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -157,6 +157,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.show_chunk = chunk_show,
 	.create_chunk = chunk_create,
 	.create_chunk_on_data_nodes = chunk_api_create_on_data_nodes,
+	.chunk_drop_replica = chunk_drop_replica,
 	.hypertable_make_distributed = hypertable_make_distributed,
 	.get_and_validate_data_node_list = hypertable_get_and_validate_data_nodes,
 	.timescaledb_fdw_handler = timescaledb_fdw_handler,

--- a/tsl/test/shared/expected/chunk_move_copy.out
+++ b/tsl/test/shared/expected/chunk_move_copy.out
@@ -1,0 +1,134 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE mvcp_hyper (time bigint NOT NULL, value integer);
+SELECT table_name FROM create_distributed_hypertable('mvcp_hyper', 'time',
+        chunk_time_interval => 200, replication_factor => 3);
+ table_name 
+------------
+ mvcp_hyper
+(1 row)
+
+-- Enable compression so that we can test dropping of compressed chunks
+ALTER TABLE mvcp_hyper  SET (timescaledb.compress, timescaledb.compress_orderby='time DESC');
+INSERT INTO mvcp_hyper SELECT g, g FROM generate_series(0,1000) g;
+-- Sanity checking of the chunk_drop_replica API
+\set ON_ERROR_STOP 0
+-- Check that it doesn't work in a read only transaction
+SET default_transaction_read_only TO on;
+SELECT _timescaledb_internal.chunk_drop_replica(NULL, NULL);
+ERROR:  cannot execute chunk_drop_replica() in a read-only transaction
+RESET default_transaction_read_only;
+-- NULL input for chunk id errors out
+SELECT _timescaledb_internal.chunk_drop_replica(NULL, NULL);
+ERROR:  invalid chunk relation
+-- Specifying any regular hypertable instead of chunk errors out
+SELECT _timescaledb_internal.chunk_drop_replica('public.metrics', NULL);
+ERROR:  invalid chunk relation
+-- Specifying regular hypertable chunk on a proper data node errors out
+SELECT _timescaledb_internal.chunk_drop_replica('_timescaledb_internal._hyper_1_1_chunk', 'data_node_1');
+ERROR:  "_hyper_1_1_chunk" is not a valid remote chunk
+-- Specifying non-existent chunk on a proper data node errors out
+SELECT _timescaledb_internal.chunk_drop_replica('_timescaledb_internal._dist_hyper_700_38_chunk', 'data_node_1');
+ERROR:  relation "_timescaledb_internal._dist_hyper_700_38_chunk" does not exist at character 49
+-- Get the last chunk for this hypertable
+SELECT ch1.schema_name|| '.' || ch1.table_name as "CHUNK_NAME", ch1.id "CHUNK_ID" FROM
+_timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht WHERE ch1.hypertable_id = ht.id
+AND ht.table_name = 'mvcp_hyper' ORDER BY ch1.id desc LIMIT 1 \gset
+-- Specifying wrong node name errors out
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'bad_node');
+ERROR:  server "bad_node" does not exist
+-- This chunk contains only one entry as of now
+SELECT * FROM :CHUNK_NAME;
+ time | value 
+------+-------
+ 1000 |  1000
+(1 row)
+
+-- Specifying NULL node name along with proper chunk errors out
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', NULL);
+ERROR:  data node name cannot be NULL
+\set ON_ERROR_STOP 1
+-- Check the current primary foreign server for this chunk, that will change
+-- post the chunk_drop_replica call
+SELECT foreign_server_name FROM information_schema.foreign_tables WHERE
+    foreign_table_name = split_part(:'CHUNK_NAME', '.', 2);
+ foreign_server_name 
+---------------------
+ data_node_3
+(1 row)
+
+-- Drop one replica of a valid chunk. Should succeed
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'data_node_3');
+ chunk_drop_replica 
+--------------------
+ 
+(1 row)
+
+-- The primary foreign server should be updated now
+SELECT foreign_server_name FROM information_schema.foreign_tables WHERE
+    foreign_table_name = split_part(:'CHUNK_NAME', '.', 2);
+ foreign_server_name 
+---------------------
+ data_node_1
+(1 row)
+
+-- Number of replicas should have been reduced by 1
+SELECT count(*) FROM _timescaledb_catalog.chunk_data_node WHERE chunk_id = :'CHUNK_ID';
+ count 
+-------
+     2
+(1 row)
+
+-- Ensure that INSERTs still work on this mvcp_hyper table into this chunk
+INSERT INTO mvcp_hyper VALUES (1001, 1001);
+-- Ensure that SELECTs are able to query data from the above chunk
+SELECT count(*) FROM mvcp_hyper WHERE time >= 1000;
+ count 
+-------
+     2
+(1 row)
+
+-- Check that chunk_drop_replica works with compressed chunk
+SELECT substr(compress_chunk(:'CHUNK_NAME')::TEXT, 1, 29);
+            substr             
+-------------------------------
+ _timescaledb_internal._dist_h
+(1 row)
+
+-- Drop one replica of a valid chunk. Should succeed on another datanode
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'data_node_2');
+ chunk_drop_replica 
+--------------------
+ 
+(1 row)
+
+-- Number of replicas should have been reduced by 1
+SELECT count(*) FROM _timescaledb_catalog.chunk_data_node WHERE chunk_id = :'CHUNK_ID';
+ count 
+-------
+     1
+(1 row)
+
+-- Decompress before checking INSERTs
+SELECT substr(decompress_chunk(:'CHUNK_NAME')::TEXT, 1, 29);
+            substr             
+-------------------------------
+ _timescaledb_internal._dist_h
+(1 row)
+
+-- Ensure that INSERTs still work on this mvcp_hyper table into this chunk
+INSERT INTO mvcp_hyper VALUES (1002, 1002);
+-- Ensure that SELECTs are able to query data from the above chunk
+SELECT count(*) FROM mvcp_hyper WHERE time >= 1000;
+ count 
+-------
+     3
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- Drop one replica of a valid chunk. Should not succeed on last datanode
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'data_node_1');
+ERROR:  cannot drop the last chunk replica
+\set ON_ERROR_STOP 1
+DROP table mvcp_hyper;

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_FILES_SHARED
   dist_distinct.sql
   dist_gapfill.sql
   dist_insert.sql
+  chunk_move_copy.sql
 )
 
 set(TEST_TEMPLATES_SHARED

--- a/tsl/test/shared/sql/chunk_move_copy.sql
+++ b/tsl/test/shared/sql/chunk_move_copy.sql
@@ -1,0 +1,91 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE mvcp_hyper (time bigint NOT NULL, value integer);
+SELECT table_name FROM create_distributed_hypertable('mvcp_hyper', 'time',
+        chunk_time_interval => 200, replication_factor => 3);
+
+-- Enable compression so that we can test dropping of compressed chunks
+ALTER TABLE mvcp_hyper  SET (timescaledb.compress, timescaledb.compress_orderby='time DESC');
+
+INSERT INTO mvcp_hyper SELECT g, g FROM generate_series(0,1000) g;
+
+-- Sanity checking of the chunk_drop_replica API
+
+\set ON_ERROR_STOP 0
+-- Check that it doesn't work in a read only transaction
+SET default_transaction_read_only TO on;
+SELECT _timescaledb_internal.chunk_drop_replica(NULL, NULL);
+RESET default_transaction_read_only;
+
+-- NULL input for chunk id errors out
+SELECT _timescaledb_internal.chunk_drop_replica(NULL, NULL);
+
+-- Specifying any regular hypertable instead of chunk errors out
+SELECT _timescaledb_internal.chunk_drop_replica('public.metrics', NULL);
+
+-- Specifying regular hypertable chunk on a proper data node errors out
+SELECT _timescaledb_internal.chunk_drop_replica('_timescaledb_internal._hyper_1_1_chunk', 'data_node_1');
+
+-- Specifying non-existent chunk on a proper data node errors out
+SELECT _timescaledb_internal.chunk_drop_replica('_timescaledb_internal._dist_hyper_700_38_chunk', 'data_node_1');
+
+-- Get the last chunk for this hypertable
+SELECT ch1.schema_name|| '.' || ch1.table_name as "CHUNK_NAME", ch1.id "CHUNK_ID" FROM
+_timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht WHERE ch1.hypertable_id = ht.id
+AND ht.table_name = 'mvcp_hyper' ORDER BY ch1.id desc LIMIT 1 \gset
+
+-- Specifying wrong node name errors out
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'bad_node');
+
+-- This chunk contains only one entry as of now
+SELECT * FROM :CHUNK_NAME;
+
+-- Specifying NULL node name along with proper chunk errors out
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', NULL);
+
+\set ON_ERROR_STOP 1
+-- Check the current primary foreign server for this chunk, that will change
+-- post the chunk_drop_replica call
+SELECT foreign_server_name FROM information_schema.foreign_tables WHERE
+    foreign_table_name = split_part(:'CHUNK_NAME', '.', 2);
+
+-- Drop one replica of a valid chunk. Should succeed
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'data_node_3');
+
+-- The primary foreign server should be updated now
+SELECT foreign_server_name FROM information_schema.foreign_tables WHERE
+    foreign_table_name = split_part(:'CHUNK_NAME', '.', 2);
+
+-- Number of replicas should have been reduced by 1
+SELECT count(*) FROM _timescaledb_catalog.chunk_data_node WHERE chunk_id = :'CHUNK_ID';
+
+-- Ensure that INSERTs still work on this mvcp_hyper table into this chunk
+INSERT INTO mvcp_hyper VALUES (1001, 1001);
+-- Ensure that SELECTs are able to query data from the above chunk
+SELECT count(*) FROM mvcp_hyper WHERE time >= 1000;
+
+-- Check that chunk_drop_replica works with compressed chunk
+SELECT substr(compress_chunk(:'CHUNK_NAME')::TEXT, 1, 29);
+
+-- Drop one replica of a valid chunk. Should succeed on another datanode
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'data_node_2');
+
+-- Number of replicas should have been reduced by 1
+SELECT count(*) FROM _timescaledb_catalog.chunk_data_node WHERE chunk_id = :'CHUNK_ID';
+
+-- Decompress before checking INSERTs
+SELECT substr(decompress_chunk(:'CHUNK_NAME')::TEXT, 1, 29);
+
+-- Ensure that INSERTs still work on this mvcp_hyper table into this chunk
+INSERT INTO mvcp_hyper VALUES (1002, 1002);
+-- Ensure that SELECTs are able to query data from the above chunk
+SELECT count(*) FROM mvcp_hyper WHERE time >= 1000;
+
+\set ON_ERROR_STOP 0
+-- Drop one replica of a valid chunk. Should not succeed on last datanode
+SELECT _timescaledb_internal.chunk_drop_replica(:'CHUNK_NAME', 'data_node_1');
+\set ON_ERROR_STOP 1
+
+DROP table mvcp_hyper;


### PR DESCRIPTION
This function drops a chunk on a specified data node. It then removes
the metadata about the datanode, chunk association on the access node.

This function is meant for internal use as part of the "move chunk"
functionality.

If only one chunk replica remains then this function refuses to drop it
to avoid data loss.