### PR TITLE
Add a few miscellaneous code fixes

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2230,6 +2230,15 @@ ts_chunk_get_by_name_with_memory_context(const char *schema_name, const char *ta
 	NameData schema, table;
 	ScanKeyData scankey[2];
 
+	/* Early check for rogue input */
+	if (schema_name == NULL || table_name == NULL)
+	{
+		if (fail_if_not_found)
+			ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("chunk not found")));
+		else
+			return NULL;
+	}
+
 	namestrcpy(&schema, schema_name);
 	namestrcpy(&table, table_name);
 

--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -861,7 +861,7 @@ deparseDistinctClause(StringInfo buf, deparse_expr_cxt *context)
 	Query *query = root->parse;
 	ListCell *l, *dc_l;
 	bool first = true, varno_assigned = false;
-	Index varno;
+	Index varno = 0; /* mostly to quell compiler warning, handled via varno_assigned */
 	RangeTblEntry *dc_rte;
 	RangeTblEntry *rte;
 


### PR DESCRIPTION
1) Quell a compiler warning about uninitialized use of "varno"
variable.

2) Fix ts_chunk_get_by_name to return early if rogue schema/table args
are passed in.
