### PR TITLE
Fix incorrect type cast when reading int64 compress after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ accidentally triggering the load of a previous DB version.**
 * #3146 Fix SkipScan for IndexPaths without pathkeys
 * #3151 Fix fdw_relinfo_get assertion failure on DELETE
 * #3155 Inherit CFLAGS from PostgreSQL
+* #3169 Fix incorrect type cast in compression policy
 
 **Thanks**
 * @Dead2, @dv8472 and @einsibjarni for reporting an issue with multinode queries and views
 * @hperez75 for reporting an issue with Skip Scan
+* @nathanloisel for reporting an issue with compression on hypertables with integer-based timestamps
+* @xin-hedera for fixing an issue with compression on hypertables with integer-based timestamps
 
 ## 2.2.0 (2021-04-13)
 

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -58,14 +58,14 @@ int64
 policy_compression_get_compress_after_int(const Jsonb *config)
 {
 	bool found;
-	int32 hypertable_id = ts_jsonb_get_int64_field(config, CONFIG_KEY_COMPRESS_AFTER, &found);
+	int64 compress_after = ts_jsonb_get_int64_field(config, CONFIG_KEY_COMPRESS_AFTER, &found);
 
 	if (!found)
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("could not find %s in config for job", CONFIG_KEY_COMPRESS_AFTER)));
 
-	return hypertable_id;
+	return compress_after;
 }
 
 Interval *


### PR DESCRIPTION
The int64 compress after read from compression policy is cast to an int32, which causes compression jobs behave not as expected when the value is > 2^31 -1.

Verified the patch fixes the issue with compress after of 7 days in nanos and chunk time interval of 1 day.

Fixes #3009 

Disable-check: commit-count
