### PR TITLE
Create chunk table from access node

### DIFF
--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -25,3 +25,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.refresh_continuous_aggregate(
     continuous_aggregate     REGCLASS,
     hypertable_chunk         REGCLASS
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh_chunk' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.create_chunk_replica_table(
+    chunk REGCLASS,
+    data_node_name NAME
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_chunk_create_replica_table' LANGUAGE C VOLATILE;

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -82,6 +82,7 @@ CROSSMODULE_WRAPPER(chunk_set_default_data_node);
 CROSSMODULE_WRAPPER(chunk_get_relstats);
 CROSSMODULE_WRAPPER(chunk_get_colstats);
 CROSSMODULE_WRAPPER(chunk_create_empty_table);
+CROSSMODULE_WRAPPER(chunk_create_replica_table);
 
 CROSSMODULE_WRAPPER(timescaledb_fdw_handler);
 CROSSMODULE_WRAPPER(timescaledb_fdw_validator);
@@ -394,6 +395,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.chunk_get_relstats = error_no_default_fn_pg_community,
 	.chunk_get_colstats = error_no_default_fn_pg_community,
 	.chunk_create_empty_table = error_no_default_fn_pg_community,
+	.chunk_create_replica_table = error_no_default_fn_pg_community,
 	.hypertable_distributed_set_replication_factor = error_no_default_fn_pg_community,
 	.update_compressed_chunk_relstats = update_compressed_chunk_relstats_default,
 };

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -158,6 +158,7 @@ typedef struct CrossModuleFunctions
 	PGFunction chunk_get_colstats;
 	PGFunction hypertable_distributed_set_replication_factor;
 	PGFunction chunk_create_empty_table;
+	PGFunction chunk_create_replica_table;
 	void (*update_compressed_chunk_relstats)(Oid uncompressed_relid, Oid compressed_relid);
 } CrossModuleFunctions;
 

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -14,5 +14,6 @@
 extern void chunk_update_foreign_server_if_needed(int32 chunk_id, Oid existing_server_id);
 extern Datum chunk_set_default_data_node(PG_FUNCTION_ARGS);
 extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type);
+extern Datum chunk_create_replica_table(PG_FUNCTION_ARGS);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_H */

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -27,12 +27,10 @@
 
 #include <catalog.h>
 #include <compat.h>
-#include <chunk.h>
 #include <chunk_data_node.h>
 #include <errors.h>
 #include <error_utils.h>
 #include <hypercube.h>
-#include <hypertable.h>
 #include <hypertable_cache.h>
 
 #include "remote/async.h"
@@ -1671,4 +1669,25 @@ chunk_create_empty_table(PG_FUNCTION_ARGS)
 	ts_cache_release(hcache);
 
 	PG_RETURN_BOOL(true);
+}
+
+#define CREATE_CHUNK_TABLE_NAME "create_chunk_table"
+
+void
+chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const Chunk *chunk,
+										const char *node_name)
+{
+	const char *create_cmd =
+		psprintf("SELECT %s.%s($1, $2, $3, $4)", INTERNAL_SCHEMA_NAME, CREATE_CHUNK_TABLE_NAME);
+	const char *params[4] = { quote_qualified_identifier(NameStr(ht->fd.schema_name),
+														 NameStr(ht->fd.table_name)),
+							  chunk_api_dimension_slices_json(chunk, ht),
+							  NameStr(chunk->fd.schema_name),
+							  NameStr(chunk->fd.table_name) };
+
+	ts_dist_cmd_close_response(
+		ts_dist_cmd_params_invoke_on_data_nodes(create_cmd,
+												stmt_params_create_from_values(params, 4),
+												list_make1((void *) node_name),
+												true));
 }

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -8,6 +8,10 @@
 
 #include <postgres.h>
 
+#include <chunk.h>
+
+#include "hypertable_data_node.h"
+
 extern Datum chunk_show(PG_FUNCTION_ARGS);
 extern Datum chunk_create(PG_FUNCTION_ARGS);
 extern void chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht);
@@ -15,5 +19,7 @@ extern Datum chunk_api_get_chunk_relstats(PG_FUNCTION_ARGS);
 extern Datum chunk_api_get_chunk_colstats(PG_FUNCTION_ARGS);
 extern void chunk_api_update_distributed_hypertable_stats(Oid relid);
 extern Datum chunk_create_empty_table(PG_FUNCTION_ARGS);
+extern void chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const Chunk *chunk,
+													const char *node_name);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_API_H */

--- a/tsl/src/data_node.h
+++ b/tsl/src/data_node.h
@@ -8,7 +8,10 @@
 
 #include <foreign/foreign.h>
 
+#include <hypertable_data_node.h>
+
 #include "catalog.h"
+#include "hypertable.h"
 #include "remote/dist_txn.h"
 
 /* Used to skip ACL checks */
@@ -38,6 +41,10 @@ extern List *data_node_array_to_node_name_list(ArrayType *nodearr);
 extern List *data_node_oids_to_node_name_list(List *data_node_oids, AclMode mode);
 extern void data_node_name_list_check_acl(List *data_node_names, AclMode mode);
 extern Datum data_node_ping(PG_FUNCTION_ARGS);
+
+extern HypertableDataNode *data_node_hypertable_get_by_node_name(const Hypertable *ht,
+																 const char *node_name,
+																 bool attach_check);
 
 /* This should only be used for testing */
 extern Datum data_node_add_without_dist_id(PG_FUNCTION_ARGS);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -186,6 +186,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.chunk_get_relstats = chunk_api_get_chunk_relstats,
 	.chunk_get_colstats = chunk_api_get_chunk_colstats,
 	.chunk_create_empty_table = chunk_create_empty_table,
+	.chunk_create_replica_table = chunk_create_replica_table,
 	.hypertable_distributed_set_replication_factor = hypertable_set_replication_factor,
 	.cache_syscache_invalidate = cache_syscache_invalidate,
 	.update_compressed_chunk_relstats = update_compressed_chunk_relstats,

--- a/tsl/src/remote/dist_commands.h
+++ b/tsl/src/remote/dist_commands.h
@@ -7,13 +7,16 @@
 #define TIMESCALEDB_TSL_REMOTE_DIST_COMMANDS_H
 
 #include <catalog.h>
-#include <libpq-fe.h>
+
+#include "async.h"
 
 typedef struct DistCmdResult DistCmdResult;
 typedef struct List PreparedDistCmd;
 
 extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes(const char *sql, List *node_names,
 													   bool transactional);
+extern DistCmdResult *ts_dist_cmd_params_invoke_on_data_nodes(const char *sql, StmtParams *params,
+															  List *data_nodes, bool transactional);
 extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes_using_search_path(const char *sql,
 																		 const char *search_path,
 																		 List *node_names,

--- a/tsl/test/shared/expected/dist_chunk.out
+++ b/tsl/test/shared/expected/dist_chunk.out
@@ -1,0 +1,114 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test function _timescaledb_internal.create_chunk_replica_table
+-- A table for the first chunk will be created on the data node, where it is not present.
+SELECT chunk_name, data_nodes 
+FROM timescaledb_information.chunks 
+WHERE hypertable_name = 'dist_chunk_copy';
+       chunk_name        |        data_nodes         
+-------------------------+---------------------------
+ _dist_hyper_15_67_chunk | {data_node_1,data_node_2}
+ _dist_hyper_15_68_chunk | {data_node_2,data_node_3}
+ _dist_hyper_15_69_chunk | {data_node_1,data_node_3}
+ _dist_hyper_15_70_chunk | {data_node_1,data_node_2}
+ _dist_hyper_15_71_chunk | {data_node_2,data_node_3}
+(5 rows)
+
+SELECT compress_chunk('_timescaledb_internal._dist_hyper_15_68_chunk');
+                compress_chunk                 
+-----------------------------------------------
+ _timescaledb_internal._dist_hyper_15_68_chunk
+(1 row)
+
+SELECT compress_chunk('_timescaledb_internal._dist_hyper_15_70_chunk');
+                compress_chunk                 
+-----------------------------------------------
+ _timescaledb_internal._dist_hyper_15_70_chunk
+(1 row)
+
+-- Non-distributed chunk will be used to test an error
+SELECT chunk_name 
+FROM timescaledb_information.chunks 
+WHERE hypertable_name = 'conditions';
+     chunk_name     
+--------------------
+ _hyper_10_51_chunk
+ _hyper_10_52_chunk
+(2 rows)
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_replica_table(NULL, 'data_node_1');
+ERROR:  chunk cannot be NULL
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', NULL);
+ERROR:  data node name cannot be NULL
+SELECT _timescaledb_internal.create_chunk_replica_table(1234, 'data_node_1');
+ERROR:  oid "1234" is not a chunk
+SELECT _timescaledb_internal.create_chunk_replica_table('metrics_int', 'data_node_1');
+ERROR:  relation "metrics_int" is not a chunk
+SELECT _timescaledb_internal.create_chunk_replica_table('conditions', 'data_node_1');
+ERROR:  relation "conditions" is not a chunk
+SELECT _timescaledb_internal. create_chunk_replica_table('_timescaledb_internal._hyper_10_51_chunk', 'data_node_1');
+ERROR:  chunk "_hyper_10_51_chunk" doesn't belong to a distributed hypertable
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_1');
+ERROR:  chunk "_dist_hyper_15_67_chunk" already exists on data node "data_node_1"
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_27_chunk', 'data_node_1');
+ERROR:  relation "_timescaledb_internal._dist_hyper_15_27_chunk" does not exist at character 57
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_4');
+ERROR:  server "data_node_4" does not exist
+BEGIN READ ONLY;
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_3');
+ERROR:  cannot execute create_chunk_replica_table() in a read-only transaction
+COMMIT;
+\set ON_ERROR_STOP 1
+\c data_node_3
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = '_timescaledb_internal' AND 
+    (table_name LIKE '_dist_hyper_15_%' OR table_name LIKE 'compress_hyper_5_%');
+        table_name        
+--------------------------
+ _dist_hyper_15_68_chunk
+ _dist_hyper_15_69_chunk
+ _dist_hyper_15_71_chunk
+ compress_hyper_5_9_chunk
+(4 rows)
+
+\c :TEST_DBNAME 
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_3');
+ create_chunk_replica_table 
+----------------------------
+ 
+(1 row)
+
+-- Test that the table cannot be created since it was already created on the data node
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_3');
+ERROR:  [data_node_3]: relation "_dist_hyper_15_67_chunk" already exists
+\set ON_ERROR_STOP 1
+-- Creating chunk replica table ignores compression now:
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_70_chunk', 'data_node_3');
+ create_chunk_replica_table 
+----------------------------
+ 
+(1 row)
+
+\c data_node_3
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = '_timescaledb_internal' AND 
+    (table_name LIKE '_dist_hyper_15_%' OR table_name LIKE 'compress_hyper_5_%');
+        table_name        
+--------------------------
+ _dist_hyper_15_67_chunk
+ _dist_hyper_15_68_chunk
+ _dist_hyper_15_69_chunk
+ _dist_hyper_15_70_chunk
+ _dist_hyper_15_71_chunk
+ compress_hyper_5_9_chunk
+(6 rows)
+
+\c :TEST_DBNAME 
+DROP TABLE dist_chunk_copy;
+CALL distributed_exec($$ DROP TABLE _timescaledb_internal._dist_hyper_15_67_chunk $$, '{"data_node_3"}');
+CALL distributed_exec($$ DROP TABLE _timescaledb_internal._dist_hyper_15_70_chunk $$, '{"data_node_3"}');

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -1,9 +1,10 @@
 set(TEST_FILES_SHARED
   constraint_exclusion_prepared.sql
   decompress_placeholdervar.sql
+  dist_chunk.sql
+  dist_distinct.sql
   dist_gapfill.sql
   dist_insert.sql
-  dist_distinct.sql
 )
 
 set(TEST_TEMPLATES_SHARED

--- a/tsl/test/shared/sql/dist_chunk.sql
+++ b/tsl/test/shared/sql/dist_chunk.sql
@@ -1,0 +1,61 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test function _timescaledb_internal.create_chunk_replica_table
+
+-- A table for the first chunk will be created on the data node, where it is not present.
+SELECT chunk_name, data_nodes 
+FROM timescaledb_information.chunks 
+WHERE hypertable_name = 'dist_chunk_copy';
+
+SELECT compress_chunk('_timescaledb_internal._dist_hyper_15_68_chunk');
+SELECT compress_chunk('_timescaledb_internal._dist_hyper_15_70_chunk');
+
+-- Non-distributed chunk will be used to test an error
+SELECT chunk_name 
+FROM timescaledb_information.chunks 
+WHERE hypertable_name = 'conditions';
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_replica_table(NULL, 'data_node_1');
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', NULL);
+SELECT _timescaledb_internal.create_chunk_replica_table(1234, 'data_node_1');
+SELECT _timescaledb_internal.create_chunk_replica_table('metrics_int', 'data_node_1');
+SELECT _timescaledb_internal.create_chunk_replica_table('conditions', 'data_node_1');
+SELECT _timescaledb_internal. create_chunk_replica_table('_timescaledb_internal._hyper_10_51_chunk', 'data_node_1');
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_1');
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_27_chunk', 'data_node_1');
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_4');
+BEGIN READ ONLY;
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_3');
+COMMIT;
+\set ON_ERROR_STOP 1
+
+\c data_node_3
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = '_timescaledb_internal' AND 
+    (table_name LIKE '_dist_hyper_15_%' OR table_name LIKE 'compress_hyper_5_%');
+\c :TEST_DBNAME 
+
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_3');
+
+-- Test that the table cannot be created since it was already created on the data node
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_67_chunk', 'data_node_3');
+\set ON_ERROR_STOP 1
+
+-- Creating chunk replica table ignores compression now:
+SELECT _timescaledb_internal.create_chunk_replica_table('_timescaledb_internal._dist_hyper_15_70_chunk', 'data_node_3');
+
+\c data_node_3
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = '_timescaledb_internal' AND 
+    (table_name LIKE '_dist_hyper_15_%' OR table_name LIKE 'compress_hyper_5_%');
+\c :TEST_DBNAME 
+
+DROP TABLE dist_chunk_copy;
+CALL distributed_exec($$ DROP TABLE _timescaledb_internal._dist_hyper_15_67_chunk $$, '{"data_node_3"}');
+CALL distributed_exec($$ DROP TABLE _timescaledb_internal._dist_hyper_15_70_chunk $$, '{"data_node_3"}');

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -211,3 +211,15 @@ INSERT INTO metrics_int_dist1 VALUES
     (5,1,2,10.0),
     (100,1,1,0.0),
     (100,1,2,-100.0);
+
+CREATE TABLE dist_chunk_copy (
+        time timestamptz NOT NULL, 
+        value integer);
+
+SELECT create_distributed_hypertable('dist_chunk_copy', 'time', replication_factor => 2);
+ALTER TABLE dist_chunk_copy SET (timescaledb.compress);
+
+SELECT setseed(0);
+INSERT INTO dist_chunk_copy 
+SELECT t, random() * 20
+FROM generate_series('2020-01-01'::timestamp, '2020-01-25'::timestamp, '1d') t;


### PR DESCRIPTION
Creates a table for chunk replica on the given data node. The table 
gets the same schema and name as the chunk. The created chunk replica 
table is not added into metadata on the access node or data node.

The primary goal is to use it during copy/move chunk.
