### PR TITLE
Drop inherit from chunk table to hypertable

### DIFF
--- a/tsl/test/expected/chunk_api-11.out
+++ b/tsl/test/expected/chunk_api-11.out
@@ -583,6 +583,14 @@ ORDER BY chunk_name DESC
 LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
+ relname  
+----------
+ chunkapi
+(1 row)
+
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  id | dimension_id |     range_start      |    range_end     
 ----+--------------+----------------------+------------------
@@ -591,12 +599,7 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
   3 |            1 |     1515024000000000 | 1519024000000000
 (3 rows)
 
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
-              drop_chunks               
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
-(1 row)
-
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  id | dimension_id |     range_start      |    range_end     
 ----+--------------+----------------------+------------------
@@ -618,6 +621,13 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
   3 |            1 |     1515024000000000 | 1519024000000000
 (2 rows)
 
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
+ relname 
+---------
+(0 rows)
+
 -- Test that creat_chunk fails since chunk table already exists
 \set ON_ERROR_STOP 0
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
@@ -625,6 +635,7 @@ ERROR:  relation "_hyper_1_1_chunk" already exists
 \set ON_ERROR_STOP 1
 -- Test create_chunk_table on a hypertable where the chunk didn't exist before
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
@@ -642,6 +653,7 @@ SELECT count(*) FROM
 
 -- Demonstrate that current settings for dimensions don't affect create_chunk_table
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
  hypertable_id | schema_name | table_name | created 
@@ -657,6 +669,7 @@ SELECT count(*) FROM
 (1 row)
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -673,6 +686,7 @@ SELECT count(*) FROM
 
 -- Test create_chunk_table if a colliding chunk exists
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -703,6 +717,7 @@ SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_S
 
 -- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
  hypertable_id | schema_name | table_name | created 
@@ -728,6 +743,7 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- Use the space partition to calculate the tablespace id to use
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -760,8 +776,9 @@ SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
  tablespace1
 (1 row)
 
-DROP TABLE chunkapi;
 -- Use the time partition to calculate the tablespace id to use
+DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time');
  hypertable_id | schema_name | table_name | created 
@@ -776,12 +793,7 @@ ORDER BY chunk_name DESC
 LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_10_10_chunk
-(1 row)
-
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 SELECT attach_tablespace('tablespace1', 'chunkapi');
  attach_tablespace 
 -------------------
@@ -808,6 +820,7 @@ SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
 (1 row)
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET client_min_messages = ERROR;
 DROP TABLESPACE tablespace1;

--- a/tsl/test/expected/chunk_api-12.out
+++ b/tsl/test/expected/chunk_api-12.out
@@ -583,6 +583,14 @@ ORDER BY chunk_name DESC
 LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
+ relname  
+----------
+ chunkapi
+(1 row)
+
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  id | dimension_id |     range_start      |    range_end     
 ----+--------------+----------------------+------------------
@@ -591,12 +599,7 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
   3 |            1 |     1515024000000000 | 1519024000000000
 (3 rows)
 
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
-              drop_chunks               
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
-(1 row)
-
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  id | dimension_id |     range_start      |    range_end     
 ----+--------------+----------------------+------------------
@@ -618,6 +621,13 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
   3 |            1 |     1515024000000000 | 1519024000000000
 (2 rows)
 
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
+ relname 
+---------
+(0 rows)
+
 -- Test that creat_chunk fails since chunk table already exists
 \set ON_ERROR_STOP 0
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
@@ -625,6 +635,7 @@ ERROR:  relation "_hyper_1_1_chunk" already exists
 \set ON_ERROR_STOP 1
 -- Test create_chunk_table on a hypertable where the chunk didn't exist before
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
@@ -642,6 +653,7 @@ SELECT count(*) FROM
 
 -- Demonstrate that current settings for dimensions don't affect create_chunk_table
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
  hypertable_id | schema_name | table_name | created 
@@ -657,6 +669,7 @@ SELECT count(*) FROM
 (1 row)
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -673,6 +686,7 @@ SELECT count(*) FROM
 
 -- Test create_chunk_table if a colliding chunk exists
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -703,6 +717,7 @@ SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_S
 
 -- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
  hypertable_id | schema_name | table_name | created 
@@ -728,6 +743,7 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- Use the space partition to calculate the tablespace id to use
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -760,8 +776,9 @@ SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
  tablespace1
 (1 row)
 
-DROP TABLE chunkapi;
 -- Use the time partition to calculate the tablespace id to use
+DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time');
  hypertable_id | schema_name | table_name | created 
@@ -776,12 +793,7 @@ ORDER BY chunk_name DESC
 LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_10_10_chunk
-(1 row)
-
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 SELECT attach_tablespace('tablespace1', 'chunkapi');
  attach_tablespace 
 -------------------
@@ -808,6 +820,7 @@ SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
 (1 row)
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET client_min_messages = ERROR;
 DROP TABLESPACE tablespace1;

--- a/tsl/test/expected/chunk_api-13.out
+++ b/tsl/test/expected/chunk_api-13.out
@@ -583,6 +583,14 @@ ORDER BY chunk_name DESC
 LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
+ relname  
+----------
+ chunkapi
+(1 row)
+
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  id | dimension_id |     range_start      |    range_end     
 ----+--------------+----------------------+------------------
@@ -591,12 +599,7 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
   3 |            1 |     1515024000000000 | 1519024000000000
 (3 rows)
 
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
-              drop_chunks               
-----------------------------------------
- _timescaledb_internal._hyper_1_1_chunk
-(1 row)
-
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
  id | dimension_id |     range_start      |    range_end     
 ----+--------------+----------------------+------------------
@@ -618,6 +621,13 @@ SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
   3 |            1 |     1515024000000000 | 1519024000000000
 (2 rows)
 
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
+ relname 
+---------
+(0 rows)
+
 -- Test that creat_chunk fails since chunk table already exists
 \set ON_ERROR_STOP 0
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
@@ -625,6 +635,7 @@ ERROR:  relation "_hyper_1_1_chunk" already exists
 \set ON_ERROR_STOP 1
 -- Test create_chunk_table on a hypertable where the chunk didn't exist before
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
@@ -642,6 +653,7 @@ SELECT count(*) FROM
 
 -- Demonstrate that current settings for dimensions don't affect create_chunk_table
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
  hypertable_id | schema_name | table_name | created 
@@ -657,6 +669,7 @@ SELECT count(*) FROM
 (1 row)
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -673,6 +686,7 @@ SELECT count(*) FROM
 
 -- Test create_chunk_table if a colliding chunk exists
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -703,6 +717,7 @@ SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_S
 
 -- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
  hypertable_id | schema_name | table_name | created 
@@ -728,6 +743,7 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 -- Use the space partition to calculate the tablespace id to use
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
  hypertable_id | schema_name | table_name | created 
@@ -760,8 +776,9 @@ SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
  tablespace1
 (1 row)
 
-DROP TABLE chunkapi;
 -- Use the time partition to calculate the tablespace id to use
+DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time');
  hypertable_id | schema_name | table_name | created 
@@ -776,12 +793,7 @@ ORDER BY chunk_name DESC
 LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
-               drop_chunks                
-------------------------------------------
- _timescaledb_internal._hyper_10_10_chunk
-(1 row)
-
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 SELECT attach_tablespace('tablespace1', 'chunkapi');
  attach_tablespace 
 -------------------
@@ -808,6 +820,7 @@ SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
 (1 row)
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET client_min_messages = ERROR;
 DROP TABLESPACE tablespace1;

--- a/tsl/test/sql/chunk_api.sql.in
+++ b/tsl/test/sql/chunk_api.sql.in
@@ -272,9 +272,13 @@ LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
 
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
+
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
 
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
 
@@ -282,6 +286,11 @@ SELECT count(*) FROM
    _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
 
 SELECT * FROM _timescaledb_catalog.dimension_slice ORDER BY id;
+
+
+SELECT relname
+FROM pg_catalog.pg_inherits, pg_class 
+WHERE inhrelid = (:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME')::regclass AND inhparent = oid;
 
 -- Test that creat_chunk fails since chunk table already exists
 \set ON_ERROR_STOP 0
@@ -291,6 +300,7 @@ SELECT * FROM _timescaledb_internal.create_chunk('chunkapi', :'SLICES', :'CHUNK_
 -- Test create_chunk_table on a hypertable where the chunk didn't exist before
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
 
@@ -300,6 +310,7 @@ SELECT count(*) FROM
 -- Demonstrate that current settings for dimensions don't affect create_chunk_table
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2, '3d');
 
@@ -307,6 +318,7 @@ SELECT count(*) FROM
    _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_SCHEMA', :'CHUNK_NAME');
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
 
@@ -316,6 +328,7 @@ SELECT count(*) FROM
 -- Test create_chunk_table if a colliding chunk exists
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
 
@@ -338,6 +351,7 @@ SELECT _timescaledb_internal.create_chunk_table('chunkapi', :'SLICES', :'CHUNK_S
 -- Test create_chunk_table when a chunk exists in different time partition and thus doesn't collide
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
 
@@ -359,6 +373,7 @@ CREATE TABLESPACE tablespace2 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 -- Use the space partition to calculate the tablespace id to use
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 3);
 
@@ -370,9 +385,10 @@ SELECT count(*) FROM
 
 SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
 
-DROP TABLE chunkapi;
-
 -- Use the time partition to calculate the tablespace id to use
+
+DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 
 CREATE TABLE chunkapi (time timestamptz not null, device int, temp float);
 SELECT * FROM create_hypertable('chunkapi', 'time');
@@ -386,7 +402,7 @@ LIMIT 1 \gset
 SELECT slices AS "SLICES"
 FROM _timescaledb_internal.show_chunk(:'CHUNK_SCHEMA'||'.'||:'CHUNK_NAME') \gset
 
-SELECT drop_chunks('chunkapi','2018-01-10'::timestamp,'2017-12-23'::timestamp);
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 
 SELECT attach_tablespace('tablespace1', 'chunkapi');
 SELECT attach_tablespace('tablespace2', 'chunkapi');
@@ -397,6 +413,7 @@ SELECT count(*) FROM
 SELECT tablespace FROM pg_tables WHERE tablename = :'CHUNK_NAME';
 
 DROP TABLE chunkapi;
+DROP TABLE :CHUNK_SCHEMA.:CHUNK_NAME;
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET client_min_messages = ERROR;


### PR DESCRIPTION
When an empty chunk table is created, it is not associated with its
hypertable in metadata, however it was inheriting from the hypertable.
This commit removes inheritance, so the chunk table is completely
standalone and cannot affect queries on the hypertable.

In future, this fix of dropping inherit can be replaced with the chunk
table creation, which does not create inheritance in the first place.
Since it is larger amount of work, it was not considered now.