### PR TITLE
Adjust pathkeys generation for unordered compressed chunks

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -24,6 +24,8 @@
 #define DROP_CHUNKS_FUNCNAME "drop_chunks"
 #define DROP_CHUNKS_NARGS 4
 
+#define CHUNK_STATUS_UNORDERED 1U
+
 typedef struct Hypercube Hypercube;
 typedef struct Point Point;
 typedef struct Hyperspace Hyperspace;
@@ -96,6 +98,12 @@ static inline bool
 chunk_stub_is_complete(ChunkStub *stub, Hyperspace *space)
 {
 	return space->num_dimensions == stub->constraints->num_dimension_constraints;
+}
+
+static inline bool
+chunk_is_unordered(Chunk *chunk)
+{
+	return ((uint32) chunk->fd.status) & CHUNK_STATUS_UNORDERED;
 }
 
 /* The hash table entry for the ChunkScanCtx */

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -1676,5 +1676,9 @@ compress_row_end(CompressSingleRowState *cr)
 void
 compress_row_destroy(CompressSingleRowState *cr)
 {
+	Chunk *chunk = ts_chunk_get_by_relid(cr->in_rel->rd_id, true);
+	if (!chunk_is_unordered(chunk))
+		ts_chunk_add_status(chunk, CHUNK_STATUS_UNORDERED);
+
 	ExecDropSingleTupleTableSlot(cr->out_slot);
 }

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -64,7 +64,8 @@ static DecompressChunkPath *decompress_chunk_path_create(PlannerInfo *root, Comp
 static void decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, Chunk *chunk,
 											 RelOptInfo *chunk_rel, bool needs_sequence_num);
 
-static SortInfo build_sortinfo(RelOptInfo *chunk_rel, CompressionInfo *info, List *pathkeys);
+static SortInfo build_sortinfo(Chunk *chunk, RelOptInfo *chunk_rel, CompressionInfo *info,
+							   List *pathkeys);
 
 /*
  * Like ts_make_pathkey_from_sortop but passes down the compressed relid so that existing
@@ -347,7 +348,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 	 */
 	int parallel_workers = 1;
 	AppendRelInfo *chunk_info = ts_get_appendrelinfo(root, chunk_rel->relid, false);
-	SortInfo sort_info = build_sortinfo(chunk_rel, info, root->query_pathkeys);
+	SortInfo sort_info = build_sortinfo(chunk, chunk_rel, info, root->query_pathkeys);
 
 	Assert(chunk_info != NULL);
 	Assert(chunk_info->parent_reloid == ht->main_table_relid);
@@ -1209,7 +1210,7 @@ find_restrictinfo_equality(RelOptInfo *chunk_rel, CompressionInfo *info)
  * If query pathkeys is shorter than segmentby + compress_orderby pushdown can still be done
  */
 static SortInfo
-build_sortinfo(RelOptInfo *chunk_rel, CompressionInfo *info, List *pathkeys)
+build_sortinfo(Chunk *chunk, RelOptInfo *chunk_rel, CompressionInfo *info, List *pathkeys)
 {
 	int pk_index;
 	PathKey *pk;
@@ -1220,7 +1221,7 @@ build_sortinfo(RelOptInfo *chunk_rel, CompressionInfo *info, List *pathkeys)
 	ListCell *lc = list_head(pathkeys);
 	SortInfo sort_info = { .can_pushdown_sort = false, .needs_sequence_num = false };
 
-	if (pathkeys == NIL)
+	if (pathkeys == NIL || chunk_is_unordered(chunk))
 		return sort_info;
 
 	/* all segmentby columns need to be prefix of pathkeys */

--- a/tsl/test/expected/compression_insert-11.out
+++ b/tsl/test/expected/compression_insert-11.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,
       b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
@@ -347,4 +348,92 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
 ----+---------
  16 | 17
 (1 row)
+
+-- test interaction between newly inserted batches and pathkeys/ordered append
+CREATE TABLE test_ordering(time int);
+SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+---------------
+ test_ordering
+(1 row)
+
+ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby='time desc');
+INSERT INTO test_ordering VALUES (5),(4),(3);
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Index Only Scan Backward using _hyper_11_15_chunk_test_ordering_time_idx on _hyper_11_15_chunk
+(3 rows)
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+(1 row)
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+         ->  Sort
+               Sort Key: compress_hyper_12_16_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_12_16_chunk
+(6 rows)
+
+INSERT INTO test_ordering SELECT 1;
+-- should not be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Sort
+   Sort Key: _hyper_11_15_chunk."time"
+   ->  Append
+         ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+               ->  Seq Scan on compress_hyper_12_16_chunk
+(5 rows)
+
+INSERT INTO test_ordering VALUES (105),(104),(103);
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Sort
+         Sort Key: _hyper_11_15_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+               ->  Seq Scan on compress_hyper_12_16_chunk
+   ->  Index Only Scan Backward using _hyper_11_17_chunk_test_ordering_time_idx on _hyper_11_17_chunk
+(7 rows)
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ 
+ _timescaledb_internal._hyper_11_17_chunk
+(2 rows)
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Sort
+         Sort Key: _hyper_11_15_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+               ->  Seq Scan on compress_hyper_12_16_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_11_17_chunk
+         ->  Sort
+               Sort Key: compress_hyper_12_18_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_12_18_chunk
+(10 rows)
 

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,
       b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
@@ -347,4 +348,91 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
 ----+---------
  16 | 17
 (1 row)
+
+-- test interaction between newly inserted batches and pathkeys/ordered append
+CREATE TABLE test_ordering(time int);
+SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+---------------
+ test_ordering
+(1 row)
+
+ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby='time desc');
+INSERT INTO test_ordering VALUES (5),(4),(3);
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Index Only Scan Backward using _hyper_11_15_chunk_test_ordering_time_idx on _hyper_11_15_chunk
+(3 rows)
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+(1 row)
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+         ->  Sort
+               Sort Key: compress_hyper_12_16_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_12_16_chunk
+(6 rows)
+
+INSERT INTO test_ordering SELECT 1;
+-- should not be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Sort
+   Sort Key: _hyper_11_15_chunk."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+         ->  Seq Scan on compress_hyper_12_16_chunk
+(4 rows)
+
+INSERT INTO test_ordering VALUES (105),(104),(103);
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Sort
+         Sort Key: _hyper_11_15_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+               ->  Seq Scan on compress_hyper_12_16_chunk
+   ->  Index Only Scan Backward using _hyper_11_17_chunk_test_ordering_time_idx on _hyper_11_17_chunk
+(7 rows)
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ 
+ _timescaledb_internal._hyper_11_17_chunk
+(2 rows)
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Sort
+         Sort Key: _hyper_11_15_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+               ->  Seq Scan on compress_hyper_12_16_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_11_17_chunk
+         ->  Sort
+               Sort Key: compress_hyper_12_18_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_12_18_chunk
+(10 rows)
 

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,
       b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
@@ -347,4 +348,91 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
 ----+---------
  16 | 17
 (1 row)
+
+-- test interaction between newly inserted batches and pathkeys/ordered append
+CREATE TABLE test_ordering(time int);
+SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+---------------
+ test_ordering
+(1 row)
+
+ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby='time desc');
+INSERT INTO test_ordering VALUES (5),(4),(3);
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Index Only Scan Backward using _hyper_11_15_chunk_test_ordering_time_idx on _hyper_11_15_chunk
+(3 rows)
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+(1 row)
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+         ->  Sort
+               Sort Key: compress_hyper_12_16_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_12_16_chunk
+(6 rows)
+
+INSERT INTO test_ordering SELECT 1;
+-- should not be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Sort
+   Sort Key: _hyper_11_15_chunk."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+         ->  Seq Scan on compress_hyper_12_16_chunk
+(4 rows)
+
+INSERT INTO test_ordering VALUES (105),(104),(103);
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Sort
+         Sort Key: _hyper_11_15_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+               ->  Seq Scan on compress_hyper_12_16_chunk
+   ->  Index Only Scan Backward using _hyper_11_17_chunk_test_ordering_time_idx on _hyper_11_17_chunk
+(7 rows)
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ 
+ _timescaledb_internal._hyper_11_17_chunk
+(2 rows)
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on test_ordering
+   Order: test_ordering."time"
+   ->  Sort
+         Sort Key: _hyper_11_15_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_11_15_chunk
+               ->  Seq Scan on compress_hyper_12_16_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_11_17_chunk
+         ->  Sort
+               Sort Key: compress_hyper_12_18_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_12_18_chunk
+(10 rows)
 

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+\set PREFIX 'EXPLAIN (costs off, summary off, timing off) '
 CREATE TABLE test1 (timec timestamptz , i integer ,
       b bigint, t text);
 SELECT table_name from create_hypertable('test1', 'timec', chunk_time_interval=> INTERVAL '7 days');
@@ -187,3 +188,28 @@ FROM show_chunks('test_gen') c;
 INSERT INTO test_gen (payload) values(17);
 SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
 
+-- test interaction between newly inserted batches and pathkeys/ordered append
+CREATE TABLE test_ordering(time int);
+SELECT table_name FROM create_hypertable('test_ordering','time',chunk_time_interval:=100);
+ALTER TABLE test_ordering SET (timescaledb.compress,timescaledb.compress_orderby='time desc');
+INSERT INTO test_ordering VALUES (5),(4),(3);
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+INSERT INTO test_ordering SELECT 1;
+
+-- should not be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+
+INSERT INTO test_ordering VALUES (105),(104),(103);
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;
+
+SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
+
+-- should be ordered append
+:PREFIX SELECT * FROM test_ordering ORDER BY 1;


### PR DESCRIPTION
Compressed chunks with inserts after being compressed have batches
that are not ordered according to compress_orderby for those
chunks we cannot set pathkeys on the DecompressChunk node and we
need an extra sort step if we require ordered output from those
chunks.