### PR TITLE
Fix segfault in calculate_chunk_interval

### DIFF
--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -439,13 +439,18 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 
 	ht = ts_hypertable_get_by_id(hypertable_id);
 
+	Assert(ht != NULL);
+
 	acl_result = pg_class_aclcheck(ht->main_table_relid, GetUserId(), ACL_SELECT);
 	if (acl_result != ACLCHECK_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("permission denied for table %s", ht->fd.table_name.data)));
 
-	Assert(ht != NULL);
+	if (hypertable_is_distributed(ht))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("adaptive chunking not supported on distributed hypertables")));
 
 	dim = ts_hyperspace_get_dimension_by_id(ht->space, dimension_id);
 

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -1882,6 +1882,9 @@ INSERT INTO disttable VALUES
        ('2018-07-01 09:11', 90, 10303.12),
        ('2018-07-01 08:01', 29, 64);
 \set ON_ERROR_STOP 0
+SELECT id AS dimension_id FROM _timescaledb_catalog.dimension WHERE column_name = 'time' \gset
+SELECT _timescaledb_internal.calculate_chunk_interval(:dimension_id,1484250460,604800000000);
+ERROR:  adaptive chunking not supported on distributed hypertables
 CREATE MATERIALIZED VIEW disttable_cagg WITH (timescaledb.continuous)
 AS SELECT time_bucket('2 days', time), device, max(value)
     FROM disttable

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -540,6 +540,9 @@ INSERT INTO disttable VALUES
        ('2018-07-01 08:01', 29, 64);
 
 \set ON_ERROR_STOP 0
+SELECT id AS dimension_id FROM _timescaledb_catalog.dimension WHERE column_name = 'time' \gset
+SELECT _timescaledb_internal.calculate_chunk_interval(:dimension_id,1484250460,604800000000);
+
 CREATE MATERIALIZED VIEW disttable_cagg WITH (timescaledb.continuous)
 AS SELECT time_bucket('2 days', time), device, max(value)
     FROM disttable


### PR DESCRIPTION
Block calling calculate_chunk_interval on distributed hypertables
to prevent segfault when finding min and max as distributed chunks
have no tableam since they are foreign tables.