### PR TITLE
Fix wrong datatype in integer based retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ accidentally triggering the load of a previous DB version.**
 * #3151 Fix fdw_relinfo_get assertion failure on DELETE
 * #3155 Inherit CFLAGS from PostgreSQL
 * #3169 Fix incorrect type cast in compression policy
+* #3185 Fix wrong datatype for integer based retention policy
 
 **Thanks**
+* @aelg for reporting an issue with policies on integer-based hypertables
 * @Dead2, @dv8472 and @einsibjarni for reporting an issue with multinode queries and views
 * @hperez75 for reporting an issue with Skip Scan
 * @nathanloisel for reporting an issue with compression on hypertables with integer-based timestamps

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -61,14 +61,14 @@ int64
 policy_retention_get_drop_after_int(const Jsonb *config)
 {
 	bool found;
-	int32 hypertable_id = ts_jsonb_get_int64_field(config, CONFIG_KEY_DROP_AFTER, &found);
+	int64 drop_after = ts_jsonb_get_int64_field(config, CONFIG_KEY_DROP_AFTER, &found);
 
 	if (!found)
 		ereport(ERROR,
 				(errcode(ERRCODE_INTERNAL_ERROR),
 				 errmsg("could not find %s in config for job", CONFIG_KEY_DROP_AFTER)));
 
-	return hypertable_id;
+	return drop_after;
 }
 
 Interval *


### PR DESCRIPTION
When reading the configuration for retention policy of integer
based hypertables int32 was used instead of int64.

Fixes #2877
