### PR TITLE
Constify parameters and return values of core APIs

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -126,7 +126,7 @@ bgw_job_accum_tuple_found(TupleInfo *ti, void *data)
 }
 
 static ScanFilterResult
-bgw_job_filter_scheduled(TupleInfo *ti, void *data)
+bgw_job_filter_scheduled(const TupleInfo *ti, void *data)
 {
 	bool isnull;
 	Datum scheduled = slot_getattr(ti->slot, Anum_bgw_job_scheduled, &isnull);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -106,14 +106,14 @@ chunk_stub_is_valid(const ChunkStub *stub, unsigned int expected_slices)
 }
 
 typedef ChunkResult (*on_chunk_stub_func)(ChunkScanCtx *ctx, ChunkStub *stub);
-static void chunk_scan_ctx_init(ChunkScanCtx *ctx, Hyperspace *hs, Point *p);
+static void chunk_scan_ctx_init(ChunkScanCtx *ctx, const Hyperspace *hs, const Point *p);
 static void chunk_scan_ctx_destroy(ChunkScanCtx *ctx);
-static void chunk_collision_scan(ChunkScanCtx *scanctx, Hypercube *cube);
+static void chunk_collision_scan(ChunkScanCtx *scanctx, const Hypercube *cube);
 static int chunk_scan_ctx_foreach_chunk_stub(ChunkScanCtx *ctx, on_chunk_stub_func on_chunk,
 											 uint16 limit);
 static Datum chunks_return_srf(FunctionCallInfo fcinfo);
 static int chunk_cmp(const void *ch1, const void *ch2);
-static Chunk *chunk_find(Hypertable *ht, Point *p, bool resurrect, bool lock_slices);
+static Chunk *chunk_find(const Hypertable *ht, const Point *p, bool resurrect, bool lock_slices);
 static void init_scan_by_qualified_table_name(ScanIterator *iterator, const char *schema_name,
 											  const char *table_name);
 static Hypertable *find_hypertable_from_table_or_cagg(Cache *hcache, Oid relid);
@@ -331,14 +331,15 @@ do_dimension_alignment(ChunkScanCtx *scanctx, ChunkStub *stub)
 {
 	CollisionInfo *info = scanctx->data;
 	Hypercube *cube = info->cube;
-	Hyperspace *space = scanctx->space;
+	const Hyperspace *space = scanctx->space;
 	ChunkResult res = CHUNK_IGNORED;
 	int i;
 
 	for (i = 0; i < space->num_dimensions; i++)
 	{
-		Dimension *dim = &space->dimensions[i];
-		DimensionSlice *chunk_slice, *cube_slice;
+		const Dimension *dim = &space->dimensions[i];
+		const DimensionSlice *chunk_slice;
+		DimensionSlice *cube_slice;
 		int64 coord = scanctx->point->coordinates[i];
 
 		if (!dim->fd.aligned)
@@ -374,7 +375,7 @@ do_dimension_alignment(ChunkScanCtx *scanctx, ChunkStub *stub)
  * Calculate, and potentially set, a new chunk interval for an open dimension.
  */
 static bool
-calculate_and_set_new_chunk_interval(Hypertable *ht, Point *p)
+calculate_and_set_new_chunk_interval(const Hypertable *ht, const Point *p)
 {
 	Hyperspace *hs = ht->space;
 	Dimension *dim = NULL;
@@ -436,7 +437,7 @@ do_collision_resolution(ChunkScanCtx *scanctx, ChunkStub *stub)
 {
 	CollisionInfo *info = scanctx->data;
 	Hypercube *cube = info->cube;
-	Hyperspace *space = scanctx->space;
+	const Hyperspace *space = scanctx->space;
 	ChunkResult res = CHUNK_IGNORED;
 	int i;
 
@@ -478,7 +479,7 @@ check_for_collisions(ChunkScanCtx *scanctx, ChunkStub *stub)
 {
 	CollisionInfo *info = scanctx->data;
 	Hypercube *cube = info->cube;
-	Hyperspace *space = scanctx->space;
+	const Hyperspace *space = scanctx->space;
 
 	/* Check if this chunk collides with our hypercube */
 	if (stub->cube->num_slices == space->num_dimensions && ts_hypercubes_collide(cube, stub->cube))
@@ -497,11 +498,11 @@ check_for_collisions(ChunkScanCtx *scanctx, ChunkStub *stub)
  * chunk.
  */
 static ChunkStub *
-chunk_collides(Hypertable *ht, Hypercube *hc)
+chunk_collides(const Hypertable *ht, const Hypercube *hc)
 {
 	ChunkScanCtx scanctx;
 	CollisionInfo info = {
-		.cube = hc,
+		.cube = (Hypercube *) hc,
 		.colliding_chunk = NULL,
 	};
 
@@ -565,7 +566,7 @@ chunk_collides(Hypertable *ht, Hypercube *hc)
  * collisions. After alignment we check for any remaining collisions.
  */
 static void
-chunk_collision_resolve(Hypertable *ht, Hypercube *cube, Point *p)
+chunk_collision_resolve(const Hypertable *ht, Hypercube *cube, const Point *p)
 {
 	ChunkScanCtx scanctx;
 	CollisionInfo info = {
@@ -709,7 +710,7 @@ get_am_name_for_rel(Oid relid)
 }
 
 static void
-copy_hypertable_acl_to_relid(Hypertable *ht, Oid relid)
+copy_hypertable_acl_to_relid(const Hypertable *ht, Oid relid)
 {
 	HeapTuple ht_tuple;
 	bool is_null;
@@ -778,13 +779,11 @@ copy_hypertable_acl_to_relid(Hypertable *ht, Oid relid)
  * instead needs the proper permissions on the database to create the schema.
  */
 Oid
-ts_chunk_create_table(Chunk *chunk, Hypertable *ht, const char *tablespacename)
+ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tablespacename)
 {
 	Relation rel;
 	ObjectAddress objaddr;
 	int sec_ctx;
-	char *namespace = NameStr(ht->fd.schema_name);
-	char *hyper_name = NameStr(ht->fd.table_name);
 
 	/*
 	 * The CreateForeignTableStmt embeds a regular CreateStmt, so we can use
@@ -792,10 +791,13 @@ ts_chunk_create_table(Chunk *chunk, Hypertable *ht, const char *tablespacename)
 	 */
 	CreateForeignTableStmt stmt = {
 		.base.type = T_CreateStmt,
-		.base.relation =
-			makeRangeVar(NameStr(chunk->fd.schema_name), NameStr(chunk->fd.table_name), 0),
-		.base.inhRelations = list_make1(makeRangeVar(namespace, hyper_name, 0)),
-		.base.tablespacename = tablespacename ? pstrdup(tablespacename) : NULL,
+		.base.relation = makeRangeVar((char *) NameStr(chunk->fd.schema_name),
+									  (char *) NameStr(chunk->fd.table_name),
+									  0),
+		.base.inhRelations = list_make1(makeRangeVar((char *) NameStr(ht->fd.schema_name),
+													 (char *) NameStr(ht->fd.table_name),
+													 0)),
+		.base.tablespacename = tablespacename ? (char *) tablespacename : NULL,
 		/* Propagate storage options of the main table to a regular chunk
 		 * table, but avoid using it for a foreign chunk table. */
 		.base.options =
@@ -814,7 +816,7 @@ ts_chunk_create_table(Chunk *chunk, Hypertable *ht, const char *tablespacename)
 	 * If the chunk is created in the internal schema, become the catalog
 	 * owner, otherwise become the hypertable owner
 	 */
-	if (namestrcmp(&chunk->fd.schema_name, INTERNAL_SCHEMA_NAME) == 0)
+	if (namestrcmp((Name) &chunk->fd.schema_name, INTERNAL_SCHEMA_NAME) == 0)
 		uid = ts_catalog_database_info_get()->owner_uid;
 	else
 		uid = rel->rd_rel->relowner;
@@ -889,7 +891,7 @@ ts_chunk_create_table(Chunk *chunk, Hypertable *ht, const char *tablespacename)
 }
 
 static List *
-chunk_assign_data_nodes(Chunk *chunk, const Hypertable *ht)
+chunk_assign_data_nodes(const Chunk *chunk, const Hypertable *ht)
 {
 	List *htnodes;
 	List *chunk_data_nodes = NIL;
@@ -1017,7 +1019,7 @@ chunk_insert_into_metadata_after_lock(const Chunk *chunk)
 }
 
 static void
-chunk_create_table_constraints(Chunk *chunk)
+chunk_create_table_constraints(const Chunk *chunk)
 {
 	/* Create the chunk's constraints, triggers, and indexes */
 	ts_chunk_constraints_create(chunk->constraints,
@@ -1037,7 +1039,7 @@ chunk_create_table_constraints(Chunk *chunk)
 }
 
 static Oid
-chunk_create_table(Chunk *chunk, Hypertable *ht)
+chunk_create_table(Chunk *chunk, const Hypertable *ht)
 {
 	/* Create the actual table relation for the chunk */
 	const char *tablespace = ts_hypertable_select_tablespace_name(ht, chunk);
@@ -1061,8 +1063,9 @@ init_scan_by_chunk_id(ScanIterator *iterator, int32 chunk_id)
 }
 
 static Chunk *
-chunk_create_from_hypercube_after_lock(Hypertable *ht, Hypercube *cube, const char *schema_name,
-									   const char *table_name, const char *prefix)
+chunk_create_from_hypercube_after_lock(const Hypertable *ht, Hypercube *cube,
+									   const char *schema_name, const char *table_name,
+									   const char *prefix)
 {
 	Chunk *chunk;
 
@@ -1083,7 +1086,7 @@ chunk_create_from_hypercube_after_lock(Hypertable *ht, Hypercube *cube, const ch
 }
 
 static Chunk *
-chunk_create_from_point_after_lock(Hypertable *ht, Point *p, const char *schema_name,
+chunk_create_from_point_after_lock(const Hypertable *ht, const Point *p, const char *schema_name,
 								   const char *table_name, const char *prefix)
 {
 	Hyperspace *hs = ht->space;
@@ -1116,7 +1119,7 @@ chunk_create_from_point_after_lock(Hypertable *ht, Point *p, const char *schema_
 }
 
 Chunk *
-ts_chunk_find_or_create_without_cuts(Hypertable *ht, Hypercube *hc, const char *schema_name,
+ts_chunk_find_or_create_without_cuts(const Hypertable *ht, Hypercube *hc, const char *schema_name,
 									 const char *table_name, bool *created)
 {
 	ChunkStub *stub;
@@ -1188,7 +1191,8 @@ ts_chunk_find_or_create_without_cuts(Hypertable *ht, Hypercube *hc, const char *
  * Create a chunk through insertion of a tuple at a given point.
  */
 Chunk *
-ts_chunk_create_from_point(Hypertable *ht, Point *p, const char *schema, const char *prefix)
+ts_chunk_create_from_point(const Hypertable *ht, const Point *p, const char *schema,
+						   const char *prefix)
 {
 	Chunk *chunk;
 
@@ -1312,7 +1316,7 @@ chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti, const ChunkStub
 }
 
 static ScanFilterResult
-chunk_tuple_dropped_filter(TupleInfo *ti, void *arg)
+chunk_tuple_dropped_filter(const TupleInfo *ti, void *arg)
 {
 	ChunkStubScanCtx *stubctx = arg;
 	bool isnull;
@@ -1331,7 +1335,7 @@ chunk_tuple_dropped_filter(TupleInfo *ti, void *arg)
  * and tuple_found function share the argument.
  */
 static ScanFilterResult
-chunk_check_ignorearg_dropped_filter(TupleInfo *ti, void *arg)
+chunk_check_ignorearg_dropped_filter(const TupleInfo *ti, void *arg)
 {
 	bool isnull;
 	Datum dropped = slot_getattr(ti->slot, Anum_chunk_dropped, &isnull);
@@ -1419,7 +1423,7 @@ chunk_create_from_stub(ChunkStubScanCtx *stubctx)
  * tables during scans.
  */
 static void
-chunk_scan_ctx_init(ChunkScanCtx *ctx, Hyperspace *hs, Point *p)
+chunk_scan_ctx_init(ChunkScanCtx *ctx, const Hyperspace *hs, const Point *p)
 {
 	struct HASHCTL hctl = {
 		.keysize = sizeof(int32),
@@ -1447,7 +1451,7 @@ chunk_scan_ctx_destroy(ChunkScanCtx *ctx)
 }
 
 static inline void
-dimension_slice_and_chunk_constraint_join(ChunkScanCtx *scanctx, DimensionVec *vec)
+dimension_slice_and_chunk_constraint_join(ChunkScanCtx *scanctx, const DimensionVec *vec)
 {
 	int i;
 
@@ -1473,7 +1477,7 @@ dimension_slice_and_chunk_constraint_join(ChunkScanCtx *scanctx, DimensionVec *v
  * to two chunks.
  */
 static void
-chunk_point_scan(ChunkScanCtx *scanctx, Point *p, bool lock_slices)
+chunk_point_scan(ChunkScanCtx *scanctx, const Point *p, bool lock_slices)
 {
 	int i;
 
@@ -1511,7 +1515,7 @@ chunk_point_scan(ChunkScanCtx *scanctx, Point *p, bool lock_slices)
  * that require alignment.
  */
 static void
-chunk_collision_scan(ChunkScanCtx *scanctx, Hypercube *cube)
+chunk_collision_scan(ChunkScanCtx *scanctx, const Hypercube *cube)
 {
 	int i;
 
@@ -1649,7 +1653,7 @@ chunk_scan_ctx_get_chunk_stub(ChunkScanCtx *ctx)
  * including recreating the table and related objects.
  */
 static Chunk *
-chunk_resurrect(Hypertable *ht, ChunkStub *stub)
+chunk_resurrect(const Hypertable *ht, const ChunkStub *stub)
 {
 	ScanIterator iterator;
 	Chunk *chunk = NULL;
@@ -1722,7 +1726,7 @@ chunk_resurrect(Hypertable *ht, ChunkStub *stub)
  * case it needs to live beyond the lifetime of the other data.
  */
 static Chunk *
-chunk_find(Hypertable *ht, Point *p, bool resurrect, bool lock_slices)
+chunk_find(const Hypertable *ht, const Point *p, bool resurrect, bool lock_slices)
 {
 	ChunkStub *stub;
 	Chunk *chunk = NULL;
@@ -1769,7 +1773,7 @@ chunk_find(Hypertable *ht, Point *p, bool resurrect, bool lock_slices)
 }
 
 Chunk *
-ts_chunk_find(Hypertable *ht, Point *p, bool lock_slices)
+ts_chunk_find(const Hypertable *ht, const Point *p, bool lock_slices)
 {
 	return chunk_find(ht, p, false, lock_slices);
 }
@@ -1781,10 +1785,10 @@ ts_chunk_find(Hypertable *ht, Point *p, bool lock_slices)
  * usage.
  */
 static void
-chunks_find_all_in_range_limit(Hypertable *ht, Dimension *time_dim, StrategyNumber start_strategy,
-							   int64 start_value, StrategyNumber end_strategy, int64 end_value,
-							   int limit, uint64 *num_found, ScanTupLock *tuplock,
-							   ChunkScanCtx *ctx)
+chunks_find_all_in_range_limit(const Hypertable *ht, const Dimension *time_dim,
+							   StrategyNumber start_strategy, int64 start_value,
+							   StrategyNumber end_strategy, int64 end_value, int limit,
+							   uint64 *num_found, ScanTupLock *tuplock, ChunkScanCtx *ctx)
 {
 	DimensionVec *slices;
 
@@ -1880,8 +1884,8 @@ append_chunk(ChunkScanCtx *scanctx, ChunkStub *stub)
 }
 
 static void *
-chunk_find_all(Hypertable *ht, List *dimension_vecs, on_chunk_stub_func on_chunk, LOCKMODE lockmode,
-			   unsigned int *num_chunks)
+chunk_find_all(const Hypertable *ht, const List *dimension_vecs, on_chunk_stub_func on_chunk,
+			   LOCKMODE lockmode, unsigned int *num_chunks)
 {
 	ChunkScanCtx ctx;
 	ListCell *lc;
@@ -1897,7 +1901,7 @@ chunk_find_all(Hypertable *ht, List *dimension_vecs, on_chunk_stub_func on_chunk
 	/* Scan all dimensions for slices enclosing the point */
 	foreach (lc, dimension_vecs)
 	{
-		DimensionVec *vec = lfirst(lc);
+		const DimensionVec *vec = lfirst(lc);
 
 		dimension_slice_and_chunk_constraint_join(&ctx, vec);
 	}
@@ -1914,7 +1918,8 @@ chunk_find_all(Hypertable *ht, List *dimension_vecs, on_chunk_stub_func on_chunk
 }
 
 Chunk **
-ts_chunk_find_all(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode, unsigned int *num_chunks)
+ts_chunk_find_all(const Hypertable *ht, const List *dimension_vecs, LOCKMODE lockmode,
+				  unsigned int *num_chunks)
 {
 	Chunk **chunks = chunk_find_all(ht, dimension_vecs, append_chunk, lockmode, num_chunks);
 
@@ -1930,7 +1935,7 @@ ts_chunk_find_all(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode, unsig
 }
 
 List *
-ts_chunk_find_all_oids(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode)
+ts_chunk_find_all_oids(const Hypertable *ht, const List *dimension_vecs, LOCKMODE lockmode)
 {
 	List *chunks = chunk_find_all(ht, dimension_vecs, append_chunk_oid, lockmode, NULL);
 
@@ -1961,7 +1966,7 @@ ts_chunk_show_chunks(PG_FUNCTION_ARGS)
 		FuncCallContext *funcctx;
 		Oid relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 		Hypertable *ht;
-		Dimension *time_dim;
+		const Dimension *time_dim;
 		Cache *hcache;
 		int64 older_than = PG_INT64_MAX;
 		int64 newer_than = PG_INT64_MIN;
@@ -2007,7 +2012,7 @@ get_chunks_in_time_range(Hypertable *ht, int64 older_than, int64 newer_than,
 	ChunkScanCtx chunk_scan_ctx;
 	Chunk *chunks;
 	ChunkScanCtxAddChunkData data;
-	Dimension *time_dim;
+	const Dimension *time_dim;
 	StrategyNumber start_strategy;
 	StrategyNumber end_strategy;
 	uint64 num_chunks = 0;
@@ -2931,7 +2936,7 @@ ts_chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_
  * contain no data.
  */
 void
-ts_chunk_drop_fks(Chunk *const chunk)
+ts_chunk_drop_fks(const Chunk *const chunk)
 {
 	Relation rel;
 	List *fks;
@@ -2959,7 +2964,7 @@ ts_chunk_drop_fks(Chunk *const chunk)
  * dropped during compression.
  */
 void
-ts_chunk_create_fks(Chunk *const chunk)
+ts_chunk_create_fks(const Chunk *const chunk)
 {
 	Relation rel;
 	List *fks;
@@ -3676,7 +3681,7 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 	int elevel;
 	List *data_node_oids = NIL;
 	Cache *hcache;
-	Dimension *time_dim;
+	const Dimension *time_dim;
 	Oid time_type;
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -93,8 +93,8 @@ typedef struct ChunkScanCtx
 {
 	HTAB *htab;
 	char relkind; /* Create chunks of this relkind */
-	Hyperspace *space;
-	Point *point;
+	const Hyperspace *space;
+	const Point *point;
 	unsigned int num_complete_chunks;
 	int num_processed;
 	bool early_abort;
@@ -106,7 +106,7 @@ typedef struct ChunkScanCtx
  * false. Used to find a stub matching a point in an N-dimensional
  * hyperspace. */
 static inline bool
-chunk_stub_is_complete(ChunkStub *stub, Hyperspace *space)
+chunk_stub_is_complete(const ChunkStub *stub, const Hyperspace *space)
 {
 	return space->num_dimensions == stub->constraints->num_dimension_constraints;
 }
@@ -118,15 +118,16 @@ typedef struct ChunkScanEntry
 	ChunkStub *stub;
 } ChunkScanEntry;
 
-extern Chunk *ts_chunk_create_from_point(Hypertable *ht, Point *p, const char *schema,
+extern Chunk *ts_chunk_create_from_point(const Hypertable *ht, const Point *p, const char *schema,
 										 const char *prefix);
 
 extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id, int16 num_constraints, const char relkind);
 extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id, int16 num_constraints);
-extern Chunk *ts_chunk_find(Hypertable *ht, Point *p, bool lock_slices);
-extern Chunk **ts_chunk_find_all(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode,
-								 unsigned int *num_chunks);
-extern List *ts_chunk_find_all_oids(Hypertable *ht, List *dimension_vecs, LOCKMODE lockmode);
+extern Chunk *ts_chunk_find(const Hypertable *ht, const Point *p, bool lock_slices);
+extern Chunk **ts_chunk_find_all(const Hypertable *ht, const List *dimension_vecs,
+								 LOCKMODE lockmode, unsigned int *num_chunks);
+extern List *ts_chunk_find_all_oids(const Hypertable *ht, const List *dimension_vecs,
+									LOCKMODE lockmode);
 extern TSDLLEXPORT Chunk *ts_chunk_copy(const Chunk *chunk);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_name_with_memory_context(const char *schema_name,
 																   const char *table_name,
@@ -134,7 +135,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_by_name_with_memory_context(const char *s
 																   bool fail_if_not_found);
 extern TSDLLEXPORT void ts_chunk_insert_lock(const Chunk *chunk, LOCKMODE lock);
 
-extern TSDLLEXPORT Oid ts_chunk_create_table(Chunk *chunk, Hypertable *ht,
+extern TSDLLEXPORT Oid ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht,
 											 const char *tablespacename);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_id(int32 id, bool fail_if_not_found);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_relid(Oid relid, bool fail_if_not_found);
@@ -147,8 +148,8 @@ extern bool ts_chunk_exists_relid(Oid relid);
 extern TSDLLEXPORT int ts_chunk_num_of_chunks_created_after(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_exists_with_compression(int32 hypertable_id);
 extern void ts_chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
-extern TSDLLEXPORT void ts_chunk_drop_fks(Chunk *const chunk);
-extern TSDLLEXPORT void ts_chunk_create_fks(Chunk *const chunk);
+extern TSDLLEXPORT void ts_chunk_drop_fks(const Chunk *const chunk);
+extern TSDLLEXPORT void ts_chunk_create_fks(const Chunk *const chunk);
 extern int ts_chunk_delete_by_hypertable_id(int32 hypertable_id);
 extern int ts_chunk_delete_by_name(const char *schema, const char *table, DropBehavior behavior);
 extern TSDLLEXPORT bool ts_chunk_add_status(Chunk *chunk, int32 status);
@@ -167,7 +168,7 @@ extern TSDLLEXPORT void ts_chunk_drop_preserve_catalog_row(const Chunk *chunk,
 														   DropBehavior behavior, int32 log_level);
 extern TSDLLEXPORT List *ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than,
 												 int32 log_level, List **affected_data_nodes);
-extern TSDLLEXPORT Chunk *ts_chunk_find_or_create_without_cuts(Hypertable *ht, Hypercube *hc,
+extern TSDLLEXPORT Chunk *ts_chunk_find_or_create_without_cuts(const Hypertable *ht, Hypercube *hc,
 															   const char *schema_name,
 															   const char *table_name,
 															   bool *created);

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -417,7 +417,7 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 	int64 current_interval;
 	int32 hypertable_id;
 	Hypertable *ht;
-	Dimension *dim;
+	const Dimension *dim;
 	List *chunks = NIL;
 	ListCell *lc;
 	int num_intervals = 0;
@@ -467,7 +467,8 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 	foreach (lc, chunks)
 	{
 		Chunk *chunk = lfirst(lc);
-		DimensionSlice *slice = ts_hypercube_get_slice_by_dimension_id(chunk->cube, dimension_id);
+		const DimensionSlice *slice =
+			ts_hypercube_get_slice_by_dimension_id(chunk->cube, dimension_id);
 		int64 chunk_size, slice_interval;
 		Datum minmax[2];
 		AttrNumber attno =
@@ -748,7 +749,7 @@ ts_chunk_adaptive_set(PG_FUNCTION_ARGS)
 		.check_for_index = true,
 	};
 	Hypertable *ht;
-	Dimension *dim;
+	const Dimension *dim;
 	Cache *hcache;
 	HeapTuple tuple;
 	TupleDesc tupdesc;

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -142,7 +142,7 @@ chunk_constraints_add(ChunkConstraints *ccs, int32 chunk_id, int32 dimension_sli
 }
 
 static void
-chunk_constraint_fill_tuple_values(ChunkConstraint *cc, Datum values[Natts_chunk_constraint],
+chunk_constraint_fill_tuple_values(const ChunkConstraint *cc, Datum values[Natts_chunk_constraint],
 								   bool nulls[Natts_chunk_constraint])
 {
 	memset(values, 0, sizeof(Datum) * Natts_chunk_constraint);
@@ -162,7 +162,7 @@ chunk_constraint_fill_tuple_values(ChunkConstraint *cc, Datum values[Natts_chunk
 }
 
 static void
-chunk_constraint_insert_relation(Relation rel, ChunkConstraint *cc)
+chunk_constraint_insert_relation(const Relation rel, const ChunkConstraint *cc)
 {
 	TupleDesc desc = RelationGetDescr(rel);
 	Datum values[Natts_chunk_constraint];
@@ -176,7 +176,7 @@ chunk_constraint_insert_relation(Relation rel, ChunkConstraint *cc)
  * Insert multiple chunk constraints into the metadata catalog.
  */
 void
-ts_chunk_constraints_insert_metadata(ChunkConstraints *ccs)
+ts_chunk_constraints_insert_metadata(const ChunkConstraints *ccs)
 {
 	Catalog *catalog = ts_catalog_get();
 	CatalogSecurityContext sec_ctx;
@@ -260,7 +260,7 @@ chunk_constraints_add_from_tuple(ChunkConstraints *ccs, TupleInfo *ti)
  * Add a constraint to a chunk table.
  */
 static Oid
-chunk_constraint_create_on_table(ChunkConstraint *cc, Oid chunk_oid)
+chunk_constraint_create_on_table(const ChunkConstraint *cc, Oid chunk_oid)
 {
 	HeapTuple tuple;
 	Datum values[Natts_chunk_constraint];
@@ -286,8 +286,8 @@ chunk_constraint_create_on_table(ChunkConstraint *cc, Oid chunk_oid)
  * the catalog.
  */
 static Oid
-chunk_constraint_create(ChunkConstraint *cc, Oid chunk_oid, int32 chunk_id, Oid hypertable_oid,
-						int32 hypertable_id)
+chunk_constraint_create(const ChunkConstraint *cc, Oid chunk_oid, int32 chunk_id,
+						Oid hypertable_oid, int32 hypertable_id)
 {
 	Oid chunk_constraint_oid;
 
@@ -333,7 +333,7 @@ chunk_constraint_create(ChunkConstraint *cc, Oid chunk_oid, int32 chunk_id, Oid 
  * Create a set of constraints on a chunk table.
  */
 void
-ts_chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid, int32 chunk_id,
+ts_chunk_constraints_create(const ChunkConstraints *ccs, Oid chunk_oid, int32 chunk_id,
 							Oid hypertable_oid, int32 hypertable_id)
 {
 	int i;
@@ -432,7 +432,7 @@ typedef struct ChunkConstraintScanData
  * constraints are saved in the chunk scan context.
  */
 int
-ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx *ctx,
+ts_chunk_constraint_scan_by_dimension_slice(const DimensionSlice *slice, ChunkScanCtx *ctx,
 											MemoryContext mctx)
 {
 	ScanIterator iterator = ts_scan_iterator_create(CHUNK_CONSTRAINT, AccessShareLock, mctx);
@@ -441,7 +441,7 @@ ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx 
 	init_scan_by_dimension_slice_id(&iterator, slice->fd.id);
 	ts_scanner_foreach(&iterator)
 	{
-		Hyperspace *hs = ctx->space;
+		const Hyperspace *hs = ctx->space;
 		ChunkStub *stub;
 		ChunkScanEntry *entry;
 		bool found;
@@ -493,7 +493,7 @@ ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx 
  * in a list, which is easier to traverse and provides deterministic chunk selection.
  */
 int
-ts_chunk_constraint_scan_by_dimension_slice_to_list(DimensionSlice *slice, List **list,
+ts_chunk_constraint_scan_by_dimension_slice_to_list(const DimensionSlice *slice, List **list,
 													MemoryContext mctx)
 {
 	ScanIterator iterator = ts_scan_iterator_create(CHUNK_CONSTRAINT, AccessShareLock, mctx);
@@ -568,7 +568,7 @@ chunk_constraint_need_on_chunk(const char chunk_relkind, Form_pg_constraint conf
 
 int
 ts_chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, int32 chunk_id,
-											   Hypercube *cube)
+											   const Hypercube *cube)
 {
 	int i;
 
@@ -615,7 +615,7 @@ ts_chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs, int32 ch
 }
 
 void
-ts_chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid)
+ts_chunk_constraint_create_on_chunk(const Chunk *chunk, Oid constraint_oid)
 {
 	HeapTuple tuple;
 	Form_pg_constraint con;
@@ -792,7 +792,7 @@ ts_chunk_constraint_delete_by_dimension_slice_id(int32 dimension_slice_id)
 }
 
 void
-ts_chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid)
+ts_chunk_constraint_recreate(const ChunkConstraint *cc, Oid chunk_oid)
 {
 	ObjectAddress constrobj = {
 		.classId = ConstraintRelationId,

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -39,24 +39,24 @@ extern TSDLLEXPORT ChunkConstraints *ts_chunk_constraints_alloc(int size_hint, M
 extern ChunkConstraints *ts_chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint,
 															  MemoryContext mctx);
 extern ChunkConstraints *ts_chunk_constraints_copy(ChunkConstraints *constraints);
-extern int ts_chunk_constraint_scan_by_dimension_slice(DimensionSlice *slice, ChunkScanCtx *ctx,
-													   MemoryContext mctx);
-extern int ts_chunk_constraint_scan_by_dimension_slice_to_list(DimensionSlice *slice, List **list,
-															   MemoryContext mctx);
+extern int ts_chunk_constraint_scan_by_dimension_slice(const DimensionSlice *slice,
+													   ChunkScanCtx *ctx, MemoryContext mctx);
+extern int ts_chunk_constraint_scan_by_dimension_slice_to_list(const DimensionSlice *slice,
+															   List **list, MemoryContext mctx);
 extern int ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id,
 														  ChunkConstraints *ccs,
 														  MemoryContext mctx);
 extern int ts_chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, int32 chunk_id,
-														  Hypercube *cube);
+														  const Hypercube *cube);
 extern TSDLLEXPORT int ts_chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs,
 																		int32 chunk_id,
 																		const char chunk_relkind,
 																		Oid hypertable_oid);
-extern TSDLLEXPORT void ts_chunk_constraints_insert_metadata(ChunkConstraints *ccs);
-extern TSDLLEXPORT void ts_chunk_constraints_create(ChunkConstraints *ccs, Oid chunk_oid,
+extern TSDLLEXPORT void ts_chunk_constraints_insert_metadata(const ChunkConstraints *ccs);
+extern TSDLLEXPORT void ts_chunk_constraints_create(const ChunkConstraints *ccs, Oid chunk_oid,
 													int32 chunk_id, Oid hypertable_oid,
 													int32 hypertable_id);
-extern void ts_chunk_constraint_create_on_chunk(Chunk *chunk, Oid constraint_oid);
+extern void ts_chunk_constraint_create_on_chunk(const Chunk *chunk, Oid constraint_oid);
 extern int ts_chunk_constraint_delete_by_hypertable_constraint_name(
 	int32 chunk_id, const char *hypertable_constraint_name, bool delete_metadata,
 	bool drop_constraint);
@@ -66,7 +66,7 @@ extern int ts_chunk_constraint_delete_by_constraint_name(int32 chunk_id,
 														 const char *constraint_name,
 														 bool delete_metadata,
 														 bool drop_constraint);
-extern void ts_chunk_constraint_recreate(ChunkConstraint *cc, Oid chunk_oid);
+extern void ts_chunk_constraint_recreate(const ChunkConstraint *cc, Oid chunk_oid);
 extern int ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname,
 															const char *newname);
 extern int ts_chunk_constraint_adjust_meta(int32 chunk_id, const char *ht_constraint_name,

--- a/src/chunk_data_node.c
+++ b/src/chunk_data_node.c
@@ -18,7 +18,8 @@
 #include "chunk.h"
 
 static void
-chunk_data_node_insert_relation(Relation rel, int32 chunk_id, int32 node_chunk_id, Name node_name)
+chunk_data_node_insert_relation(const Relation rel, int32 chunk_id, int32 node_chunk_id,
+								const NameData *node_name)
 {
 	TupleDesc desc = RelationGetDescr(rel);
 	Datum values[Natts_chunk_data_node];
@@ -36,7 +37,7 @@ chunk_data_node_insert_relation(Relation rel, int32 chunk_id, int32 node_chunk_i
 }
 
 static void
-chunk_data_node_insert_internal(int32 chunk_id, int32 node_chunk_id, Name node_name)
+chunk_data_node_insert_internal(int32 chunk_id, int32 node_chunk_id, const NameData *node_name)
 {
 	Catalog *catalog = ts_catalog_get();
 	Relation rel;
@@ -49,7 +50,7 @@ chunk_data_node_insert_internal(int32 chunk_id, int32 node_chunk_id, Name node_n
 }
 
 void
-ts_chunk_data_node_insert(ChunkDataNode *node)
+ts_chunk_data_node_insert(const ChunkDataNode *node)
 {
 	chunk_data_node_insert_internal(node->fd.chunk_id, node->fd.node_chunk_id, &node->fd.node_name);
 }

--- a/src/chunk_data_node.h
+++ b/src/chunk_data_node.h
@@ -22,7 +22,7 @@ ts_chunk_data_node_scan_by_chunk_id_and_node_name(int32 chunk_id, const char *no
 extern TSDLLEXPORT ChunkDataNode *
 ts_chunk_data_node_scan_by_remote_chunk_id_and_node_name(int32 chunk_id, const char *node_name,
 														 MemoryContext mctx);
-extern TSDLLEXPORT void ts_chunk_data_node_insert(ChunkDataNode *node);
+extern TSDLLEXPORT void ts_chunk_data_node_insert(const ChunkDataNode *node);
 extern void ts_chunk_data_node_insert_multi(List *chunk_data_nodes);
 extern int ts_chunk_data_node_delete_by_chunk_id(int32 chunk_id);
 extern TSDLLEXPORT int ts_chunk_data_node_delete_by_chunk_id_and_node_name(int32 chunk_id,

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -657,7 +657,7 @@ chunk_index_tuple_delete(TupleInfo *ti, void *data)
 }
 
 static ScanFilterResult
-chunk_index_name_and_schema_filter(TupleInfo *ti, void *data)
+chunk_index_name_and_schema_filter(const TupleInfo *ti, void *data)
 {
 	bool should_free;
 	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
@@ -803,7 +803,7 @@ ts_chunk_index_get_by_indexrelid(Chunk *chunk, Oid chunk_indexrelid, ChunkIndexM
 }
 
 static ScanFilterResult
-chunk_hypertable_index_name_filter(TupleInfo *ti, void *data)
+chunk_hypertable_index_name_filter(const TupleInfo *ti, void *data)
 {
 	ChunkIndexMapping *cim = data;
 	const char *hypertable_indexname = get_rel_name(cim->parent_indexoid);

--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -200,7 +200,7 @@ continuous_agg_init(ContinuousAgg *cagg, const Form_continuous_agg fd)
 {
 	Oid nspid = get_namespace_oid(NameStr(fd->user_view_schema), false);
 	Hypertable *cagg_ht = ts_hypertable_get_by_id(fd->mat_hypertable_id);
-	Dimension *time_dim;
+	const Dimension *time_dim;
 
 	Assert(NULL != cagg_ht);
 	time_dim = hyperspace_get_open_dimension(cagg_ht->space, 0);
@@ -909,15 +909,15 @@ find_raw_hypertable_for_materialization(int32 mat_hypertable_id)
  * Walk the materialization hypertable ->raw hypertable tree till
  * we find a hypertable that has integer_now_func set.
  */
-TSDLLEXPORT Dimension *
+TSDLLEXPORT const Dimension *
 ts_continuous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid)
 {
 	int32 raw_htid = mat_htid;
-	Dimension *par_dim = NULL;
+	const Dimension *par_dim = NULL;
 	while (raw_htid != INVALID_HYPERTABLE_ID)
 	{
 		Hypertable *raw_ht = ts_hypertable_get_by_id(raw_htid);
-		Dimension *open_dim = hyperspace_get_open_dimension(raw_ht->space, 0);
+		const Dimension *open_dim = hyperspace_get_open_dimension(raw_ht->space, 0);
 		if (strlen(NameStr(open_dim->fd.integer_now_func)) != 0 &&
 			strlen(NameStr(open_dim->fd.integer_now_func_schema)) != 0)
 		{
@@ -977,7 +977,7 @@ static Watermark *
 watermark_create(const ContinuousAgg *cagg, MemoryContext top_mctx)
 {
 	Hypertable *ht;
-	Dimension *dim;
+	const Dimension *dim;
 	Datum maxdat;
 	bool max_isnull;
 	Oid timetype;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -86,7 +86,7 @@ extern void ts_continuous_agg_rename_view(const char *old_schema, const char *na
 extern TSDLLEXPORT int32 ts_number_of_continuous_aggs(void);
 
 extern Oid ts_continuous_agg_get_user_view_oid(ContinuousAgg *agg);
-extern TSDLLEXPORT Dimension *
+extern TSDLLEXPORT const Dimension *
 ts_continuous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid);
 extern ContinuousAgg *ts_continuous_agg_find_userview_name(const char *schema, const char *name);
 

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -224,7 +224,7 @@ empty_fn(PG_FUNCTION_ARGS)
 }
 
 static void
-create_chunk_on_data_nodes_default(Chunk *chunk, Hypertable *ht)
+create_chunk_on_data_nodes_default(const Chunk *chunk, const Hypertable *ht)
 {
 	error_no_default_fn_community();
 }

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -141,7 +141,7 @@ typedef struct CrossModuleFunctions
 	PGFunction remote_txn_id_out;
 	PGFunction remote_txn_heal_data_node;
 	PGFunction remote_connection_cache_show;
-	void (*create_chunk_on_data_nodes)(Chunk *chunk, Hypertable *ht);
+	void (*create_chunk_on_data_nodes)(const Chunk *chunk, const Hypertable *ht);
 	Path *(*distributed_insert_path_create)(PlannerInfo *root, ModifyTablePath *mtpath,
 											Index hypertable_rti, int subpath_index);
 	uint64 (*distributed_copy)(const CopyStmt *stmt, CopyChunkState *ccstate, List *attnums);

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -59,8 +59,8 @@ cmp_dimension_id(const void *left, const void *right)
 	return 0;
 }
 
-Dimension *
-ts_hyperspace_get_dimension_by_id(Hyperspace *hs, int32 id)
+const Dimension *
+ts_hyperspace_get_dimension_by_id(const Hyperspace *hs, int32 id)
 {
 	Dimension dim = {
 		.fd.id = id,
@@ -70,7 +70,7 @@ ts_hyperspace_get_dimension_by_id(Hyperspace *hs, int32 id)
 }
 
 Dimension *
-ts_hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionType type, const char *name)
+ts_hyperspace_get_mutable_dimension_by_name(Hyperspace *hs, DimensionType type, const char *name)
 {
 	int i;
 
@@ -86,8 +86,14 @@ ts_hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionType type, const ch
 	return NULL;
 }
 
+const Dimension *
+ts_hyperspace_get_dimension_by_name(const Hyperspace *hs, DimensionType type, const char *name)
+{
+	return ts_hyperspace_get_mutable_dimension_by_name((Hyperspace *) hs, type, name);
+}
+
 Dimension *
-ts_hyperspace_get_dimension(Hyperspace *hs, DimensionType type, Index n)
+ts_hyperspace_get_mutable_dimension(Hyperspace *hs, DimensionType type, Index n)
 {
 	int i;
 
@@ -102,6 +108,12 @@ ts_hyperspace_get_dimension(Hyperspace *hs, DimensionType type, Index n)
 	}
 
 	return NULL;
+}
+
+const Dimension *
+ts_hyperspace_get_dimension(const Hyperspace *hs, DimensionType type, Index n)
+{
+	return ts_hyperspace_get_mutable_dimension((Hyperspace *) hs, type, n);
 }
 
 static int
@@ -284,7 +296,7 @@ ts_dimension_calculate_open_range_default(PG_FUNCTION_ARGS)
 }
 
 static int64
-calculate_closed_range_interval(Dimension *dim)
+calculate_closed_range_interval(const Dimension *dim)
 {
 	Assert(NULL != dim && IS_CLOSED_DIMENSION(dim));
 
@@ -292,7 +304,7 @@ calculate_closed_range_interval(Dimension *dim)
 }
 
 static DimensionSlice *
-calculate_closed_range_default(Dimension *dim, int64 value)
+calculate_closed_range_default(const Dimension *dim, int64 value)
 {
 	int64 range_start, range_end;
 
@@ -343,7 +355,7 @@ ts_dimension_calculate_closed_range_default(PG_FUNCTION_ARGS)
 }
 
 DimensionSlice *
-ts_dimension_calculate_default_slice(Dimension *dim, int64 value)
+ts_dimension_calculate_default_slice(const Dimension *dim, int64 value)
 {
 	if (IS_OPEN_DIMENSION(dim))
 		return calculate_open_range_default(dim, value);
@@ -367,7 +379,7 @@ ts_dimension_calculate_default_slice(Dimension *dim, int64 value)
  * ' | A | B | C | D | E |
  */
 static int
-ts_dimension_get_open_slice_ordinal(Dimension *dim, DimensionSlice *slice)
+ts_dimension_get_open_slice_ordinal(const Dimension *dim, const DimensionSlice *slice)
 {
 	DimensionVec *vec;
 	int i;
@@ -402,7 +414,7 @@ ts_dimension_get_open_slice_ordinal(Dimension *dim, DimensionSlice *slice)
  * the ordinal of current slice most overlapping the given slice (or first fully overlapped slice).
  */
 static int
-ts_dimension_get_closed_slice_ordinal(Dimension *dim, DimensionSlice *target_slice)
+ts_dimension_get_closed_slice_ordinal(const Dimension *dim, const DimensionSlice *target_slice)
 {
 	int64 current_slice_size;
 	int64 target_slice_size;
@@ -450,7 +462,7 @@ ts_dimension_get_closed_slice_ordinal(Dimension *dim, DimensionSlice *target_sli
  * dimensional axis gets the lowest ordinal value and the "latest" the largest.
  */
 int
-ts_dimension_get_slice_ordinal(Dimension *dim, DimensionSlice *slice)
+ts_dimension_get_slice_ordinal(const Dimension *dim, const DimensionSlice *slice)
 {
 	Assert(NULL != dim);
 	Assert(NULL != slice);
@@ -589,7 +601,7 @@ ts_dimension_get_hypertable_id(int32 dimension_id)
 }
 
 DimensionVec *
-ts_dimension_get_slices(Dimension *dim)
+ts_dimension_get_slices(const Dimension *dim)
 {
 	return ts_dimension_slice_scan_by_dimension(dim->fd.id, 0);
 }
@@ -860,7 +872,7 @@ ts_dimension_set_number_of_slices(Dimension *dim, int16 num_slices)
  * the restype parameter.
  */
 Datum
-ts_dimension_transform_value(Dimension *dim, Oid collation, Datum value, Oid const_datum_type,
+ts_dimension_transform_value(const Dimension *dim, Oid collation, Datum value, Oid const_datum_type,
 							 Oid *restype)
 {
 	if (NULL != dim->partitioning)
@@ -891,14 +903,14 @@ point_create(int16 num_dimensions)
 }
 
 TSDLLEXPORT Point *
-ts_hyperspace_calculate_point(Hyperspace *hs, TupleTableSlot *slot)
+ts_hyperspace_calculate_point(const Hyperspace *hs, TupleTableSlot *slot)
 {
 	Point *p = point_create(hs->num_dimensions);
 	int i;
 
 	for (i = 0; i < hs->num_dimensions; i++)
 	{
-		Dimension *d = &hs->dimensions[i];
+		const Dimension *d = &hs->dimensions[i];
 		Datum datum;
 		bool isnull;
 		Oid dimtype;
@@ -1060,8 +1072,8 @@ dimension_add_not_null_on_column(Oid table_relid, char *colname)
 }
 
 void
-ts_dimension_update(Hypertable *ht, Name dimname, DimensionType dimtype, Datum *interval,
-					Oid *intervaltype, int16 *num_slices, Oid *integer_now_func)
+ts_dimension_update(const Hypertable *ht, const NameData *dimname, DimensionType dimtype,
+					Datum *interval, Oid *intervaltype, int16 *num_slices, Oid *integer_now_func)
 {
 	Dimension *dim;
 
@@ -1082,10 +1094,10 @@ ts_dimension_update(Hypertable *ht, Name dimname, DimensionType dimtype, Datum *
 							dimtype == DIMENSION_TYPE_OPEN ? "time" : "space"),
 					 errhint("An explicit dimension name must be specified.")));
 
-		dim = ts_hyperspace_get_dimension(ht->space, dimtype, 0);
+		dim = ts_hyperspace_get_mutable_dimension(ht->space, dimtype, 0);
 	}
 	else
-		dim = ts_hyperspace_get_dimension_by_name(ht->space, dimtype, NameStr(*dimname));
+		dim = ts_hyperspace_get_mutable_dimension_by_name(ht->space, dimtype, NameStr(*dimname));
 
 	if (NULL == dim)
 		ereport(ERROR,
@@ -1302,7 +1314,7 @@ dimension_info_validate_closed(DimensionInfo *info)
 void
 ts_dimension_info_validate(DimensionInfo *info)
 {
-	Dimension *dim;
+	const Dimension *dim;
 	HeapTuple tuple;
 	Datum datum;
 	bool isnull = false;
@@ -1608,13 +1620,12 @@ dimension_rename_schema_name(TupleInfo *ti, void *data)
 
 /* Go through internal dimensions table and rename all relevant schema */
 void
-ts_dimensions_rename_schema_name(char *old_name, char *new_name)
+ts_dimensions_rename_schema_name(const char *old_name, const char *new_name)
 {
 	NameData old_schema_name;
 	ScanKeyData scankey[1];
 	Catalog *catalog = ts_catalog_get();
-	char *names[2] = { old_name, new_name };
-
+	char *names[2] = { (char *) old_name, (char *) new_name };
 	ScannerCtx scanctx = {
 		.table = catalog_get_table_id(catalog, DIMENSION),
 		.index = InvalidOid,
@@ -1652,7 +1663,7 @@ ts_dimensions_rename_schema_name(char *old_name, char *new_name)
  * a partitioning key.
  */
 List *
-ts_dimension_get_partexprs(Dimension *dim, Index hyper_varno)
+ts_dimension_get_partexprs(const Dimension *dim, Index hyper_varno)
 {
 	Expr *expr = NULL;
 	HeapTuple tuple;

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -105,22 +105,26 @@ typedef struct DimensionInfo
 
 extern Hyperspace *ts_dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension,
 									 MemoryContext mctx);
-extern DimensionSlice *ts_dimension_calculate_default_slice(Dimension *dim, int64 value);
-extern TSDLLEXPORT Point *ts_hyperspace_calculate_point(Hyperspace *h, TupleTableSlot *slot);
-extern int ts_dimension_get_slice_ordinal(Dimension *dim, DimensionSlice *slice);
-extern Dimension *ts_hyperspace_get_dimension_by_id(Hyperspace *hs, int32 id);
-extern TSDLLEXPORT Dimension *ts_hyperspace_get_dimension(Hyperspace *hs, DimensionType type,
-														  Index n);
+extern DimensionSlice *ts_dimension_calculate_default_slice(const Dimension *dim, int64 value);
+extern TSDLLEXPORT Point *ts_hyperspace_calculate_point(const Hyperspace *h, TupleTableSlot *slot);
+extern int ts_dimension_get_slice_ordinal(const Dimension *dim, const DimensionSlice *slice);
+extern const Dimension *ts_hyperspace_get_dimension_by_id(const Hyperspace *hs, int32 id);
+extern TSDLLEXPORT const Dimension *ts_hyperspace_get_dimension(const Hyperspace *hs,
+																DimensionType type, Index n);
+extern TSDLLEXPORT Dimension *ts_hyperspace_get_mutable_dimension(Hyperspace *hs,
+																  DimensionType type, Index n);
+extern TSDLLEXPORT const Dimension *
+ts_hyperspace_get_dimension_by_name(const Hyperspace *hs, DimensionType type, const char *name);
 extern TSDLLEXPORT Dimension *
-ts_hyperspace_get_dimension_by_name(Hyperspace *hs, DimensionType type, const char *name);
-extern DimensionVec *ts_dimension_get_slices(Dimension *dim);
+ts_hyperspace_get_mutable_dimension_by_name(Hyperspace *hs, DimensionType type, const char *name);
+extern DimensionVec *ts_dimension_get_slices(const Dimension *dim);
 extern int32 ts_dimension_get_hypertable_id(int32 dimension_id);
 extern int ts_dimension_set_type(Dimension *dim, Oid newtype);
 extern TSDLLEXPORT Oid ts_dimension_get_partition_type(const Dimension *dim);
 extern int ts_dimension_set_name(Dimension *dim, const char *newname);
 extern int ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
 extern TSDLLEXPORT int ts_dimension_set_number_of_slices(Dimension *dim, int16 num_slices);
-extern Datum ts_dimension_transform_value(Dimension *dim, Oid collation, Datum value,
+extern Datum ts_dimension_transform_value(const Dimension *dim, Oid collation, Datum value,
 										  Oid const_datum_type, Oid *restype);
 extern int ts_dimension_delete_by_hypertable_id(int32 hypertable_id, bool delete_slices);
 
@@ -134,11 +138,12 @@ extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_closed(Oid table_reli
 
 extern void ts_dimension_info_validate(DimensionInfo *info);
 extern int32 ts_dimension_add_from_info(DimensionInfo *info);
-extern void ts_dimensions_rename_schema_name(char *oldname, char *newname);
-extern TSDLLEXPORT void ts_dimension_update(Hypertable *ht, Name dimname, DimensionType dimtype,
-											Datum *interval, Oid *intervaltype, int16 *num_slices,
+extern void ts_dimensions_rename_schema_name(const char *oldname, const char *newname);
+extern TSDLLEXPORT void ts_dimension_update(const Hypertable *ht, const NameData *dimname,
+											DimensionType dimtype, Datum *interval,
+											Oid *intervaltype, int16 *num_slices,
 											Oid *integer_now_func);
-extern TSDLLEXPORT List *ts_dimension_get_partexprs(Dimension *dim, Index hyper_varno);
+extern TSDLLEXPORT List *ts_dimension_get_partexprs(const Dimension *dim, Index hyper_varno);
 
 #define hyperspace_get_open_dimension(space, i)                                                    \
 	ts_hyperspace_get_dimension(space, DIMENSION_TYPE_OPEN, i)

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -43,16 +43,17 @@ typedef struct DimensionVec DimensionVec;
 typedef struct Hypercube Hypercube;
 
 extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit,
-												   ScanTupLock *tuplock);
+												   const ScanTupLock *tuplock);
 extern DimensionVec *
 ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy,
 									int64 start_value, StrategyNumber end_strategy, int64 end_value,
-									int limit, ScanTupLock *tuplock);
+									int limit, const ScanTupLock *tuplock);
 extern DimensionVec *ts_dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start,
 															 int64 range_end, int limit);
-extern bool ts_dimension_slice_scan_for_existing(DimensionSlice *slice, ScanTupLock *tuplock);
+extern bool ts_dimension_slice_scan_for_existing(const DimensionSlice *slice,
+												 const ScanTupLock *tuplock);
 extern DimensionSlice *ts_dimension_slice_scan_by_id_and_lock(int32 dimension_slice_id,
-															  ScanTupLock *tuplock,
+															  const ScanTupLock *tuplock,
 															  MemoryContext mctx);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension(int32 dimension_id, int limit);
 extern DimensionVec *ts_dimension_slice_scan_by_dimension_before_point(int32 dimension_id,
@@ -63,10 +64,12 @@ extern int ts_dimension_slice_delete_by_dimension_id(int32 dimension_id, bool de
 extern int ts_dimension_slice_delete_by_id(int32 dimension_slice_id, bool delete_constraints);
 extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_create(int dimension_id, int64 range_start,
 															 int64 range_end);
-extern DimensionSlice *ts_dimension_slice_copy(const DimensionSlice *original);
-extern TSDLLEXPORT bool ts_dimension_slices_collide(DimensionSlice *slice1, DimensionSlice *slice2);
-extern bool ts_dimension_slices_equal(DimensionSlice *slice1, DimensionSlice *slice2);
-extern bool ts_dimension_slice_cut(DimensionSlice *to_cut, DimensionSlice *other, int64 coord);
+extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_copy(const DimensionSlice *original);
+extern TSDLLEXPORT bool ts_dimension_slices_collide(const DimensionSlice *slice1,
+													const DimensionSlice *slice2);
+extern bool ts_dimension_slices_equal(const DimensionSlice *slice1, const DimensionSlice *slice2);
+extern bool ts_dimension_slice_cut(DimensionSlice *to_cut, const DimensionSlice *other,
+								   int64 coord);
 extern void ts_dimension_slice_free(DimensionSlice *slice);
 extern int ts_dimension_slice_insert_multi(DimensionSlice **slice, Size num_slices);
 extern int ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right);

--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -133,7 +133,7 @@ ts_dimension_vec_remove_slice(DimensionVec **vecptr, int32 index)
 
 #if defined(USE_ASSERT_CHECKING)
 static inline bool
-dimension_vec_is_sorted(DimensionVec *vec)
+dimension_vec_is_sorted(const DimensionVec *vec)
 {
 	int i;
 
@@ -149,7 +149,7 @@ dimension_vec_is_sorted(DimensionVec *vec)
 #endif
 
 DimensionSlice *
-ts_dimension_vec_find_slice(DimensionVec *vec, int64 coordinate)
+ts_dimension_vec_find_slice(const DimensionVec *vec, int64 coordinate)
 {
 	DimensionSlice **res;
 
@@ -171,7 +171,7 @@ ts_dimension_vec_find_slice(DimensionVec *vec, int64 coordinate)
 }
 
 int
-ts_dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id)
+ts_dimension_vec_find_slice_index(const DimensionVec *vec, int32 dimension_slice_id)
 {
 	int i;
 
@@ -182,8 +182,8 @@ ts_dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id)
 	return -1;
 }
 
-DimensionSlice *
-ts_dimension_vec_get(DimensionVec *vec, int32 index)
+const DimensionSlice *
+ts_dimension_vec_get(const DimensionVec *vec, int32 index)
 {
 	if (index >= vec->num_slices)
 		return NULL;

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -35,9 +35,9 @@ extern DimensionVec *ts_dimension_vec_add_slice(DimensionVec **vecptr, Dimension
 extern DimensionVec *ts_dimension_vec_add_unique_slice(DimensionVec **vecptr,
 													   DimensionSlice *slice);
 extern void ts_dimension_vec_remove_slice(DimensionVec **vecptr, int32 index);
-extern DimensionSlice *ts_dimension_vec_find_slice(DimensionVec *vec, int64 coordinate);
-extern int ts_dimension_vec_find_slice_index(DimensionVec *vec, int32 dimension_slice_id);
-extern DimensionSlice *ts_dimension_vec_get(DimensionVec *vec, int32 index);
+extern DimensionSlice *ts_dimension_vec_find_slice(const DimensionVec *vec, int64 coordinate);
+extern int ts_dimension_vec_find_slice_index(const DimensionVec *vec, int32 dimension_slice_id);
+extern const DimensionSlice *ts_dimension_vec_get(const DimensionVec *vec, int32 index);
 extern void ts_dimension_vec_free(DimensionVec *vec);
 
 #endif /* TIMESCALEDB_DIMENSION_VECTOR_H */

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -28,15 +28,21 @@ typedef struct Hypercube
 
 extern TSDLLEXPORT Hypercube *ts_hypercube_alloc(int16 num_dimensions);
 extern void ts_hypercube_free(Hypercube *hc);
-extern TSDLLEXPORT void ts_hypercube_add_slice(Hypercube *hc, DimensionSlice *slice);
-extern Hypercube *ts_hypercube_from_constraints(ChunkConstraints *constraints, MemoryContext mctx);
-extern int ts_hypercube_find_existing_slices(Hypercube *cube, ScanTupLock *tuplock);
-extern Hypercube *ts_hypercube_calculate_from_point(Hyperspace *hs, Point *p, ScanTupLock *tuplock);
-extern bool ts_hypercubes_collide(Hypercube *cube1, Hypercube *cube2);
-extern TSDLLEXPORT DimensionSlice *ts_hypercube_get_slice_by_dimension_id(const Hypercube *hc,
-																		  int32 dimension_id);
-extern Hypercube *ts_hypercube_copy(Hypercube *hc);
-extern bool ts_hypercube_equal(Hypercube *hc1, Hypercube *hc2);
+
+extern TSDLLEXPORT DimensionSlice *
+ts_hypercube_add_slice_from_range(Hypercube *hc, int32 dimension_id, int64 start, int64 end);
+extern TSDLLEXPORT DimensionSlice *ts_hypercube_add_slice(Hypercube *hc,
+														  const DimensionSlice *slice);
+extern Hypercube *ts_hypercube_from_constraints(const ChunkConstraints *constraints,
+												MemoryContext mctx);
+extern int ts_hypercube_find_existing_slices(const Hypercube *cube, const ScanTupLock *tuplock);
+extern Hypercube *ts_hypercube_calculate_from_point(const Hyperspace *hs, const Point *p,
+													const ScanTupLock *tuplock);
+extern bool ts_hypercubes_collide(const Hypercube *cube1, const Hypercube *cube2);
+extern TSDLLEXPORT const DimensionSlice *ts_hypercube_get_slice_by_dimension_id(const Hypercube *hc,
+																				int32 dimension_id);
+extern Hypercube *ts_hypercube_copy(const Hypercube *hc);
+extern bool ts_hypercube_equal(const Hypercube *hc1, const Hypercube *hc2);
 extern void ts_hypercube_slice_sort(Hypercube *hc);
 
 #endif /* TIMESCALEDB_HYPERCUBE_H */

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -131,41 +131,44 @@ extern int ts_hypertable_set_schema(Hypertable *ht, const char *newname);
 extern int ts_hypertable_set_num_dimensions(Hypertable *ht, int16 num_dimensions);
 extern int ts_hypertable_delete_by_name(const char *schema_name, const char *table_name);
 extern int ts_hypertable_delete_by_id(int32 hypertable_id);
-extern TSDLLEXPORT ObjectAddress ts_hypertable_create_trigger(Hypertable *ht, CreateTrigStmt *stmt,
+extern TSDLLEXPORT ObjectAddress ts_hypertable_create_trigger(const Hypertable *ht,
+															  CreateTrigStmt *stmt,
 															  const char *query);
 extern TSDLLEXPORT void ts_hypertable_drop_trigger(Oid relid, const char *trigger_name);
 extern TSDLLEXPORT void ts_hypertable_drop(Hypertable *hypertable, DropBehavior behavior);
 
-extern TSDLLEXPORT void ts_hypertable_check_partitioning(Hypertable *ht,
+extern TSDLLEXPORT void ts_hypertable_check_partitioning(const Hypertable *ht,
 														 int32 id_of_updated_dimension);
 extern int ts_hypertable_reset_associated_schema_name(const char *associated_schema);
 extern TSDLLEXPORT Oid ts_hypertable_id_to_relid(int32 hypertable_id);
 extern TSDLLEXPORT int32 ts_hypertable_relid_to_id(Oid relid);
-extern TSDLLEXPORT Chunk *ts_hypertable_find_chunk_if_exists(Hypertable *h, Point *point);
-extern TSDLLEXPORT Chunk *ts_hypertable_get_or_create_chunk(Hypertable *h, Point *point);
+extern TSDLLEXPORT Chunk *ts_hypertable_find_chunk_if_exists(const Hypertable *h,
+															 const Point *point);
+extern TSDLLEXPORT Chunk *ts_hypertable_get_or_create_chunk(const Hypertable *h,
+															const Point *point);
 extern Oid ts_hypertable_relid(RangeVar *rv);
 extern TSDLLEXPORT bool ts_is_hypertable(Oid relid);
-extern bool ts_hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid);
-extern Tablespace *ts_hypertable_select_tablespace(Hypertable *ht, Chunk *chunk);
-extern const char *ts_hypertable_select_tablespace_name(Hypertable *ht, Chunk *chunk);
+extern bool ts_hypertable_has_tablespace(const Hypertable *ht, Oid tspc_oid);
+extern Tablespace *ts_hypertable_select_tablespace(const Hypertable *ht, const Chunk *chunk);
+extern const char *ts_hypertable_select_tablespace_name(const Hypertable *ht, const Chunk *chunk);
 extern Tablespace *ts_hypertable_get_tablespace_at_offset_from(int32 hypertable_id,
 															   Oid tablespace_oid, int16 offset);
 extern bool ts_hypertable_has_chunks(Oid table_relid, LOCKMODE lockmode);
 extern void ts_hypertables_rename_schema_name(const char *old_name, const char *new_name);
-extern bool ts_is_partitioning_column(Hypertable *ht, Index column_attno);
+extern bool ts_is_partitioning_column(const Hypertable *ht, Index column_attno);
 extern TSDLLEXPORT bool ts_hypertable_set_compressed(Hypertable *ht,
 													 int32 compressed_hypertable_id);
 extern TSDLLEXPORT bool ts_hypertable_unset_compressed(Hypertable *ht);
-extern TSDLLEXPORT void ts_hypertable_clone_constraints_to_compressed(Hypertable *ht,
+extern TSDLLEXPORT void ts_hypertable_clone_constraints_to_compressed(const Hypertable *ht,
 																	  List *constraint_list);
 extern List *ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cube);
-extern TSDLLEXPORT List *ts_hypertable_get_data_node_name_list(Hypertable *ht);
-extern TSDLLEXPORT List *ts_hypertable_get_data_node_serverids_list(Hypertable *ht);
+extern TSDLLEXPORT List *ts_hypertable_get_data_node_name_list(const Hypertable *ht);
+extern TSDLLEXPORT List *ts_hypertable_get_data_node_serverids_list(const Hypertable *ht);
 extern TSDLLEXPORT List *ts_hypertable_get_available_data_nodes(const Hypertable *ht,
 																bool error_if_missing);
-extern TSDLLEXPORT List *ts_hypertable_get_available_data_node_server_oids(Hypertable *ht);
-extern TSDLLEXPORT HypertableType ts_hypertable_get_type(Hypertable *ht);
-extern TSDLLEXPORT void ts_hypertable_func_call_on_data_nodes(Hypertable *ht,
+extern TSDLLEXPORT List *ts_hypertable_get_available_data_node_server_oids(const Hypertable *ht);
+extern TSDLLEXPORT HypertableType ts_hypertable_get_type(const Hypertable *ht);
+extern TSDLLEXPORT void ts_hypertable_func_call_on_data_nodes(const Hypertable *ht,
 															  FunctionCallInfo fcinfo);
 extern TSDLLEXPORT int16 ts_validate_replication_factor(int32 replication_factor, bool is_null,
 														bool is_dist_call);

--- a/src/hypertable_data_node.c
+++ b/src/hypertable_data_node.c
@@ -111,7 +111,7 @@ static ScanTupleResult
 hypertable_data_node_tuple_update(TupleInfo *ti, void *data)
 {
 	CatalogSecurityContext sec_ctx;
-	HypertableDataNode *update = data;
+	const HypertableDataNode *update = data;
 	bool should_free;
 	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
 	HeapTuple new_tuple = heap_copytuple(tuple);
@@ -331,13 +331,13 @@ ts_hypertable_data_node_scan_by_node_name(const char *node_name, MemoryContext m
 }
 
 int
-ts_hypertable_data_node_update(HypertableDataNode *hypertable_data_node)
+ts_hypertable_data_node_update(const HypertableDataNode *hypertable_data_node)
 {
 	return hypertable_data_node_scan_by_hypertable_id_and_node_name(
 		hypertable_data_node->fd.hypertable_id,
 		NameStr(hypertable_data_node->fd.node_name),
 		hypertable_data_node_tuple_update,
-		hypertable_data_node,
+		(void *) hypertable_data_node,
 		RowExclusiveLock,
 		CurrentMemoryContext);
 }

--- a/src/hypertable_data_node.h
+++ b/src/hypertable_data_node.h
@@ -24,6 +24,7 @@ extern TSDLLEXPORT void ts_hypertable_data_node_insert_multi(List *hypertable_da
 extern TSDLLEXPORT int
 ts_hypertable_data_node_delete_by_node_name_and_hypertable_id(const char *node_name,
 															  int32 hypertable_id);
-extern TSDLLEXPORT int ts_hypertable_data_node_update(HypertableDataNode *hypertable_data_node);
+extern TSDLLEXPORT int
+ts_hypertable_data_node_update(const HypertableDataNode *hypertable_data_node);
 
 #endif /* TIMESCALEDB_HYPERTABLE_DATA_NODE_H */

--- a/src/indexing.h
+++ b/src/indexing.h
@@ -13,10 +13,10 @@
 #include "export.h"
 #include "dimension.h"
 
-extern void ts_indexing_verify_columns(Hyperspace *hs, List *indexelems);
-extern void ts_indexing_verify_index(Hyperspace *hs, IndexStmt *stmt);
-extern void ts_indexing_verify_indexes(Hypertable *ht);
-extern void ts_indexing_create_default_indexes(Hypertable *ht);
+extern void ts_indexing_verify_columns(const Hyperspace *hs, const List *indexelems);
+extern void ts_indexing_verify_index(const Hyperspace *hs, const IndexStmt *stmt);
+extern void ts_indexing_verify_indexes(const Hypertable *ht);
+extern void ts_indexing_create_default_indexes(const Hypertable *ht);
 extern ObjectAddress ts_indexing_root_table_create_index(IndexStmt *stmt, const char *queryString,
 														 bool is_multitransaction,
 														 bool is_distributed);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1618,7 +1618,7 @@ process_rename_column(ProcessUtilityArgs *args, Cache *hcache, Oid relid, Rename
 
 	add_hypertable_to_process_args(args, ht);
 
-	dim = ts_hyperspace_get_dimension_by_name(ht->space, DIMENSION_TYPE_ANY, stmt->subname);
+	dim = ts_hyperspace_get_mutable_dimension_by_name(ht->space, DIMENSION_TYPE_ANY, stmt->subname);
 
 	if (dim)
 		ts_dimension_set_name(dim, stmt->newname);
@@ -2705,7 +2705,8 @@ process_alter_column_type_end(Hypertable *ht, AlterTableCmd *cmd)
 {
 	ColumnDef *coldef = (ColumnDef *) cmd->def;
 	Oid new_type = TypenameGetTypid(typename_get_unqual_name(coldef->typeName));
-	Dimension *dim = ts_hyperspace_get_dimension_by_name(ht->space, DIMENSION_TYPE_ANY, cmd->name);
+	Dimension *dim =
+		ts_hyperspace_get_mutable_dimension_by_name(ht->space, DIMENSION_TYPE_ANY, cmd->name);
 
 	if (NULL == dim)
 		return;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -60,7 +60,7 @@ typedef enum ScanFilterResult
 } ScanFilterResult;
 
 typedef ScanTupleResult (*tuple_found_func)(TupleInfo *ti, void *data);
-typedef ScanFilterResult (*tuple_filter_func)(TupleInfo *ti, void *data);
+typedef ScanFilterResult (*tuple_filter_func)(const TupleInfo *ti, void *data);
 typedef void (*postscan_func)(int num_tuples, void *data);
 
 typedef struct ScannerCtx
@@ -75,7 +75,7 @@ typedef struct ScannerCtx
 	LOCKMODE lockmode;
 	MemoryContext result_mctx; /* The memory context to allocate the result
 								* on */
-	ScanTupLock *tuplock;
+	const ScanTupLock *tuplock;
 	ScanDirection scandirection;
 	Snapshot snapshot; /* Snapshot requested by the caller. Set automatically
 						* when NULL */
@@ -99,7 +99,7 @@ typedef struct ScannerCtx
 	 * tuples that should be passed on to tuple_found, or SCAN_EXCLUDE
 	 * otherwise.
 	 */
-	ScanFilterResult (*filter)(TupleInfo *ti, void *data);
+	ScanFilterResult (*filter)(const TupleInfo *ti, void *data);
 
 	/*
 	 * Handler for found tuples. Should return SCAN_CONTINUE to continue the

--- a/src/subspace_store.c
+++ b/src/subspace_store.c
@@ -58,7 +58,7 @@ subspace_store_internal_node_free(void *node)
 static size_t
 subspace_store_internal_node_descendants(SubspaceStoreInternalNode *node, int index)
 {
-	DimensionSlice *slice = ts_dimension_vec_get(node->vector, index);
+	const DimensionSlice *slice = ts_dimension_vec_get(node->vector, index);
 
 	if (slice == NULL)
 		return 0;
@@ -70,7 +70,7 @@ subspace_store_internal_node_descendants(SubspaceStoreInternalNode *node, int in
 }
 
 SubspaceStore *
-ts_subspace_store_init(Hyperspace *space, MemoryContext mcxt, int16 max_items)
+ts_subspace_store_init(const Hyperspace *space, MemoryContext mcxt, int16 max_items)
 {
 	MemoryContext old = MemoryContextSwitchTo(mcxt);
 	SubspaceStore *sst = palloc(sizeof(SubspaceStore));
@@ -195,7 +195,7 @@ ts_subspace_store_add(SubspaceStore *store, const Hypercube *hc, void *object,
 }
 
 void *
-ts_subspace_store_get(SubspaceStore *store, Point *target)
+ts_subspace_store_get(const SubspaceStore *store, const Point *target)
 {
 	int i;
 	DimensionVec *vec = store->origin->vector;
@@ -224,7 +224,7 @@ ts_subspace_store_free(SubspaceStore *store)
 }
 
 MemoryContext
-ts_subspace_store_mcxt(SubspaceStore *store)
+ts_subspace_store_mcxt(const SubspaceStore *store)
 {
 	return store->mcxt;
 }

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -19,7 +19,7 @@ typedef struct Hypercube Hypercube;
 typedef struct Point Point;
 typedef struct SubspaceStore SubspaceStore;
 
-extern SubspaceStore *ts_subspace_store_init(Hyperspace *space, MemoryContext mcxt,
+extern SubspaceStore *ts_subspace_store_init(const Hyperspace *space, MemoryContext mcxt,
 											 int16 max_items);
 
 /* Store an object associate with the subspace represented by a hypercube */
@@ -29,8 +29,8 @@ extern void ts_subspace_store_add(SubspaceStore *cache, const Hypercube *hc, voi
 /* Get the object stored for the subspace that a point is in.
  * Return the object stored or NULL if this subspace is not in the store.
  */
-extern void *ts_subspace_store_get(SubspaceStore *cache, Point *target);
+extern void *ts_subspace_store_get(const SubspaceStore *cache, const Point *target);
 extern void ts_subspace_store_free(SubspaceStore *cache);
-extern MemoryContext ts_subspace_store_mcxt(SubspaceStore *cache);
+extern MemoryContext ts_subspace_store_mcxt(const SubspaceStore *cache);
 
 #endif /* TIMESCALEDB_SUBSPACE_STORE_H */

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -39,7 +39,7 @@ tablespaces_alloc(int capacity)
 }
 
 Tablespace *
-ts_tablespaces_add(Tablespaces *tspcs, FormData_tablespace *form, Oid tspc_oid)
+ts_tablespaces_add(Tablespaces *tspcs, const FormData_tablespace *form, Oid tspc_oid)
 {
 	Tablespace *tspc;
 
@@ -57,7 +57,7 @@ ts_tablespaces_add(Tablespaces *tspcs, FormData_tablespace *form, Oid tspc_oid)
 }
 
 bool
-ts_tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid)
+ts_tablespaces_contain(const Tablespaces *tspcs, Oid tspc_oid)
 {
 	int i;
 
@@ -401,7 +401,7 @@ ts_tablespace_delete(int32 hypertable_id, const char *tspcname, Oid tspcoid)
 }
 
 static ScanFilterResult
-tablespace_tuple_owner_filter(TupleInfo *ti, void *data)
+tablespace_tuple_owner_filter(const TupleInfo *ti, void *data)
 {
 	TablespaceScanInfo *info = data;
 	bool isnull;

--- a/src/tablespace.h
+++ b/src/tablespace.h
@@ -24,9 +24,9 @@ typedef struct Tablespaces
 	Tablespace *tablespaces;
 } Tablespaces;
 
-extern Tablespace *ts_tablespaces_add(Tablespaces *tablespaces, FormData_tablespace *form,
+extern Tablespace *ts_tablespaces_add(Tablespaces *tablespaces, const FormData_tablespace *form,
 									  Oid tspc_oid);
-extern bool ts_tablespaces_contain(Tablespaces *tspcs, Oid tspc_oid);
+extern bool ts_tablespaces_contain(const Tablespaces *tspcs, Oid tspc_oid);
 extern Tablespaces *ts_tablespace_scan(int32 hypertable_id);
 extern TSDLLEXPORT void ts_tablespace_attach_internal(Name tspcname, Oid hypertable_oid,
 													  bool if_not_attached);

--- a/src/trigger.h
+++ b/src/trigger.h
@@ -15,9 +15,9 @@
 	((trigger) != NULL && TRIGGER_FOR_ROW((trigger)->tgtype) && !(trigger)->tgisinternal &&        \
 	 strcmp((trigger)->tgname, INSERT_BLOCKER_NAME) != 0)
 
-extern void ts_trigger_create_on_chunk(Oid trigger_oid, char *chunk_schema_name,
-									   char *chunk_table_name);
-extern TSDLLEXPORT void ts_trigger_create_all_on_chunk(Chunk *chunk);
+extern void ts_trigger_create_on_chunk(Oid trigger_oid, const char *chunk_schema_name,
+									   const char *chunk_table_name);
+extern TSDLLEXPORT void ts_trigger_create_all_on_chunk(const Chunk *chunk);
 extern bool ts_relation_has_transition_table_trigger(Oid relid);
 
 #endif /* TIMESCALEDB_TRIGGER_H */

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -159,7 +159,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 	Interval *default_schedule_interval = DEFAULT_SCHEDULE_INTERVAL;
 	Hypertable *hypertable;
 	Cache *hcache;
-	Dimension *dim;
+	const Dimension *dim;
 	Oid owner_id;
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -83,8 +83,8 @@ enable_fast_restart(int32 job_id, const char *job_name)
 static int
 get_chunk_id_to_reorder(int32 job_id, Hypertable *ht)
 {
-	Dimension *time_dimension = hyperspace_get_open_dimension(ht->space, 0);
-	DimensionSlice *nth_dimension =
+	const Dimension *time_dimension = hyperspace_get_open_dimension(ht->space, 0);
+	const DimensionSlice *nth_dimension =
 		ts_dimension_slice_nth_latest_slice(time_dimension->fd.id,
 											REORDER_SKIP_RECENT_DIM_SLICES_N);
 
@@ -262,11 +262,11 @@ policy_reorder_read_and_validate_config(Jsonb *config, PolicyReorderData *policy
 	}
 }
 
-static Dimension *
-get_open_dimension_for_hypertable(Hypertable *ht)
+static const Dimension *
+get_open_dimension_for_hypertable(const Hypertable *ht)
 {
 	int32 mat_id = ht->fd.id;
-	Dimension *open_dim = hyperspace_get_open_dimension(ht->space, 0);
+	const Dimension *open_dim = hyperspace_get_open_dimension(ht->space, 0);
 	Oid partitioning_type = ts_dimension_get_partition_type(open_dim);
 	if (IS_INTEGER_TYPE(partitioning_type))
 	{
@@ -306,7 +306,7 @@ policy_retention_read_and_validate_config(Jsonb *config, PolicyRetentionData *po
 	Oid object_relid;
 	Hypertable *hypertable;
 	Cache *hcache;
-	Dimension *open_dim;
+	const Dimension *open_dim;
 	Datum boundary;
 	Datum boundary_type;
 	ContinuousAgg *cagg;
@@ -360,7 +360,7 @@ policy_refresh_cagg_read_and_validate_config(Jsonb *config, PolicyContinuousAggD
 {
 	int32 materialization_id;
 	Hypertable *mat_ht;
-	Dimension *open_dim;
+	const Dimension *open_dim;
 	Oid dim_type;
 	int64 refresh_start, refresh_end;
 
@@ -514,7 +514,7 @@ bool
 policy_compression_execute(int32 job_id, Jsonb *config)
 {
 	int32 chunkid;
-	Dimension *dim;
+	const Dimension *dim;
 	PolicyCompressionData policy_data;
 
 	policy_compression_read_and_validate_config(config, &policy_data);
@@ -593,7 +593,7 @@ bool
 policy_recompression_execute(int32 job_id, Jsonb *config)
 {
 	int32 chunkid;
-	Dimension *dim;
+	const Dimension *dim;
 	PolicyCompressionData policy_data;
 
 	policy_recompression_read_and_validate_config(config, &policy_data);

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -124,7 +124,7 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 	NameData application_name;
 	NameData proc_name, proc_schema, owner;
 	int32 job_id;
-	Dimension *dim;
+	const Dimension *dim;
 	Interval schedule_interval = DEFAULT_SCHEDULE_INTERVAL;
 	Oid ht_oid = PG_GETARG_OID(0);
 	Name index_name = PG_GETARG_NAME(1);

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -146,7 +146,7 @@ policy_retention_add(PG_FUNCTION_ARGS)
 
 	Oid owner_id = ts_hypertable_permissions_check(ht_oid, GetUserId());
 	Oid partitioning_type;
-	Dimension *dim;
+	const Dimension *dim;
 	/* Default scheduled interval for drop_chunks jobs is currently 1 day (24 hours) */
 	Interval default_schedule_interval = { .day = 1 };
 	/* Default max runtime should not be very long. Right now set to 5 minutes */

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -8,9 +8,11 @@
 
 #include <postgres.h>
 
+#include <chunk.h>
+
 extern Datum chunk_show(PG_FUNCTION_ARGS);
 extern Datum chunk_create(PG_FUNCTION_ARGS);
-extern void chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht);
+extern void chunk_api_create_on_data_nodes(const Chunk *chunk, const Hypertable *ht);
 extern Datum chunk_api_get_chunk_relstats(PG_FUNCTION_ARGS);
 extern Datum chunk_api_get_chunk_colstats(PG_FUNCTION_ARGS);
 extern void chunk_api_update_distributed_hypertable_stats(Oid relid);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -652,8 +652,8 @@ static List *
 add_time_to_order_by_if_not_included(List *orderby_cols, List *segmentby_cols, Hypertable *ht)
 {
 	ListCell *lc;
-	Dimension *time_dim;
-	char *time_col_name;
+	const Dimension *time_dim;
+	const char *time_col_name;
 	bool found = false;
 
 	time_dim = hyperspace_get_open_dimension(ht->space, 0);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -762,7 +762,7 @@ cagg_validate_query(Query *query)
 	}
 	if (rte->relkind == RELKIND_RELATION)
 	{
-		Dimension *part_dimension = NULL;
+		const Dimension *part_dimension = NULL;
 
 		ht = ts_hypertable_cache_get_cache_and_entry(rte->relid, CACHE_FLAG_NONE, &hcache);
 

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -33,19 +33,23 @@ static Datum internal_to_time_value_or_infinite(int64 internal, Oid time_type,
  ***************************/
 
 static void spi_update_materializations(SchemaAndName partial_view,
-										SchemaAndName materialization_table, Name time_column_name,
+										SchemaAndName materialization_table,
+										const NameData *time_column_name,
 										TimeRange invalidation_range, const int32 chunk_id);
-static void spi_delete_materializations(SchemaAndName materialization_table, Name time_column_name,
+static void spi_delete_materializations(SchemaAndName materialization_table,
+										const NameData *time_column_name,
 										TimeRange invalidation_range,
 										const char *const chunk_condition);
 static void spi_insert_materializations(SchemaAndName partial_view,
-										SchemaAndName materialization_table, Name time_column_name,
+										SchemaAndName materialization_table,
+										const NameData *time_column_name,
 										TimeRange materialization_range,
 										const char *const chunk_condition);
 
 void
 continuous_agg_update_materialization(SchemaAndName partial_view,
-									  SchemaAndName materialization_table, Name time_column_name,
+									  SchemaAndName materialization_table,
+									  const NameData *time_column_name,
 									  InternalTimeRange new_materialization_range,
 									  InternalTimeRange invalidation_range, int32 chunk_id)
 {
@@ -205,7 +209,7 @@ internal_time_range_to_time_range(InternalTimeRange internal)
 
 static void
 spi_update_materializations(SchemaAndName partial_view, SchemaAndName materialization_table,
-							Name time_column_name, TimeRange invalidation_range,
+							const NameData *time_column_name, TimeRange invalidation_range,
 							const int32 chunk_id)
 {
 	StringInfo chunk_condition = makeStringInfo();
@@ -230,7 +234,7 @@ spi_update_materializations(SchemaAndName partial_view, SchemaAndName materializ
 }
 
 static void
-spi_delete_materializations(SchemaAndName materialization_table, Name time_column_name,
+spi_delete_materializations(SchemaAndName materialization_table, const NameData *time_column_name,
 							TimeRange invalidation_range, const char *const chunk_condition)
 {
 	int res;
@@ -268,7 +272,7 @@ spi_delete_materializations(SchemaAndName materialization_table, Name time_colum
 
 static void
 spi_insert_materializations(SchemaAndName partial_view, SchemaAndName materialization_table,
-							Name time_column_name, TimeRange materialization_range,
+							const NameData *time_column_name, TimeRange materialization_range,
 							const char *const chunk_condition)
 {
 	int res;

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -38,7 +38,7 @@ typedef struct InternalTimeRange
 InternalTimeRange continuous_agg_materialize_window_max(Oid timetype);
 void continuous_agg_update_materialization(SchemaAndName partial_view,
 										   SchemaAndName materialization_table,
-										   Name time_column_name,
+										   const NameData *time_column_name,
 										   InternalTimeRange new_materialization_range,
 										   InternalTimeRange invalidation_range, int32 chunk_id);
 

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -253,7 +253,7 @@ continuous_agg_refresh_execute(const CaggRefreshState *refresh,
 		.start = 0,
 		.end = 0,
 	};
-	Dimension *time_dim = hyperspace_get_open_dimension(refresh->cagg_ht->space, 0);
+	const Dimension *time_dim = hyperspace_get_open_dimension(refresh->cagg_ht->space, 0);
 
 	Assert(time_dim != NULL);
 

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -885,8 +885,7 @@ data_node_attach(PG_FUNCTION_ARGS)
 
 	/* Get the first closed (space) dimension, which is the one along which we
 	 * partition across data nodes. */
-	dim = hyperspace_get_closed_dimension(ht->space, 0);
-
+	dim = ts_hyperspace_get_mutable_dimension(ht->space, DIMENSION_TYPE_CLOSED, 0);
 	num_nodes = list_length(ht->data_nodes) + 1;
 
 	if (num_nodes > MAX_NUM_HYPERTABLE_DATA_NODES)
@@ -1088,7 +1087,8 @@ data_node_modify_hypertable_data_nodes(const char *node_name, List *hypertable_d
 
 			if (repartition)
 			{
-				Dimension *dim = hyperspace_get_closed_dimension(ht->space, 0);
+				Dimension *dim =
+					ts_hyperspace_get_mutable_dimension(ht->space, DIMENSION_TYPE_CLOSED, 0);
 				int num_nodes = list_length(ht->data_nodes) - 1;
 
 				if (dim != NULL && num_nodes < dim->fd.num_slices && num_nodes > 0)

--- a/tsl/src/fdw/data_node_chunk_assignment.c
+++ b/tsl/src/fdw/data_node_chunk_assignment.c
@@ -57,7 +57,7 @@ get_or_create_sca(DataNodeChunkAssignments *scas, Oid serverid, RelOptInfo *rel)
 	return sca;
 }
 
-static DimensionSlice *
+static const DimensionSlice *
 get_slice_for_dimension(Oid chunk_relid, int32 dimension_id)
 {
 	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
@@ -170,13 +170,13 @@ data_node_chunk_assignment_get_or_create(DataNodeChunkAssignments *scas, RelOptI
  * approach would be to use, e.g., an interval tree.
  */
 static bool
-dimension_slice_overlaps_with_others(DimensionSlice *slice, List *other_slices)
+dimension_slice_overlaps_with_others(const DimensionSlice *slice, const List *other_slices)
 {
 	ListCell *lc;
 
 	foreach (lc, other_slices)
 	{
-		DimensionSlice *other_slice = lfirst(lc);
+		const DimensionSlice *other_slice = lfirst(lc);
 
 		if (ts_dimension_slices_collide(slice, other_slice))
 			return true;
@@ -255,7 +255,7 @@ data_node_chunk_assignments_are_overlapping(DataNodeChunkAssignments *scas,
 		foreach (lc, sca->chunk_oids)
 		{
 			Oid chunk_oid = lfirst_oid(lc);
-			DimensionSlice *slice;
+			const DimensionSlice *slice;
 			DataNodeSlice *ss;
 			bool found;
 
@@ -270,7 +270,7 @@ data_node_chunk_assignments_are_overlapping(DataNodeChunkAssignments *scas,
 			{
 				ss->sliceid = slice->fd.id;
 				ss->node_serverid = sca->node_server_oid;
-				data_node_slices = lappend(data_node_slices, slice);
+				data_node_slices = lappend(data_node_slices, ts_dimension_slice_copy(slice));
 			}
 
 			/* First detect "same-slice overlap", and then do a more expensive

--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -345,7 +345,7 @@ static void
 push_down_group_bys(PlannerInfo *root, RelOptInfo *hyper_rel, Hyperspace *hs,
 					DataNodeChunkAssignments *scas)
 {
-	Dimension *dim;
+	const Dimension *dim;
 	bool overlaps;
 
 	Assert(hs->num_dimensions >= 1);

--- a/tsl/src/fdw/relinfo.c
+++ b/tsl/src/fdw/relinfo.c
@@ -126,8 +126,8 @@ get_relation_qualified_name(Oid relid)
 static const double FILL_FACTOR_CURRENT_CHUNK = 0.5;
 static const double FILL_FACTOR_HISTORICAL_CHUNK = 1;
 
-static DimensionSlice *
-get_chunk_time_slice(Chunk *chunk, Hyperspace *space)
+static const DimensionSlice *
+get_chunk_time_slice(const Chunk *chunk, const Hyperspace *space)
 {
 	int32 time_dim_id = hyperspace_get_open_dimension(space, 0)->fd.id;
 	return ts_hypercube_get_slice_by_dimension_id(chunk->cube, time_dim_id);
@@ -178,8 +178,8 @@ get_total_number_of_slices(Hyperspace *space)
 static double
 estimate_chunk_fillfactor(Chunk *chunk, Hyperspace *space)
 {
-	Dimension *time_dim = hyperspace_get_open_dimension(space, 0);
-	DimensionSlice *time_slice = get_chunk_time_slice(chunk, space);
+	const Dimension *time_dim = hyperspace_get_open_dimension(space, 0);
+	const DimensionSlice *time_slice = get_chunk_time_slice(chunk, space);
 	Oid time_dim_type = ts_dimension_get_partition_type(time_dim);
 	int num_created_after = ts_chunk_num_of_chunks_created_after(chunk);
 	int total_slices = get_total_number_of_slices(space);
@@ -248,7 +248,7 @@ estimate_tuples_and_pages_using_prev_chunks(PlannerInfo *root, Hyperspace *space
 	int32 total_pages = 0;
 	int non_zero_reltuples_cnt = 0;
 	int non_zero_relpages_cnt = 0;
-	DimensionSlice *time_slice = get_chunk_time_slice(current_chunk, space);
+	const DimensionSlice *time_slice = get_chunk_time_slice(current_chunk, space);
 	List *prev_chunks = ts_chunk_get_window(time_slice->fd.dimension_id,
 											time_slice->fd.range_start,
 											DEFAULT_CHUNK_LOOKBACK_WINDOW,


### PR DESCRIPTION
Harden core APIs by adding the `const` qualifier to pointer parameters
and return values passed by reference. Adding `const` to APIs has
several benefits and potentially reduces bugs.

* Allows core APIs to be called using `const` objects.
* Callers know that objects passed by reference are not modified as a
  side-effect of a function call.
* Returning `const` pointers enforces "read-only" usage of pointers to
  internal objects, forcing users to copy objects when mutating them
  or using explicit APIs for mutations.
* Allows compiler to apply optimizations and helps static analysis.

Note that these changes are so far only applied to core API
functions. Further work can be done to improve other parts of the
code.