### PR TITLE
Make "pg_dump" a SOLO test

### DIFF
--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SOLO_TESTS
   index-13
   loader
   net
+  pg_dump
   pg_dump_unprivileged
   tablespace
   telemetry


### PR DESCRIPTION
The "pg_dump" test exhibits flaky behavior in CI runs. Intermittently
it fails with "ERROR: source database "db_pg_dump" is being accessed by
other users". The command that fails is a "CREATE DATABASE" one which
is trying to use this "db_pg_dump" database as a template.

If this test is run in a parallel group where the other tests end up
accessing this db, then we will run into this issue. To solve this, the
"pg_dump" test will now be run as a SOLO test.