### PR TITLE
Fix accidental misused acronym for Data Manipulation Language

### DIFF
--- a/tsl/LICENSE-TIMESCALE
+++ b/tsl/LICENSE-TIMESCALE
@@ -162,7 +162,7 @@ Agreement ("You").
    analytical function, procedural, and other types of application programming
    interfaces or commands, that allow the use, manipulation, and control of
    data present in a Timescale Database, including Data Manipulation Language
-   (DDL) commands such as SELECT, INSERT, UPDATE, and DELETE, Data Control
+   (DML) commands such as SELECT, INSERT, UPDATE, and DELETE, Data Control
    Language (DCL) commands such as GRANT and REVOKE, and Transaction Control
    Language (TCL) commands such as COMMIT, ROLLBACK, SAVEPOINT, and SET
    TRANSACTION.


### PR DESCRIPTION
In the definition of "Timescale Data Manipulation Interfaces", the description of
Data Manipulation Language was accidentally and erroneously given the acronym
"DDL" as a parenthetical, when it should have been (and was meant to be) given
the proper acronym of "DML". No intent is changed with this correction.