### PR TITLE
Use chunk status for is_compressed field in view

### DIFF
--- a/sql/views.sql
+++ b/sql/views.sql
@@ -206,12 +206,10 @@ FROM (
     ELSE
       dimsl.range_end
     END AS integer_range_end,
-    CASE WHEN node_list IS NULL THEN 
-      CASE WHEN srcch.compressed_chunk_id IS NOT NULL THEN
-         TRUE
-      ELSE FALSE
-      END
-    ELSE NULL   --distributed chunk case
+    CASE WHEN (srcch.status & 1 = 1) THEN --distributed compress_chunk() has definitely been called
+                                          --remote chunk compression status still uncertain
+        TRUE
+    ELSE FALSE --remote chunk compression status uncertain
     END AS is_compressed,
     pgtab.spcname AS chunk_table_space,
     chdn.node_list

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -379,7 +379,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | 
+is_compressed          | f
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_1,db_dist_compression_2}
 -[ RECORD 2 ]----------+----------------------------------------------
@@ -393,7 +393,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | 
+is_compressed          | f
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_2,db_dist_compression_3}
 -[ RECORD 3 ]----------+----------------------------------------------
@@ -407,7 +407,7 @@ range_start            | Wed Feb 28 16:00:00 2018 PST
 range_end              | Wed Mar 07 16:00:00 2018 PST
 range_start_integer    | 
 range_end_integer      | 
-is_compressed          | 
+is_compressed          | f
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_1,db_dist_compression_3}
 

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -77,9 +77,9 @@ SELECT * from timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
  hypertable_schema | hypertable_name |     chunk_schema      |      chunk_name       | primary_dimension |  primary_dimension_type  |         range_start          |          range_end           | range_start_integer | range_end_integer | is_compressed | chunk_tablespace |        data_nodes         
 -------------------+-----------------+-----------------------+-----------------------+-------------------+--------------------------+------------------------------+------------------------------+---------------------+-------------------+---------------+------------------+---------------------------
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_1_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   |               |                  | {view_node_1,view_node_2}
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_2_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   |               |                  | {view_node_2,view_node_3}
- public            | dist_table      | _timescaledb_internal | _dist_hyper_1_3_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   |               |                  | {view_node_1,view_node_3}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_1_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | t             |                  | {view_node_1,view_node_2}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_2_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_2,view_node_3}
+ public            | dist_table      | _timescaledb_internal | _dist_hyper_1_3_chunk | time              | timestamp with time zone | Wed Feb 28 16:00:00 2018 PST | Wed Mar 07 16:00:00 2018 PST |                     |                   | f             |                  | {view_node_1,view_node_3}
 (3 rows)
 
 SELECT * from timescaledb_information.dimensions 


### PR DESCRIPTION
The timescaledb_information.chunks view used to return NULL in the is_compressed field for distributed chunks. This changes the view to always return true or false, depending on the chunk status flags in the Access Node. This is a hint and cannot be used as a source of truth for the compression state of the actual chunks in the Data Nodes.

The documentation used to say:
```
is_compressed | BOOLEAN |
Is the data in the chunk compressed?
NULL for distributed chunks.
Use chunk_compression_stats() function to get compression status for distributed chunks.
```

The new semantics are going to be:
```
is_compressed | BOOLEAN |
Is the data in the chunk compressed?
Hint for distributed chunks, it cannot be relied upon as a source of truth.
Use chunk_compression_stats() function to get reliable status for distributed chunks.
```

In more detail some cases are,

TRUE:
- This means that remote `compress_chunk()` has definitely been called. However, the Data Node chunks may have been manually decompressed in the data nodes.

FALSE:
- Remote `decompress_chunk()` may have been called. In this case the Data Node chunks may have been manually compressed in the data nodes though.
- In a power failure scenario `decompress_chunk()` may have been called but hasn't succeeded in decompressing the Data Node chunks.
- Remote `compress_chunk()` may have been called in a previous version of timescaledb. In this case it is impossible to return TRUE.