### PR TITLE
Add tap tests infrastructure support

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -37,7 +37,7 @@ jobs:
         apt-get update
         apt-get install -y gnupg postgresql-common
         yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-        apt-get install -y gcc make cmake libssl-dev libkrb5-dev sudo gdb git wget
+        apt-get install -y gcc make cmake libssl-dev libkrb5-dev libipc-run-perl libtest-most-perl sudo gdb git wget
         apt-get install -y postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
 
     - name: Build pg_isolation_regress

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -34,11 +34,17 @@ jobs:
       CXX: ${{ matrix.cxx }}
 
     steps:
-    - name: Install Dependencies
+    - name: Install Linux Dependencies
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install flex bison lcov systemd-coredump gdb ${{ matrix.extra_packages }}
+        sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl libtest-most-perl ${{ matrix.extra_packages }}
+
+    - name: Install macOS Dependencies using perl 5.18
+      if: runner.os == 'macOS'
+      run: |
+        sudo perl5.18 -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
+        sudo perl5.18 -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 
     # on macOS the path used is depending on the runner version leading to cache failure
     # when the runner version changes so we extract runner version from path and add it

--- a/scripts/check_file_license.sh
+++ b/scripts/check_file_license.sh
@@ -49,6 +49,11 @@ check_file() {
             LICENSE_STRING=`get_sql_license ${LICENSE_FILE}`
             FIRST_COMMENT=`get_sql_license ${FILE}`
             ;;
+        ('-p')
+            LICENSE_FILE="${SCRIPTPATH}/license_tsl.spec"
+            LICENSE_STRING=`get_sql_license ${LICENSE_FILE}`
+            FIRST_COMMENT=`get_sql_license ${FILE}`
+            ;;
         ("--")
             return 0;
             ;;
@@ -67,7 +72,7 @@ check_file() {
     fi
 }
 
-args=`getopt "c:e:i:j:s:t:" $*`; errcode=$?; set -- $args
+args=`getopt "c:e:i:j:p:s:t:" $*`; errcode=$?; set -- $args
 
 if [[ ${errcode} != 0 ]]; then
         echo 'Usage: check_file_license ((-c|-e|-i|-j|-s|-t) <filename> ...)'

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -19,6 +19,9 @@ check_file() {
     elif [[ ${1} == '-i' || ${1} == '-j' ]]; then
         SUFFIX0='*.spec'
         SUFFIX1='*.spec.in'
+    elif [[ ${1} == '-p' ]]; then
+        SUFFIX0='*.pl'
+        SUFFIX1='*.pm'
     else
         SUFFIX0='*.sql'
         SUFFIX1='*.sql.in'
@@ -27,7 +30,7 @@ check_file() {
     find $2 -type f \( -name "${SUFFIX0}" -or -name "${SUFFIX1}" \) -and -not -path "${SRC_DIR}/sql/updates/*.sql" -and -not -path "${SRC_DIR}/test/sql/dump/*.sql" -and -not -path "${SRC_DIR}/src/chunk_adaptive.*" -print0 | xargs -0 -n1 $(dirname ${0})/check_file_license.sh ${1}
 }
 
-args=`getopt "c:e:i:j:s:t:" $*`; errcode=$?; set -- $args
+args=`getopt "c:e:i:j:p:s:t:" $*`; errcode=$?; set -- $args
 
 ERRORCODE=0
 

--- a/scripts/check_license_all.sh
+++ b/scripts/check_license_all.sh
@@ -4,7 +4,7 @@ BASE_DIR=$(dirname ${SCRIPT_DIR})
 
 SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -c ${BASE_DIR}/src -s ${BASE_DIR}/sql -c ${BASE_DIR}/test -s ${BASE_DIR}/test -i ${BASE_DIR}/test
 exit_apache=$?
-SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -e ${BASE_DIR}/tsl/src -t ${BASE_DIR}/tsl/test -e ${BASE_DIR}/tsl/test -j ${BASE_DIR}/tsl/test
+SRC_DIR=$BASE_DIR ${SCRIPT_DIR}/check_license.sh -e ${BASE_DIR}/tsl/src -t ${BASE_DIR}/tsl/test -e ${BASE_DIR}/tsl/test -j ${BASE_DIR}/tsl/test -p ${BASE_DIR}/tsl/test -p ${BASE_DIR}/test/perl
 exit_tsl=$?
 
 if [ ${exit_apache} -ne 0 ] || [ ${exit_tsl} -ne 0 ]; then

--- a/scripts/perltidyrc
+++ b/scripts/perltidyrc
@@ -1,0 +1,16 @@
+--add-whitespace
+--backup-and-modify-in-place
+--backup-file-extension=/
+--delete-old-whitespace
+--entab-leading-whitespace=4
+--keep-old-blank-lines=2
+--maximum-line-length=78
+--nooutdent-long-comments
+--nooutdent-long-quotes
+--nospace-for-semicolon
+--opening-brace-on-new-line
+--output-line-ending=unix
+--paren-tightness=2
+--paren-vertical-tightness=2
+--paren-vertical-tightness-closing=2
+--noblanks-before-comments

--- a/test/perl/README.md
+++ b/test/perl/README.md
@@ -1,0 +1,97 @@
+# Perl-based TAP tests
+
+`test/perl/` contains shared infrastructure that's used by Perl-based tests
+across the source tree
+
+The tests are invoked via perl's `prove` command. By default every
+test in the t/ subdirectory is run. Individual test(s) can be run
+instead by passing something like `PROVE_TESTS="t/001_testname.pl
+t/002_othertestname.pl"` to make.
+
+You should prefer to write tests using `pg_regress`, or
+isolation tester specs, if possible.
+
+Note that all tests and test tools should have perltidy run on them
+using perltidy, for example:
+
+```
+perltidy --profile=$TS_SRC_DIR/scripts/perltidyrc /path/to/taptest
+```
+
+## Writing tests
+
+Tests are written using Perl's `Test::More` with some PostgreSQL-specific
+infrastructure from `src/test/perl` providing node management, support for
+invoking `psql` to run queries and get results, etc. You should read the
+documentation for `Test::More` before trying to write tests.
+
+The PG specific infrastructure has been extended via the `TimescaleNode`
+class in this directory to add timescale specific configuration parameters
+and some often used helper functions.
+
+Test scripts in the t/ subdirectory of a suite are executed in alphabetical
+order.
+
+Each test script should begin with:
+
+```
+    use strict;
+    use warnings;
+    use TimescaleNode;
+    use TestLib;
+    # Replace with the number of tests to execute:
+    use Test::More tests => 1;
+```
+
+then it will generally need to set up one or more nodes, run commands
+against them and evaluate the results. For example:
+
+```
+    my $node = get_new_ts_node('access_node');
+    $node->init;
+    $node->start;
+
+    my $ret = $node->safe_psql('postgres', 'SELECT 1');
+    is($ret, '1', 'SELECT 1 returns 1');
+
+    $node->stop('fast');
+```
+
+`Test::More::like` entails use of the qr// operator.  Avoid Perl 5.8.8 bug
+#39185 by not using the "$" regular expression metacharacter in qr// when also
+using the "/m" modifier.  Instead of "$", use "\n" or "(?=\n|\z)".
+
+Read the `Test::More` documentation for more on how to write tests:
+
+```
+    perldoc Test::More
+```
+
+For available PostgreSQL-specific test methods and some example tests read the
+perldoc for the test modules, e.g.:
+
+```
+    cd $COMMUNITY_PG_SRCS
+    perldoc src/test/perl/PostgresNode.pm
+```
+
+## Required Perl
+
+Tests must run on perl `5.8.0` and newer. `perlbrew` is a good way to obtain such
+a Perl; see http://perlbrew.pl .
+
+Just install and
+
+```
+    perlbrew --force install 5.8.0
+    perlbrew use 5.8.0
+    perlbrew install-cpanm
+    cpanm install IPC::Run
+```
+
+then re-run configure to ensure the correct Perl is used when running
+tests. To verify that the right Perl was found:
+
+```
+    grep ^PERL= config.log
+```

--- a/test/perl/TimescaleNode.pm
+++ b/test/perl/TimescaleNode.pm
@@ -1,0 +1,65 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# This class extends PostgresNode with Timescale-specific
+# routines for setup.
+
+package TimescaleNode;
+use parent ("PostgresNode");
+use TestLib qw(slurp_file);
+use strict;
+use warnings;
+
+use Carp 'verbose';
+$SIG{__DIE__} = \&Carp::confess;
+
+use Exporter 'import';
+use vars qw(@EXPORT @EXPORT_OK);
+@EXPORT = qw(
+  get_new_ts_node
+);
+@EXPORT_OK = qw(
+);
+
+#
+# Get a new TS-enabled PostgreSQL instance
+#
+# It's not created yet, but ready to restore from backup,
+# initdb, etc.
+#
+sub get_new_ts_node
+{
+	my ($name, $class) = @_;
+
+    $class //= 'TimescaleNode';
+
+	my $self = PostgresNode::get_new_node($name);
+	$self = bless $self, $class;
+
+	return $self;
+}
+
+# initialize the data directory and add TS specific parameters
+sub init
+{
+	my ($self, %kwargs) = @_;
+
+	$self->SUPER::init(%kwargs);
+	# append into postgresql.conf from Timescale
+	# template config file
+	$self->append_conf('postgresql.conf', TestLib::slurp_file("$ENV{'BUILDIR'}/tsl/test/postgresql.conf"));
+}
+
+# helper function to check output from PSQL for a query
+sub psql_is
+{
+	my ($self, $db, $query, $expected_stdout, $testname) = @_;
+	my ($psql_rc, $psql_out, $psql_err) = $self->SUPER::psql($db, $query);
+	PostgresNode::ok(!$psql_rc, "$testname: err_code check");
+	PostgresNode::is($psql_err, '', "$testname: error_msg check");
+	PostgresNode::is($psql_out, $expected_stdout,
+		"$testname: psql output check");
+}
+
+1;

--- a/tsl/test/CMakeLists.txt
+++ b/tsl/test/CMakeLists.txt
@@ -5,6 +5,9 @@ add_subdirectory(ssl)
 set(_local_install_checks)
 set(_install_checks)
 
+find_program(PROVE prove
+  "/usr/bin")
+
 if(PG_REGRESS)
   add_custom_target(regresscheck-t
     COMMAND ${CMAKE_COMMAND} -E env
@@ -59,7 +62,21 @@ if(PG_REGRESS)
     ${PG_REGRESS_OPTS_LOCAL_INSTANCE}
     USES_TERMINAL)
 
+  add_custom_target(provecheck
+    COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/tmp_check
+    COMMAND BUILDIR=${CMAKE_BINARY_DIR}
+    TESTDIR=${CMAKE_CURRENT_BINARY_DIR}
+    PATH="${PG_BINDIR}:$ENV{PATH}"
+    PGPORT=6${TEST_PGPORT_LOCAL}
+    PG_REGRESS=${PG_REGRESS}
+    ${PROVE} -I "${PG_SOURCE_DIR}/src/test/perl"
+    -I "${CMAKE_SOURCE_DIR}/test/perl"
+    -I "$ENV{HOME}/perl5/lib/perl5"
+    t/*.pl
+    USES_TERMINAL)
+
   list(APPEND _install_checks regresscheck-shared)
+  list(APPEND _install_checks provecheck)
   list(APPEND _local_install_checks regresschecklocal-shared)
 
 endif()
@@ -98,6 +115,7 @@ endif()
 add_subdirectory(shared)
 add_subdirectory(sql)
 add_subdirectory(isolation)
+add_subdirectory(t)
 
 # installchecklocal tests against an existing postgres instance
 add_custom_target(installchecklocal-t DEPENDS ${_local_install_checks})

--- a/tsl/test/t/001_simple_multinode.pl
+++ b/tsl/test/t/001_simple_multinode.pl
@@ -1,0 +1,74 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# test a simple multi node cluster creation and basic operations
+use strict;
+use warnings;
+use TimescaleNode qw(get_new_ts_node);
+use TestLib;
+use Test::More tests => 9;
+
+#Initialize all the multi-node instances
+my @nodes = ();
+foreach my $nodename ('an', 'dn1', 'dn2')
+{
+	my $node = get_new_ts_node($nodename);
+	$node->init;
+	$node->start;
+	# set up the access node
+	if ($node->name eq 'an')
+	{
+		$node->safe_psql('postgres', "CREATE DATABASE an");
+		$node->safe_psql('an',       "CREATE EXTENSION timescaledb");
+	}
+	push @nodes, $node;
+}
+
+#Add the data nodes from the access node
+foreach my $i (1 .. 2)
+{
+	my $host = $nodes[$i]->host();
+	my $port = $nodes[$i]->port();
+
+	$nodes[0]->safe_psql('an',
+		"SELECT add_data_node('dn$i', database => 'dn$i', host => '$host', port => $port)"
+	);
+}
+
+#Create a distributed hypertable and insert a few rows
+$nodes[0]->safe_psql(
+	'an',
+	qq[
+    CREATE TABLE test(time timestamp NOT NULL, device int, temp float);
+    SELECT create_distributed_hypertable('test', 'time', 'device', 3);
+    INSERT INTO test SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, 0.10 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-08 1:00', '1 hour') t;
+    ]);
+
+#Check that chunks are shown appropriately on all nodes of the multi-node setup
+my $query = q[SELECT * from show_chunks('test');];
+
+#Query Access node
+$nodes[0]->psql_is(
+	'an', $query, q[_timescaledb_internal._dist_hyper_1_1_chunk
+_timescaledb_internal._dist_hyper_1_2_chunk
+_timescaledb_internal._dist_hyper_1_3_chunk
+_timescaledb_internal._dist_hyper_1_4_chunk], 'AN shows correct set of chunks'
+);
+
+#Query datanode1
+$nodes[1]->psql_is(
+	'dn1',
+	$query,
+	"_timescaledb_internal._dist_hyper_1_1_chunk\n_timescaledb_internal._dist_hyper_1_3_chunk\n_timescaledb_internal._dist_hyper_1_4_chunk",
+	'DN1 shows correct set of chunks');
+
+#Query datanode2
+$nodes[2]->psql_is(
+	'dn2', $query,
+	"_timescaledb_internal._dist_hyper_1_2_chunk",
+	'DN2 shows correct set of chunks');
+
+done_testing();
+
+1;

--- a/tsl/test/t/CMakeLists.txt
+++ b/tsl/test/t/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(PROVE_TEST_FILES
+    001_simple_multinode.pl
+)
+
+foreach(P_FILE ${PROVE_TEST_FILES})
+    configure_file(${P_FILE} ${CMAKE_CURRENT_BINARY_DIR}/${P_FILE} COPYONLY)
+endforeach(P_FILE)


### PR DESCRIPTION
The TAP testing PG framework meets our requirements for doing
multinode/stand-alone-binaries testing for scenarios which need
individual multiple PG instances (multi-node testing is a prime
example).
    
This commit adds the necessary wrappers to allow the use of the TAP
testing framework in timescale code base. The README in "test/perl"
directory gives a fair idea of how to write tap tests. A simple tap
test has been added to provide a reference point for developers to
write new ones.
    
One can go to build/tsl/test and invoke "make checkprove" to see
the tap test in action.
    
Also includes changes for enabling github CI to run these taptests by
installing the requisite dependencies.
    
Includes changes to license checking scripts to handle new *.pl and
*.pm files.
    
Also added a new scripts/perltidyrc to aid in formatting of these
files.