### PR TITLE
Bump postgres versions used in CI

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: ["12.6", "13.2"]
+        pg: ["12.7", "13.3"]
         os: [ubuntu-20.04]
     env:
       PG_SRC_DIR: pgbuild

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        pg: ["11.11","12.6","13.2"]
+        pg: ["11.12","12.7","13.3"]
         include:
-          - pg: 11.11
+          - pg: 11.12
             pg_major: 11
-          - pg: 12.6
+          - pg: 12.7
             pg_major: 12
-          - pg: 13.2
+          - pg: 13.3
             pg_major: 13
       fail-fast: false
     env:

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -17,11 +17,11 @@ jobs:
         build_type: [ Debug, Release ]
         include:
           - pg: 11
-            pkg_version: 11.11.1
+            pkg_version: 11.12.1
           - pg: 12
-            pkg_version: 12.6.1
+            pkg_version: 12.7.1
           - pg: 13
-            pkg_version: 13.2.1
+            pkg_version: 13.3.1
     env:
       # PostgreSQL configuration
       PGPORT: 6543

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -21,11 +21,11 @@ import sys
 event_type = sys.argv[1]
 
 PG11_EARLIEST = "11.0"
-PG11_LATEST = "11.11"
+PG11_LATEST = "11.12"
 PG12_EARLIEST = "12.0"
-PG12_LATEST = "12.6"
+PG12_LATEST = "12.7"
 PG13_EARLIEST = "13.2"
-PG13_LATEST = "13.2"
+PG13_LATEST = "13.3"
 
 m = {"include": [],}
 
@@ -135,15 +135,18 @@ if event_type != "pull_request":
   }
   m["include"].append(build_debug_config(pg12_debug_earliest))
 
+  # add debug test for first supported PG13 version
+  m["include"].append(build_debug_config({"pg":PG13_EARLIEST}))
+
   # add debug test for MacOS
   m["include"].append(build_debug_config(macos_config({})))
 
-  # add release test for latest pg11 and latest pg12
+  # add release test for latest pg 11, 12 and 13
   m["include"].append(build_release_config({"pg":PG11_LATEST}))
   m["include"].append(build_release_config({"pg":PG12_LATEST}))
   m["include"].append(build_release_config({"pg":PG13_LATEST}))
 
-  # add apache only test for latest pg11 and latest pg 12
+  # add apache only test for latest pg 11, 12 and 13
   m["include"].append(build_apache_config({"pg":PG11_LATEST}))
   m["include"].append(build_apache_config({"pg":PG12_LATEST}))
   m["include"].append(build_apache_config({"pg":PG13_LATEST}))

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -25,6 +25,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testtablespace)
 # Tests to ignore
 set(PG_IGNORE_TESTS
   advisory_lock
+  event_trigger
   foreign_data
   identity
   opr_sanity


### PR DESCRIPTION
Change CI tests to run against pg 11.12, 12.7 and 13.3.