### PR TITLE
More cleanup

### DIFF
--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -207,7 +207,7 @@ ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compres
 insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
 do update set b = excluded.b;
-ERROR:  insert with ON CONFLICT and RETURNING clause is not supported on compressed chunks
+ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 --TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12);
 update _timescaledb_internal._hyper_1_2_chunk

--- a/tsl/test/expected/compression_permissions.out
+++ b/tsl/test/expected/compression_permissions.out
@@ -162,6 +162,7 @@ NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to view v2
 -- Testing that permissions propagate to compressed hypertables and to
 -- compressed chunks.
+-- Table is created by superuser
 CREATE TABLE conditions (
       timec TIMESTAMPTZ NOT NULL,
       location TEXT NOT NULL,
@@ -348,3 +349,32 @@ chunk          | _timescaledb_internal.compress_hyper_4_27_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 
 \x off
+--TEST user that has insert permission can insert into a compressed chunk
+GRANT INSERT ON conditions TO :ROLE_DEFAULT_PERM_USER;
+SELECT count(*) FROM conditions; 
+ count 
+-------
+    63
+(1 row)
+
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 
+ count 
+-------
+    11
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--insert into a compressed chunk --
+INSERT INTO conditions VALUES( '2018-12-02 00:00'::timestamp, 'NYC', 75, 95);
+SELECT count(*) FROM conditions; 
+ count 
+-------
+    64
+(1 row)
+
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 
+ count 
+-------
+    11
+(1 row)
+

--- a/tsl/test/sql/compression_permissions.sql
+++ b/tsl/test/sql/compression_permissions.sql
@@ -125,6 +125,7 @@ DROP TABLE conditions CASCADE;
 
 -- Testing that permissions propagate to compressed hypertables and to
 -- compressed chunks.
+-- Table is created by superuser
 
 CREATE TABLE conditions (
       timec TIMESTAMPTZ NOT NULL,
@@ -178,3 +179,13 @@ SELECT htd.hypertable, htd.hypertable_acl, chunk, chunk_acl
   FROM chunk_details chd JOIN hypertable_details htd ON chd.hypertable = htd.compressed
 ORDER BY hypertable, chunk;
 \x off
+
+--TEST user that has insert permission can insert into a compressed chunk
+GRANT INSERT ON conditions TO :ROLE_DEFAULT_PERM_USER;
+SELECT count(*) FROM conditions; 
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--insert into a compressed chunk --
+INSERT INTO conditions VALUES( '2018-12-02 00:00'::timestamp, 'NYC', 75, 95);
+SELECT count(*) FROM conditions; 
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 


### PR DESCRIPTION
Make use of BulkInsertState optional in row compressor
Add test for insert into compressed chunk by a different role
other than the owner
Fix broken test output