### PR TITLE
Move trigger execution code for compressed chunks

### DIFF
--- a/tsl/test/expected/compression_insert-11.out
+++ b/tsl/test/expected/compression_insert-11.out
@@ -435,6 +435,7 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
  17 | 18
 (1 row)
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -465,16 +466,19 @@ BEGIN
   RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
      create_hypertable      
 ----------------------------
  (11,public,trigger_test,t)
 (1 row)
 
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
               compress_chunk              
 ------------------------------------------
@@ -700,6 +704,44 @@ SELECT count(*) FROM trigger_test;
      1
 (1 row)
 
+DROP trigger t4_constraint ON trigger_test;
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+ _timescaledb_internal._hyper_11_18_chunk
+(2 rows)
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+SELECT count(*) FROM trigger_test;
+ count 
+-------
+     2
+(1 row)
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_15_chunk: ("Sat Jan 01 00:00:00 2000 PST",1,11,eleven,111) <NULL>
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_18_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+             time             | device | value | addcolv | addcoli 
+------------------------------+--------+-------+---------+---------
+ Sat Jan 01 00:00:00 2000 PST |      1 |   111 | eleven  |     111
+ Sat Jan 01 00:00:00 2000 PST |      1 |     1 |         |        
+ Fri Jan 01 00:00:00 2010 PST |     10 |    10 | ten     |     222
+ Fri Jan 01 00:00:00 2010 PST |     10 |   110 | ten     |     222
+(4 rows)
+
+ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
 CREATE TABLE test_ordering(time int);
@@ -718,13 +760,13 @@ INSERT INTO test_ordering VALUES (5),(4),(3);
 ------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_18_chunk_test_ordering_time_idx on _hyper_13_18_chunk
+   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
 (3 rows)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
+ _timescaledb_internal._hyper_13_20_chunk
 (1 row)
 
 -- should be ordered append
@@ -733,10 +775,10 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 -------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
          ->  Sort
-               Sort Key: compress_hyper_14_19_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_19_chunk
+               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (6 rows)
 
 INSERT INTO test_ordering SELECT 1;
@@ -745,10 +787,10 @@ INSERT INTO test_ordering SELECT 1;
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Sort
-   Sort Key: _hyper_13_18_chunk."time"
+   Sort Key: _hyper_13_20_chunk."time"
    ->  Append
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (5 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
@@ -759,10 +801,10 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
 (7 rows)
 
 --insert into compressed + uncompressed chunk
@@ -785,11 +827,11 @@ INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
 ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
-NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
+NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
  _timescaledb_internal._hyper_13_20_chunk
+ _timescaledb_internal._hyper_13_22_chunk
 (2 rows)
 
 -- should be ordered append
@@ -799,12 +841,12 @@ NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
                ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
+         ->  Sort
+               Sort Key: compress_hyper_14_23_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -435,6 +435,7 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
  17 | 18
 (1 row)
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -465,16 +466,19 @@ BEGIN
   RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
      create_hypertable      
 ----------------------------
  (11,public,trigger_test,t)
 (1 row)
 
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
               compress_chunk              
 ------------------------------------------
@@ -700,6 +704,44 @@ SELECT count(*) FROM trigger_test;
      1
 (1 row)
 
+DROP trigger t4_constraint ON trigger_test;
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+ _timescaledb_internal._hyper_11_18_chunk
+(2 rows)
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+SELECT count(*) FROM trigger_test;
+ count 
+-------
+     2
+(1 row)
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_15_chunk: ("Sat Jan 01 00:00:00 2000 PST",1,11,eleven,111) <NULL>
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_18_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+             time             | device | value | addcolv | addcoli 
+------------------------------+--------+-------+---------+---------
+ Sat Jan 01 00:00:00 2000 PST |      1 |   111 | eleven  |     111
+ Sat Jan 01 00:00:00 2000 PST |      1 |     1 |         |        
+ Fri Jan 01 00:00:00 2010 PST |     10 |    10 | ten     |     222
+ Fri Jan 01 00:00:00 2010 PST |     10 |   110 | ten     |     222
+(4 rows)
+
+ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
 CREATE TABLE test_ordering(time int);
@@ -718,13 +760,13 @@ INSERT INTO test_ordering VALUES (5),(4),(3);
 ------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_18_chunk_test_ordering_time_idx on _hyper_13_18_chunk
+   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
 (3 rows)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
+ _timescaledb_internal._hyper_13_20_chunk
 (1 row)
 
 -- should be ordered append
@@ -733,10 +775,10 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 -------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
          ->  Sort
-               Sort Key: compress_hyper_14_19_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_19_chunk
+               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (6 rows)
 
 INSERT INTO test_ordering SELECT 1;
@@ -745,9 +787,9 @@ INSERT INTO test_ordering SELECT 1;
                         QUERY PLAN                         
 -----------------------------------------------------------
  Sort
-   Sort Key: _hyper_13_18_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-         ->  Seq Scan on compress_hyper_14_19_chunk
+   Sort Key: _hyper_13_20_chunk."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+         ->  Seq Scan on compress_hyper_14_21_chunk
 (4 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
@@ -758,10 +800,10 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
 (7 rows)
 
 --insert into compressed + uncompressed chunk
@@ -784,11 +826,11 @@ INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
 ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
-NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
+NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
  _timescaledb_internal._hyper_13_20_chunk
+ _timescaledb_internal._hyper_13_22_chunk
 (2 rows)
 
 -- should be ordered append
@@ -798,12 +840,12 @@ NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
                ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
+         ->  Sort
+               Sort Key: compress_hyper_14_23_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -435,6 +435,7 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
  17 | 18
 (1 row)
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -465,16 +466,19 @@ BEGIN
   RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
      create_hypertable      
 ----------------------------
  (11,public,trigger_test,t)
 (1 row)
 
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
               compress_chunk              
 ------------------------------------------
@@ -700,6 +704,44 @@ SELECT count(*) FROM trigger_test;
      1
 (1 row)
 
+DROP trigger t4_constraint ON trigger_test;
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+ _timescaledb_internal._hyper_11_18_chunk
+(2 rows)
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+SELECT count(*) FROM trigger_test;
+ count 
+-------
+     2
+(1 row)
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_15_chunk: ("Sat Jan 01 00:00:00 2000 PST",1,11,eleven,111) <NULL>
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_18_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+             time             | device | value | addcolv | addcoli 
+------------------------------+--------+-------+---------+---------
+ Sat Jan 01 00:00:00 2000 PST |      1 |   111 | eleven  |     111
+ Sat Jan 01 00:00:00 2000 PST |      1 |     1 |         |        
+ Fri Jan 01 00:00:00 2010 PST |     10 |    10 | ten     |     222
+ Fri Jan 01 00:00:00 2010 PST |     10 |   110 | ten     |     222
+(4 rows)
+
+ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
 CREATE TABLE test_ordering(time int);
@@ -718,13 +760,13 @@ INSERT INTO test_ordering VALUES (5),(4),(3);
 ------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_18_chunk_test_ordering_time_idx on _hyper_13_18_chunk
+   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
 (3 rows)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
+ _timescaledb_internal._hyper_13_20_chunk
 (1 row)
 
 -- should be ordered append
@@ -733,10 +775,10 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 -------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
          ->  Sort
-               Sort Key: compress_hyper_14_19_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_19_chunk
+               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (6 rows)
 
 INSERT INTO test_ordering SELECT 1;
@@ -745,9 +787,9 @@ INSERT INTO test_ordering SELECT 1;
                         QUERY PLAN                         
 -----------------------------------------------------------
  Sort
-   Sort Key: _hyper_13_18_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-         ->  Seq Scan on compress_hyper_14_19_chunk
+   Sort Key: _hyper_13_20_chunk."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+         ->  Seq Scan on compress_hyper_14_21_chunk
 (4 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
@@ -758,10 +800,10 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
 (7 rows)
 
 --insert into compressed + uncompressed chunk
@@ -784,11 +826,11 @@ INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
 ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
-NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
+NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
  _timescaledb_internal._hyper_13_20_chunk
+ _timescaledb_internal._hyper_13_22_chunk
 (2 rows)
 
 -- should be ordered append
@@ -798,12 +840,12 @@ NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
                ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
+         ->  Sort
+               Sort Key: compress_hyper_14_23_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -259,6 +259,7 @@ COPY test_gen(payload) FROM STDIN DELIMITER ',';
 
 SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -293,12 +294,16 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
 
 -- BEFORE ROW trigger
@@ -486,6 +491,26 @@ COPY trigger_test FROM STDIN DELIMITER ',';
 
 -- should not insert rows. count is 1
 SELECT count(*) FROM trigger_test;
+DROP trigger t4_constraint ON trigger_test;
+
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+
+SELECT count(*) FROM trigger_test;
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+ROLLBACK;
 
 DROP TABLE trigger_test;
 


### PR DESCRIPTION
We first compute the tuple mapping between the hypertable
and chunk, before executing the triggers. This ensures that
metadata differences between a chunk and hypertable are
accounted for when the trigger is executed.