### PR TITLE
Fix assertion failure in decompress_chunk_plan_create

### DIFF
--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -289,6 +289,7 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 	Scan *compressed_scan = linitial(custom_plans);
 	Path *compressed_path = linitial(path->custom_paths);
 	List *settings;
+	ListCell *lc;
 
 	Assert(list_length(custom_plans) == 1);
 	Assert(list_length(path->custom_paths) == 1);
@@ -306,7 +307,6 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 	{
 		/* from create_indexscan_plan() */
 		IndexPath *ipath = castNode(IndexPath, compressed_path);
-		ListCell *lc;
 		List *indexqual = NIL;
 		Plan *indexplan;
 		foreach (lc, clauses)
@@ -334,8 +334,8 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 			Index compress_relid = dcpath->info->compressed_rel->relid;
 			cxt.compress_relid = compress_relid;
 			cxt.compressed_attnos = dcpath->info->compressed_chunk_compressed_attnos;
-			if (!clause_has_compressed_attrs((Node *) expr, &cxt))
 
+			if (!clause_has_compressed_attrs((Node *) expr, &cxt))
 				indexqual = lappend(indexqual, expr);
 		}
 		indexplan->qual = indexqual;
@@ -346,11 +346,19 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 		 * Code from create_bitmap_scan_plan does something similar, and could be used as a starting
 		 * point.
 		 */
-		cscan->scan.plan.qual = get_actual_clauses(clauses);
+		foreach (lc, clauses)
+		{
+			RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+			cscan->scan.plan.qual = lappend(cscan->scan.plan.qual, rinfo->clause);
+		}
 	}
 	else
 	{
-		cscan->scan.plan.qual = get_actual_clauses(clauses);
+		foreach (lc, clauses)
+		{
+			RestrictInfo *rinfo = lfirst_node(RestrictInfo, lc);
+			cscan->scan.plan.qual = lappend(cscan->scan.plan.qual, rinfo->clause);
+		}
 	}
 
 	cscan->scan.plan.qual =

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -202,3 +202,25 @@ WHERE check_equal_228(rtt) and ts < '2019-12-15 00:00:00' order by ts;
                      Filter: (_ts_meta_min_1 < 'Sun Dec 15 00:00:00 2019'::timestamp without time zone)
 (10 rows)
 
+-- test pseudoconstant qual #3241
+CREATE TABLE pseudo(time timestamptz NOT NULL);
+SELECT create_hypertable('pseudo','time');
+  create_hypertable  
+---------------------
+ (5,public,pseudo,t)
+(1 row)
+
+ALTER TABLE pseudo SET (timescaledb.compress);
+INSERT INTO pseudo SELECT '2000-01-01';
+SELECT compress_chunk(show_chunks('pseudo'));
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_11_chunk
+(1 row)
+
+SELECT * FROM pseudo WHERE now() IS NOT NULL;
+             time             
+------------------------------
+ Sat Jan 01 00:00:00 2000 PST
+(1 row)
+

--- a/tsl/test/sql/transparent_decompression_queries.sql
+++ b/tsl/test/sql/transparent_decompression_queries.sql
@@ -88,3 +88,13 @@ WHERE check_equal_228(rtt) ORDER BY ts;
 EXPLAIN (analyze,costs off,timing off,summary off) 
 SELECT * from test_chartab 
 WHERE check_equal_228(rtt) and ts < '2019-12-15 00:00:00' order by ts;
+
+-- test pseudoconstant qual #3241
+CREATE TABLE pseudo(time timestamptz NOT NULL);
+SELECT create_hypertable('pseudo','time');
+ALTER TABLE pseudo SET (timescaledb.compress);
+INSERT INTO pseudo SELECT '2000-01-01';
+SELECT compress_chunk(show_chunks('pseudo'));
+
+SELECT * FROM pseudo WHERE now() IS NOT NULL;
+


### PR DESCRIPTION
decompress_chunk_plan_create used get_actual_clauses to extract
RestrictInfo clauses and adds them as quals. This function is only
supposed to be used when none of the RestrictInfos are pseudoconstant
leading to an assertion failure when the query has pseudoconstant
quals.

Fixes #3241