### PR TITLE
Add TimescaleNode subclasses for TAP Testing

### DIFF
--- a/test/perl/AccessNode.pm
+++ b/test/perl/AccessNode.pm
@@ -1,0 +1,21 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+package AccessNode;
+use parent qw(TimescaleNode);
+use strict;
+use warnings;
+
+sub add_data_node
+{
+	my ($self, $dn) = @_;
+	my $name = $dn->name;
+	my $host = $dn->host;
+	my $port = $dn->port;
+	$self->safe_psql('postgres',
+		"SELECT add_data_node('$name', host => '$host', port => $port)");
+	return $self;
+}
+
+1;

--- a/test/perl/DataNode.pm
+++ b/test/perl/DataNode.pm
@@ -1,0 +1,10 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+package DataNode;
+use parent qw(TimescaleNode);
+use strict;
+use warnings;
+
+1;

--- a/test/perl/TimescaleNode.pm
+++ b/test/perl/TimescaleNode.pm
@@ -6,7 +6,7 @@
 # routines for setup.
 
 package TimescaleNode;
-use parent ("PostgresNode");
+use parent qw(PostgresNode);
 use TestLib qw(slurp_file);
 use strict;
 use warnings;
@@ -14,29 +14,13 @@ use warnings;
 use Carp 'verbose';
 $SIG{__DIE__} = \&Carp::confess;
 
-use Exporter 'import';
-use vars qw(@EXPORT @EXPORT_OK);
-@EXPORT = qw(
-  get_new_ts_node
-);
-@EXPORT_OK = qw(
-);
-
-#
-# Get a new TS-enabled PostgreSQL instance
-#
-# It's not created yet, but ready to restore from backup,
-# initdb, etc.
-#
-sub get_new_ts_node
+sub create
 {
-	my ($name, $class) = @_;
-
-	$class //= 'TimescaleNode';
-
-	my $self = PostgresNode::get_new_node($name);
-	$self = bless $self, $class;
-
+	my ($class, $name, %kwargs) = @_;
+	my $self = $class->get_new_node($name);
+	$self->init(%kwargs);
+	$self->start(%kwargs);
+	$self->safe_psql('postgres', 'CREATE EXTENSION timescaledb');
 	return $self;
 }
 


### PR DESCRIPTION
Use subclassing to inherit from `PostgresNode` and create a hierarchy
containing `AccessNode` and `DataNode` to simplify creating tests with
multiple nodes.

Also, two new functions are added: 
 
`TimescaleNode::create` 
  Creates the new node by calling `get_new_node`, `init` and `start` in 
  that order.

`AccessNode::add_data_node`
  Adds a new data node to the access node.

Also rewrite the test to use the new hierarchy.
