### PR TITLE
Fix segmentation fault due to incorrect call to chunk_scan_internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ accidentally triggering the load of a previous DB version.**
 * #3209 Propagate grants to compressed hypertables
 * #3241 Fix assertion failure in decompress_chunk_plan_create
 * #3250 Fix constraint triggers on hypertables
+* #3251 Fix segmentation fault due to incorrect call to chunk_scan_internal
 * #3252 Fix blocking triggers with transition tables
+
+**Thanks**
+* @yyjdelete for reporting a crash with decompress_chunk and identifying the bug in the code
 
 ## 2.2.1 (2021-05-05)
 


### PR DESCRIPTION
chunk_scan_internal is called with 2 callback functions, a
filter function and a tuple_found function that
are invoked with the same argument. ts_chunk_set_compressed
and ts_chunk_clear_compressed use chunk_tuple_dropped_filter
but do not pass in the required ChunkStubScanCtx* as argument.
Instead an argument of type int* is passed in. This causes
 a segmentation fault.

Add a new chunk filter function that is compatible with
the tuple_found function used by ts_chunk_clear_compressed_chunk
and ts_chunk_set_compressed_chunk
Fixes #3158