### PR TITLE
Fix hypertable_chunk_local_size view

### DIFF
--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -129,19 +129,18 @@ create_compress_chunk_result_relation_info(ChunkDispatch *dispatch, Relation com
 	InitResultRelInfo(rri, compress_rel, hyper_rti, NULL, dispatch->estate->es_instrument);
 
 	rri_orig = dispatch->hypertable_result_rel_info;
-	if (rri_orig->ri_WithCheckOptions || rri_orig->ri_WithCheckOptionExprs ||
-		rri_orig->ri_junkFilter || rri_orig->ri_projectReturning)
-	{
-		elog(ERROR, "CHECK options, RETURNING clause are not supported");
-	}
-	rri->ri_junkFilter = rri_orig->ri_junkFilter; // TODO does this need any translation
+	/* RLS policies are not supported if compression is enabled */
+	Assert(rri_orig->ri_WithCheckOptions == NULL && rri_orig->ri_WithCheckOptionExprs == NULL);
+	Assert(rri_orig->ri_projectReturning == NULL);
+	rri->ri_junkFilter = rri_orig->ri_junkFilter;
 
 	/* compressed rel chunk is on data node. Does not need any FDW access on AN */
 	rri->ri_FdwState = NULL;
 	rri->ri_usesFdwDirectModify = false;
 	rri->ri_FdwRoutine = NULL;
-	// TODO revisit this
-	// create_chunk_rri_constraint_expr(rri, compress_rel);
+	/* constraints are executed on the orig base chunk. So we do
+	 * not call create_chunk_rri_constraint_expr here
+	 */
 	return rri;
 }
 
@@ -595,7 +594,7 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 		(onconflict_action != ONCONFLICT_NONE || ts_chunk_dispatch_has_returning(dispatch)))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("insert with ON CONFLICT and RETURNING clause is not supported on "
+				 errmsg("insert with ON CONFLICT or RETURNING clause is not supported on "
 						"compressed chunks")));
 
 	/*
@@ -777,18 +776,17 @@ ts_chunk_insert_state_destroy(ChunkInsertState *state)
 
 	destroy_on_conflict_state(state);
 	ExecCloseIndices(state->result_relation_info);
-	table_close(state->rel, NoLock);
 
 	if (state->compress_rel)
 	{
 		ResultRelInfo *orig_chunk_rri = state->orig_result_relation_info;
 		Oid chunk_relid = RelationGetRelid(orig_chunk_rri->ri_RelationDesc);
-		table_close(state->compress_rel, NoLock);
 		ts_cm_functions->compress_row_end(state->compress_state);
 		ts_cm_functions->compress_row_destroy(state->compress_state);
 		Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
 		if (!ts_chunk_is_unordered(chunk))
 			ts_chunk_set_unordered(chunk);
+		table_close(state->compress_rel, NoLock);
 	}
 	else if (RelationGetForm(state->result_relation_info->ri_RelationDesc)->relkind ==
 			 RELKIND_FOREIGN_TABLE)
@@ -803,6 +801,7 @@ ts_chunk_insert_state_destroy(ChunkInsertState *state)
 			ts_chunk_set_unordered(chunk);
 	}
 
+	table_close(state->rel, NoLock);
 	if (NULL != state->slot)
 		ExecDropSingleTupleTableSlot(state->slot);
 

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -150,7 +150,7 @@ $$);
 SELECT * FROM chunks_detailed_size('toast_test');
      chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -----------------------+------------------+-------------+-------------+-------------+-------------+-----------
- _timescaledb_internal | _hyper_4_9_chunk |       24576 |       16384 |        8192 |       49152 | 
+ _timescaledb_internal | _hyper_4_9_chunk |        8192 |       16384 |       24576 |       49152 | 
 (1 row)
 
 -- Tests for approximate_row_count()

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -439,19 +439,19 @@ select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
 pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('foo');
 -[ RECORD 1 ]--+-----------
-pg_size_pretty | 32 kB
+pg_size_pretty | 72 kB
 pg_size_pretty | 160 kB
 pg_size_pretty | 8192 bytes
-pg_size_pretty | 200 kB
+pg_size_pretty | 240 kB
 
 select pg_size_pretty(table_bytes), pg_size_pretty(index_bytes),
 pg_size_pretty(toast_bytes), pg_size_pretty(total_bytes)
 from hypertable_detailed_size('conditions');
 -[ RECORD 1 ]--+-------
-pg_size_pretty | 16 kB
+pg_size_pretty | 64 kB
 pg_size_pretty | 56 kB
 pg_size_pretty | 32 kB
-pg_size_pretty | 112 kB
+pg_size_pretty | 160 kB
 
 select * from timescaledb_information.hypertables
 where hypertable_name like 'foo' or hypertable_name like 'conditions'

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -207,7 +207,7 @@ ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compres
 insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
 do update set b = excluded.b;
-ERROR:  insert with ON CONFLICT and RETURNING clause is not supported on compressed chunks
+ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 --TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12);
 update _timescaledb_internal._hyper_1_2_chunk

--- a/tsl/test/expected/compression_insert-11.out
+++ b/tsl/test/expected/compression_insert-11.out
@@ -782,7 +782,7 @@ INSERT INTO test_ordering VALUES (106) RETURNING *;
 -- insert into compressed chunk does not support RETURNING
 \set ON_ERROR_STOP 0
 INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-ERROR:  insert with ON CONFLICT and RETURNING clause is not supported on compressed chunks
+ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 NOTICE:  chunk "_hyper_13_18_chunk" is already compressed

--- a/tsl/test/expected/compression_insert-11.out
+++ b/tsl/test/expected/compression_insert-11.out
@@ -435,6 +435,7 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
  17 | 18
 (1 row)
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -465,16 +466,19 @@ BEGIN
   RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
      create_hypertable      
 ----------------------------
  (11,public,trigger_test,t)
 (1 row)
 
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
               compress_chunk              
 ------------------------------------------
@@ -700,6 +704,44 @@ SELECT count(*) FROM trigger_test;
      1
 (1 row)
 
+DROP trigger t4_constraint ON trigger_test;
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+ _timescaledb_internal._hyper_11_18_chunk
+(2 rows)
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+SELECT count(*) FROM trigger_test;
+ count 
+-------
+     2
+(1 row)
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_15_chunk: ("Sat Jan 01 00:00:00 2000 PST",1,11,eleven,111) <NULL>
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_18_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+             time             | device | value | addcolv | addcoli 
+------------------------------+--------+-------+---------+---------
+ Sat Jan 01 00:00:00 2000 PST |      1 |   111 | eleven  |     111
+ Sat Jan 01 00:00:00 2000 PST |      1 |     1 |         |        
+ Fri Jan 01 00:00:00 2010 PST |     10 |    10 | ten     |     222
+ Fri Jan 01 00:00:00 2010 PST |     10 |   110 | ten     |     222
+(4 rows)
+
+ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
 CREATE TABLE test_ordering(time int);
@@ -718,13 +760,13 @@ INSERT INTO test_ordering VALUES (5),(4),(3);
 ------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_18_chunk_test_ordering_time_idx on _hyper_13_18_chunk
+   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
 (3 rows)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
+ _timescaledb_internal._hyper_13_20_chunk
 (1 row)
 
 -- should be ordered append
@@ -733,10 +775,10 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 -------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
          ->  Sort
-               Sort Key: compress_hyper_14_19_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_19_chunk
+               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (6 rows)
 
 INSERT INTO test_ordering SELECT 1;
@@ -745,10 +787,10 @@ INSERT INTO test_ordering SELECT 1;
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Sort
-   Sort Key: _hyper_13_18_chunk."time"
+   Sort Key: _hyper_13_20_chunk."time"
    ->  Append
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (5 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
@@ -759,10 +801,10 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
 (7 rows)
 
 --insert into compressed + uncompressed chunk
@@ -785,11 +827,11 @@ INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
 ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
-NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
+NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
  _timescaledb_internal._hyper_13_20_chunk
+ _timescaledb_internal._hyper_13_22_chunk
 (2 rows)
 
 -- should be ordered append
@@ -799,12 +841,12 @@ NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
                ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
+         ->  Sort
+               Sort Key: compress_hyper_14_23_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -781,7 +781,7 @@ INSERT INTO test_ordering VALUES (106) RETURNING *;
 -- insert into compressed chunk does not support RETURNING
 \set ON_ERROR_STOP 0
 INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-ERROR:  insert with ON CONFLICT and RETURNING clause is not supported on compressed chunks
+ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 NOTICE:  chunk "_hyper_13_18_chunk" is already compressed

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -435,6 +435,7 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
  17 | 18
 (1 row)
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -465,16 +466,19 @@ BEGIN
   RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
      create_hypertable      
 ----------------------------
  (11,public,trigger_test,t)
 (1 row)
 
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
               compress_chunk              
 ------------------------------------------
@@ -700,6 +704,44 @@ SELECT count(*) FROM trigger_test;
      1
 (1 row)
 
+DROP trigger t4_constraint ON trigger_test;
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+ _timescaledb_internal._hyper_11_18_chunk
+(2 rows)
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+SELECT count(*) FROM trigger_test;
+ count 
+-------
+     2
+(1 row)
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_15_chunk: ("Sat Jan 01 00:00:00 2000 PST",1,11,eleven,111) <NULL>
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_18_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+             time             | device | value | addcolv | addcoli 
+------------------------------+--------+-------+---------+---------
+ Sat Jan 01 00:00:00 2000 PST |      1 |   111 | eleven  |     111
+ Sat Jan 01 00:00:00 2000 PST |      1 |     1 |         |        
+ Fri Jan 01 00:00:00 2010 PST |     10 |    10 | ten     |     222
+ Fri Jan 01 00:00:00 2010 PST |     10 |   110 | ten     |     222
+(4 rows)
+
+ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
 CREATE TABLE test_ordering(time int);
@@ -718,13 +760,13 @@ INSERT INTO test_ordering VALUES (5),(4),(3);
 ------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_18_chunk_test_ordering_time_idx on _hyper_13_18_chunk
+   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
 (3 rows)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
+ _timescaledb_internal._hyper_13_20_chunk
 (1 row)
 
 -- should be ordered append
@@ -733,10 +775,10 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 -------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
          ->  Sort
-               Sort Key: compress_hyper_14_19_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_19_chunk
+               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (6 rows)
 
 INSERT INTO test_ordering SELECT 1;
@@ -745,9 +787,9 @@ INSERT INTO test_ordering SELECT 1;
                         QUERY PLAN                         
 -----------------------------------------------------------
  Sort
-   Sort Key: _hyper_13_18_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-         ->  Seq Scan on compress_hyper_14_19_chunk
+   Sort Key: _hyper_13_20_chunk."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+         ->  Seq Scan on compress_hyper_14_21_chunk
 (4 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
@@ -758,10 +800,10 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
 (7 rows)
 
 --insert into compressed + uncompressed chunk
@@ -784,11 +826,11 @@ INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
 ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
-NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
+NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
  _timescaledb_internal._hyper_13_20_chunk
+ _timescaledb_internal._hyper_13_22_chunk
 (2 rows)
 
 -- should be ordered append
@@ -798,12 +840,12 @@ NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
                ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
+         ->  Sort
+               Sort Key: compress_hyper_14_23_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -781,7 +781,7 @@ INSERT INTO test_ordering VALUES (106) RETURNING *;
 -- insert into compressed chunk does not support RETURNING
 \set ON_ERROR_STOP 0
 INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-ERROR:  insert with ON CONFLICT and RETURNING clause is not supported on compressed chunks
+ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 NOTICE:  chunk "_hyper_13_18_chunk" is already compressed

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -435,6 +435,7 @@ SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
  17 | 18
 (1 row)
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -465,16 +466,19 @@ BEGIN
   RETURN NULL;
 END
 $$ LANGUAGE plpgsql;
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
      create_hypertable      
 ----------------------------
  (11,public,trigger_test,t)
 (1 row)
 
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
               compress_chunk              
 ------------------------------------------
@@ -700,6 +704,44 @@ SELECT count(*) FROM trigger_test;
      1
 (1 row)
 
+DROP trigger t4_constraint ON trigger_test;
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+NOTICE:  chunk "_hyper_11_15_chunk" is already compressed
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_15_chunk
+ _timescaledb_internal._hyper_11_18_chunk
+(2 rows)
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+SELECT count(*) FROM trigger_test;
+ count 
+-------
+     2
+(1 row)
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_15_chunk: ("Sat Jan 01 00:00:00 2000 PST",1,11,eleven,111) <NULL>
+NOTICE:  Trigger t1_mod BEFORE INSERT ROW on _hyper_11_18_chunk: ("Fri Jan 01 00:00:00 2010 PST",10,10,ten,222) <NULL>
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+             time             | device | value | addcolv | addcoli 
+------------------------------+--------+-------+---------+---------
+ Sat Jan 01 00:00:00 2000 PST |      1 |   111 | eleven  |     111
+ Sat Jan 01 00:00:00 2000 PST |      1 |     1 |         |        
+ Fri Jan 01 00:00:00 2010 PST |     10 |    10 | ten     |     222
+ Fri Jan 01 00:00:00 2010 PST |     10 |   110 | ten     |     222
+(4 rows)
+
+ROLLBACK;
 DROP TABLE trigger_test;
 -- test interaction between newly inserted batches and pathkeys/ordered append
 CREATE TABLE test_ordering(time int);
@@ -718,13 +760,13 @@ INSERT INTO test_ordering VALUES (5),(4),(3);
 ------------------------------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Index Only Scan Backward using _hyper_13_18_chunk_test_ordering_time_idx on _hyper_13_18_chunk
+   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
 (3 rows)
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
+ _timescaledb_internal._hyper_13_20_chunk
 (1 row)
 
 -- should be ordered append
@@ -733,10 +775,10 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 -------------------------------------------------------------------------------
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
          ->  Sort
-               Sort Key: compress_hyper_14_19_chunk._ts_meta_sequence_num DESC
-               ->  Seq Scan on compress_hyper_14_19_chunk
+               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_21_chunk
 (6 rows)
 
 INSERT INTO test_ordering SELECT 1;
@@ -745,9 +787,9 @@ INSERT INTO test_ordering SELECT 1;
                         QUERY PLAN                         
 -----------------------------------------------------------
  Sort
-   Sort Key: _hyper_13_18_chunk."time"
-   ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-         ->  Seq Scan on compress_hyper_14_19_chunk
+   Sort Key: _hyper_13_20_chunk."time"
+   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+         ->  Seq Scan on compress_hyper_14_21_chunk
 (4 rows)
 
 INSERT INTO test_ordering VALUES (105),(104),(103);
@@ -758,10 +800,10 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Index Only Scan Backward using _hyper_13_20_chunk_test_ordering_time_idx on _hyper_13_20_chunk
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
+               ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Index Only Scan Backward using _hyper_13_22_chunk_test_ordering_time_idx on _hyper_13_22_chunk
 (7 rows)
 
 --insert into compressed + uncompressed chunk
@@ -784,11 +826,11 @@ INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
 ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
 \set ON_ERROR_STOP 1
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
-NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
+NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_13_18_chunk
  _timescaledb_internal._hyper_13_20_chunk
+ _timescaledb_internal._hyper_13_22_chunk
 (2 rows)
 
 -- should be ordered append
@@ -798,12 +840,12 @@ NOTICE:  chunk "_hyper_13_18_chunk" is already compressed
  Custom Scan (ChunkAppend) on test_ordering
    Order: test_ordering."time"
    ->  Sort
-         Sort Key: _hyper_13_18_chunk."time"
-         ->  Custom Scan (DecompressChunk) on _hyper_13_18_chunk
-               ->  Seq Scan on compress_hyper_14_19_chunk
-   ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
-         ->  Sort
-               Sort Key: compress_hyper_14_21_chunk._ts_meta_sequence_num DESC
+         Sort Key: _hyper_13_20_chunk."time"
+         ->  Custom Scan (DecompressChunk) on _hyper_13_20_chunk
                ->  Seq Scan on compress_hyper_14_21_chunk
+   ->  Custom Scan (DecompressChunk) on _hyper_13_22_chunk
+         ->  Sort
+               Sort Key: compress_hyper_14_23_chunk._ts_meta_sequence_num DESC
+               ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 

--- a/tsl/test/expected/compression_permissions.out
+++ b/tsl/test/expected/compression_permissions.out
@@ -162,6 +162,7 @@ NOTICE:  drop cascades to 2 other objects
 NOTICE:  drop cascades to view v2
 -- Testing that permissions propagate to compressed hypertables and to
 -- compressed chunks.
+-- Table is created by superuser
 CREATE TABLE conditions (
       timec TIMESTAMPTZ NOT NULL,
       location TEXT NOT NULL,
@@ -348,3 +349,32 @@ chunk          | _timescaledb_internal.compress_hyper_4_27_chunk
 chunk_acl      | {super_user=arwdDxt/super_user,default_perm_user=r/super_user}
 
 \x off
+--TEST user that has insert permission can insert into a compressed chunk
+GRANT INSERT ON conditions TO :ROLE_DEFAULT_PERM_USER;
+SELECT count(*) FROM conditions; 
+ count 
+-------
+    63
+(1 row)
+
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 
+ count 
+-------
+    11
+(1 row)
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--insert into a compressed chunk --
+INSERT INTO conditions VALUES( '2018-12-02 00:00'::timestamp, 'NYC', 75, 95);
+SELECT count(*) FROM conditions; 
+ count 
+-------
+    64
+(1 row)
+
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 
+ count 
+-------
+    11
+(1 row)
+

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -880,3 +880,120 @@ SELECT * from test_recomp_int_chunk_status ORDER BY 1;
  _dist_hyper_4_14_chunk |            1
 (1 row)
 
+---run copy tests
+--copy data into existing chunk + for a new chunk
+COPY test_recomp_int  FROM STDIN WITH DELIMITER ',';
+SELECT time_bucket(20, time ), count(*)
+FROM test_recomp_int
+GROUP BY time_bucket( 20, time) ORDER BY 1;
+ time_bucket | count 
+-------------+-------
+           0 |    12
+         100 |     3
+(2 rows)
+
+--another new chunk
+INSERT INTO test_recomp_int VALUES( 65, 10);
+SELECT * from test_recomp_int_chunk_status ORDER BY 1;
+       chunk_name       | chunk_status 
+------------------------+--------------
+ _dist_hyper_4_14_chunk |            3
+ _dist_hyper_4_15_chunk |            0
+ _dist_hyper_4_16_chunk |            0
+(3 rows)
+
+--compress all 3 chunks ---
+--check status, unordered chunk status will not change
+SELECT compress_chunk(chunk, true)
+FROM show_chunks('test_recomp_int') AS chunk
+ORDER BY chunk;
+                compress_chunk                
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_4_14_chunk
+ _timescaledb_internal._dist_hyper_4_15_chunk
+ _timescaledb_internal._dist_hyper_4_16_chunk
+(3 rows)
+
+SELECT * from test_recomp_int_chunk_status ORDER BY 1;
+       chunk_name       | chunk_status 
+------------------------+--------------
+ _dist_hyper_4_14_chunk |            3
+ _dist_hyper_4_15_chunk |            1
+ _dist_hyper_4_16_chunk |            1
+(3 rows)
+
+--interleave copy into 3 different chunks and check status--
+COPY test_recomp_int  FROM STDIN WITH DELIMITER ',';
+SELECT * from test_recomp_int_chunk_status ORDER BY 1;
+       chunk_name       | chunk_status 
+------------------------+--------------
+ _dist_hyper_4_14_chunk |            3
+ _dist_hyper_4_15_chunk |            3
+ _dist_hyper_4_16_chunk |            3
+(3 rows)
+
+SELECT time_bucket(20, time ), count(*)
+FROM test_recomp_int
+GROUP BY time_bucket( 20, time) ORDER BY 1;
+ time_bucket | count 
+-------------+-------
+           0 |    14
+          60 |     3
+         100 |     5
+(3 rows)
+
+--check compression_status afterwards--
+SELECT recompress_chunk(chunk, true) FROM
+( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 2)q;
+               recompress_chunk               
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_4_14_chunk
+ _timescaledb_internal._dist_hyper_4_15_chunk
+(2 rows)
+
+SELECT * from test_recomp_int_chunk_status ORDER BY 1;
+       chunk_name       | chunk_status 
+------------------------+--------------
+ _dist_hyper_4_14_chunk |            1
+ _dist_hyper_4_15_chunk |            1
+ _dist_hyper_4_16_chunk |            3
+(3 rows)
+
+CALL run_job(:compressjob_id);
+SELECT * from test_recomp_int_chunk_status ORDER BY 1;
+       chunk_name       | chunk_status 
+------------------------+--------------
+ _dist_hyper_4_14_chunk |            1
+ _dist_hyper_4_15_chunk |            1
+ _dist_hyper_4_16_chunk |            1
+(3 rows)
+
+--verify that there are no errors if the policy/recompress_chunk is executed again
+--on previously compressed chunks
+CALL run_job(:compressjob_id);
+NOTICE:  no chunks for hypertable public.test_recomp_int that satisfy compress chunk policy
+SELECT recompress_chunk(chunk, true) FROM
+( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk )q;
+NOTICE:  chunk "_dist_hyper_4_14_chunk" is already compressed
+NOTICE:  chunk "_dist_hyper_4_15_chunk" is already compressed
+NOTICE:  chunk "_dist_hyper_4_16_chunk" is already compressed
+ recompress_chunk 
+------------------
+ 
+ 
+ 
+(3 rows)
+
+--decompress and recompress chunk
+\set ON_ERROR_STOP 0
+SELECT decompress_chunk(chunk, true) FROM
+( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 1 )q;
+               decompress_chunk               
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_4_14_chunk
+(1 row)
+
+SELECT recompress_chunk(chunk)  FROM
+( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 1 )q;
+ERROR:  call compress_chunk instead of recompress_chunk
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/dist_util.out
+++ b/tsl/test/expected/dist_util.out
@@ -763,42 +763,42 @@ LIMIT 2;
 SELECT * FROM hypertable_size('disttable');
  hypertable_size 
 -----------------
-          131072
+          180224
 (1 row)
 
 SELECT * FROM hypertable_size('nondisttable');
  hypertable_size 
 -----------------
-          114688
+          163840
 (1 row)
 
 SELECT * FROM hypertable_detailed_size('disttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
-       16384 |       49152 |        8192 |       73728 | data_node_1
-        8192 |       32768 |        8192 |       49152 | data_node_2
+       40960 |       49152 |        8192 |       98304 | data_node_1
+       32768 |       32768 |        8192 |       73728 | data_node_2
            0 |        8192 |           0 |        8192 | 
 (3 rows)
 
 SELECT * FROM hypertable_detailed_size('nondisttable') ORDER BY node_name;
  table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -------------+-------------+-------------+-------------+-----------
-       24576 |       73728 |       16384 |      114688 | 
+       73728 |       73728 |       16384 |      163840 | 
 (1 row)
 
 SELECT * FROM chunks_detailed_size('disttable') ORDER BY chunk_schema, chunk_name, node_name;
      chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
- _timescaledb_internal | _dist_hyper_2_2_chunk |        8192 |       24576 |        8192 |       40960 | data_node_1
- _timescaledb_internal | _dist_hyper_2_5_chunk |        8192 |       24576 |        8192 |       40960 | data_node_2
+ _timescaledb_internal | _dist_hyper_2_2_chunk |       32768 |       24576 |        8192 |       65536 | data_node_1
+ _timescaledb_internal | _dist_hyper_2_5_chunk |       32768 |       24576 |        8192 |       65536 | data_node_2
  _timescaledb_internal | _dist_hyper_2_6_chunk |        8192 |       16384 |           0 |       24576 | data_node_1
 (3 rows)
 
 SELECT * FROM chunks_detailed_size('nondisttable') ORDER BY chunk_schema, chunk_name, node_name;
      chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -----------------------+------------------+-------------+-------------+-------------+-------------+-----------
- _timescaledb_internal | _hyper_1_1_chunk |        8192 |       24576 |        8192 |       40960 | 
- _timescaledb_internal | _hyper_1_3_chunk |        8192 |       24576 |        8192 |       40960 | 
+ _timescaledb_internal | _hyper_1_1_chunk |       32768 |       24576 |        8192 |       65536 | 
+ _timescaledb_internal | _hyper_1_3_chunk |       32768 |       24576 |        8192 |       65536 | 
  _timescaledb_internal | _hyper_1_4_chunk |        8192 |       16384 |           0 |       24576 | 
 (3 rows)
 

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -95,8 +95,8 @@ SELECT * FROM chunks_detailed_size('dist_table'::regclass)
 ORDER BY chunk_name, node_name;
      chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-------------
- _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |        8192 |       49152 | view_node_1
- _timescaledb_internal | _dist_hyper_1_1_chunk |        8192 |       32768 |        8192 |       49152 | view_node_2
+ _timescaledb_internal | _dist_hyper_1_1_chunk |       32768 |       32768 |        8192 |       73728 | view_node_1
+ _timescaledb_internal | _dist_hyper_1_1_chunk |       32768 |       32768 |        8192 |       73728 | view_node_2
  _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | view_node_2
  _timescaledb_internal | _dist_hyper_1_2_chunk |        8192 |       32768 |           0 |       40960 | view_node_3
  _timescaledb_internal | _dist_hyper_1_3_chunk |        8192 |       32768 |           0 |       40960 | view_node_1
@@ -107,8 +107,8 @@ SELECT * FROM hypertable_detailed_size('dist_table'::regclass)
 ORDER BY node_name;;
  table_bytes | index_bytes | toast_bytes | total_bytes |  node_name  
 -------------+-------------+-------------+-------------+-------------
-       16384 |       81920 |        8192 |      106496 | view_node_1
-       16384 |       81920 |        8192 |      106496 | view_node_2
+       40960 |       81920 |        8192 |      131072 | view_node_1
+       40960 |       81920 |        8192 |      131072 | view_node_2
        16384 |       81920 |           0 |       98304 | view_node_3
            0 |       16384 |           0 |       16384 | 
 (4 rows)

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -259,6 +259,7 @@ COPY test_gen(payload) FROM STDIN DELIMITER ',';
 
 SELECT * from test_gen WHERE id = (Select max(id) from test_gen);
 
+-- TEST triggers
 -- insert into compressed hypertables with triggers
 CREATE OR REPLACE FUNCTION row_trig_value_gt_0() RETURNS TRIGGER AS $$
 BEGIN
@@ -293,12 +294,16 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
-CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int);
+CREATE TABLE trigger_test(time timestamptz NOT NULL, device int, value int, dropcol1 int);
 SELECT create_hypertable('trigger_test','time');
-ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 
 --create chunk and compress
-INSERT INTO trigger_test SELECT '2000-01-01',1,1;
+--the first chunk is created with dropcol1
+INSERT INTO trigger_test(time, device, value,dropcol1) SELECT '2000-01-01',1,1,1;
+-- drop the column before we compress
+ALTER TABLE trigger_test DROP COLUMN dropcol1;
+
+ALTER TABLE trigger_test SET (timescaledb.compress,timescaledb.compress_segmentby='device');
 SELECT compress_chunk(c) FROM show_chunks('trigger_test') c;
 
 -- BEFORE ROW trigger
@@ -486,6 +491,26 @@ COPY trigger_test FROM STDIN DELIMITER ',';
 
 -- should not insert rows. count is 1
 SELECT count(*) FROM trigger_test;
+DROP trigger t4_constraint ON trigger_test;
+
+-- test row triggers after adding/dropping columns
+-- now add a new column to the table and insert into a new chunk
+ALTER TABLE trigger_test ADD COLUMN addcolv varchar(10);
+ALTER TABLE trigger_test ADD COLUMN addcoli integer;
+INSERT INTO trigger_test(time, device, value, addcolv, addcoli) 
+VALUES ( '2010-01-01', 10, 10, 'ten', 222);
+SELECT compress_chunk(c, true) FROM show_chunks('trigger_test') c;
+
+CREATE TRIGGER t1_mod BEFORE INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION row_trig_value_mod();
+
+SELECT count(*) FROM trigger_test;
+
+BEGIN;
+INSERT INTO trigger_test VALUES
+                   ( '2000-01-01',1,11, 'eleven', 111),
+                   ( '2010-01-01',10,10, 'ten', 222);
+SELECT * FROM trigger_test ORDER BY 1 ,2, 5;
+ROLLBACK;
 
 DROP TABLE trigger_test;
 

--- a/tsl/test/sql/compression_permissions.sql
+++ b/tsl/test/sql/compression_permissions.sql
@@ -125,6 +125,7 @@ DROP TABLE conditions CASCADE;
 
 -- Testing that permissions propagate to compressed hypertables and to
 -- compressed chunks.
+-- Table is created by superuser
 
 CREATE TABLE conditions (
       timec TIMESTAMPTZ NOT NULL,
@@ -178,3 +179,13 @@ SELECT htd.hypertable, htd.hypertable_acl, chunk, chunk_acl
   FROM chunk_details chd JOIN hypertable_details htd ON chd.hypertable = htd.compressed
 ORDER BY hypertable, chunk;
 \x off
+
+--TEST user that has insert permission can insert into a compressed chunk
+GRANT INSERT ON conditions TO :ROLE_DEFAULT_PERM_USER;
+SELECT count(*) FROM conditions; 
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+--insert into a compressed chunk --
+INSERT INTO conditions VALUES( '2018-12-02 00:00'::timestamp, 'NYC', 75, 95);
+SELECT count(*) FROM conditions; 
+SELECT count(*) FROM ( SELECT show_chunks('conditions'))q; 


### PR DESCRIPTION
The view uses cached information from compression_chunk_size to
report the size of compressed chunks. Since compressed chunks
can be modified, we call pg_relation_size on the compressed chunk
while reporting the size.