### PR TITLE
Fix broken links in notice

### DIFF
--- a/sql/notice.sql
+++ b/sql/notice.sql
@@ -10,7 +10,7 @@ BEGIN
   THEN
     telemetry_string = E'Note: Please enable telemetry to help us improve our product by running: ALTER DATABASE "' || current_database() || E'" SET timescaledb.telemetry_level = ''basic'';';
   ELSE
-    telemetry_string = E'Note: TimescaleDB collects anonymous reports to better understand and assist our users.\nFor more information and how to disable, please see our docs https://docs.timescaledb.com/using-timescaledb/telemetry.';
+    telemetry_string = E'Note: TimescaleDB collects anonymous reports to better understand and assist our users.\nFor more information and how to disable, please see our docs https://docs.timescale.com/timescaledb/latest/how-to-guides/configuration/telemetry.';
   END IF;
 
   RAISE WARNING E'%\n%\n',
@@ -25,9 +25,9 @@ BEGIN
 
     E'For more information on TimescaleDB, please visit the following links:\n\n'
     ||
-    E' 1. Getting started: https://docs.timescale.com/getting-started\n' ||
-    E' 2. API reference documentation: https://docs.timescale.com/api\n' ||
-    E' 3. How TimescaleDB is designed: https://docs.timescale.com/introduction/architecture\n',
+    E' 1. Getting started: https://docs.timescale.com/timescaledb/latest/getting-started\n' ||
+    E' 2. API reference documentation: https://docs.timescale.com/api/latest\n' ||
+    E' 3. How TimescaleDB is designed: https://docs.timescale.com/timescaledb/latest/overview/core-concepts\n',
     telemetry_string;
 END;
 $$;


### PR DESCRIPTION
Hi 👋🏼 🐯

I was trying Timescale and found these links were moved to somewhere else after installed the extension:

<img width="956" alt="CleanShot 2021-05-22 at 17 01 06@2x" src="https://user-images.githubusercontent.com/1000669/119219211-533fc300-bb1f-11eb-9e2b-9437b5cef3f9.png">

We could either:

1) Add page redirects to existing links and keep these links unchanged, then close this PR
2) Change these links to something that should never change. Add redirects of these links so the `notice.sql` won’t need to be changed in the future:

- https://docs.timescale.com/telemetry
- https://docs.timescale.com/getting-started
- https://docs.timescale.com/api
- https://docs.timescale.com/core-concepts

3) Merge this PR and call it a day 😅


I am happy with any options.

Thanks!