### PR TITLE
Explicitly install clang-9 in coverity workflow

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -21,7 +21,7 @@ jobs:
       MAKE_JOBS: 4
     steps:
     - name: Install Dependencies
-      run: sudo apt install flex bison
+      run: sudo apt install flex bison clang-9 llvm-9 llvm-9-dev llvm-9-tools
 
     # this workflow depends on the cached postgres build from the main regression
     # workflow since that workflow runs daily there should always be a cache hit


### PR DESCRIPTION
GitHub only has the last 3 clang versions installed by default in
the virtual environment and no longer installed clang-9 when they
added clang-12. Since we need clang-9 to build postgres with
llvm support we need to explicitly install the required package.

https://github.com/actions/virtual-environments/pull/3381