### PR TITLE
Fix hypertable_chunk_local_size view

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -124,3 +124,6 @@ UPDATE pg_class
    SET relacl = (SELECT relacl FROM pg_class WHERE oid = hypertable_oid)
   FROM chunks
  WHERE oid = chunk_oid;
+
+-- drop the view as view definition changed
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size ;

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -150,7 +150,7 @@ $$);
 SELECT * FROM chunks_detailed_size('toast_test');
      chunk_schema      |    chunk_name    | table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
 -----------------------+------------------+-------------+-------------+-------------+-------------+-----------
- _timescaledb_internal | _hyper_4_9_chunk |       24576 |       16384 |        8192 |       49152 | 
+ _timescaledb_internal | _hyper_4_9_chunk |        8192 |       16384 |       24576 |       49152 | 
 (1 row)
 
 -- Tests for approximate_row_count()


### PR DESCRIPTION
The view uses cached information from compression_chunk_size to
report the size of compressed chunks. Since compressed chunks
can be modified, we call pg_relation_size on the compressed chunk
while reporting the size

The view also incorrectly used the hypertable's reltoastrelid to
calculate toast bytes. It has been changed to use the chunk's
reltoastrelid.