### PR TITLE
Remove unused job_type from policies

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -871,7 +871,7 @@ ts_bgw_job_run_and_set_next_start(BgwJob *job, job_main_func func, int64 initial
 }
 
 int
-ts_bgw_job_insert_relation(Name application_name, Name job_type, Interval *schedule_interval,
+ts_bgw_job_insert_relation(Name application_name, Interval *schedule_interval,
 						   Interval *max_runtime, int32 max_retries, Interval *retry_period,
 						   Name proc_schema, Name proc_name, Name owner, bool scheduled,
 						   int32 hypertable_id, Jsonb *config)

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -40,7 +40,7 @@ extern bool ts_bgw_job_has_timeout(BgwJob *job);
 extern TimestampTz ts_bgw_job_timeout_at(BgwJob *job, TimestampTz start_time);
 
 extern TSDLLEXPORT bool ts_bgw_job_delete_by_id(int32 job_id);
-extern TSDLLEXPORT int32 ts_bgw_job_insert_relation(Name application_name, Name job_type,
+extern TSDLLEXPORT int32 ts_bgw_job_insert_relation(Name application_name,
 													Interval *schedule_interval,
 													Interval *max_runtime, int32 max_retries,
 													Interval *retry_period, Name proc_schema,

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -150,7 +150,6 @@ Datum
 policy_compression_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData compress_chunks_name;
 	NameData proc_name, proc_schema, owner;
 	int32 job_id;
 	Oid ht_oid = PG_GETARG_OID(0);
@@ -234,7 +233,6 @@ policy_compression_add(PG_FUNCTION_ARGS)
 
 	/* insert a new job into jobs table */
 	namestrcpy(&application_name, "Compression Policy");
-	namestrcpy(&compress_chunks_name, "compress_chunks");
 	namestrcpy(&proc_name, POLICY_COMPRESSION_PROC_NAME);
 	namestrcpy(&proc_schema, INTERNAL_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));
@@ -278,7 +276,6 @@ policy_compression_add(PG_FUNCTION_ARGS)
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	job_id = ts_bgw_job_insert_relation(&application_name,
-										&compress_chunks_name,
 										default_schedule_interval,
 										DEFAULT_MAX_RUNTIME,
 										DEFAULT_MAX_RETRIES,

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -449,7 +449,6 @@ Datum
 policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData refresh_name;
 	NameData proc_name, proc_schema, owner;
 	ContinuousAgg *cagg;
 	CaggPolicyConfig policyconf;
@@ -531,7 +530,6 @@ policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 
 	/* Next, insert a new job into jobs table */
 	namestrcpy(&application_name, "Refresh Continuous Aggregate Policy");
-	namestrcpy(&refresh_name, "custom");
 	namestrcpy(&proc_name, POLICY_REFRESH_CAGG_PROC_NAME);
 	namestrcpy(&proc_schema, INTERNAL_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));
@@ -557,7 +555,6 @@ policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	job_id = ts_bgw_job_insert_relation(&application_name,
-										&refresh_name,
 										&refresh_interval,
 										DEFAULT_MAX_RUNTIME,
 										DEFAULT_MAX_RETRIES,

--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -62,7 +62,6 @@ Datum
 job_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData custom_name;
 	NameData proc_name;
 	NameData proc_schema;
 	NameData owner_name;
@@ -106,7 +105,6 @@ job_add(PG_FUNCTION_ARGS)
 
 	/* Next, insert a new job into jobs table */
 	namestrcpy(&application_name, "User-Defined Action");
-	namestrcpy(&custom_name, "custom");
 	namestrcpy(&proc_schema, get_namespace_name(get_func_namespace(proc)));
 	namestrcpy(&proc_name, func_name);
 	namestrcpy(&owner_name, GetUserNameFromId(owner, false));
@@ -115,7 +113,6 @@ job_add(PG_FUNCTION_ARGS)
 		job_config_check(&proc_schema, &proc_name, config);
 
 	job_id = ts_bgw_job_insert_relation(&application_name,
-										&custom_name,
 										schedule_interval,
 										&max_runtime,
 										DEFAULT_MAX_RETRIES,

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -122,7 +122,6 @@ Datum
 policy_reorder_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData reorder_name;
 	NameData proc_name, proc_schema, owner;
 	int32 job_id;
 	Dimension *dim;
@@ -212,7 +211,6 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 
 	/* Next, insert a new job into jobs table */
 	namestrcpy(&application_name, "Reorder Policy");
-	namestrcpy(&reorder_name, "reorder");
 	namestrcpy(&proc_name, POLICY_REORDER_PROC_NAME);
 	namestrcpy(&proc_schema, INTERNAL_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));
@@ -226,7 +224,6 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	job_id = ts_bgw_job_insert_relation(&application_name,
-										&reorder_name,
 										&schedule_interval,
 										DEFAULT_MAX_RUNTIME,
 										DEFAULT_MAX_RETRIES,

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -136,7 +136,6 @@ Datum
 policy_retention_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData drop_chunks_name;
 	int32 job_id;
 	Oid ht_oid = PG_GETARG_OID(0);
 	Datum window_datum = PG_GETARG_DATUM(1);
@@ -257,14 +256,12 @@ policy_retention_add(PG_FUNCTION_ARGS)
 
 	/* Next, insert a new job into jobs table */
 	namestrcpy(&application_name, "Retention Policy");
-	namestrcpy(&drop_chunks_name, "drop_chunks");
 	NameData proc_name, proc_schema, owner;
 	namestrcpy(&proc_name, POLICY_RETENTION_PROC_NAME);
 	namestrcpy(&proc_schema, INTERNAL_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));
 
 	job_id = ts_bgw_job_insert_relation(&application_name,
-										&drop_chunks_name,
 										&default_schedule_interval,
 										&default_max_runtime,
 										default_max_retries,

--- a/tsl/src/continuous_aggs/job.c
+++ b/tsl/src/continuous_aggs/job.c
@@ -70,11 +70,9 @@ int32
 ts_continuous_agg_job_add(int32 mat_table_id, int32 raw_table_id, int64 bucket_width)
 {
 	NameData application_name;
-	NameData job_type;
 	NameData proc_name, proc_schema, owner;
 	int32 job_id;
 
-	namestrcpy(&job_type, "continuous_aggregate");
 	namestrcpy(&application_name, "Continuous Aggregate Policy");
 
 	Interval *refresh_interval =
@@ -92,7 +90,6 @@ ts_continuous_agg_job_add(int32 mat_table_id, int32 raw_table_id, int64 bucket_w
 	Jsonb *config = JsonbValueToJsonb(result);
 
 	job_id = ts_bgw_job_insert_relation(&application_name,
-										&job_type,
 										refresh_interval,
 										DEFAULT_MAX_RUNTIME,
 										DEFAULT_MAX_RETRIES,


### PR DESCRIPTION
When refactoring the job code the job_type was removed from our
catalog but a few places got overlooked that still had a variable
holding the job type.