### PR TITLE
Add some more randomness to chunk assignment

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1191,10 +1191,11 @@ ts_hypertable_has_tablespace(Hypertable *ht, Oid tspc_oid)
 }
 
 static int
-hypertable_get_chunk_slice_ordinal(const Hypertable *ht, const Hypercube *hc)
+hypertable_get_chunk_round_robin_index(const Hypertable *ht, const Hypercube *hc)
 {
 	Dimension *dim;
 	DimensionSlice *slice;
+	int offset = 0;
 
 	Assert(NULL != ht);
 	Assert(NULL != hc);
@@ -1202,7 +1203,17 @@ hypertable_get_chunk_slice_ordinal(const Hypertable *ht, const Hypercube *hc)
 	dim = hyperspace_get_closed_dimension(ht->space, 0);
 
 	if (NULL == dim)
+	{
 		dim = hyperspace_get_open_dimension(ht->space, 0);
+		/* Add some randomness between hypertables so that
+		 * if there is no space partitions, but multiple hypertables
+		 * the initial index is different for different hypertables.
+		 * This protects against creating a lot of chunks on the same
+		 * data node when many hypertables are created at roughly
+		 * the same time, e.g., from a bootstrap script.
+		 */
+		offset = (int) ht->fd.id;
+	}
 
 	Assert(NULL != dim);
 
@@ -1210,7 +1221,7 @@ hypertable_get_chunk_slice_ordinal(const Hypertable *ht, const Hypercube *hc)
 
 	Assert(NULL != slice);
 
-	return ts_dimension_get_slice_ordinal(dim, slice);
+	return ts_dimension_get_slice_ordinal(dim, slice) + offset;
 }
 
 /*
@@ -1232,7 +1243,7 @@ ts_hypertable_select_tablespace(Hypertable *ht, Chunk *chunk)
 	if (NULL == tspcs || tspcs->num_tablespaces == 0)
 		return NULL;
 
-	i = hypertable_get_chunk_slice_ordinal(ht, chunk->cube);
+	i = hypertable_get_chunk_round_robin_index(ht, chunk->cube);
 
 	/* Use the index of the slice to find the tablespace */
 	return &tspcs->tablespaces[i % tspcs->num_tablespaces];
@@ -2568,7 +2579,7 @@ ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cub
 	int num_assigned = MIN(ht->fd.replication_factor, list_length(available_nodes));
 	int n, i;
 
-	n = hypertable_get_chunk_slice_ordinal(ht, cube);
+	n = hypertable_get_chunk_round_robin_index(ht, cube);
 
 	for (i = 0; i < num_assigned; i++)
 	{

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -677,7 +677,7 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
       chunk_name       |       node_name       | before_total | after_total 
 -----------------------+-----------------------+--------------+-------------
  _dist_hyper_2_6_chunk | db_dist_compression_1 | 32 kB        | 32 kB
- _dist_hyper_2_6_chunk | db_dist_compression_2 | 32 kB        | 32 kB
+ _dist_hyper_2_6_chunk | db_dist_compression_3 | 32 kB        | 32 kB
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -1616,9 +1616,9 @@ WARNING:  insufficient number of data nodes
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
  chunk_id | node_chunk_id |      node_name       
 ----------+---------------+----------------------
+       10 |             4 | db_dist_hypertable_3
        10 |             4 | db_dist_hypertable_1
        10 |             4 | db_dist_hypertable_2
-       10 |             4 | db_dist_hypertable_3
 (3 rows)
 
 SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
@@ -1632,9 +1632,9 @@ FROM show_chunks('underreplicated');
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
  chunk_id | node_chunk_id |      node_name       
 ----------+---------------+----------------------
+       10 |             4 | db_dist_hypertable_3
        10 |             4 | db_dist_hypertable_1
        10 |             4 | db_dist_hypertable_2
-       10 |             4 | db_dist_hypertable_3
 (3 rows)
 
 -- Show that chunks are created on remote data nodes and that all
@@ -2958,18 +2958,18 @@ Tue Jan 01 01:02:00 2019 PST|ts-1-11-20-30|  2|abcabcabcabcabcabcab
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT time, txn_id, val, substring(info for 20) FROM disttable_with_ct
 NOTICE:  [db_dist_hypertable_2]:
-time                        |txn_id       |val|substring           
-----------------------------+-------------+---+--------------------
-Tue Jan 01 01:02:00 2019 PST|ts-1-11-20-30|  2|abcabcabcabcabcabcab
-(1 row)
+time|txn_id|val|substring
+----+------+---+---------
+(0 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT time, txn_id, val, substring(info for 20) FROM disttable_with_ct
 NOTICE:  [db_dist_hypertable_3]:
-time|txn_id|val|substring
-----+------+---+---------
-(0 rows)
+time                        |txn_id       |val|substring           
+----------------------------+-------------+---+--------------------
+Tue Jan 01 01:02:00 2019 PST|ts-1-11-20-30|  2|abcabcabcabcabcabcab
+(1 row)
 
 
  remote_exec 
@@ -3044,10 +3044,10 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      16|            8|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
-      17|            8|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
-      18|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      19|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      15|            8|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
+      16|            8|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
+      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (4 rows)
 
 
@@ -3057,10 +3057,10 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      14|            7|_timescaledb_internal|_dist_hyper_10_28_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [1431655764, 9223372036854775807]}
-      15|            7|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
-      16|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
-      17|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
+      15|            7|_timescaledb_internal|_dist_hyper_10_28_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [1431655764, 9223372036854775807]}
+      16|            7|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
+      17|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      18|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
 (4 rows)
 
 
@@ -3116,8 +3116,8 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      18|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      19|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (2 rows)
 
 
@@ -3127,8 +3127,8 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      16|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
-      17|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
+      17|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      18|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
 (2 rows)
 
 
@@ -3495,7 +3495,7 @@ SELECT * FROM dist_device;
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
    Chunks: _dist_hyper_15_37_chunk
-   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[24])
+   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
 (5 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
@@ -3509,7 +3509,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
    Chunks: _dist_hyper_15_37_chunk
-   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[24]) ORDER BY "time" ASC NULLS LAST
+   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
      Custom Scan (ChunkAppend) on public.dist_device
        Output: dist_device."time", dist_device.dist_device, dist_device.temp
@@ -3680,7 +3680,7 @@ ORDER BY 1;
 INSERT INTO devices VALUES (6, 'E999');
 \set ON_ERROR_STOP 0
 INSERT INTO hyper VALUES ('2017-01-01 06:01', 6, 1.1);
-ERROR:  [db_dist_hypertable_1]: insert or update on table "_dist_hyper_17_45_chunk" violates foreign key constraint "28_17_hyper_device_fkey"
+ERROR:  [db_dist_hypertable_1]: insert or update on table "_dist_hyper_17_45_chunk" violates foreign key constraint "26_17_hyper_device_fkey"
 \set ON_ERROR_STOP 1
 -- Test alter replication factor with data
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
@@ -3693,9 +3693,9 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3716,8 +3716,8 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
 (2 rows)
 
 
@@ -3744,9 +3744,9 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3767,8 +3767,8 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
 (2 rows)
 
 
@@ -3788,10 +3788,10 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
-      31|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      29|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (4 rows)
 
 
@@ -3813,9 +3813,9 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
-      23|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      25|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3842,11 +3842,11 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
-      31|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      32|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      29|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      30|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
 (5 rows)
 
 
@@ -3869,9 +3869,9 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
-      23|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      25|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3898,11 +3898,11 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
-      31|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      32|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      29|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      30|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
 (5 rows)
 
 
@@ -3926,10 +3926,10 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
-      23|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      24|           14|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      25|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           14|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
 (4 rows)
 
 
@@ -4189,10 +4189,9 @@ NOTICE:  [db_dist_hypertable_1]:
     (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name FROM show_chunks('disttable_with_relopts_2'))
     ORDER BY relname
 NOTICE:  [db_dist_hypertable_1]:
-relname                |reloptions                        
------------------------+----------------------------------
-_dist_hyper_19_57_chunk|{fillfactor=10,parallel_workers=1}
-(1 row)
+relname|reloptions
+-------+----------
+(0 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
@@ -4202,7 +4201,7 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 relname                |reloptions                        
 -----------------------+----------------------------------
-_dist_hyper_19_58_chunk|{fillfactor=10,parallel_workers=1}
+_dist_hyper_19_57_chunk|{fillfactor=10,parallel_workers=1}
 (1 row)
 
 
@@ -4211,9 +4210,10 @@ NOTICE:  [db_dist_hypertable_3]:
     (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name FROM show_chunks('disttable_with_relopts_2'))
     ORDER BY relname
 NOTICE:  [db_dist_hypertable_3]:
-relname|reloptions
--------+----------
-(0 rows)
+relname                |reloptions                        
+-----------------------+----------------------------------
+_dist_hyper_19_58_chunk|{fillfactor=10,parallel_workers=1}
+(1 row)
 
 
  remote_exec 

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -1615,9 +1615,9 @@ WARNING:  insufficient number of data nodes
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
  chunk_id | node_chunk_id |      node_name       
 ----------+---------------+----------------------
+       10 |             4 | db_dist_hypertable_3
        10 |             4 | db_dist_hypertable_1
        10 |             4 | db_dist_hypertable_2
-       10 |             4 | db_dist_hypertable_3
 (3 rows)
 
 SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
@@ -1631,9 +1631,9 @@ FROM show_chunks('underreplicated');
 SELECT * FROM _timescaledb_catalog.chunk_data_node;
  chunk_id | node_chunk_id |      node_name       
 ----------+---------------+----------------------
+       10 |             4 | db_dist_hypertable_3
        10 |             4 | db_dist_hypertable_1
        10 |             4 | db_dist_hypertable_2
-       10 |             4 | db_dist_hypertable_3
 (3 rows)
 
 -- Show that chunks are created on remote data nodes and that all
@@ -2957,18 +2957,18 @@ Tue Jan 01 01:02:00 2019 PST|ts-1-11-20-30|  2|abcabcabcabcabcabcab
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT time, txn_id, val, substring(info for 20) FROM disttable_with_ct
 NOTICE:  [db_dist_hypertable_2]:
-time                        |txn_id       |val|substring           
-----------------------------+-------------+---+--------------------
-Tue Jan 01 01:02:00 2019 PST|ts-1-11-20-30|  2|abcabcabcabcabcabcab
-(1 row)
+time|txn_id|val|substring
+----+------+---+---------
+(0 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT time, txn_id, val, substring(info for 20) FROM disttable_with_ct
 NOTICE:  [db_dist_hypertable_3]:
-time|txn_id|val|substring
-----+------+---+---------
-(0 rows)
+time                        |txn_id       |val|substring           
+----------------------------+-------------+---+--------------------
+Tue Jan 01 01:02:00 2019 PST|ts-1-11-20-30|  2|abcabcabcabcabcabcab
+(1 row)
 
 
  remote_exec 
@@ -3043,10 +3043,10 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      16|            8|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
-      17|            8|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
-      18|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      19|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      15|            8|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
+      16|            8|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
+      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (4 rows)
 
 
@@ -3056,10 +3056,10 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      14|            7|_timescaledb_internal|_dist_hyper_10_28_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [1431655764, 9223372036854775807]}
-      15|            7|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
-      16|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
-      17|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
+      15|            7|_timescaledb_internal|_dist_hyper_10_28_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [1431655764, 9223372036854775807]}
+      16|            7|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
+      17|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      18|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
 (4 rows)
 
 
@@ -3115,8 +3115,8 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      18|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      19|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (2 rows)
 
 
@@ -3126,8 +3126,8 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      16|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
-      17|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
+      17|            7|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      18|            7|_timescaledb_internal|_dist_hyper_10_32_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [1431655764, 9223372036854775807]}
 (2 rows)
 
 
@@ -3494,7 +3494,7 @@ SELECT * FROM dist_device;
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
    Chunks: _dist_hyper_15_37_chunk
-   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[24])
+   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
 (5 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
@@ -3508,7 +3508,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
    Chunks: _dist_hyper_15_37_chunk
-   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[24]) ORDER BY "time" ASC NULLS LAST
+   Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
      Custom Scan (ChunkAppend) on public.dist_device
        Output: dist_device."time", dist_device.dist_device, dist_device.temp
@@ -3679,7 +3679,7 @@ ORDER BY 1;
 INSERT INTO devices VALUES (6, 'E999');
 \set ON_ERROR_STOP 0
 INSERT INTO hyper VALUES ('2017-01-01 06:01', 6, 1.1);
-ERROR:  [db_dist_hypertable_1]: insert or update on table "_dist_hyper_17_45_chunk" violates foreign key constraint "28_17_hyper_device_fkey"
+ERROR:  [db_dist_hypertable_1]: insert or update on table "_dist_hyper_17_45_chunk" violates foreign key constraint "26_17_hyper_device_fkey"
 \set ON_ERROR_STOP 1
 -- Test alter replication factor with data
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
@@ -3692,9 +3692,9 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3715,8 +3715,8 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
 (2 rows)
 
 
@@ -3743,9 +3743,9 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3766,8 +3766,8 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
 (2 rows)
 
 
@@ -3787,10 +3787,10 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
-      31|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      29|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (4 rows)
 
 
@@ -3812,9 +3812,9 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
-      23|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      25|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3841,11 +3841,11 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
-      31|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      32|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      29|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      30|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
 (5 rows)
 
 
@@ -3868,9 +3868,9 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
-      23|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      25|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3897,11 +3897,11 @@ NOTICE:  [db_dist_hypertable_1]:
 NOTICE:  [db_dist_hypertable_1]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      28|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
-      29|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
-      30|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
-      31|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      32|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_45_chunk|r      |{"time": [1483272000000000, 1483336800000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_46_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [-9223372036854775808, 715827882]}
+      28|           16|_timescaledb_internal|_dist_hyper_17_49_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [-9223372036854775808, 715827882]}
+      29|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      30|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
 (5 rows)
 
 
@@ -3925,10 +3925,10 @@ NOTICE:  [db_dist_hypertable_3]:
 NOTICE:  [db_dist_hypertable_3]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      21|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
-      22|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
-      23|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      24|           14|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
+      23|           14|_timescaledb_internal|_dist_hyper_17_48_chunk|r      |{"time": [1483401600000000, 1483466400000000], "device": [1431655764, 9223372036854775807]}
+      24|           14|_timescaledb_internal|_dist_hyper_17_51_chunk|r      |{"time": [1515866400000000, 1515931200000000], "device": [1431655764, 9223372036854775807]}
+      25|           14|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           14|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
 (4 rows)
 
 
@@ -4188,10 +4188,9 @@ NOTICE:  [db_dist_hypertable_1]:
     (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name FROM show_chunks('disttable_with_relopts_2'))
     ORDER BY relname
 NOTICE:  [db_dist_hypertable_1]:
-relname                |reloptions                        
------------------------+----------------------------------
-_dist_hyper_19_57_chunk|{fillfactor=10,parallel_workers=1}
-(1 row)
+relname|reloptions
+-------+----------
+(0 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
@@ -4201,7 +4200,7 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 relname                |reloptions                        
 -----------------------+----------------------------------
-_dist_hyper_19_58_chunk|{fillfactor=10,parallel_workers=1}
+_dist_hyper_19_57_chunk|{fillfactor=10,parallel_workers=1}
 (1 row)
 
 
@@ -4210,9 +4209,10 @@ NOTICE:  [db_dist_hypertable_3]:
     (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name FROM show_chunks('disttable_with_relopts_2'))
     ORDER BY relname
 NOTICE:  [db_dist_hypertable_3]:
-relname|reloptions
--------+----------
-(0 rows)
+relname                |reloptions                        
+-----------------------+----------------------------------
+_dist_hyper_19_58_chunk|{fillfactor=10,parallel_workers=1}
+(1 row)
 
 
  remote_exec 

--- a/tsl/test/expected/dist_query.out
+++ b/tsl/test/expected/dist_query.out
@@ -1148,9 +1148,9 @@ ORDER BY 1,2
                Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
-                     Data node: data_node_1
+                     Data node: data_node_3
                      Chunks: _dist_hyper_2_19_chunk
-                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
 (32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2142,9 +2142,9 @@ ORDER BY 1,2
                Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
-                     Data node: data_node_1
+                     Data node: data_node_3
                      Chunks: _dist_hyper_2_19_chunk
-                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
 (32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2851,9 +2851,9 @@ ORDER BY 1,2
                Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
-                     Data node: data_node_1
+                     Data node: data_node_3
                      Chunks: _dist_hyper_2_19_chunk
-                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
 (32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -3859,9 +3859,9 @@ ORDER BY 1,2
                Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
-                     Data node: data_node_1
+                     Data node: data_node_3
                      Chunks: _dist_hyper_2_19_chunk
-                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
 (32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -4876,9 +4876,9 @@ ORDER BY 1,2
                Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
-                     Data node: data_node_1
+                     Data node: data_node_3
                      Chunks: _dist_hyper_2_19_chunk
-                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
 (32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -4914,19 +4914,19 @@ ORDER BY 1
                Output: hyper1d."time", (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Chunks: _dist_hyper_2_19_chunk
+               Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Chunks: _dist_hyper_2_20_chunk
+               Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Chunks: _dist_hyper_2_21_chunk
+               Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
 (22 rows)
 
@@ -4953,19 +4953,19 @@ ORDER BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
 (25 rows)
 
@@ -5026,19 +5026,19 @@ GROUP BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (24 rows)
 
@@ -5064,19 +5064,19 @@ GROUP BY 1,2
                      Output: (date_trunc('month'::text, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (24 rows)
 
@@ -5103,19 +5103,19 @@ HAVING device > 4
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
 (24 rows)
 
@@ -5140,19 +5140,19 @@ HAVING avg(temp) > 40 AND max(temp) < 70
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp)), (PARTIAL max(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp)), (PARTIAL max(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp)), (PARTIAL max(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (25 rows)
 
@@ -5221,7 +5221,7 @@ ORDER BY 1
                            Output: hyper1d.location, hyper1d.temp
                            Filter: ((hyper1d.temp * random()) >= '0'::double precision)
                            Data node: data_node_1
-                           Chunks: _dist_hyper_2_19_chunk
+                           Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
                      Output: hyper1d_1.location, PARTIAL avg(hyper1d_1.temp)
@@ -5230,7 +5230,7 @@ ORDER BY 1
                            Output: hyper1d_1.location, hyper1d_1.temp
                            Filter: ((hyper1d_1.temp * random()) >= '0'::double precision)
                            Data node: data_node_2
-                           Chunks: _dist_hyper_2_20_chunk
+                           Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
                      Output: hyper1d_2.location, PARTIAL avg(hyper1d_2.temp)
@@ -5239,7 +5239,7 @@ ORDER BY 1
                            Output: hyper1d_2.location, hyper1d_2.temp
                            Filter: ((hyper1d_2.temp * random()) >= '0'::double precision)
                            Data node: data_node_3
-                           Chunks: _dist_hyper_2_21_chunk
+                           Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
 (34 rows)
 
@@ -5266,7 +5266,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: time_bucket('@ 2 days'::interval, hyper1d."time"), hyper1d.device, hyper1d.temp
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
                Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, PARTIAL avg(hyper1d_1.temp), PARTIAL sum((hyper1d_1.temp * (((random() <= '1'::double precision))::integer)::double precision))
@@ -5274,7 +5274,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: time_bucket('@ 2 days'::interval, hyper1d_1."time"), hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
                Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, PARTIAL avg(hyper1d_2.temp), PARTIAL sum((hyper1d_2.temp * (((random() <= '1'::double precision))::integer)::double precision))
@@ -5282,7 +5282,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: time_bucket('@ 2 days'::interval, hyper1d_2."time"), hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
 (29 rows)
 
@@ -5309,7 +5309,7 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: hyper1d."time", hyper1d.device, hyper1d.temp
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
                Output: hyper1d_1."time", hyper1d_1.device, avg(hyper1d_1.temp)
@@ -5318,7 +5318,7 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
                Output: hyper1d_2."time", hyper1d_2.device, avg(hyper1d_2.temp)
@@ -5327,7 +5327,7 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (30 rows)
 
@@ -5352,7 +5352,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: hyper1d."time", hyper1d.device, hyper1d.temp
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
                Output: hyper1d_1."time", hyper1d_1.device, avg(hyper1d_1.temp), custom_sum(hyper1d_1.device)
@@ -5360,7 +5360,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
                Output: hyper1d_2."time", hyper1d_2.device, avg(hyper1d_2.temp), custom_sum(hyper1d_2.device)
@@ -5368,7 +5368,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
 (27 rows)
 
@@ -5389,19 +5389,19 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Chunks: _dist_hyper_2_19_chunk
+               Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Chunks: _dist_hyper_2_20_chunk
+               Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Chunks: _dist_hyper_2_21_chunk
+               Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (21 rows)
 
@@ -5414,19 +5414,19 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Chunks: _dist_hyper_2_19_chunk
+               Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Chunks: _dist_hyper_2_20_chunk
+               Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Chunks: _dist_hyper_2_21_chunk
+               Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (21 rows)
 
@@ -5444,19 +5444,19 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Chunks: _dist_hyper_2_19_chunk
+               Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Chunks: _dist_hyper_2_20_chunk
+               Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Chunks: _dist_hyper_2_21_chunk
+               Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
 (21 rows)
 
@@ -5478,17 +5478,17 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 10
 (20 rows)
 
@@ -5511,17 +5511,17 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 10
 (20 rows)
 
@@ -5543,17 +5543,17 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 1
 (20 rows)
 
@@ -5575,17 +5575,17 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 2000
 (20 rows)
 
@@ -5607,17 +5607,17 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Chunks: _dist_hyper_2_19_chunk
+                     Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Chunks: _dist_hyper_2_20_chunk
+                     Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Chunks: _dist_hyper_2_21_chunk
+                     Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5])
 (20 rows)
 
@@ -5642,17 +5642,17 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time", hyper1d_1.temp
                            Data node: data_node_1
-                           Chunks: _dist_hyper_2_19_chunk
+                           Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time", hyper1d_2.temp
                            Data node: data_node_2
-                           Chunks: _dist_hyper_2_20_chunk
+                           Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time", hyper1d_3.temp
                            Data node: data_node_3
-                           Chunks: _dist_hyper_2_21_chunk
+                           Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
@@ -5677,17 +5677,17 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
-                           Chunks: _dist_hyper_2_19_chunk
+                           Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
-                           Chunks: _dist_hyper_2_20_chunk
+                           Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
-                           Chunks: _dist_hyper_2_21_chunk
+                           Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
 (23 rows)
 
@@ -5712,17 +5712,17 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
-                           Chunks: _dist_hyper_2_19_chunk
+                           Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
-                           Chunks: _dist_hyper_2_20_chunk
+                           Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
-                           Chunks: _dist_hyper_2_21_chunk
+                           Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
 (23 rows)
 
@@ -5742,17 +5742,17 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
-                           Chunks: _dist_hyper_2_19_chunk
+                           Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
-                           Chunks: _dist_hyper_2_20_chunk
+                           Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
-                           Chunks: _dist_hyper_2_21_chunk
+                           Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5])
          ->  Materialize
                Output: join_test.device
@@ -5795,17 +5795,17 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                                  Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                                  Data node: data_node_1
-                                 Chunks: _dist_hyper_2_19_chunk
-                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                                 Chunks: _dist_hyper_2_20_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone))
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                                  Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                                  Data node: data_node_2
-                                 Chunks: _dist_hyper_2_20_chunk
-                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone))
+                                 Chunks: _dist_hyper_2_21_chunk
+                                 Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                                  Output: hyper1d_3."time", hyper1d_3.device, hyper1d_3.temp
                                  Data node: data_node_3
-                                 Chunks: _dist_hyper_2_21_chunk
+                                 Chunks: _dist_hyper_2_19_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
                      Output: top_n.device
@@ -5826,20 +5826,20 @@ ORDER BY 1,2
                                                                Output: hyper1d_4.device, (PARTIAL avg(hyper1d_4.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_1
-                                                               Chunks: _dist_hyper_2_19_chunk
-                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
+                                                               Chunks: _dist_hyper_2_20_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper1d_5.device, (PARTIAL avg(hyper1d_5.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_2
-                                                               Chunks: _dist_hyper_2_20_chunk
+                                                               Chunks: _dist_hyper_2_21_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper1d_6.device, (PARTIAL avg(hyper1d_6.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_3
-                                                               Chunks: _dist_hyper_2_21_chunk
-                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
+                                                               Chunks: _dist_hyper_2_19_chunk
+                                                               Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
 (61 rows)
 
 
@@ -5883,9 +5883,9 @@ ORDER BY 1,2
                Output: h2.temp, h2."time", h2.device, (time_bucket('@ 1 min'::interval, h2."time"))
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
-                     Data node: data_node_1
+                     Data node: data_node_3
                      Chunks: _dist_hyper_2_19_chunk
-                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
+                     Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
 (32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/tsl/test/expected/dist_triggers.out
+++ b/tsl/test/expected/dist_triggers.out
@@ -152,6 +152,17 @@ FROM trigger_events
 GROUP BY 1,2,3,4
 ORDER BY 1,2,3,4
 NOTICE:  [db_dist_triggers_1]:
+tg_when|tg_level|tg_op|tg_name|count
+-------+--------+-----+-------+-----
+(0 rows)
+
+
+NOTICE:  [db_dist_triggers_2]: 
+SELECT tg_when, tg_level, tg_op, tg_name, count(*)
+FROM trigger_events
+GROUP BY 1,2,3,4
+ORDER BY 1,2,3,4
+NOTICE:  [db_dist_triggers_2]:
 tg_when|tg_level |tg_op |tg_name                               |count
 -------+---------+------+--------------------------------------+-----
 AFTER  |ROW      |INSERT|_0_test_trigger_insert_after          |    1
@@ -162,17 +173,6 @@ BEFORE |ROW      |INSERT|_0_test_trigger_insert                |    1
 BEFORE |ROW      |INSERT|z_test_trigger_all                    |    1
 BEFORE |STATEMENT|INSERT|_0_test_trigger_insert_s_before       |    1
 (7 rows)
-
-
-NOTICE:  [db_dist_triggers_2]: 
-SELECT tg_when, tg_level, tg_op, tg_name, count(*)
-FROM trigger_events
-GROUP BY 1,2,3,4
-ORDER BY 1,2,3,4
-NOTICE:  [db_dist_triggers_2]:
-tg_when|tg_level|tg_op|tg_name|count
--------+--------+-----+-------+-----
-(0 rows)
 
 
 NOTICE:  [db_dist_triggers_3]: 
@@ -225,22 +225,6 @@ FROM trigger_events
 GROUP BY 1,2,3,4
 ORDER BY 1,2,3,4
 NOTICE:  [db_dist_triggers_1]:
-tg_when|tg_level|tg_op |tg_name                     |count
--------+--------+------+----------------------------+-----
-AFTER  |ROW     |UPDATE|_0_test_trigger_update_after|    1
-AFTER  |ROW     |UPDATE|z_test_trigger_all_after    |    1
-BEFORE |ROW     |DELETE|_0_test_trigger_delete      |    1
-BEFORE |ROW     |UPDATE|_0_test_trigger_update      |    1
-BEFORE |ROW     |UPDATE|z_test_trigger_all          |    1
-(5 rows)
-
-
-NOTICE:  [db_dist_triggers_2]: 
-SELECT tg_when, tg_level, tg_op, tg_name, count(*)
-FROM trigger_events
-GROUP BY 1,2,3,4
-ORDER BY 1,2,3,4
-NOTICE:  [db_dist_triggers_2]:
 tg_when|tg_level |tg_op |tg_name                        |count
 -------+---------+------+-------------------------------+-----
 AFTER  |ROW      |INSERT|_0_test_trigger_insert_after   |    1
@@ -255,6 +239,22 @@ BEFORE |ROW      |UPDATE|_0_test_trigger_update         |    1
 BEFORE |ROW      |UPDATE|z_test_trigger_all             |    1
 BEFORE |STATEMENT|INSERT|_0_test_trigger_insert_s_before|    1
 (11 rows)
+
+
+NOTICE:  [db_dist_triggers_2]: 
+SELECT tg_when, tg_level, tg_op, tg_name, count(*)
+FROM trigger_events
+GROUP BY 1,2,3,4
+ORDER BY 1,2,3,4
+NOTICE:  [db_dist_triggers_2]:
+tg_when|tg_level|tg_op |tg_name                     |count
+-------+--------+------+----------------------------+-----
+AFTER  |ROW     |UPDATE|_0_test_trigger_update_after|    1
+AFTER  |ROW     |UPDATE|z_test_trigger_all_after    |    1
+BEFORE |ROW     |DELETE|_0_test_trigger_delete      |    1
+BEFORE |ROW     |UPDATE|_0_test_trigger_update      |    1
+BEFORE |ROW     |UPDATE|z_test_trigger_all          |    1
+(5 rows)
 
 
 NOTICE:  [db_dist_triggers_3]: 


### PR DESCRIPTION
Previously the assignment of data nodes to chunks had a bit
of a thundering-herd problem for multiple hypertables
without space partions: the data node assigned for the
first chunk was always the same across hypertables.
We fix this by adding the hypertable_id to the
index into the datanode array. This de-synchronizes
across hypertables but maintains consistency for any
given hypertable.

We could make this consistent for space partitioned tables
as well but avoid doing so now to prevent partitions
jumping nodes due to this change.

This also effects tablespace selection in the same way.