### PR TITLE
Use correct heading level in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
-# 2.3.0 (2021-05-25)
+## 2.3.0 (2021-05-25)
 
 This release adds major new features since the 2.2.1 release. 
 We deem it moderate priority for upgrading.


### PR DESCRIPTION
The 2.3.0 release used the wrong heading level. Fix it for future
releases.