### PR TITLE
Fix failed update with parallel workers

### DIFF
--- a/sql/updates/pre-update.sql
+++ b/sql/updates/pre-update.sql
@@ -5,6 +5,11 @@
 
 -- This file is always prepended to all upgrade scripts.
 
+-- Disable parallel execution for the duration of the update process.
+-- This avoids version mismatch errors that would have beeen triggered by the
+-- parallel workers in ts_extension_check_version().
+SET LOCAL max_parallel_workers = 0;
+
 -- Triggers should be disabled during upgrades to avoid having them
 -- invoke functions that might load an old version of the shared
 -- library before those functions have been updated.


### PR DESCRIPTION
When executing "ALTER EXTENSION timescaledb UPDATE TO ..." it will fail
if parallel workers spawn for the update itself. Add the appropriate
check to fix this.

Fixes #3286 
Fixes #2795

Tested as described in #3286