### PR TITLE
Fix flaky pg_dump test

### DIFF
--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -314,6 +314,14 @@ SHOW timescaledb.restoring;
  off
 (1 row)
 
+-- timescaledb_post_restore restarts background worker so we have to stop them
+-- to make sure they dont interfere with this database being used as template below
+SELECT _timescaledb_internal.stop_background_workers();
+ stop_background_workers 
+-------------------------
+ t
+(1 row)
+
 --should be same as count above
 SELECT count(*) = :num_dependent_objects as dependent_objects_match
   FROM pg_depend

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -107,6 +107,9 @@ VALUES (1357894000000000000, 'dev5', 1.5, 2);
 -- Now run our post-restore function.
 SELECT timescaledb_post_restore();
 SHOW timescaledb.restoring;
+-- timescaledb_post_restore restarts background worker so we have to stop them
+-- to make sure they dont interfere with this database being used as template below
+SELECT _timescaledb_internal.stop_background_workers();
 
 --should be same as count above
 SELECT count(*) = :num_dependent_objects as dependent_objects_match


### PR DESCRIPTION
Stop background workers in test after calling timescaledb_post_restore
since this function restarts background workers.