### PR TITLE
Remove TTSOps pointer macros

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -66,11 +66,6 @@
 	ExecComputeStoredGenerated(estate, slot)
 #endif
 
-#define TTSOpsVirtualP (&TTSOpsVirtual)
-#define TTSOpsHeapTupleP (&TTSOpsHeapTuple)
-#define TTSOpsMinimalTupleP (&TTSOpsMinimalTuple)
-#define TTSOpsBufferHeapTupleP (&TTSOpsBufferHeapTuple)
-
 /* fmgr
  * In a9c35cf postgres changed how it calls SQL functions so that the number of
  * argument-slots allocated is chosen dynamically, instead of being fixed. This

--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -54,7 +54,7 @@ ts_event_trigger_ddl_commands(void)
 
 	FunctionCallInvoke(fcinfo);
 
-	slot = MakeSingleTupleTableSlot(rsinfo.setDesc, TTSOpsMinimalTupleP);
+	slot = MakeSingleTupleTableSlot(rsinfo.setDesc, &TTSOpsMinimalTuple);
 
 	while (tuplestore_gettupleslot(rsinfo.setResult, true, false, slot))
 	{
@@ -238,7 +238,7 @@ ts_event_trigger_dropped_objects(void)
 
 	FunctionCallInvoke(fcinfo);
 
-	slot = MakeSingleTupleTableSlot(rsinfo.setDesc, TTSOpsMinimalTupleP);
+	slot = MakeSingleTupleTableSlot(rsinfo.setDesc, &TTSOpsMinimalTuple);
 
 	while (tuplestore_gettupleslot(rsinfo.setResult, true, false, slot))
 	{

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -374,7 +374,7 @@ compress_chunk_sort_relation(Relation in_rel, int n_keys, const ColumnCompressio
 	Tuplesortstate *tuplesortstate;
 	HeapTuple tuple;
 	TableScanDesc heapScan;
-	TupleTableSlot *heap_tuple_slot = MakeTupleTableSlot(tupDesc, TTSOpsHeapTupleP);
+	TupleTableSlot *heap_tuple_slot = MakeTupleTableSlot(tupDesc, &TTSOpsHeapTuple);
 	AttrNumber *sort_keys = palloc(sizeof(*sort_keys) * n_keys);
 	Oid *sort_operators = palloc(sizeof(*sort_operators) * n_keys);
 	Oid *sort_collations = palloc(sizeof(*sort_collations) * n_keys);
@@ -602,7 +602,7 @@ row_compressor_append_sorted_rows(RowCompressor *row_compressor, Tuplesortstate 
 								  TupleDesc sorted_desc)
 {
 	CommandId mycid = GetCurrentCommandId(true);
-	TupleTableSlot *slot = MakeTupleTableSlot(sorted_desc, TTSOpsMinimalTupleP);
+	TupleTableSlot *slot = MakeTupleTableSlot(sorted_desc, &TTSOpsMinimalTuple);
 	bool got_tuple;
 	bool first_iteration = true;
 

--- a/tsl/src/nodes/gapfill/exec.c
+++ b/tsl/src/nodes/gapfill/exec.c
@@ -29,7 +29,6 @@
 #include "nodes/gapfill/interpolate.h"
 #include "nodes/gapfill/exec.h"
 #include "time_bucket.h"
-#include "compat.h"
 
 typedef enum GapFillBoundary
 {
@@ -609,8 +608,8 @@ gapfill_begin(CustomScanState *node, EState *estate, int eflags)
 
 	state->gapfill_typid = func->funcresulttype;
 	state->state = FETCHED_NONE;
-	state->subslot = MakeSingleTupleTableSlot(tupledesc, TTSOpsVirtualP);
-	state->scanslot = MakeSingleTupleTableSlot(tupledesc, TTSOpsVirtualP);
+	state->subslot = MakeSingleTupleTableSlot(tupledesc, &TTSOpsVirtual);
+	state->scanslot = MakeSingleTupleTableSlot(tupledesc, &TTSOpsVirtual);
 
 	/* bucket_width */
 	if (!is_simple_expr(linitial(args)))
@@ -707,7 +706,7 @@ gapfill_begin(CustomScanState *node, EState *estate, int eflags)
 	}
 	state->pi = ExecBuildProjectionInfo(targetlist,
 										state->csstate.ss.ps.ps_ExprContext,
-										MakeSingleTupleTableSlot(tupledesc, TTSOpsVirtualP),
+										MakeSingleTupleTableSlot(tupledesc, &TTSOpsVirtual),
 										&state->csstate.ss.ps,
 										NULL);
 


### PR DESCRIPTION
Remove TTSOpsVirtualP, TTSOpsHeapTupleP, TTSOpsMinimalTupleP and
TTSOpsBufferHeapTupleP macros since they were only needed on PG11
to allow us to define compatibility macros for TupleTableSlot
operations.