### PR TITLE
Detect TAP test prerequisites with CMake

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -40,11 +40,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install flex bison lcov systemd-coredump gdb libipc-run-perl libtest-most-perl ${{ matrix.extra_packages }}
 
-    - name: Install macOS Dependencies using perl 5.18
+    - name: Install macOS Dependencies using Perl
       if: runner.os == 'macOS'
       run: |
-        sudo perl5.18 -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
-        sudo perl5.18 -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
+        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
+        sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 
     # on macOS the path used is depending on the runner version leading to cache failure
     # when the runner version changes so we extract runner version from path and add it

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
         choco feature disable --name=showDownloadProgress
         choco install postgresql${{ matrix.pg }} --version ${{ matrix.pkg_version }} --force -y --install-args="'--prefix $HOME\PostgreSQL\${{ matrix.pg }} --extract-only yes'"
     - name: Configure [${{ matrix.build_type }}]
-      run: cmake -B ${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREGRESS_CHECKS=OFF -DPG_PATH="$HOME/PostgreSQL/${{ matrix.pg }}" -DOPENSSL_ROOT_DIR="$HOME/PostgreSQL/${{ matrix.pg }}"
+      run: cmake -B ${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DREGRESS_CHECKS=OFF -DPG_PATH="$HOME/PostgreSQL/${{ matrix.pg }}" -DOPENSSL_ROOT_DIR="$HOME/PostgreSQL/${{ matrix.pg }}" -DTAP_CHECKS=OFF
       # Build step: could potentially speed things up with --parallel
       # <num_cpu> or "-- -m:<num_cpu>", but MSBuild doesn't seem to be
       # able to realize interdependencies between targets, which leads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,6 +487,38 @@ if (CODECOVERAGE)
   add_link_options(--coverage)
 endif (CODECOVERAGE)
 
+# TAP test support
+option(TAP_CHECKS "Enable TAP test support" ON)
+
+if (TAP_CHECKS)
+  find_package(Perl 5.8)
+
+  if (PERL_FOUND)
+    get_filename_component(PERL_BIN_PATH ${PERL_EXECUTABLE} DIRECTORY)
+
+    find_program(PROVE prove
+      HINTS
+      ${PERL_BIN_PATH}
+      PATHS
+      "/usr/bin"
+      NO_DEFAULT_PATH)
+
+    if (NOT PROVE)
+      message(FATAL_ERROR "The prove binary was not found. Disable TAP tests with -DTAP_CHECKS=OFF.")
+    endif ()
+
+    # Check for the IPC::Run module
+    execute_process(COMMAND ${PERL_EXECUTABLE} -MIPC::Run -e ""
+      ERROR_QUIET RESULT_VARIABLE PERL_MODULE_STATUS)
+
+    if (PERL_MODULE_STATUS)
+      message(FATAL_ERROR "IPC::Run Perl module not found. Disable TAP tests with -DTAP_CHECKS=OFF.")
+    endif ()
+  else ()
+    message(FATAL_ERROR "Perl not found. Disable TAP tests with -DTAP_CHECKS=OFF or set -DPERL_EXECUTABLE=<path/to/perl>. Requires Perl 5.8 or greater (http://perlbrew.pl).")
+  endif()
+endif (TAP_CHECKS)
+
 if (UNIX)
   add_subdirectory(scripts)
 endif (UNIX)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -129,7 +129,7 @@ build_script:
 
     # build timescale
 
-     .\bootstrap -DUSE_OPENSSL=0 -DPG_PATH="C:\Program Files\PostgreSQL\12" -DREGRESS_CHECKS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CONFIGURATION_TYPES=Debug -DCMAKE_C_FLAGS=/MP
+     .\bootstrap -DUSE_OPENSSL=0 -DPG_PATH="C:\Program Files\PostgreSQL\12" -DREGRESS_CHECKS=OFF -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CONFIGURATION_TYPES=Debug -DCMAKE_C_FLAGS=/MP -DTAP_CHECKS=OFF
 
     # Filter ssl and local configuration from pg_hba.conf file since
     # we have turned off SSL and local (unix domain socket)
@@ -178,7 +178,7 @@ build_script:
 
     docker exec -it pgregress /bin/bash -c "git clone  --depth 1 https://github.com/timescale/timescaledb.git /timescaledb && cd /timescaledb && git fetch -q origin $commit && git checkout -qf FETCH_HEAD"
 
-    docker exec -it pgregress /bin/bash -c "cd /timescaledb && ./bootstrap -DCMAKE_BUILD_TYPE=Debug -DREGRESS_CHECKS=OFF -DPG_REGRESS=/usr/local/bin/pg_regress -DTEST_PGHOST=docker.for.win.localhost -DTEST_PGPORT_LOCAL=55432"
+    docker exec -it pgregress /bin/bash -c "cd /timescaledb && ./bootstrap -DCMAKE_BUILD_TYPE=Debug -DREGRESS_CHECKS=OFF -DPG_REGRESS=/usr/local/bin/pg_regress -DTEST_PGHOST=docker.for.win.localhost -DTEST_PGPORT_LOCAL=55432 -DTAP_CHECKS=OFF"
 
 test_script:
 - ps: >-

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -77,7 +77,7 @@ build_timescaledb()
 
     # Build and install the extension with debug symbols and assertions
     tar -c -C ${BASE_DIR} {src,sql,test,scripts,tsl,version.config,CMakeLists.txt,timescaledb.control.in} | docker cp - ${BUILD_CONTAINER_NAME}:/build/
-    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "cd /build/debug && cmake -DUSE_OPENSSL=${USE_OPENSSL} -DREGRESS_CHECKS=OFF -DCMAKE_BUILD_TYPE=${BUILD_TYPE} .. && make && make install && echo \"shared_preload_libraries = 'timescaledb'\" >> /usr/local/share/postgresql/postgresql.conf.sample && echo \"timescaledb.telemetry_level=off\" >> /usr/local/share/postgresql/postgresql.conf.sample && cd / && rm -rf /build"
+    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "cd /build/debug && cmake -DUSE_OPENSSL=${USE_OPENSSL} -DREGRESS_CHECKS=OFF -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DTAP_CHECKS=OFF .. && make && make install && echo \"shared_preload_libraries = 'timescaledb'\" >> /usr/local/share/postgresql/postgresql.conf.sample && echo \"timescaledb.telemetry_level=off\" >> /usr/local/share/postgresql/postgresql.conf.sample && cd / && rm -rf /build"
     if [ $? -ne 0 ]; then
       echo "Building timescaledb failed"
       return 1

--- a/tsl/test/CMakeLists.txt
+++ b/tsl/test/CMakeLists.txt
@@ -5,9 +5,6 @@ add_subdirectory(ssl)
 set(_local_install_checks)
 set(_install_checks)
 
-find_program(PROVE prove
-  "/usr/bin")
-
 if(PG_REGRESS)
   add_custom_target(regresscheck-t
     COMMAND ${CMAKE_COMMAND} -E env
@@ -62,6 +59,7 @@ if(PG_REGRESS)
     ${PG_REGRESS_OPTS_LOCAL_INSTANCE}
     USES_TERMINAL)
 
+if (TAP_CHECKS)
   add_custom_target(provecheck
     COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/tmp_check
     COMMAND BUILDIR=${CMAKE_BINARY_DIR}
@@ -71,12 +69,12 @@ if(PG_REGRESS)
     PG_REGRESS=${PG_REGRESS}
     ${PROVE} -I "${PG_SOURCE_DIR}/src/test/perl"
     -I "${CMAKE_SOURCE_DIR}/test/perl"
-    -I "$ENV{HOME}/perl5/lib/perl5"
     t/*.pl
     USES_TERMINAL)
+  list(APPEND _install_checks provecheck)
+endif()
 
   list(APPEND _install_checks regresscheck-shared)
-  list(APPEND _install_checks provecheck)
   list(APPEND _local_install_checks regresschecklocal-shared)
 
 endif()


### PR DESCRIPTION
CMake now detects if the necessary prerequisites for running TAP
tests are installed on the local system. This includes perl
installation and other dependencies, such as the IPC::Run module and
prove binary.