### PR TITLE
Use ExecComputeStoredGeneratedCompat macro

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -367,11 +367,8 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 			/* Compute stored generated columns */
 			if (check_resultRelInfo->ri_RelationDesc->rd_att->constr &&
 				check_resultRelInfo->ri_RelationDesc->rd_att->constr->has_generated_stored)
-#if PG13_GE
-				ExecComputeStoredGenerated(estate, myslot, CMD_INSERT);
-#else
-				ExecComputeStoredGenerated(estate, myslot);
-#endif
+				ExecComputeStoredGeneratedCompat(estate, myslot, CMD_INSERT);
+
 			/*
 			 * If the target is a plain table, check the constraints of
 			 * the tuple.

--- a/tsl/src/nodes/data_node_copy.c
+++ b/tsl/src/nodes/data_node_copy.c
@@ -182,13 +182,7 @@ data_node_copy_exec(CustomScanState *node)
 
 			if (NULL != rri_chunk->ri_projectReturning && rri_desc->constr &&
 				rri_desc->constr->has_generated_stored)
-				ExecComputeStoredGenerated(estate,
-										   slot
-#if PG13_GE
-										   ,
-										   CMD_INSERT
-#endif
-				);
+				ExecComputeStoredGeneratedCompat(estate, slot, CMD_INSERT);
 
 			ResetPerTupleExprContext(estate);
 			oldmctx = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));

--- a/tsl/src/nodes/data_node_dispatch.c
+++ b/tsl/src/nodes/data_node_dispatch.c
@@ -709,13 +709,7 @@ handle_read(DataNodeDispatchState *sds)
 
 			if (NULL != rri->ri_projectReturning && rri_desc->constr &&
 				rri_desc->constr->has_generated_stored)
-				ExecComputeStoredGenerated(estate,
-										   slot
-#if PG13_GE
-										   ,
-										   CMD_INSERT
-#endif
-				);
+				ExecComputeStoredGeneratedCompat(estate, slot, CMD_INSERT);
 
 			Assert(NULL != cis);
 


### PR DESCRIPTION
When adding support for PG13 we introduced a macro to  hide the
function signature differences of ExecComputeStoredGenerated
but the callers of this function never got adjusted to use the
macro.