### PR TITLE
Move internal API functions to experimental schema

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -28,7 +28,8 @@ set(SOURCE_FILES
   hypertable.sql
   chunk.sql
   data_node.sql
-  ddl_internal.sql  
+  ddl_internal.sql
+  ddl_experimental.sql
   util_time.sql
   util_internal_table_ddl.sql
   chunk_constraint.sql

--- a/sql/ddl_experimental.sql
+++ b/sql/ddl_experimental.sql
@@ -1,0 +1,27 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+------------------------------------------------------------------------
+-- Experimental DDL functions and APIs.
+-- 
+-- Users should not rely on these functions unless they accept that
+-- they can change and/or be removed at any time.
+------------------------------------------------------------------------
+
+-- Block new chunk creation on a data node for a distributed
+-- hypertable. NULL hypertable means it will block chunks for all
+-- distributed hypertables
+CREATE OR REPLACE FUNCTION timescaledb_experimental.block_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL, force BOOLEAN = FALSE) RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_data_node_block_new_chunks' LANGUAGE C VOLATILE;
+
+-- Allow chunk creation on a blocked data node for a distributed
+-- hypertable. NULL hypertable means it will allow chunks for all
+-- distributed hypertables
+CREATE OR REPLACE FUNCTION timescaledb_experimental.allow_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL) RETURNS INTEGER
+AS '@MODULE_PATHNAME@', 'ts_data_node_allow_new_chunks' LANGUAGE C VOLATILE;
+
+CREATE OR REPLACE FUNCTION timescaledb_experimental.refresh_continuous_aggregate(
+    continuous_aggregate     REGCLASS,
+    hypertable_chunk         REGCLASS
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh_chunk' LANGUAGE C VOLATILE;

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -8,20 +8,3 @@ AS '@MODULE_PATHNAME@', 'ts_chunk_index_clone' LANGUAGE C VOLATILE STRICT;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_index_replace(chunk_index_oid_old OID, chunk_index_oid_new OID) RETURNS VOID
 AS '@MODULE_PATHNAME@', 'ts_chunk_index_replace' LANGUAGE C VOLATILE STRICT;
-
--- Block new chunk creation on a data node for a distributed
--- hypertable. NULL hypertable means it will block chunks for all
--- distributed hypertables
-CREATE OR REPLACE FUNCTION _timescaledb_internal.block_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL, force BOOLEAN = FALSE) RETURNS INTEGER
-AS '@MODULE_PATHNAME@', 'ts_data_node_block_new_chunks' LANGUAGE C VOLATILE;
-
--- Allow chunk creation on a blocked data node for a distributed
--- hypertable. NULL hypertable means it will allow chunks for all
--- distributed hypertables
-CREATE OR REPLACE FUNCTION _timescaledb_internal.allow_new_chunks(data_node_name NAME, hypertable REGCLASS = NULL) RETURNS INTEGER
-AS '@MODULE_PATHNAME@', 'ts_data_node_allow_new_chunks' LANGUAGE C VOLATILE;
-
-CREATE OR REPLACE FUNCTION _timescaledb_internal.refresh_continuous_aggregate(
-    continuous_aggregate     REGCLASS,
-    hypertable_chunk         REGCLASS
-) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh_chunk' LANGUAGE C VOLATILE;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,2 +1,5 @@
 CREATE SCHEMA IF NOT EXISTS timescaledb_experimental;
 GRANT USAGE ON SCHEMA timescaledb_experimental TO PUBLIC;
+DROP FUNCTION IF EXISTS _timescaledb_internal.block_new_chunks;
+DROP FUNCTION IF EXISTS _timescaledb_internal.allow_new_chunks;
+DROP FUNCTION IF EXISTS _timescaledb_internal.refresh_continuous_aggregate;

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -560,7 +560,7 @@ SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 (6 rows)
 
 --refresh to process the invalidations and then drop
-SELECT _timescaledb_internal.refresh_continuous_aggregate('drop_chunks_view', 
+SELECT timescaledb_experimental.refresh_continuous_aggregate('drop_chunks_view', 
   show_chunks('drop_chunks_table', older_than => (integer_now_test2()-9)));
  refresh_continuous_aggregate 
 ------------------------------
@@ -813,7 +813,7 @@ ORDER BY 1;
 -- Insert a large value in one of the chunks that will be dropped
 INSERT INTO drop_chunks_table VALUES (:range_start_integer-1, 100);
 -- Now refresh and drop the two adjecent chunks
-SELECT _timescaledb_internal.refresh_continuous_aggregate('drop_chunks_view',
+SELECT timescaledb_experimental.refresh_continuous_aggregate('drop_chunks_view',
   show_chunks('drop_chunks_table', older_than=>30));
  refresh_continuous_aggregate 
 ------------------------------

--- a/tsl/test/expected/continuous_aggs_drop_chunks.out
+++ b/tsl/test/expected/continuous_aggs_drop_chunks.out
@@ -197,7 +197,7 @@ UPDATE conditions SET value = 4.00 WHERE time_int = 2;
 -- two different chunks.
 UPDATE conditions SET value = 4.00 WHERE time_int = 9;
 UPDATE conditions SET value = 4.00 WHERE time_int = 11;
-SELECT _timescaledb_internal.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 20));
+SELECT timescaledb_experimental.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 20));
  refresh_continuous_aggregate 
 ------------------------------
  
@@ -238,7 +238,7 @@ UPDATE conditions SET value = 4.00 WHERE time_int = 41;
 -- After the call to drop_chunks the update in 39 will be refreshed and present in the cagg, 
 -- but not the update in 41.
 BEGIN;
-    SELECT _timescaledb_internal.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 40));
+    SELECT timescaledb_experimental.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 40));
  refresh_continuous_aggregate 
 ------------------------------
  
@@ -270,7 +270,7 @@ SELECT * FROM see_cagg;
 (11 rows)
 
 -- Now refresh includes the update in 41.
-SELECT _timescaledb_internal.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 60));
+SELECT timescaledb_experimental.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 60));
  refresh_continuous_aggregate 
 ------------------------------
  

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -500,7 +500,7 @@ SELECT create_hypertable('measurements', 'time');
 INSERT INTO measurements VALUES ('2019-03-04 13:30', 1, 1.3);
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.refresh_continuous_aggregate(
+SELECT timescaledb_experimental.refresh_continuous_aggregate(
   'mat_with_test',
   show_chunks('measurements')
 );

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -852,14 +852,14 @@ SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 (6 rows)
 
 -- Block one data node for specific hypertable
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'disttable');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1', 'disttable');
  block_new_chunks 
 ------------------
                 1
 (1 row)
 
 -- Block one data node for all hypertables
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1');
 NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "disttable"
  block_new_chunks 
 ------------------
@@ -903,26 +903,26 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 -- some ERROR cases
 \set ON_ERROR_STOP 0
 -- Will error due to under-replication
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_2');
 ERROR:  insufficient number of data nodes for distributed hypertable "disttable"
 -- can't block/allow non-existing data node
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_12345', 'disttable');
 ERROR:  server "data_node_12345" does not exist
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_12345', 'disttable');
 ERROR:  server "data_node_12345" does not exist
 -- NULL data node
-SELECT * FROM _timescaledb_internal.block_new_chunks(NULL, 'disttable');
+SELECT * FROM timescaledb_experimental.block_new_chunks(NULL, 'disttable');
 ERROR:  data node name cannot be NULL
-SELECT * FROM _timescaledb_internal.allow_new_chunks(NULL, 'disttable');
+SELECT * FROM timescaledb_experimental.allow_new_chunks(NULL, 'disttable');
 ERROR:  data node name cannot be NULL
 -- can't block/allow on non hypertable
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'devices');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1', 'devices');
 ERROR:  table "devices" is not a hypertable
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1', 'devices');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_1', 'devices');
 ERROR:  table "devices" is not a hypertable
 \set ON_ERROR_STOP 1
 -- Force block all data nodes
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2', force => true);
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_2', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable_2"
  block_new_chunks 
@@ -930,7 +930,7 @@ WARNING:  insufficient number of data nodes for distributed hypertable "disttabl
                 2
 (1 row)
 
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', force => true);
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1', force => true);
 NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "disttable"
 NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "disttable_2"
  block_new_chunks 
@@ -938,7 +938,7 @@ NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "d
                 0
 (1 row)
 
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_3', force => true);
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_3', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable_2"
  block_new_chunks 
@@ -964,19 +964,19 @@ INSERT INTO disttable VALUES ('2019-11-02 02:45', 1, 13.3);
 ERROR:  insufficient number of data nodes
 \set ON_ERROR_STOP 1
 -- unblock data nodes for all hypertables
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_1');
  allow_new_chunks 
 ------------------
                 2
 (1 row)
 
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_2');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_2');
  allow_new_chunks 
 ------------------
                 2
 (1 row)
 
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_3');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_3');
  allow_new_chunks 
 ------------------
                 2
@@ -1175,9 +1175,9 @@ NOTICE:  adding not-null constraint to column "time"
 -- error due to missing permissions
 SELECT * FROM detach_data_node('data_node_4', 'disttable_3');
 ERROR:  must be owner of hypertable "disttable_3"
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_4', 'disttable_3');
 ERROR:  must be owner of hypertable "disttable_3"
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_4', 'disttable_3');
 ERROR:  must be owner of hypertable "disttable_3"
 \set ON_ERROR_STOP 1
 -- detach table(s) where user has permissions, otherwise show NOTICE

--- a/tsl/test/sql/continuous_aggs_ddl.sql
+++ b/tsl/test/sql/continuous_aggs_ddl.sql
@@ -374,7 +374,7 @@ WHERE hypertable_name = 'drop_chunks_table';
 SELECT * FROM drop_chunks_view ORDER BY time_bucket DESC;
 
 --refresh to process the invalidations and then drop
-SELECT _timescaledb_internal.refresh_continuous_aggregate('drop_chunks_view', 
+SELECT timescaledb_experimental.refresh_continuous_aggregate('drop_chunks_view', 
   show_chunks('drop_chunks_table', older_than => (integer_now_test2()-9)));
 SELECT drop_chunks('drop_chunks_table', older_than => (integer_now_test2()-9));
 
@@ -488,7 +488,7 @@ ORDER BY 1;
 -- Insert a large value in one of the chunks that will be dropped
 INSERT INTO drop_chunks_table VALUES (:range_start_integer-1, 100);
 -- Now refresh and drop the two adjecent chunks
-SELECT _timescaledb_internal.refresh_continuous_aggregate('drop_chunks_view',
+SELECT timescaledb_experimental.refresh_continuous_aggregate('drop_chunks_view',
   show_chunks('drop_chunks_table', older_than=>30));
 SELECT drop_chunks('drop_chunks_table', older_than=>30);
 

--- a/tsl/test/sql/continuous_aggs_drop_chunks.sql
+++ b/tsl/test/sql/continuous_aggs_drop_chunks.sql
@@ -92,7 +92,7 @@ UPDATE conditions SET value = 4.00 WHERE time_int = 2;
 UPDATE conditions SET value = 4.00 WHERE time_int = 9;
 UPDATE conditions SET value = 4.00 WHERE time_int = 11;
 
-SELECT _timescaledb_internal.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 20));
+SELECT timescaledb_experimental.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 20));
 SELECT drop_chunks('conditions', 20);
 SELECT * FROM see_cagg;
 
@@ -109,13 +109,13 @@ UPDATE conditions SET value = 4.00 WHERE time_int = 41;
 -- After the call to drop_chunks the update in 39 will be refreshed and present in the cagg, 
 -- but not the update in 41.
 BEGIN;
-    SELECT _timescaledb_internal.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 40));
+    SELECT timescaledb_experimental.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 40));
     SELECT drop_chunks('conditions', 40);
 END;
 SELECT * FROM see_cagg;
 
 -- Now refresh includes the update in 41.
-SELECT _timescaledb_internal.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 60));
+SELECT timescaledb_experimental.refresh_continuous_aggregate('conditions_7', show_chunks('conditions', 60));
 SELECT drop_chunks('conditions', 60);
 SELECT * FROM see_cagg;
 

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -473,7 +473,7 @@ INSERT INTO measurements VALUES ('2019-03-04 13:30', 1, 1.3);
 
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.refresh_continuous_aggregate(
+SELECT timescaledb_experimental.refresh_continuous_aggregate(
   'mat_with_test',
   show_chunks('measurements')
 );

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -431,10 +431,10 @@ CREATE TABLE devices(device int, name text);
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 
 -- Block one data node for specific hypertable
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'disttable');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1', 'disttable');
 
 -- Block one data node for all hypertables
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1');
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
 
@@ -450,22 +450,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 -- some ERROR cases
 \set ON_ERROR_STOP 0
 -- Will error due to under-replication
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_2');
 -- can't block/allow non-existing data node
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_12345', 'disttable');
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_12345', 'disttable');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_12345', 'disttable');
 -- NULL data node
-SELECT * FROM _timescaledb_internal.block_new_chunks(NULL, 'disttable');
-SELECT * FROM _timescaledb_internal.allow_new_chunks(NULL, 'disttable');
+SELECT * FROM timescaledb_experimental.block_new_chunks(NULL, 'disttable');
+SELECT * FROM timescaledb_experimental.allow_new_chunks(NULL, 'disttable');
 -- can't block/allow on non hypertable
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', 'devices');
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1', 'devices');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1', 'devices');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_1', 'devices');
 \set ON_ERROR_STOP 1
 
 -- Force block all data nodes
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_2', force => true);
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_1', force => true);
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_3', force => true);
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_2', force => true);
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1', force => true);
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_3', force => true);
 
 -- All data nodes are blocked
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
@@ -476,9 +476,9 @@ INSERT INTO disttable VALUES ('2019-11-02 02:45', 1, 13.3);
 \set ON_ERROR_STOP 1
 
 -- unblock data nodes for all hypertables
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_1');
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_2');
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_3');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_1');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_2');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_3');
 
 SELECT table_name, node_name, block_chunks
 FROM _timescaledb_catalog.hypertable_data_node dn,
@@ -561,8 +561,8 @@ SELECT * FROM create_distributed_hypertable('disttable_4', 'time', replication_f
 \set ON_ERROR_STOP 0
 -- error due to missing permissions
 SELECT * FROM detach_data_node('data_node_4', 'disttable_3');
-SELECT * FROM _timescaledb_internal.block_new_chunks('data_node_4', 'disttable_3');
-SELECT * FROM _timescaledb_internal.allow_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_4', 'disttable_3');
+SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_4', 'disttable_3');
 \set ON_ERROR_STOP 1
 
 -- detach table(s) where user has permissions, otherwise show NOTICE


### PR DESCRIPTION
Move the "block new chunks" functions and the chunk-based continuous
aggregate refresh function to the new experimental schema.