### PR TITLE
Fix pull_varnos miscomputation of relids set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Bugfixes**
+* #3305 Fix pull_varnos miscomputation of relids set
+
 ## 2.3.0 (2021-05-25)
 
 This release adds major new features since the 2.2.1 release. 

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -26,6 +26,7 @@
 #include <utils/syscache.h>
 
 #include "chunk.h"
+#include "compat.h"
 #include "cross_module_fn.h"
 #include "guc.h"
 #include "extension.h"
@@ -597,7 +598,7 @@ process_quals(Node *quals, CollectQualCtx *ctx, bool is_outer_join)
 		 prev = lc, lc = lnext_compat((List *) quals, lc))
 	{
 		Expr *qual = lfirst(lc);
-		Relids relids = pull_varnos((Node *) qual);
+		Relids relids = pull_varnos_compat(ctx->root, (Node *) qual);
 		int num_rels = bms_num_members(relids);
 
 		/* stop processing if not for current rel */
@@ -658,7 +659,8 @@ process_quals(Node *quals, CollectQualCtx *ctx, bool is_outer_join)
 		 * the restriction would exclude chunks and thus rows of the outer
 		 * relation when it should show all rows */
 		if (!is_outer_join)
-			ctx->restrictions = lappend(ctx->restrictions, make_simple_restrictinfo(qual));
+			ctx->restrictions =
+				lappend(ctx->restrictions, make_simple_restrictinfo_compat(ctx->root, qual));
 	}
 	return (Node *) list_concat((List *) quals, additional_quals);
 }
@@ -707,7 +709,7 @@ timebucket_annotate(Node *quals, CollectQualCtx *ctx)
 	foreach (lc, castNode(List, quals))
 	{
 		Expr *qual = lfirst(lc);
-		Relids relids = pull_varnos((Node *) qual);
+		Relids relids = pull_varnos_compat(ctx->root, (Node *) qual);
 		int num_rels = bms_num_members(relids);
 
 		/* stop processing if not for current rel */
@@ -741,7 +743,8 @@ timebucket_annotate(Node *quals, CollectQualCtx *ctx)
 			}
 		}
 
-		ctx->restrictions = lappend(ctx->restrictions, make_simple_restrictinfo(qual));
+		ctx->restrictions =
+			lappend(ctx->restrictions, make_simple_restrictinfo_compat(ctx->root, qual));
 	}
 	return (Node *) list_concat((List *) quals, additional_quals);
 }
@@ -771,7 +774,7 @@ collect_join_quals(Node *quals, CollectQualCtx *ctx, bool can_propagate)
 	foreach (lc, (List *) quals)
 	{
 		Expr *qual = lfirst(lc);
-		Relids relids = pull_varnos((Node *) qual);
+		Relids relids = pull_varnos_compat(ctx->root, (Node *) qual);
 		int num_rels = bms_num_members(relids);
 
 		/*
@@ -1466,17 +1469,18 @@ propagate_join_quals(PlannerInfo *root, RelOptInfo *rel, CollectQualCtx *ctx)
 
 			if (new_qual)
 			{
-				Relids relids = pull_varnos((Node *) propagated);
+				Relids relids = pull_varnos_compat(root, (Node *) propagated);
 				RestrictInfo *restrictinfo;
 
-				restrictinfo = make_restrictinfo((Expr *) propagated,
-												 true,
-												 false,
-												 false,
-												 ctx->root->qual_security_level,
-												 relids,
-												 NULL,
-												 NULL);
+				restrictinfo = make_restrictinfo_compat(root,
+														(Expr *) propagated,
+														true,
+														false,
+														false,
+														ctx->root->qual_security_level,
+														relids,
+														NULL,
+														NULL);
 				ctx->restrictions = lappend(ctx->restrictions, restrictinfo);
 				/*
 				 * since hypertable expansion happens later in PG12 the propagated

--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -177,14 +177,15 @@ adjust_data_node_rel_attrs(PlannerInfo *root, RelOptInfo *data_node_rel, RelOptI
 			}
 			/* reconstitute RestrictInfo with appropriate properties */
 			nodequals = lappend(nodequals,
-								make_restrictinfo((Expr *) onecq,
-												  rinfo->is_pushed_down,
-												  rinfo->outerjoin_delayed,
-												  pseudoconstant,
-												  rinfo->security_level,
-												  NULL,
-												  NULL,
-												  NULL));
+								make_restrictinfo_compat(root,
+														 (Expr *) onecq,
+														 rinfo->is_pushed_down,
+														 rinfo->outerjoin_delayed,
+														 pseudoconstant,
+														 rinfo->security_level,
+														 NULL,
+														 NULL,
+														 NULL));
 		}
 	}
 

--- a/tsl/src/fdw/scan_plan.c
+++ b/tsl/src/fdw/scan_plan.c
@@ -502,14 +502,15 @@ foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel, GroupPathExtraDa
 			 * RestrictInfos, so we must make our own.
 			 */
 			Assert(!IsA(expr, RestrictInfo));
-			rinfo = make_restrictinfo(expr,
-									  true,
-									  false,
-									  false,
-									  root->qual_security_level,
-									  grouped_rel->relids,
-									  NULL,
-									  NULL);
+			rinfo = make_restrictinfo_compat(root,
+											 expr,
+											 true,
+											 false,
+											 false,
+											 root->qual_security_level,
+											 grouped_rel->relids,
+											 NULL,
+											 NULL);
 			if (is_foreign_expr(root, grouped_rel, expr))
 				fpinfo->remote_conds = lappend(fpinfo->remote_conds, rinfo);
 			else

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -73,12 +73,13 @@ pushdown_quals(PlannerInfo *root, RelOptInfo *chunk_rel, RelOptInfo *compressed_
 				{
 					compressed_rel->baserestrictinfo =
 						lappend(compressed_rel->baserestrictinfo,
-								make_simple_restrictinfo(lfirst(lc_and)));
+								make_simple_restrictinfo_compat(root, lfirst(lc_and)));
 				}
 			}
 			else
 				compressed_rel->baserestrictinfo =
-					lappend(compressed_rel->baserestrictinfo, make_simple_restrictinfo(expr));
+					lappend(compressed_rel->baserestrictinfo,
+							make_simple_restrictinfo_compat(root, expr));
 		}
 		/* We need to check the restriction clause on the decompress node if the clause can't be
 		 * pushed down or needs re-checking */

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -48,7 +48,8 @@ static EquivalenceMember *find_ec_member_for_tle(EquivalenceClass *ec, TargetEnt
 static int get_idx_key(IndexOptInfo *idxinfo, AttrNumber attno);
 static List *sort_indexquals(IndexOptInfo *indexinfo, List *quals);
 static OpExpr *fix_indexqual(IndexOptInfo *index, RestrictInfo *rinfo, AttrNumber distinct_column);
-static bool build_skip_qual(SkipScanPath *skip_scan_path, IndexPath *index_path, Var *var);
+static bool build_skip_qual(PlannerInfo *root, SkipScanPath *skip_scan_path, IndexPath *index_path,
+							Var *var);
 static List *build_subpath(PlannerInfo *root, List *subpaths, double ndistinct);
 static ChunkAppendPath *copy_chunk_append_path(ChunkAppendPath *ca, List *subpaths);
 
@@ -384,7 +385,7 @@ skip_scan_path_create(PlannerInfo *root, IndexPath *index_path, double ndistinct
 		return NULL;
 
 	/* build skip qual this may fail if we cannot look up the operator */
-	if (!build_skip_qual(skip_scan_path, index_path, castNode(Var, tle->expr)))
+	if (!build_skip_qual(root, skip_scan_path, index_path, castNode(Var, tle->expr)))
 		return NULL;
 
 	return skip_scan_path;
@@ -430,7 +431,7 @@ build_subpath(PlannerInfo *root, List *subpaths, double ndistinct)
 }
 
 static bool
-build_skip_qual(SkipScanPath *skip_scan_path, IndexPath *index_path, Var *var)
+build_skip_qual(PlannerInfo *root, SkipScanPath *skip_scan_path, IndexPath *index_path, Var *var)
 {
 	IndexOptInfo *info = index_path->indexinfo;
 	Oid column_type = exprType((Node *) var);
@@ -473,7 +474,7 @@ build_skip_qual(SkipScanPath *skip_scan_path, IndexPath *index_path, Var *var)
 										  info->indexcollations[idx_key] /*inputcollid*/);
 	set_opfuncid(castNode(OpExpr, comparison_expr));
 
-	skip_scan_path->skip_clause = make_simple_restrictinfo(comparison_expr);
+	skip_scan_path->skip_clause = make_simple_restrictinfo_compat(root, comparison_expr);
 
 	return true;
 }


### PR DESCRIPTION
Upstream fixed a bug with miscomputation of relids for
PlaceHolderVar. Those fixes changed the signature of pull_varnos,
make_simple_restrictinfo and make_restrictinfo.
The fixes got backported to the PG12 and PG13 branch but to not
break compatibility with extensions the old functions were left in.
This patch makes our code use the new functions when compiling
against a postgres version that has them.

https://github.com/postgres/postgres/commit/1cce024fd2
https://github.com/postgres/postgres/commit/73fc2e5bab