### PR TITLE
Run ABI tests with TAP support

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Build TimescaleDB
       run: |
         PATH="$GITHUB_WORKSPACE/coverity/bin:$PATH"
-        ./bootstrap -DCMAKE_BUILD_TYPE=Release -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR
+        ./bootstrap -DCMAKE_BUILD_TYPE=Release -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR -DTAP_CHECKS=off
         cov-build --dir cov-int make -C build
 
     - name: Upload report

--- a/scripts/docker-run-abi-test.sh
+++ b/scripts/docker-run-abi-test.sh
@@ -35,7 +35,7 @@ create_base_container() {
   docker run -u postgres -d -e POSTGRES_HOST_AUTH_METHOD=trust --name $1 -v ${BASE_DIR}:/src -v ${COMPILE_VOLUME}:/compile $2
 
   # Install build dependencies
-  docker exec -u root $1 /bin/bash -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake bison flex openssl-dev && mkdir -p /build/debug"
+  docker exec -u root $1 /bin/bash -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake bison flex openssl-dev perl perl-utils perl-test-harness-utils perl-ipc-run && mkdir -p /build/debug "
 
   # Copy the source files to build directory
   docker exec -u root $1 /bin/bash -c "cp -a /src/{src,sql,scripts,test,tsl,CMakeLists.txt,timescaledb.control.in,version.config} /build/ && cd /build/debug/ && CFLAGS=-Werror cmake .. -DCMAKE_BUILD_TYPE=Debug -DREGRESS_CHECKS=OFF && make -C /build/debug install && chown -R postgres /build"


### PR DESCRIPTION
Install the Perl prerequisites when building the image for ABI tests,
including the `prove` binary.

Although the ABI tests currently don't run TAP tests, CMake still
failed the configuration since it expects the prerequisites to be
installed unless it is run with `-DTAP_CHECKS=off`.