### PR TITLE
End-to-end wrapper API for copy/move chunk

### DIFF
--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -19,6 +19,14 @@ CREATE OR REPLACE FUNCTION move_chunk(
     verbose BOOLEAN=FALSE
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_move_chunk' LANGUAGE C VOLATILE;
 
+-- Use the experimental schema for this new procedure
+CREATE OR REPLACE PROCEDURE timescaledb_experimental.move_chunk(
+    chunk REGCLASS,
+    source_node Name = NULL,
+    destination_node Name = NULL,
+    verbose BOOLEAN=FALSE)
+AS '@MODULE_PATHNAME@', 'ts_move_chunk_proc' LANGUAGE C;
+
 CREATE OR REPLACE FUNCTION compress_chunk(
     uncompressed_chunk REGCLASS,
     if_not_compressed BOOLEAN = false

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -2,3 +2,30 @@ CREATE SCHEMA IF NOT EXISTS timescaledb_experimental;
 GRANT USAGE ON SCHEMA timescaledb_experimental TO PUBLIC;
 
 DROP FUNCTION IF EXISTS _timescaledb_internal.create_chunk;
+
+-- Use the experimental schema for ths new procedure
+CREATE OR REPLACE PROCEDURE timescaledb_experimental.move_chunk(
+    chunk REGCLASS,
+    source_node Name = NULL,
+    destination_node Name = NULL,
+    verbose BOOLEAN=FALSE)
+AS '@MODULE_PATHNAME@', 'ts_move_chunk_proc' LANGUAGE C;
+
+CREATE SEQUENCE IF NOT EXISTS _timescaledb_catalog.chunk_copy_activity_id_seq MINVALUE 1;
+
+CREATE TABLE IF NOT EXISTS _timescaledb_catalog.chunk_copy_activity (
+  id integer PRIMARY KEY DEFAULT nextval('_timescaledb_catalog.chunk_copy_activity_id_seq'),
+  operation_id name NOT NULL UNIQUE, -- the publisher/subscriber identifier used
+  backend_pid integer NOT NULL, -- the pid of the backend running this activity
+  completed_stage text NOT NULL, -- the completed stage/step
+  time_start timestamptz NOT NULL DEFAULT NOW(), -- start time of the activity
+  chunk_id integer NOT NULL REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE,
+  source_node_name name NOT NULL,
+  dest_node_name name NOT NULL,
+  delete_on_source_node bool NOT NULL -- is a move or copy activity
+);
+
+ALTER SEQUENCE _timescaledb_catalog.chunk_copy_activity_id_seq OWNED BY _timescaledb_catalog.chunk_copy_activity.id;
+
+GRANT SELECT ON _timescaledb_catalog.chunk_copy_activity_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.chunk_copy_activity TO PUBLIC;

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -103,6 +103,10 @@ static const TableInfoDef catalog_table_names[_MAX_CATALOG_TABLES + 1] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = REMOTE_TXN_TABLE_NAME,
 	},
+	[CHUNK_COPY_ACTIVITY] = {
+		.schema_name = CATALOG_SCHEMA_NAME,
+		.table_name = CHUNK_COPY_ACTIVITY_TABLE_NAME,
+	},
 	[_MAX_CATALOG_TABLES] = {
 		.schema_name = "invalid schema",
 		.table_name = "invalid table",
@@ -245,6 +249,12 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 			[REMOTE_TXN_PKEY_IDX] = "remote_txn_pkey",
 			[REMOTE_TXN_DATA_NODE_NAME_IDX] = "remote_txn_data_node_name_idx"
 		}
+	},
+	[CHUNK_COPY_ACTIVITY] = {
+		.length = _MAX_CHUNK_COPY_ACTIVITY_INDEX,
+		.names = (char *[]) {
+			[CHUNK_COPY_ACTIVITY_PKEY_IDX] = "chunk_copy_activity_pkey",
+		},
 	}
 };
 
@@ -266,6 +276,7 @@ static const char *catalog_table_serial_id_names[_MAX_CATALOG_TABLES] = {
 	[HYPERTABLE_COMPRESSION] = NULL,
 	[COMPRESSION_CHUNK_SIZE] = NULL,
 	[REMOTE_TXN] = NULL,
+	[CHUNK_COPY_ACTIVITY] = CATALOG_SCHEMA_NAME ".chunk_copy_activity_id_seq",
 };
 
 typedef struct InternalFunctionDef

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -53,6 +53,7 @@ typedef enum CatalogTable
 	HYPERTABLE_COMPRESSION,
 	COMPRESSION_CHUNK_SIZE,
 	REMOTE_TXN,
+	CHUNK_COPY_ACTIVITY,
 	_MAX_CATALOG_TABLES,
 } CatalogTable;
 
@@ -1175,6 +1176,58 @@ enum Anum_remote_data_node_name_idx
 	Anum_remote_txn_data_node_name_idx_data_node_name = 1,
 	_Anum_remote_txn_data_node_name_idx_max,
 };
+
+/********************************************
+ *
+ * table to track chunk copy/move operations
+ *
+ ********************************************/
+
+#define CHUNK_COPY_ACTIVITY_TABLE_NAME "chunk_copy_activity"
+
+enum Anum_chunk_copy_activity
+{
+	Anum_chunk_copy_activity_id = 1,
+	Anum_chunk_copy_activity_operation_id,
+	Anum_chunk_copy_activity_backend_pid,
+	Anum_chunk_copy_activity_completed_stage,
+	Anum_chunk_copy_activity_time_start,
+	Anum_chunk_copy_activity_chunk_id,
+	Anum_chunk_copy_activity_source_node_name,
+	Anum_chunk_copy_activity_dest_node_name,
+	Anum_chunk_copy_activity_delete_on_src_node,
+	_Anum_chunk_copy_activity_max,
+};
+
+#define Natts_chunk_copy_activity (_Anum_chunk_copy_activity_max - 1)
+
+typedef struct FormData_chunk_copy_activity
+{
+	int32 id;
+	NameData operation_id;
+	int32 backend_pid;
+	text *completed_stage;
+	TimestampTz time_start;
+	int32 chunk_id;
+	NameData source_node_name;
+	NameData dest_node_name;
+	bool delete_on_src_node;
+} FormData_chunk_copy_activity;
+
+typedef FormData_chunk_copy_activity *Form_chunk_copy_activity;
+
+enum
+{
+	CHUNK_COPY_ACTIVITY_PKEY_IDX = 0,
+	_MAX_CHUNK_COPY_ACTIVITY_INDEX,
+};
+
+enum Anum_chunk_copy_activity_pkey_idx
+{
+	Anum_chunk_copy_activity_pkey_idx_id = 1,
+	_Anum_chunk_copy_activity_pkey_idx_max,
+};
+#define Natts_chunk_copy_activity_pkey_idx (_Anum_chunk_copy_activity_pkey_idx_max - 1)
 
 typedef enum CacheType
 {

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -874,7 +874,7 @@ ts_chunk_create_table(Chunk *chunk, Hypertable *ht, const char *tablespacename)
 			SetUserIdAndSecContext(saved_uid, sec_ctx);
 
 		/* Create the corresponding chunk replicas on the remote data nodes */
-		ts_cm_functions->create_chunk_on_data_nodes(chunk, ht);
+		ts_cm_functions->create_chunk_on_data_nodes(chunk, ht, NULL, NIL);
 
 		/* Record the remote data node chunk ID mappings */
 		ts_chunk_data_node_insert_multi(chunk->data_nodes);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -118,6 +118,26 @@ typedef struct ChunkScanEntry
 	ChunkStub *stub;
 } ChunkScanEntry;
 
+/* To track a chunk move or copy activity */
+typedef struct ChunkCopyData
+{
+	/* numeric id for this chunk copy/move activity */
+	int32 id;
+	/* chunk to copy */
+	Chunk *chunk;
+	/* shared name used to name replication slot, publication and
+	 * subscription */
+	NameData operation_id;
+	/* from node */
+	const char *src_node;
+	/* to node */
+	const char *dst_node;
+	/* should the chunk be deleted on the source node? */
+	bool delete_on_src_node;
+	/* stage that just completed */
+	const char *completed_stage;
+} ChunkCopyData;
+
 extern Chunk *ts_chunk_create_from_point(Hypertable *ht, Point *p, const char *schema,
 										 const char *prefix);
 

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -42,6 +42,7 @@ CROSSMODULE_WRAPPER(job_alter);
 
 CROSSMODULE_WRAPPER(reorder_chunk);
 CROSSMODULE_WRAPPER(move_chunk);
+CROSSMODULE_WRAPPER(move_chunk_proc);
 
 /* partialize/finalize aggregate */
 CROSSMODULE_WRAPPER(partialize_agg);
@@ -227,7 +228,8 @@ empty_fn(PG_FUNCTION_ARGS)
 }
 
 static void
-create_chunk_on_data_nodes_default(Chunk *chunk, Hypertable *ht)
+create_chunk_on_data_nodes_default(const Chunk *chunk, const Hypertable *ht,
+								   const char *remote_chunk_name, List *data_nodes)
 {
 	error_no_default_fn_community();
 }
@@ -331,6 +333,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.job_execute = job_execute_default_fn,
 
 	.move_chunk = error_no_default_fn_pg_community,
+	.move_chunk_proc = error_no_default_fn_pg_community,
 	.reorder_chunk = error_no_default_fn_pg_community,
 
 	.partialize_agg = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -79,6 +79,7 @@ typedef struct CrossModuleFunctions
 
 	PGFunction reorder_chunk;
 	PGFunction move_chunk;
+	PGFunction move_chunk_proc;
 	void (*ddl_command_start)(ProcessUtilityArgs *args);
 	void (*ddl_command_end)(EventTriggerData *command);
 	void (*sql_drop)(List *dropped_objects);
@@ -143,7 +144,8 @@ typedef struct CrossModuleFunctions
 	PGFunction remote_txn_id_out;
 	PGFunction remote_txn_heal_data_node;
 	PGFunction remote_connection_cache_show;
-	void (*create_chunk_on_data_nodes)(Chunk *chunk, Hypertable *ht);
+	void (*create_chunk_on_data_nodes)(const Chunk *chunk, const Hypertable *ht,
+									   const char *remote_chunk_name, List *data_nodes);
 	Path *(*distributed_insert_path_create)(PlannerInfo *root, ModifyTablePath *mtpath,
 											Index hypertable_rti, int subpath_index);
 	uint64 (*distributed_copy)(const CopyStmt *stmt, CopyChunkState *ccstate, List *attnums);

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -196,6 +196,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 ----------------------+--------------------------------------------------+-------+------------
  _timescaledb_catalog | chunk                                            | table | super_user
  _timescaledb_catalog | chunk_constraint                                 | table | super_user
+ _timescaledb_catalog | chunk_copy_activity                              | table | super_user
  _timescaledb_catalog | chunk_data_node                                  | table | super_user
  _timescaledb_catalog | chunk_index                                      | table | super_user
  _timescaledb_catalog | compression_algorithm                            | table | super_user
@@ -212,7 +213,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
  _timescaledb_catalog | metadata                                         | table | super_user
  _timescaledb_catalog | remote_txn                                       | table | super_user
  _timescaledb_catalog | tablespace                                       | table | super_user
-(18 rows)
+(19 rows)
 
 \dt "_timescaledb_internal".*
                           List of relations

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -555,11 +555,13 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
  timescaledb_information.hypertables
  _timescaledb_internal.compressed_chunk_stats
  _timescaledb_internal.hypertable_chunk_local_size
+ _timescaledb_catalog.chunk_copy_activity
+ _timescaledb_catalog.chunk_copy_activity_id_seq
  _timescaledb_catalog.compression_algorithm
  _timescaledb_internal.bgw_policy_chunk_stats
  _timescaledb_internal.bgw_job_stat
  _timescaledb_catalog.tablespace_id_seq
-(14 rows)
+(16 rows)
 
 -- Make sure we can't run our restoring functions as a normal perm user as that would disable functionality for the whole db
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -13,12 +13,14 @@
 #include <access/htup_details.h>
 #include <access/xact.h>
 #include <nodes/makefuncs.h>
+#include <utils/acl.h>
 #include <utils/builtins.h>
 #include <utils/syscache.h>
 #include <utils/inval.h>
 #include <utils/tuplestore.h>
 #include <utils/palloc.h>
 #include <utils/memutils.h>
+#include <utils/snapmgr.h>
 #include <executor/executor.h>
 #include <parser/parse_func.h>
 #include <funcapi.h>
@@ -334,6 +336,62 @@ chunk_create_replica_table(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
+static void
+chunk_api_call_chunk_drop_replica(const Chunk *chunk, const char *node_name, Oid serverid)
+{
+	const char *drop_cmd;
+	List *data_nodes;
+
+	/*
+	 * Drop chunk on the data node using a regular "DROP TABLE".
+	 * Note that CASCADE is not required as it takes care of dropping compressed
+	 * chunk (if any).
+	 *
+	 * If there are any other non-TimescaleDB objects attached to this table due
+	 * to some manual user activity then they should be dropped by the user
+	 * before invoking this function.
+	 */
+
+	drop_cmd = psprintf("DROP TABLE %s.%s",
+						quote_identifier(chunk->fd.schema_name.data),
+						quote_identifier(chunk->fd.table_name.data));
+	data_nodes = list_make1((char *) node_name);
+	ts_dist_cmd_run_on_data_nodes(drop_cmd, data_nodes, true);
+
+	/*
+	 * This chunk might have this data node as primary, change that association
+	 * if so. Then delete the chunk_id and node_name association.
+	 */
+	chunk_update_foreign_server_if_needed(chunk->fd.id, serverid);
+	ts_chunk_data_node_delete_by_chunk_id_and_node_name(chunk->fd.id, node_name);
+}
+
+void
+chunk_api_call_chunk_drop_replica_wrapper(ChunkCopyData *ccd, Oid serverid, bool transactional)
+{
+	if (transactional)
+		StartTransactionCommand();
+
+	chunk_api_call_chunk_drop_replica(ccd->chunk, ccd->src_node, serverid);
+
+	if (transactional)
+	{
+		NameData application_name;
+
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "chunk_dropped_srcdn:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		ccd->completed_stage = "chunk_dropped_srcdn";
+		/* it gets committed as part of the overall transaction */
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
+}
+
 /*
  * chunk_drop_replica:
  *
@@ -346,10 +404,8 @@ chunk_drop_replica(PG_FUNCTION_ARGS)
 {
 	Oid chunk_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
 	const char *node_name = PG_ARGISNULL(1) ? NULL : NameStr(*PG_GETARG_NAME(1));
-	List *data_nodes;
 	ForeignServer *server;
 	Chunk *chunk;
-	const char *drop_cmd;
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
@@ -398,58 +454,49 @@ chunk_drop_replica(PG_FUNCTION_ARGS)
 				 errmsg("cannot drop the last chunk replica"),
 				 errdetail("Dropping the last chunk replica could lead to data loss.")));
 
-	/*
-	 * Drop chunk on the data node using a regular "DROP TABLE".
-	 * Note that CASCADE is not required as it takes care of dropping compressed
-	 * chunk (if any).
-	 *
-	 * If there are any other non-TimescaleDB objects attached to this table due
-	 * to some manual user activity then they should be dropped by the user
-	 * before invoking this function.
-	 */
-	drop_cmd = psprintf("DROP TABLE %s.%s",
-						quote_identifier(chunk->fd.schema_name.data),
-						quote_identifier(chunk->fd.table_name.data));
-	data_nodes = list_make1((char *) node_name);
-	ts_dist_cmd_run_on_data_nodes(drop_cmd, data_nodes, true);
-
-	/*
-	 * This chunk might have this data node as primary, change that association
-	 * if so. Then delete the chunk_id and node_name association.
-	 */
-	chunk_update_foreign_server_if_needed(chunk->fd.id, server->serverid);
-	ts_chunk_data_node_delete_by_chunk_id_and_node_name(chunk->fd.id, node_name);
+	chunk_api_call_chunk_drop_replica(chunk, node_name, server->serverid);
 
 	PG_RETURN_VOID();
 }
 
-typedef struct
-{
-	/* chunk to copy */
-	Chunk *chunk;
-	/* shared name used to name replication slot, publication and
-	 * subscription */
-	NameData operation_id;
-	/* from node */
-	List *src_node;
-	/* to node */
-	List *dst_node;
-} ChunkCopyData;
-
 static void
-chunk_copy_data_prepare(ChunkCopyData *ccd)
+chunk_copy_data_prepare(ChunkCopyData *ccd, bool transactional)
 {
 	const char *cmd;
 	const char *connection_string;
+	NameData application_name;
+
+	if (transactional)
+		StartTransactionCommand();
 
 	/* create publication on the source data node */
 	cmd = psprintf("CREATE PUBLICATION %s FOR TABLE %s",
 				   NameStr(ccd->operation_id),
 				   quote_qualified_identifier(NameStr(ccd->chunk->fd.schema_name),
 											  NameStr(ccd->chunk->fd.table_name)));
-	ts_dist_cmd_run_on_data_nodes(cmd, ccd->src_node, false);
 
-	/* create subscription on the destination data node */
+	/* create the publication in autocommit mode */
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1((char *) ccd->src_node), false);
+
+	/* track the progress in the catalog */
+	if (transactional)
+	{
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "publication_created:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		Assert(ccd->id != 0);
+		ccd->completed_stage = "publication_created";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
+
+	/* create subscription on the destination data node in a new transaction block */
+	if (transactional)
+		StartTransactionCommand();
 
 	/*
 	 * CREATE SUBSCRIPTION from a database within the same database cluster will hang,
@@ -457,44 +504,164 @@ chunk_copy_data_prepare(ChunkCopyData *ccd)
 	 */
 	cmd = psprintf("SELECT pg_create_logical_replication_slot('%s', 'pgoutput')",
 				   NameStr(ccd->operation_id));
-	ts_dist_cmd_run_on_data_nodes(cmd, ccd->src_node, false);
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1((char *) ccd->src_node), false);
 
+	if (transactional)
+	{
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "replslot_created:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		Assert(ccd->id != 0);
+		ccd->completed_stage = "replslot_created";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
+
+	if (transactional)
+		StartTransactionCommand();
 	/* prepare connection string to the source node */
-	connection_string = remote_connection_get_connstr(lfirst(list_head(ccd->src_node)));
+	connection_string = remote_connection_get_connstr(ccd->src_node);
 
 	cmd = psprintf("CREATE SUBSCRIPTION %s CONNECTION '%s' PUBLICATION %s"
 				   " WITH (create_slot = false, enabled = false)",
 				   NameStr(ccd->operation_id),
 				   connection_string,
 				   NameStr(ccd->operation_id));
-	ts_dist_cmd_run_on_data_nodes(cmd, ccd->dst_node, false);
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1((char *) ccd->dst_node), false);
+
+	if (transactional)
+	{
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "subscription_created:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		Assert(ccd->id != 0);
+		ccd->completed_stage = "subscription_created";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
 }
 
 static void
-chunk_copy_data_perform(ChunkCopyData *ccd)
+chunk_copy_data_perform(ChunkCopyData *ccd, bool transactional)
 {
 	const char *cmd;
+	NameData application_name;
+
+	if (transactional)
+		StartTransactionCommand();
 
 	/* start data transfer on the destination node */
 	cmd = psprintf("ALTER SUBSCRIPTION %s ENABLE", NameStr(ccd->operation_id));
-	ts_dist_cmd_run_on_data_nodes(cmd, ccd->dst_node, false);
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1((char *) ccd->dst_node), false);
 
-	/* wait until data transfer finishes */
+	if (transactional)
+	{
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "subscription_syncing:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		Assert(ccd->id != 0);
+		ccd->completed_stage = "subscription_syncing";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
+
+	/* wait until data transfer finishes in its own transaction */
+	if (transactional)
+		StartTransactionCommand();
+
 	cmd = psprintf("CALL _timescaledb_internal.wait_subscription_sync(%s, %s)",
 				   quote_literal_cstr(NameStr(ccd->chunk->fd.schema_name)),
 				   quote_literal_cstr(NameStr(ccd->chunk->fd.table_name)));
-	ts_dist_cmd_run_on_data_nodes(cmd, ccd->dst_node, false);
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1((char *) ccd->dst_node), false);
+
+	if (transactional)
+	{
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "subscription_syncdone:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		Assert(ccd->id != 0);
+		ccd->completed_stage = "subscription_syncdone";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
 }
 
 static void
-chunk_copy_data_end(ChunkCopyData *ccd)
+chunk_copy_data_end(ChunkCopyData *ccd, bool transactional)
 {
 	const char *cmd;
+	NameData application_name;
+
+	if (transactional)
+		StartTransactionCommand();
+
 	cmd = psprintf("DROP SUBSCRIPTION %s", NameStr(ccd->operation_id));
-	ts_dist_cmd_run_on_data_nodes(cmd, ccd->dst_node, false);
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1((char *) ccd->dst_node), false);
+
+	if (transactional)
+	{
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "subscription_drop:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		Assert(ccd->id != 0);
+		ccd->completed_stage = "subscription_drop";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
+
+	/* Drop publication in its own transaction */
+	if (transactional)
+		StartTransactionCommand();
 
 	cmd = psprintf("DROP PUBLICATION %s", NameStr(ccd->operation_id));
-	ts_dist_cmd_run_on_data_nodes(cmd, ccd->src_node, false);
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1((char *) ccd->src_node), false);
+	if (transactional)
+	{
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "publication_drop:%s",
+				 ccd->operation_id.data);
+		pgstat_report_appname(application_name.data);
+
+		Assert(ccd->id != 0);
+		ccd->completed_stage = "publication_drop";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
+}
+
+static void
+chunk_api_call_copy_chunk_data_wrapper(ChunkCopyData *ccd, bool transactional)
+{
+	/* setup logical replication publication and subscription */
+	chunk_copy_data_prepare(ccd, transactional);
+
+	/* begin data transfer and wait for completion */
+	chunk_copy_data_perform(ccd, transactional);
+
+	/* cleanup */
+	chunk_copy_data_end(ccd, transactional);
 }
 
 Datum
@@ -536,25 +703,312 @@ chunk_copy_data(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 (errmsg("must be superuser to copy chunk to data node"))));
 
+	ccd.id = 0; /* no id assigned since we don't want to persist it */
 	ccd.chunk = chunk;
-	ccd.src_node = list_make1((char *) src_node_name);
-	ccd.dst_node = list_make1((char *) dst_node_name);
+	ccd.src_node = src_node_name;
+	ccd.dst_node = dst_node_name;
 
-	/* prepare shared operation id name for publication and subscription */
+	/*
+	 * Prepare shared operation id name for publication and subscription
+	 *
+	 * Get the operation id for this chunk move/copy activity. The naming
+	 * convention is "ts_copy_seq-id_chunk-id_table-name_schema-name and it can
+	 * get truncated due to NAMEDATALEN restrictions
+	 */
 	snprintf(ccd.operation_id.data,
 			 sizeof(ccd.operation_id.data),
-			 "ts_copy_%s_%s",
-			 quote_identifier(NameStr(chunk->fd.schema_name)),
-			 quote_identifier(NameStr(chunk->fd.table_name)));
+			 "ts_copy_%d_%s_%s",
+			 chunk->fd.id,
+			 NameStr(chunk->fd.table_name),
+			 NameStr(chunk->fd.schema_name));
 
-	/* setup logical replication publication and subscription */
-	chunk_copy_data_prepare(&ccd);
-
-	/* begin data transfer and wait for completion */
-	chunk_copy_data_perform(&ccd);
-
-	/* cleanup */
-	chunk_copy_data_end(&ccd);
+	/* perform all the steps for the copy chunk */
+	chunk_api_call_copy_chunk_data_wrapper(&ccd, false);
 
 	PG_RETURN_VOID();
+}
+
+static ScanTupleResult
+chunk_copy_activity_tuple_delete(TupleInfo *ti, void *data)
+{
+	CatalogSecurityContext sec_ctx;
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+	ts_catalog_restore_user(&sec_ctx);
+
+	return SCAN_CONTINUE;
+}
+
+static int
+chunk_copy_activity_delete_by_id(int32 id)
+{
+	Catalog *catalog = ts_catalog_get();
+	ScanKeyData scankey[1];
+	ScannerCtx scanctx = {
+		.table = catalog_get_table_id(catalog, CHUNK_COPY_ACTIVITY),
+		.index = catalog_get_index(catalog, CHUNK_COPY_ACTIVITY, CHUNK_COPY_ACTIVITY_PKEY_IDX),
+		.nkeys = 1,
+		.limit = 1,
+		.scankey = scankey,
+		.data = NULL,
+		.tuple_found = chunk_copy_activity_tuple_delete,
+		.lockmode = RowExclusiveLock,
+		.scandirection = ForwardScanDirection,
+	};
+
+	ScanKeyInit(&scankey[0],
+				Anum_chunk_copy_activity_pkey_idx_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(id));
+
+	return ts_scanner_scan(&scanctx);
+}
+
+static void
+chunk_copy_activity_insert_rel(Relation rel, ChunkCopyData *ccd)
+{
+	TupleDesc desc = RelationGetDescr(rel);
+	Datum values[Natts_chunk_copy_activity];
+	bool nulls[Natts_chunk_copy_activity] = { false };
+	CatalogSecurityContext sec_ctx;
+
+	memset(values, 0, sizeof(values));
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_id)] = Int32GetDatum(ccd->id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_operation_id)] =
+		NameGetDatum(&ccd->operation_id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_backend_pid)] =
+		Int32GetDatum(MyProcPid);
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_completed_stage)] =
+		CStringGetTextDatum(ccd->completed_stage);
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_time_start)] =
+		TimestampTzGetDatum(GetCurrentTimestamp());
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_chunk_id)] =
+		Int32GetDatum(ccd->chunk->fd.id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_source_node_name)] =
+		DirectFunctionCall1(namein, CStringGetDatum(ccd->src_node));
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_dest_node_name)] =
+		DirectFunctionCall1(namein, CStringGetDatum(ccd->dst_node));
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_delete_on_src_node)] =
+		BoolGetDatum(ccd->delete_on_src_node);
+
+	/* nulls is FALSE above, insert the row now */
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	ts_catalog_insert_values(rel, desc, values, nulls);
+	ts_catalog_restore_user(&sec_ctx);
+}
+
+static void
+chunk_copy_activity_insert(ChunkCopyData *ccd)
+{
+	Catalog *catalog;
+	Relation rel;
+
+	catalog = ts_catalog_get();
+	rel = table_open(catalog_get_table_id(catalog, CHUNK_COPY_ACTIVITY), RowExclusiveLock);
+
+	chunk_copy_activity_insert_rel(rel, ccd);
+	table_close(rel, RowExclusiveLock);
+}
+
+static ScanTupleResult
+chunk_copy_activity_tuple_update(TupleInfo *ti, void *data)
+{
+	ChunkCopyData *ccd = data;
+	Datum values[Natts_chunk_copy_activity];
+	bool nulls[Natts_chunk_copy_activity];
+	CatalogSecurityContext sec_ctx;
+	bool should_free;
+	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
+	HeapTuple new_tuple;
+
+	heap_deform_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls);
+
+	/* We only update the "stage" field */
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_activity_completed_stage)] =
+		CStringGetTextDatum(ccd->completed_stage);
+
+	new_tuple = heap_form_tuple(ts_scanner_get_tupledesc(ti), values, nulls);
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	ts_catalog_update_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti), new_tuple);
+	ts_catalog_restore_user(&sec_ctx);
+	heap_freetuple(new_tuple);
+
+	if (should_free)
+		heap_freetuple(tuple);
+
+	return SCAN_DONE;
+}
+
+static int
+chunk_copy_activity_scan_update_by_id(int32 id, tuple_found_func tuple_found, void *data,
+									  LOCKMODE lockmode)
+{
+	Catalog *catalog = ts_catalog_get();
+	ScanKeyData scankey[1];
+	ScannerCtx scanctx = {
+		.table = catalog_get_table_id(catalog, CHUNK_COPY_ACTIVITY),
+		.index = catalog_get_index(catalog, CHUNK_COPY_ACTIVITY, CHUNK_COPY_ACTIVITY_PKEY_IDX),
+		.nkeys = 1,
+		.limit = 1,
+		.scankey = scankey,
+		.data = data,
+		.tuple_found = tuple_found,
+		.lockmode = lockmode,
+		.scandirection = ForwardScanDirection,
+	};
+
+	ScanKeyInit(&scankey[0],
+				Anum_chunk_copy_activity_pkey_idx_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(id));
+
+	return ts_scanner_scan(&scanctx);
+}
+
+int
+chunk_copy_activity_update(ChunkCopyData *ccd)
+{
+	return chunk_copy_activity_scan_update_by_id(ccd->id,
+												 chunk_copy_activity_tuple_update,
+												 ccd,
+												 RowExclusiveLock);
+}
+
+void
+chunk_perform_distributed_copy(Oid chunk_relid, bool verbose, const char *src_node,
+							   const char *dst_node, bool delete_on_src_node)
+{
+	Chunk *chunk;
+	Cache *hcache;
+	Hypertable *ht;
+	ForeignServer *src_server, *dst_server;
+	MemoryContext old, mcxt;
+	NameData operation_id;
+	ChunkCopyData ccd;
+
+	/*
+	 * The chunk and foreign server info needs to be on a memory context
+	 * that will survive moving to a new transaction for each stage
+	 */
+	mcxt = AllocSetContextCreate(PortalContext, "chunk move activity", ALLOCSET_DEFAULT_SIZES);
+
+	old = MemoryContextSwitchTo(mcxt);
+
+	chunk = ts_chunk_get_by_relid(chunk_relid, true);
+
+	/* It has to be a foreign table chunk */
+	if (chunk->relkind != RELKIND_FOREIGN_TABLE)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("\"%s\" is not a valid remote chunk", get_rel_name(chunk_relid))));
+
+	/* It has to be an uncompressed chunk, we query the status field on the AN for this */
+	if (ts_chunk_is_compressed(chunk))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("\"%s\" is a compressed remote chunk. Chunk copy/move not supported"
+						" currently on compressed chunks",
+						get_rel_name(chunk_relid))));
+
+	ht = ts_hypertable_cache_get_cache_and_entry(chunk->hypertable_relid, CACHE_FLAG_NONE, &hcache);
+
+	ts_hypertable_permissions_check(ht->main_table_relid, GetUserId());
+
+	if (!hypertable_is_distributed(ht))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("hypertable \"%s\" is not distributed",
+						get_rel_name(ht->main_table_relid))));
+
+	/* check that src_node is a valid DN and that chunk exists on it */
+	src_server = data_node_get_foreign_server(src_node, ACL_USAGE, true, false);
+	Assert(NULL != src_server);
+
+	if (!ts_chunk_has_data_node(chunk, src_node))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("chunk \"%s\" does not exist on source data node \"%s\"",
+						get_rel_name(chunk_relid),
+						src_node)));
+
+	/* check that dst_node is a valid DN and that chunk does not exist on it */
+	dst_server = data_node_get_foreign_server(dst_node, ACL_USAGE, true, false);
+	Assert(NULL != dst_server);
+
+	if (ts_chunk_has_data_node(chunk, dst_node))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				 errmsg("chunk \"%s\" already exists on destination data node \"%s\"",
+						get_rel_name(chunk_relid),
+						dst_node)));
+
+	/*
+	 * Populate the ChunkCopyData structure for use by various stages
+	 *
+	 * Get the operation id for this chunk move/copy activity. The naming
+	 * convention is "ts_copy_seq-id_chunk-id_table-name_schema-name and it can
+	 * get truncated due to NAMEDATALEN restrictions
+	 */
+	ccd.id = ts_catalog_table_next_seq_id(ts_catalog_get(), CHUNK_COPY_ACTIVITY);
+	ccd.chunk = chunk;
+	snprintf(ccd.operation_id.data,
+			 sizeof(operation_id.data),
+			 "ts_copy_%d_%d_%s_%s",
+			 ccd.id,
+			 chunk->fd.id,
+			 NameStr(chunk->fd.table_name),
+			 NameStr(chunk->fd.schema_name));
+	ccd.src_node = pstrdup(src_node);
+	ccd.dst_node = pstrdup(dst_node);
+	ccd.delete_on_src_node = delete_on_src_node;
+	/* each step below should modify this field according to their actions */
+	ccd.completed_stage = "initial";
+
+	/*
+	 * Step 0: Persist the entry in the catalog
+	 */
+	chunk_copy_activity_insert(&ccd);
+
+	ts_cache_release(hcache);
+	MemoryContextSwitchTo(old);
+
+	/* Commit to get out of starting transaction */
+	PopActiveSnapshot();
+	CommitTransactionCommand();
+
+	/*
+	 * All sanity checks are done. Start with the actual process
+	 *
+	 * Step 1: Create an empty chunk table on the dst_node.
+	 */
+	chunk_api_call_create_empty_chunk_table_wrapper(&ccd, true);
+
+	/*
+	 * Step 2: Copy the data from the src_node chunk to this newly created
+	 * dst_node chunk.
+	 */
+	chunk_api_call_copy_chunk_data_wrapper(&ccd, true);
+
+	/*
+	 * Step 3: Attach this chunk to the hypertable on the dst_node.
+	 */
+	chunk_api_call_chunk_attach_replica_wrapper(dst_server, &ccd, true);
+
+	/*
+	 * Step 4: Remove this chunk from the src_node to complete the move. But
+	 * only if explicitly told to do so.
+	 */
+	if (ccd.delete_on_src_node)
+		chunk_api_call_chunk_drop_replica_wrapper(&ccd, src_server->serverid, true);
+
+	/* done using this long lived memory context */
+	MemoryContextReset(mcxt);
+
+	/* start a transaction for the final outer transaction */
+	StartTransactionCommand();
+	/* All steps complete, delete this ccd entry from the catalog now */
+	chunk_copy_activity_delete_by_id(ccd.id);
 }

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -17,5 +17,8 @@ extern Datum chunk_drop_replica(PG_FUNCTION_ARGS);
 extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type);
 extern Datum chunk_create_replica_table(PG_FUNCTION_ARGS);
 extern Datum chunk_copy_data(PG_FUNCTION_ARGS);
+extern void chunk_perform_distributed_copy(Oid chunk_relid, bool verbose, const char *src_node,
+										   const char *dst_node, bool delete_on_src_node);
+extern int chunk_copy_activity_update(ChunkCopyData *ccd);
 
 #endif /* TIMESCALEDB_TSL_CHUNK_H */

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -38,7 +38,9 @@
 #include "remote/stmt_params.h"
 #include "remote/dist_commands.h"
 #include "remote/tuplefactory.h"
+#include "chunk.h"
 #include "chunk_api.h"
+#include "data_node.h"
 
 /*
  * These values come from the pg_type table.
@@ -442,10 +444,14 @@ chunk_api_dimension_slices_json(const Chunk *chunk, const Hypertable *ht)
 }
 
 /*
- * Create a replica of a chunk on all its assigned data nodes.
+ * Create a replica of a chunk on all its assigned or specified list of data nodes.
+ *
+ * If "data_nodes" list is explicitly specified use that instead of the list of
+ * data nodes from the chunk.
  */
 void
-chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht)
+chunk_api_create_on_data_nodes(const Chunk *chunk, const Hypertable *ht,
+							   const char *remote_chunk_name, List *data_nodes)
 {
 	AsyncRequestSet *reqset = async_request_set_create();
 	const char *params[CREATE_CHUNK_NUM_ARGS] = {
@@ -453,17 +459,18 @@ chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht)
 		chunk_api_dimension_slices_json(chunk, ht),
 		NameStr(chunk->fd.schema_name),
 		NameStr(chunk->fd.table_name),
-		NULL,
+		remote_chunk_name ? remote_chunk_name : NULL,
 	};
 	AsyncResponseResult *res;
 	ListCell *lc;
 	TupleDesc tupdesc;
 	AttInMetadata *attinmeta;
+	List *target_data_nodes = data_nodes ? data_nodes : chunk->data_nodes;
 
 	get_create_chunk_result_type(&tupdesc);
 	attinmeta = TupleDescGetAttInMetadata(tupdesc);
 
-	foreach (lc, chunk->data_nodes)
+	foreach (lc, target_data_nodes)
 	{
 		ChunkDataNode *cdn = lfirst(lc);
 		TSConnectionId id = remote_connection_id(cdn->foreign_server_oid, GetUserId());
@@ -511,8 +518,8 @@ chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht)
 			DatumGetCString(values[AttrNumberGetAttrOffset(Anum_create_chunk_schema_name)]);
 		table_name = DatumGetCString(values[AttrNumberGetAttrOffset(Anum_create_chunk_table_name)]);
 
-		if (namestrcmp(&chunk->fd.schema_name, schema_name) != 0 ||
-			namestrcmp(&chunk->fd.table_name, table_name) != 0)
+		if (namestrcmp((Name) &chunk->fd.schema_name, schema_name) != 0 ||
+			namestrcmp((Name) &chunk->fd.table_name, table_name) != 0)
 			elog(ERROR, "remote chunk has mismatching schema or table name");
 
 		cdn->fd.node_chunk_id =
@@ -1678,6 +1685,41 @@ chunk_create_empty_table(PG_FUNCTION_ARGS)
 #define CREATE_CHUNK_TABLE_NAME "create_chunk_table"
 
 void
+chunk_api_call_create_empty_chunk_table_wrapper(ChunkCopyData *ccd, bool transactional)
+{
+	Cache *hcache;
+	Hypertable *ht;
+
+	if (transactional)
+		StartTransactionCommand();
+
+	ht = ts_hypertable_cache_get_cache_and_entry(ccd->chunk->hypertable_relid,
+												 CACHE_FLAG_NONE,
+												 &hcache);
+
+	chunk_api_call_create_empty_chunk_table(ht, ccd->chunk, ccd->dst_node);
+
+	ts_cache_release(hcache);
+
+	/* Add a new entry in CHUNK_COPY_ACTIVITY to indicate completion of "empty_chunk_create" step */
+	if (transactional)
+	{
+		NameData application_name;
+
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "chunk_created:%s",
+				 application_name.data);
+		pgstat_report_appname(application_name.data);
+
+		ccd->completed_stage = "chunk_created";
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
+}
+
+void
 chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const Chunk *chunk,
 										const char *node_name)
 {
@@ -1693,5 +1735,64 @@ chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const Chunk *chunk
 		ts_dist_cmd_params_invoke_on_data_nodes(create_cmd,
 												stmt_params_create_from_values(params, 4),
 												list_make1((void *) node_name),
-												true));
+												false));
+}
+
+void
+chunk_api_call_chunk_attach_replica_wrapper(ForeignServer *server, ChunkCopyData *ccd,
+											bool transactional)
+{
+	Cache *hcache;
+	Hypertable *ht;
+	ChunkDataNode *chunk_data_node;
+	const char *remote_chunk_name;
+	Chunk *chunk = ccd->chunk;
+
+	/* We use a 2PC to commit the transaction on the DN as well as on the AN */
+	if (transactional)
+		StartTransactionCommand();
+
+	ht = ts_hypertable_cache_get_cache_and_entry(ccd->chunk->hypertable_relid,
+												 CACHE_FLAG_NONE,
+												 &hcache);
+
+	/* Check that the hypertable is already attached to this data node */
+	data_node_hypertable_get_by_node_name(ht, server->servername, true);
+
+	chunk_data_node = palloc0(sizeof(ChunkDataNode));
+
+	chunk_data_node->fd.chunk_id = chunk->fd.id;
+	chunk_data_node->fd.node_chunk_id = -1; /* below API will fill it up*/
+	namestrcpy(&chunk_data_node->fd.node_name, server->servername);
+	chunk_data_node->foreign_server_oid = server->serverid;
+
+	remote_chunk_name = psprintf("%s.%s",
+								 quote_identifier(chunk->fd.schema_name.data),
+								 quote_identifier(chunk->fd.table_name.data));
+
+	chunk_api_create_on_data_nodes(chunk, ht, remote_chunk_name, list_make1(chunk_data_node));
+
+	/* All ok, update the AN chunk metadata to add this data node to it */
+	chunk->data_nodes = lappend(chunk->data_nodes, chunk_data_node);
+
+	/* persist this association in the metadata */
+	ts_chunk_data_node_insert(chunk_data_node);
+
+	ts_cache_release(hcache);
+	if (transactional)
+	{
+		NameData application_name;
+
+		snprintf(application_name.data,
+				 sizeof(application_name.data),
+				 "chunk_attached_dstdn:%s",
+				 application_name.data);
+		pgstat_report_appname(application_name.data);
+
+		ccd->completed_stage = "chunk_attached_dstdn";
+		/* it gets committed as part of the overall transaction */
+		chunk_copy_activity_update(ccd);
+
+		CommitTransactionCommand();
+	}
 }

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -14,12 +14,17 @@
 
 extern Datum chunk_show(PG_FUNCTION_ARGS);
 extern Datum chunk_create(PG_FUNCTION_ARGS);
-extern void chunk_api_create_on_data_nodes(Chunk *chunk, Hypertable *ht);
+extern void chunk_api_create_on_data_nodes(const Chunk *chunk, const Hypertable *ht,
+										   const char *remote_chunk_name, List *data_nodes);
 extern Datum chunk_api_get_chunk_relstats(PG_FUNCTION_ARGS);
 extern Datum chunk_api_get_chunk_colstats(PG_FUNCTION_ARGS);
 extern void chunk_api_update_distributed_hypertable_stats(Oid relid);
 extern Datum chunk_create_empty_table(PG_FUNCTION_ARGS);
+extern void chunk_api_call_create_empty_chunk_table_wrapper(ChunkCopyData *ccd, bool transactional);
+extern void chunk_api_call_chunk_attach_replica_wrapper(ForeignServer *server, ChunkCopyData *ccd,
+														bool transactional);
+void chunk_api_call_chunk_drop_replica_wrapper(ChunkCopyData *ccd, Oid serverid,
+											   bool transactional);
 extern void chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const Chunk *chunk,
 													const char *node_name);
-
 #endif /* TIMESCALEDB_TSL_CHUNK_API_H */

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -119,6 +119,7 @@ CrossModuleFunctions tsl_cm_functions = {
 
 	.reorder_chunk = tsl_reorder_chunk,
 	.move_chunk = tsl_move_chunk,
+	.move_chunk_proc = tsl_move_chunk_proc,
 	.partialize_agg = tsl_partialize_agg,
 	.finalize_agg_sfunc = tsl_finalize_agg_sfunc,
 	.finalize_agg_ffunc = tsl_finalize_agg_ffunc,

--- a/tsl/src/remote/dist_commands.c
+++ b/tsl/src/remote/dist_commands.c
@@ -78,6 +78,10 @@ ts_dist_cmd_collect_responses(List *requests)
  *
  * The list of data nodes can either be a list of data node names, or foreign
  * server OIDs.
+ *
+ * If "transactional" is false then it means that the SQL should be executed
+ * in autocommit (implicit statement level commit) mode without the need for
+ * an explicit 2PC from the access node
  */
 DistCmdResult *
 ts_dist_cmd_params_invoke_on_data_nodes(const char *sql, StmtParams *params, List *data_nodes,

--- a/tsl/src/reorder.h
+++ b/tsl/src/reorder.h
@@ -11,6 +11,7 @@
 
 extern Datum tsl_reorder_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_move_chunk(PG_FUNCTION_ARGS);
+extern Datum tsl_move_chunk_proc(PG_FUNCTION_ARGS);
 extern void reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id,
 						  Oid destination_tablespace, Oid index_tablespace);
 

--- a/tsl/test/t/003_chunk_copy_move.pl
+++ b/tsl/test/t/003_chunk_copy_move.pl
@@ -1,0 +1,88 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# test the multi node chunk copy/move operation end-to-end
+use strict;
+use warnings;
+use AccessNode;
+use DataNode;
+use TestLib;
+use Test::More tests => 21;
+
+#Initialize all the multi-node instances
+my $an  = AccessNode->create('an');
+my $dn1 = DataNode->create('dn1', allows_streaming => 'logical');
+my $dn2 = DataNode->create('dn2');
+
+$an->add_data_node($dn1);
+$an->add_data_node($dn2);
+
+#Create a distributed hypertable and insert a few rows
+$an->safe_psql(
+	'postgres',
+	qq[
+    CREATE TABLE test(time timestamp NOT NULL, device int, temp float);
+    SELECT create_distributed_hypertable('test', 'time', 'device', 3);
+    INSERT INTO test SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, 0.10 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-08 1:00', '1 hour') t;
+    ]);
+
+#Check that chunks are shown appropriately on all nodes of the multi-node setup
+my $query = q[SELECT * from show_chunks('test');];
+
+#Query Access node
+$an->psql_is(
+	'postgres', $query, q[_timescaledb_internal._dist_hyper_1_1_chunk
+_timescaledb_internal._dist_hyper_1_2_chunk
+_timescaledb_internal._dist_hyper_1_3_chunk
+_timescaledb_internal._dist_hyper_1_4_chunk], 'AN shows correct set of chunks'
+);
+
+#Query datanode1
+$dn1->psql_is(
+	'postgres',
+	$query,
+	"_timescaledb_internal._dist_hyper_1_1_chunk\n_timescaledb_internal._dist_hyper_1_3_chunk\n_timescaledb_internal._dist_hyper_1_4_chunk",
+	'DN1 shows correct set of chunks');
+
+#Check contents on the chunk on DN1
+$dn1->psql_is('postgres',
+	"SELECT sum(device) FROM _timescaledb_internal._dist_hyper_1_1_chunk",
+	qq[406], "DN1 has correct contents in the chunk");
+
+#Query datanode2
+$dn2->psql_is(
+	'postgres', $query,
+	"_timescaledb_internal._dist_hyper_1_2_chunk",
+	'DN2 shows correct set of chunks');
+
+#Move chunk _timescaledb_internal._dist_hyper_1_1_chunk to DN2 from AN
+$an->safe_psql('postgres',
+	"CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_1_chunk', source_node=> 'dn1', destination_node => 'dn2')"
+);
+
+#Query datanode1 after the above move
+$dn1->psql_is(
+	'postgres',
+	$query,
+	"_timescaledb_internal._dist_hyper_1_3_chunk\n_timescaledb_internal._dist_hyper_1_4_chunk",
+	'DN1 shows correct set of chunks');
+
+#Check contents on the chunk on DN2, after the move
+$dn2->psql_is(
+	'postgres',
+	"SELECT sum(device) FROM _timescaledb_internal._dist_hyper_1_1_chunk",
+	qq[406],
+	"DN2 has correct contents after the move in the chunk");
+
+#Query datanode2
+$dn2->psql_is(
+	'postgres',
+	$query,
+	"_timescaledb_internal._dist_hyper_1_2_chunk\n_timescaledb_internal._dist_hyper_1_1_chunk",
+	'DN2 shows correct set of chunks');
+
+
+done_testing();
+
+1;

--- a/tsl/test/t/CMakeLists.txt
+++ b/tsl/test/t/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PROVE_TEST_FILES
     001_simple_multinode.pl
     002_copy_chunk_data.pl
+    003_chunk_copy_move.pl
 )
 
 foreach(P_FILE ${PROVE_TEST_FILES})


### PR DESCRIPTION
The building blocks required for implementing end-to-end copy/move
chunk functionality have now been wrapped in a procedure.
    
A procedure is required because multiple transactions are needed to
carry out the activity across the access node and the involved two data
nodes.
    
The following steps are encapsulated in this procedure
    
1) Create an empty chunk table on the destination data node
    
2) Copy the data from the src data node chunk to this newly created
 destination node chunk. This is done via inbuilt PostgreSQL logical
 replication functionality
    
3) Attach this chunk to the hypertable on the dst data node
    
4) Remove this chunk from the src data node to complete the move if
 requested
    
 A new catalog table "chunk_copy_activity" has been added to track
 the progress of the above stages. A unique id gets assigned to each
 activity and it is updated with the completed stages as things
 progress.