### PR TITLE
Look for PostgresNode.pm in the right path

### DIFF
--- a/test/pg_prove.sh
+++ b/test/pg_prove.sh
@@ -30,4 +30,9 @@ else
     FINAL_TESTS=$PROVE_TESTS
 fi
 
-${PROVE} -I "${SRC_DIR}/src/test/perl" -I "${CM_SRC_DIR}/test/perl" $FINAL_TESTS
+${PROVE} \
+    -I "${SRC_DIR}/src/test/perl" \
+    -I "${CM_SRC_DIR}/test/perl" \
+    -I "${PG_LIBDIR}/pgxs/src/test/perl" \
+    -I "${PG_LIBDIR}/postgresql/pgxs/src/test/perl" \
+    $FINAL_TESTS

--- a/tsl/test/CMakeLists.txt
+++ b/tsl/test/CMakeLists.txt
@@ -67,6 +67,7 @@ if (TAP_CHECKS)
     PG_REGRESS=${PG_REGRESS}
     SRC_DIR=${PG_SOURCE_DIR}
     CM_SRC_DIR=${CMAKE_SOURCE_DIR}
+    PG_LIBDIR=${PG_LIBDIR}
     ${PRIMARY_TEST_DIR}/pg_prove.sh
     USES_TERMINAL)
   list(APPEND _install_checks provecheck)


### PR DESCRIPTION
    Look for PostgresNode.pm in the right path

    $(pg_config --libdir)/pgxs/src/test/perl is the right path for
    PostgresNode.pm on Linux. On MaxOS and PG 13.x another path seems
    to be used: $(pg_config --libdir)/postgresql/pgxs/src/test/perl