### PR TITLE
Remove unused bucket_width argument

### DIFF
--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -47,8 +47,7 @@ void
 continuous_agg_update_materialization(SchemaAndName partial_view,
 									  SchemaAndName materialization_table, Name time_column_name,
 									  InternalTimeRange new_materialization_range,
-									  InternalTimeRange invalidation_range, int64 bucket_width,
-									  int32 chunk_id)
+									  InternalTimeRange invalidation_range, int32 chunk_id)
 {
 	InternalTimeRange combined_materialization_range = new_materialization_range;
 	bool materialize_invalidations_separately = range_length(invalidation_range) > 0;

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -40,7 +40,6 @@ void continuous_agg_update_materialization(SchemaAndName partial_view,
 										   SchemaAndName materialization_table,
 										   Name time_column_name,
 										   InternalTimeRange new_materialization_range,
-										   InternalTimeRange invalidation_range, int64 bucket_width,
-										   int32 chunk_id);
+										   InternalTimeRange invalidation_range, int32 chunk_id);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_MATERIALIZE_H */

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -262,7 +262,6 @@ continuous_agg_refresh_execute(const CaggRefreshState *refresh,
 										  &time_dim->fd.column_name,
 										  *bucketed_refresh_window,
 										  unused_invalidation_range,
-										  refresh->cagg.data.bucket_width,
 										  chunk_id);
 }
 


### PR DESCRIPTION
continuous_agg_update_materialization() doesn't use this argument and
we can't rely on a fixed bucket_width in the future anyway.