### PR TITLE
Make provecheck run specific tap tests

### DIFF
--- a/test/pg_prove.sh
+++ b/test/pg_prove.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Wrapper around perl prove utility to control running of TAP tests
+#
+# The following control variable is supported:
+#
+# PROVE_TESTS  only run TAP tests from this list
+# e.g make provecheck PROVE_TESTS="t/foo.pl t/bar.pl"
+#
+# Note that you can also use regular expressions to run multiple
+# taps tests matching the pattern:
+#
+# e.g make provecheck PROVE_TESTS="t/*chunk*"
+#
+
+PROVE_TESTS=${PROVE_TESTS:-}
+PROVE=${PROVE:-prove}
+
+# If PROVE_TESTS is specified then run those subset of TAP tests even if
+# TESTS is also specified
+if [ -z "$PROVE_TESTS" ]
+then
+    # Exit early if we are running with TESTS=expr
+    if [ ! -z "$TESTS" ]
+    then
+        exit 0
+    fi
+    FINAL_TESTS="t/*.pl"
+else
+    FINAL_TESTS=$PROVE_TESTS
+fi
+
+${PROVE} -I "${SRC_DIR}/src/test/perl" -I "${CM_SRC_DIR}/test/perl" $FINAL_TESTS

--- a/tsl/test/CMakeLists.txt
+++ b/tsl/test/CMakeLists.txt
@@ -63,13 +63,11 @@ if (TAP_CHECKS)
   add_custom_target(provecheck
     COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/tmp_check
     COMMAND BUILDIR=${CMAKE_BINARY_DIR}
-    TESTDIR=${CMAKE_CURRENT_BINARY_DIR}
     PATH="${PG_BINDIR}:$ENV{PATH}"
-    PGPORT=6${TEST_PGPORT_LOCAL}
     PG_REGRESS=${PG_REGRESS}
-    ${PROVE} -I "${PG_SOURCE_DIR}/src/test/perl"
-    -I "${CMAKE_SOURCE_DIR}/test/perl"
-    t/*.pl
+    SRC_DIR=${PG_SOURCE_DIR}
+    CM_SRC_DIR=${CMAKE_SOURCE_DIR}
+    ${PRIMARY_TEST_DIR}/pg_prove.sh
     USES_TERMINAL)
   list(APPEND _install_checks provecheck)
 endif()


### PR DESCRIPTION
Introduce a shell wrapper around perl prove utility to control running
of TAP tests. The following control variable is supported:

PROVE_TESTS: only run TAP tests from this list

e.g make provecheck PROVE_TESTS="t/foo.pl t/bar.pl"

Note that you can also use regular expressions to run multiple taps
tests matching the pattern:

e.g make provecheck PROVE_TESTS="t/\*chunk\*"

If the existing "TESTS=" option is used along with PROVE_TESTS then
the subset represented by PROVE_TESTS will also get run. Otherwise tap
tests will be skipped if "TESTS=" is specified.

e.g make installcheck TESTS=dist_hyper* PROVE_TESTS="t/001_*"