### PR TITLE
Fix compile error

### DIFF
--- a/tsl/src/remote/stmt_params.c
+++ b/tsl/src/remote/stmt_params.c
@@ -179,7 +179,7 @@ stmt_params_convert_values(StmtParams *params, TupleTableSlot *slot, ItemPointer
 	MemoryContext old;
 	int idx;
 	ListCell *lc;
-	int nest_level;
+	int nest_level = 0;
 	bool all_binary;
 	int param_idx = 0;
 


### PR DESCRIPTION
Fix the following compile error:
```
tsl/src/remote/stmt_params.c: In function 'stmt_params_convert_values':
tsl/src/remote/stmt_params.c:246:3: error: 'nest_level' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  246 |   reset_transmission_modes(nest_level);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tsl/src/remote/stmt_params.c: At top level:
cc1: error: unrecognized command line option '-Wno-unused-command-line-argument' [-Werror]
cc1: all warnings being treated as errors
make[2]: *** [tsl/src/CMakeFiles/timescaledb-tsl.dir/build.make:1077: tsl/src/CMakeFiles/timescaledb-tsl.dir/remote/stmt_params.c.o] Error 1
```