### PR TITLE
Fix pg_init_privs objsubid handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #3305 Fix pull_varnos miscomputation of relids set
 * #3327 Make aggregates in caggs fully qualified
+* #3336 Fix pg_init_privs objsubid handling
 
 **Thanks**
 * @db-adrian for reporting an issue when accessing cagg view through postgres_fdw
 * @fncaldas and @pgwhalen for reporting an issue accessing caggs when public is not in search_path
+* @fvannee, @mglonnro and @ebreijo for reporting an issue with the upgrade script
 
 ## 2.3.0 (2021-05-25)
 

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -42,12 +42,12 @@ DROP FUNCTION IF EXISTS _timescaledb_internal.cagg_watermark(oid);
 -- first installation.
 INSERT INTO saved_privs
      SELECT nspname, relname, relacl,
- 	    (SELECT tmpini FROM saved_privs
-	      WHERE tmpnsp = '_timescaledb_catalog' AND tmpname = 'chunk')
+       (SELECT tmpini FROM saved_privs
+        WHERE tmpnsp = '_timescaledb_catalog' AND tmpname = 'chunk')
        FROM pg_class JOIN pg_namespace ns ON ns.oid = relnamespace
-		LEFT JOIN saved_privs ON tmpnsp = nspname AND tmpname = relname
+         LEFT JOIN saved_privs ON tmpnsp = nspname AND tmpname = relname
       WHERE nspname IN ('_timescaledb_catalog', '_timescaledb_config')
- 	 OR nspname = '_timescaledb_internal'
+        OR nspname = '_timescaledb_internal'
         AND relname IN ('hypertable_chunk_local_size', 'compressed_chunk_stats',
                         'bgw_job_stat', 'bgw_policy_chunk_stats')
 ON CONFLICT DO NOTHING;
@@ -56,13 +56,14 @@ ON CONFLICT DO NOTHING;
 WITH to_update AS (
      SELECT objoid, tmpini
      FROM pg_class cl JOIN pg_namespace ns ON ns.oid = relnamespace
-   		      JOIN pg_init_privs ip ON ip.objoid = cl.oid
-		      JOIN saved_privs ON tmpnsp = nspname AND tmpname = relname)
+        JOIN pg_init_privs ip ON ip.objoid = cl.oid AND ip.objsubid = 0
+        JOIN saved_privs ON tmpnsp = nspname AND tmpname = relname)
 UPDATE pg_init_privs
    SET initprivs = tmpini
   FROM to_update
  WHERE to_update.objoid = pg_init_privs.objoid
-   AND classoid = 'pg_class'::regclass;
+   AND classoid = 'pg_class'::regclass
+   AND objsubid = 0;
 
 -- Can only restore permissions on views after they have been rebuilt,
 -- so we restore for all types of objects here.

--- a/sql/updates/pre-update.sql
+++ b/sql/updates/pre-update.sql
@@ -28,7 +28,7 @@ LANGUAGE C VOLATILE;
 
 SELECT _timescaledb_internal.restart_background_workers();
 
--- Table for ACL and initprivs of tables. 
+-- Table for ACL and initprivs of tables.
 CREATE TABLE saved_privs(
        tmpnsp name,
        tmpname name,
@@ -42,10 +42,10 @@ CREATE TABLE saved_privs(
 INSERT INTO saved_privs
 SELECT nspname, relname, relacl, initprivs
   FROM pg_class cl JOIN pg_namespace ns ON ns.oid = relnamespace
-                   JOIN pg_init_privs ip ON ip.objoid = cl.oid
+                   JOIN pg_init_privs ip ON ip.objoid = cl.oid AND ip.objsubid = 0
 WHERE nspname IN ('_timescaledb_catalog', '_timescaledb_config')
    OR nspname = '_timescaledb_internal'
   AND relname IN ('hypertable_chunk_local_size', 'compressed_chunk_stats',
-      	      	  'bgw_job_stat', 'bgw_policy_chunk_stats');
+                  'bgw_job_stat', 'bgw_policy_chunk_stats');
 
 

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -21,7 +21,7 @@ SELECT nspname AS schema,
        relname AS name,
        unnest(initprivs)::text AS initpriv
 FROM pg_class cl JOIN pg_namespace ns ON ns.oid = relnamespace
-            LEFT JOIN pg_init_privs ON objoid = cl.oid
+            LEFT JOIN pg_init_privs ON objoid = cl.oid AND objsubid = 0
 WHERE classoid = 'pg_class'::regclass
   AND nspname IN ('_timescaledb_catalog', '_timescaledb_config')
 ORDER BY schema, name, initpriv;


### PR DESCRIPTION
pg_init_privs can have multiple entries per relation if the relation
has per column privileges. An objsubid different from 0 means that
the entry is for a column privilege. Since we do not currently
restore column privileges we have to ignore those rows otherwise
the update script will fail when tables with column privileges are
present.

Fixes #3331 