### PR TITLE
Don't access bucket_width directly

### DIFF
--- a/src/catalog.h
+++ b/src/catalog.h
@@ -871,6 +871,12 @@ typedef struct FormData_continuous_agg
 	NameData user_view_name;
 	NameData partial_view_schema;
 	NameData partial_view_name;
+	/*
+	 * Don't access bucket_width directly to determine the width of the bucket.
+	 * Use corresponding procedures instead:
+	 * - ts_continuous_agg_bucket_width
+	 * - ts_continuous_agg_max_bucket_width
+	 */
 	int64 bucket_width;
 	NameData direct_view_schema;
 	NameData direct_view_name;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -90,4 +90,7 @@ extern TSDLLEXPORT const Dimension *
 ts_continuous_agg_find_integer_now_func_by_materialization_id(int32 mat_htid);
 extern ContinuousAgg *ts_continuous_agg_find_userview_name(const char *schema, const char *name);
 
+extern TSDLLEXPORT int64 ts_continuous_agg_bucket_width(const ContinuousAgg *agg);
+extern TSDLLEXPORT int64 ts_continuous_agg_max_bucket_width(const ContinuousAgg *agg);
+
 #endif /* TIMESCALEDB_CONTINUOUS_AGG_H */

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -358,6 +358,7 @@ validate_window_size(const ContinuousAgg *cagg, const CaggPolicyConfig *config)
 {
 	int64 start_offset;
 	int64 end_offset;
+	int64 max_bucket_width;
 
 	if (config->offset_start.isnull)
 		start_offset = ts_time_get_max(cagg->partition_type);
@@ -369,7 +370,8 @@ validate_window_size(const ContinuousAgg *cagg, const CaggPolicyConfig *config)
 	else
 		end_offset = interval_to_int64(config->offset_end.value, config->offset_end.type);
 
-	if (ts_time_saturating_add(end_offset, cagg->data.bucket_width * 2, INT8OID) > start_offset)
+	max_bucket_width = ts_continuous_agg_max_bucket_width(cagg);
+	if (ts_time_saturating_add(end_offset, max_bucket_width * 2, INT8OID) > start_offset)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("policy refresh window too small"),

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -711,6 +711,7 @@ move_invalidations_from_hyper_to_cagg_log(const CaggInvalidationState *state)
 			TupleInfo *ti;
 			MemoryContext oldmctx;
 			Invalidation logentry;
+			int64 bucket_width = ts_continuous_agg_bucket_width(cagg);
 
 			oldmctx = MemoryContextSwitchTo(state->per_tuple_mctx);
 			ti = ts_scan_iterator_tuple_info(&iterator);
@@ -719,7 +720,7 @@ move_invalidations_from_hyper_to_cagg_log(const CaggInvalidationState *state)
 														   ti,
 														   cagg_hyper_id,
 														   state->dimtype,
-														   cagg->data.bucket_width);
+														   bucket_width);
 
 			if (!IS_VALID_INVALIDATION(&mergedentry))
 			{
@@ -882,12 +883,10 @@ clear_cagg_invalidations_for_refresh(const CaggInvalidationState *state,
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
 		MemoryContext oldmctx;
 		Invalidation logentry;
+		int64 bucket_width = ts_continuous_agg_bucket_width(&state->cagg);
 
 		oldmctx = MemoryContextSwitchTo(state->per_tuple_mctx);
-		invalidation_entry_set_from_cagg_invalidation(&logentry,
-													  ti,
-													  state->dimtype,
-													  state->cagg.data.bucket_width);
+		invalidation_entry_set_from_cagg_invalidation(&logentry, ti, state->dimtype, bucket_width);
 
 		if (!IS_VALID_INVALIDATION(&mergedentry))
 			mergedentry = logentry;

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -299,13 +299,11 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 		}
 		else
 		{
+			int64 bucket_width = ts_continuous_agg_bucket_width(cagg);
 			int64 maxval = ts_time_value_to_internal(maxdat, refresh_window->type);
-			int64 bucket_start =
-				ts_time_bucket_by_type(cagg->data.bucket_width, maxval, refresh_window->type);
+			int64 bucket_start = ts_time_bucket_by_type(bucket_width, maxval, refresh_window->type);
 			/* Add one bucket to get to the end of the last bucket */
-			return ts_time_saturating_add(bucket_start,
-										  cagg->data.bucket_width,
-										  refresh_window->type);
+			return ts_time_saturating_add(bucket_start, bucket_width, refresh_window->type);
 		}
 	}
 


### PR DESCRIPTION
```
Don't access bucket_width directly

Refactoring. Since bucket_width will not be fixed in the future this
patch introduces two new procedures:

- ts_continuous_agg_bucket_width(), for determining the exact width
  of given bucket;
- ts_continuous_agg_max_bucket_width(), for estimating the maximum
  bucket width for given continuous aggregate;

This will allow determining the bucket width on the fly, which is
not possible when ContinuousAgg* -> data.bucket_width is accessed
directly. All accesses to data.bucket_width were changed accordingly.
```