### PR TITLE
Fix memory overflow

### DIFF
--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -90,10 +90,8 @@ is_time_bucket_function(Expr *node)
 	return false;
 }
 
-#if PG13_GE
-/* PG13 merged setup_append_rel_array with setup_simple_rel_arrays */
 static void
-setup_append_rel_array(PlannerInfo *root)
+ts_setup_append_rel_array(PlannerInfo *root)
 {
 	root->append_rel_array =
 		repalloc(root->append_rel_array, root->simple_rel_array_size * sizeof(AppendRelInfo *));
@@ -106,7 +104,6 @@ setup_append_rel_array(PlannerInfo *root)
 		root->append_rel_array[child_relid] = appinfo;
 	}
 }
-#endif
 
 /*
  * Pre-check to determine if an expression is eligible for constification.
@@ -1365,7 +1362,7 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 	}
 
 	root->append_rel_list = list_concat(root->append_rel_list, appinfos);
-	setup_append_rel_array(root);
+	ts_setup_append_rel_array(root);
 
 	/* In pg12 postgres will not set up the child rels for use, due to the games
 	 * we're playing with inheritance, so we must do it ourselves.


### PR DESCRIPTION
Fix heap buffer overflow in hypertable expansion.

Fixes #3316

Force the use of our own function implementation since the semantics appear to be different than postgreSQL's:
```
void
setup_append_rel_array(PlannerInfo *root)
{
	ListCell   *lc;
	int			size = list_length(root->parse->rtable) + 1;

	if (root->append_rel_list == NIL)
	{
		root->append_rel_array = NULL;
		return;
	}

	root->append_rel_array = (AppendRelInfo **)
		palloc0(size * sizeof(AppendRelInfo *));

	foreach(lc, root->append_rel_list)
	{
		AppendRelInfo *appinfo = lfirst_node(AppendRelInfo, lc);
		int			child_relid = appinfo->child_relid;

		/* Sanity check */
		Assert(child_relid < size);

		if (root->append_rel_array[child_relid])
			elog(ERROR, "child relation already exists");

		root->append_rel_array[child_relid] = appinfo;
	}
}
```

We use `root->simple_rel_array_size` instead of `list_length(root->parse->rtable) + 1` and `repalloc()` instead of `palloc0()`.