### PR TITLE
Fix SkipScan distinct column identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,17 @@ accidentally triggering the load of a previous DB version.**
 * #3305 Fix pull_varnos miscomputation of relids set
 * #3327 Make aggregates in caggs fully qualified
 * #3336 Fix pg_init_privs objsubid handling
+* #3345 Fix SkipScan distinct column identification
 
 **Thanks**
 * @db-adrian for reporting an issue when accessing cagg view through postgres_fdw
 * @fncaldas and @pgwhalen for reporting an issue accessing caggs when public is not in search_path
 * @fvannee, @mglonnro and @ebreijo for reporting an issue with the upgrade script
+* @fvannee for reporting a performance regression with SkipScan
 
 ## 2.3.0 (2021-05-25)
 
-This release adds major new features since the 2.2.1 release. 
+This release adds major new features since the 2.2.1 release.
 We deem it moderate priority for upgrading.
 
 This release adds support for inserting data into compressed chunks

--- a/src/compat.h
+++ b/src/compat.h
@@ -205,4 +205,11 @@ get_vacuum_options(const VacuumStmt *stmt)
 	map_variable_attnos((node), (varno), (sublevels_up), (map), (rowtype), (found_wholerow))
 #endif
 
+/* PG13 removes msg parameter from convert_tuples_by_name */
+#if PG12
+#define convert_tuples_by_name_compat(in, out, msg) convert_tuples_by_name(in, out, msg)
+#else
+#define convert_tuples_by_name_compat(in, out, msg) convert_tuples_by_name(in, out)
+#endif
+
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -377,13 +377,9 @@ setup_on_conflict_state(ChunkInsertState *state, ChunkDispatch *dispatch,
 		Assert(map->outdesc == RelationGetDescr(chunk_rel));
 
 		if (NULL == chunk_map)
-			chunk_map = convert_tuples_by_name(RelationGetDescr(chunk_rel),
-											   RelationGetDescr(hyper_rel)
-#if PG13_LT
-												   ,
-											   gettext_noop("could not convert row type")
-#endif
-			);
+			chunk_map = convert_tuples_by_name_compat(RelationGetDescr(chunk_rel),
+													  RelationGetDescr(hyper_rel),
+													  gettext_noop("could not convert row type"));
 
 		onconflset = translate_clause(ts_chunk_dispatch_get_on_conflict_set(dispatch),
 									  chunk_map,
@@ -492,13 +488,9 @@ adjust_projections(ChunkInsertState *cis, ChunkDispatch *dispatch, Oid rowtype)
 		 * to have the hypertable_desc in the out spot for map_variable_attnos
 		 * to work correctly in mapping hypertable attnos->chunk attnos.
 		 */
-		chunk_map = convert_tuples_by_name(RelationGetDescr(chunk_rel),
-										   RelationGetDescr(hyper_rel)
-#if PG13_LT
-											   ,
-										   gettext_noop("could not convert row type")
-#endif
-		);
+		chunk_map = convert_tuples_by_name_compat(RelationGetDescr(chunk_rel),
+												  RelationGetDescr(hyper_rel),
+												  gettext_noop("could not convert row type"));
 
 		chunk_rri->ri_projectReturning =
 			get_adjusted_projection_info_returning(chunk_rri->ri_projectReturning,
@@ -628,13 +620,9 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 	 * data nodes for insert on that node's local hypertable. */
 	if (chunk->relkind != RELKIND_FOREIGN_TABLE)
 		state->hyper_to_chunk_map =
-			convert_tuples_by_name(RelationGetDescr(parent_rel),
-								   RelationGetDescr(rel)
-#if PG13_LT
-									   ,
-								   gettext_noop("could not convert row type")
-#endif
-			);
+			convert_tuples_by_name_compat(RelationGetDescr(parent_rel),
+										  RelationGetDescr(rel),
+										  gettext_noop("could not convert row type"));
 
 	adjust_projections(state, dispatch, RelationGetForm(rel)->reltype);
 

--- a/tsl/test/expected/plan_skip_scan-12.out
+++ b/tsl/test/expected/plan_skip_scan-12.out
@@ -684,6 +684,27 @@ stable expression in targetlist on skip_scan
                ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
 (4 rows)
 
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_time_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=10022 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: skip_scan.*
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
 \qecho LIMIT queries on :TABLE
 LIMIT queries on skip_scan
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
@@ -1024,6 +1045,16 @@ WHERE CLAUSES
                Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
                Heap Fetches: 1
 (5 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (dev = 1)
+(4 rows)
 
 -- CTE
 :PREFIX WITH devices AS (
@@ -2522,6 +2553,39 @@ stable expression in targetlist on skip_scan_ht
                      ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
 (12 rows)
 
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Unique (actual rows=10020 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: ((_hyper_1_1_chunk.*)::skip_scan_ht)
+         Sort Method: quicksort 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(9 rows)
+
 \qecho LIMIT queries on :TABLE
 LIMIT queries on skip_scan_ht
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
@@ -3181,6 +3245,27 @@ WHERE CLAUSES
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
                      Heap Fetches: 1
 (19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
 
 -- CTE
 :PREFIX WITH devices AS (

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -692,6 +692,27 @@ stable expression in targetlist on skip_scan
                ->  Index Scan using skip_scan_dev_name_idx on skip_scan (actual rows=12 loops=1)
 (4 rows)
 
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Unique (actual rows=12 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=12 loops=1)
+         ->  Index Scan using skip_scan_dev_idx on skip_scan (actual rows=12 loops=1)
+(3 rows)
+
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Unique (actual rows=10022 loops=1)
+   ->  Sort (actual rows=10022 loops=1)
+         Sort Key: skip_scan.*
+         Sort Method: quicksort 
+         ->  Seq Scan on skip_scan (actual rows=10022 loops=1)
+(5 rows)
+
 \qecho LIMIT queries on :TABLE
 LIMIT queries on skip_scan
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
@@ -1031,6 +1052,16 @@ WHERE CLAUSES
                Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
                Heap Fetches: 1
 (5 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Custom Scan (SkipScan) on skip_scan (actual rows=1 loops=1)
+         ->  Index Scan Backward using skip_scan_dev_time_idx on skip_scan (actual rows=1 loops=1)
+               Index Cond: (dev = 1)
+(4 rows)
 
 -- CTE
 :PREFIX WITH devices AS (
@@ -2522,6 +2553,39 @@ stable expression in targetlist on skip_scan_ht
                      ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_name_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
 (12 rows)
 
+\qecho DISTINCT with wholerow var
+DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=11 loops=1)
+   ->  Merge Append (actual rows=44 loops=1)
+         Sort Key: _hyper_1_1_chunk.dev
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_1_chunk_skip_scan_ht_dev_idx on _hyper_1_1_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_2_chunk_skip_scan_ht_dev_idx on _hyper_1_2_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_3_chunk_skip_scan_ht_dev_idx on _hyper_1_3_chunk (actual rows=11 loops=1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=11 loops=1)
+               ->  Index Scan using _hyper_1_4_chunk_skip_scan_ht_dev_idx on _hyper_1_4_chunk (actual rows=11 loops=1)
+(11 rows)
+
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Unique (actual rows=10020 loops=1)
+   ->  Sort (actual rows=10020 loops=1)
+         Sort Key: ((skip_scan_ht.*)::skip_scan_ht)
+         Sort Method: quicksort 
+         ->  Append (actual rows=10020 loops=1)
+               ->  Seq Scan on _hyper_1_1_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
+               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(9 rows)
+
 \qecho LIMIT queries on :TABLE
 LIMIT queries on skip_scan_ht
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
@@ -3173,6 +3237,27 @@ WHERE CLAUSES
                      Index Cond: ((dev_name > NULL::text) AND (dev_name IS NULL))
                      Heap Fetches: 1
 (19 rows)
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Unique (actual rows=1 loops=1)
+   ->  Merge Append (actual rows=4 loops=1)
+         Sort Key: _hyper_1_1_chunk."time" DESC
+         ->  Custom Scan (SkipScan) on _hyper_1_1_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_1_chunk_skip_scan_ht_dev_time_idx on _hyper_1_1_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_1_2_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_2_chunk_skip_scan_ht_dev_time_idx on _hyper_1_2_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_1_3_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_3_chunk_skip_scan_ht_dev_time_idx on _hyper_1_3_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+         ->  Custom Scan (SkipScan) on _hyper_1_4_chunk (actual rows=1 loops=1)
+               ->  Index Scan Backward using _hyper_1_4_chunk_skip_scan_ht_dev_time_idx on _hyper_1_4_chunk (actual rows=1 loops=1)
+                     Index Cond: (dev = 1)
+(15 rows)
 
 -- CTE
 :PREFIX WITH devices AS (

--- a/tsl/test/expected/skip_scan.out
+++ b/tsl/test/expected/skip_scan.out
@@ -153,6 +153,10 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
 \qecho LIMIT queries on :TABLE
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -198,6 +202,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -351,6 +357,10 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
 \qecho LIMIT queries on :TABLE
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -396,6 +406,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -564,6 +576,10 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
 \qecho LIMIT queries on :TABLE
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -609,6 +625,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE
@@ -762,6 +780,10 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_immutable(), 'q3_13' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
 \qecho LIMIT queries on :TABLE
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -807,6 +829,8 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev) dev,time,val FROM :TABLE WHERE time > 100 AND time < 200 AND val > 10 AND val < 10000 AND dev > 2 AND dev < 7 ORDER BY dev,time;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
 -- CTE
 :PREFIX WITH devices AS (
 	SELECT DISTINCT ON (dev) dev FROM :TABLE

--- a/tsl/test/shared/expected/timestamp_limits.out
+++ b/tsl/test/shared/expected/timestamp_limits.out
@@ -109,15 +109,13 @@ NOTICE:  adding not-null constraint to column "time"
 table_name | smallint_table
 
 INSERT INTO smallint_table VALUES (-32768), (32767);
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('smallint_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
--[ RECORD 1 ]--------+-----------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
+AND c.contype = 'c' ORDER BY chunk;
+-[ RECORD 1 ]--------+--------------------------------------
 pg_get_constraintdef | CHECK (("time" < '-32760'::smallint))
--[ RECORD 2 ]--------+-----------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
+-[ RECORD 2 ]--------+--------------------------------------
 pg_get_constraintdef | CHECK (("time" >= '32760'::smallint))
 
 CREATE TABLE int_table(time int);
@@ -127,15 +125,13 @@ NOTICE:  adding not-null constraint to column "time"
 table_name | int_table
 
 INSERT INTO int_table VALUES (-2147483648), (2147483647);
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('int_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 -[ RECORD 1 ]--------+------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" < '-2147483640'::integer))
 -[ RECORD 2 ]--------+------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" >= 2147483640))
 
 CREATE TABLE bigint_table(time bigint);
@@ -145,15 +141,13 @@ NOTICE:  adding not-null constraint to column "time"
 table_name | bigint_table
 
 INSERT INTO bigint_table VALUES (-9223372036854775808), (9223372036854775807);
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('bigint_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 -[ RECORD 1 ]--------+--------------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" < '-9223372036854775800'::bigint))
 -[ RECORD 2 ]--------+--------------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" >= '9223372036854775800'::bigint))
 
 CREATE TABLE date_table(time date);
@@ -170,15 +164,13 @@ ERROR:  timestamp out of range
 INSERT INTO date_table VALUES (test.end_ts_date());
 ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('date_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 -[ RECORD 1 ]--------+-----------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" < '4714-11-27 BC'::date))
 -[ RECORD 2 ]--------+-----------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" >= '294246-12-31'::date))
 
 CREATE TABLE timestamp_table(time timestamp);
@@ -196,15 +188,13 @@ ERROR:  timestamp out of range
 INSERT INTO timestamp_table VALUES (test.end_ts_timestamp());
 ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('timestamp_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 -[ RECORD 1 ]--------+-------------------------------------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" < '4714-11-27 00:00:00 BC'::timestamp without time zone))
 -[ RECORD 2 ]--------+-------------------------------------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" >= '294246-12-31 00:00:00'::timestamp without time zone))
 
 CREATE TABLE timestamptz_table(time timestamp);
@@ -223,15 +213,13 @@ ERROR:  timestamp out of range
 INSERT INTO timestamptz_table VALUES (test.end_ts_timestamptz());
 ERROR:  timestamp out of range
 \set ON_ERROR_STOP 1
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('timestamptz_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 -[ RECORD 1 ]--------+-------------------------------------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" < '4714-11-27 00:00:00 BC'::timestamp without time zone))
 -[ RECORD 2 ]--------+-------------------------------------------------------------------------
-chunk                | _timescaledb_internal._hyper_X_X_chunk
 pg_get_constraintdef | CHECK (("time" >= '294246-12-31 00:00:00'::timestamp without time zone))
 
 RESET datestyle;

--- a/tsl/test/shared/sql/timestamp_limits.sql
+++ b/tsl/test/shared/sql/timestamp_limits.sql
@@ -106,28 +106,28 @@ CREATE TABLE smallint_table(time smallint);
 SELECT table_name FROM create_hypertable('smallint_table', 'time', chunk_time_interval=>10);
 INSERT INTO smallint_table VALUES (-32768), (32767);
 
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('smallint_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 
 CREATE TABLE int_table(time int);
 SELECT table_name FROM create_hypertable('int_table', 'time', chunk_time_interval=>10);
 INSERT INTO int_table VALUES (-2147483648), (2147483647);
 
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('int_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 
 CREATE TABLE bigint_table(time bigint);
 SELECT table_name FROM create_hypertable('bigint_table', 'time', chunk_time_interval=>10);
 INSERT INTO bigint_table VALUES (-9223372036854775808), (9223372036854775807);
 
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('bigint_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 
 CREATE TABLE date_table(time date);
 SELECT table_name FROM create_hypertable('date_table', 'time');
@@ -138,10 +138,10 @@ INSERT INTO date_table VALUES (test.min_ts_date() - INTERVAL '1 day');
 INSERT INTO date_table VALUES (test.end_ts_date());
 \set ON_ERROR_STOP 1
 
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('date_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 
 CREATE TABLE timestamp_table(time timestamp);
 SELECT table_name FROM create_hypertable('timestamp_table', 'time');
@@ -155,10 +155,10 @@ INSERT INTO timestamp_table VALUES (test.min_ts_timestamp() - INTERVAL '1 micros
 INSERT INTO timestamp_table VALUES (test.end_ts_timestamp());
 \set ON_ERROR_STOP 1
 
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('timestamp_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 
 CREATE TABLE timestamptz_table(time timestamp);
 SELECT table_name FROM create_hypertable('timestamptz_table', 'time');
@@ -173,10 +173,10 @@ INSERT INTO timestamptz_table VALUES (test.min_ts_timestamptz() - INTERVAL '1 mi
 INSERT INTO timestamptz_table VALUES (test.end_ts_timestamptz());
 \set ON_ERROR_STOP 1
 
-SELECT chunk, pg_get_constraintdef(c.oid)
+SELECT pg_get_constraintdef(c.oid)
 FROM show_chunks('timestamptz_table') chunk, pg_constraint c
 WHERE c.conrelid = chunk
-AND c.contype = 'c' ORDER BY 1;
+AND c.contype = 'c' ORDER BY chunk;
 
 RESET datestyle;
 RESET timezone;

--- a/tsl/test/sql/include/skip_scan_query.sql
+++ b/tsl/test/sql/include/skip_scan_query.sql
@@ -110,6 +110,11 @@ CREATE INDEX ON :TABLE(time,dev,val);
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_stable(), 'q3_14' FROM :TABLE;
 :PREFIX SELECT DISTINCT ON (dev_name) dev, int_func_volatile(), 'q3_15' FROM :TABLE;
 
+\qecho DISTINCT with wholerow var
+:PREFIX SELECT DISTINCT ON (dev) :TABLE FROM :TABLE;
+-- should not use SkipScan since we only support SkipScan on single-column distinct
+:PREFIX SELECT DISTINCT :TABLE FROM :TABLE;
+
 \qecho LIMIT queries on :TABLE
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE LIMIT 3;
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE ORDER BY dev DESC, time DESC LIMIT 3;
@@ -161,6 +166,9 @@ CREATE INDEX ON :TABLE(time,dev,val);
 
 :PREFIX SELECT DISTINCT ON (dev) dev FROM :TABLE WHERE dev IS NULL;
 :PREFIX SELECT DISTINCT ON (dev_name) dev_name FROM :TABLE WHERE dev_name IS NULL;
+
+-- test constants in ORDER BY
+:PREFIX SELECT DISTINCT ON (dev) * FROM :TABLE WHERE dev = 1 ORDER BY dev, time DESC;
 
 -- CTE
 :PREFIX WITH devices AS (


### PR DESCRIPTION
The SkipScan code assumed the first entry in PathKeys would match the distinct column. This is not always true as postgres will remove entries from PathKeys it considers constant leading to SkipScan operating on the wrong column under those circumstances. This did most likely not cause any wrong results as the other constraints for SkipScan to apply still had to be satisfied but resulted in very inefficient query execution for those affected
queries.
This patch refactors the SkipScan code to use the distinctClause from the Query instead.

Fixes #3330

Disable-check: commit-count
