### PR TITLE
Refactor initialize_func_info()

### DIFF
--- a/src/func_cache.c
+++ b/src/func_cache.c
@@ -378,7 +378,7 @@ initialize_func_info()
 		.entrysize = sizeof(FuncEntry),
 		.hcxt = CacheMemoryContext,
 	};
-	Oid extension_nsp = get_namespace_oid(ts_extension_schema_name(), false);
+	Oid extension_nsp = ts_extension_schema_oid();
 	Oid pg_nsp = get_namespace_oid("pg_catalog", false);
 	HeapTuple tuple;
 	Relation rel;


### PR DESCRIPTION
```
Refactor initialize_func_info()

Replace unnecessary chain of ts_extension_schema_oid() ->
ts_extension_schema_name() -> get_namespace_oid() calls with
a single OID lookup.
```