### PR TITLE
time_bucket_ng() may be IMMUTABLE depending on arguments

### DIFF
--- a/sql/time_bucket_ng.sql
+++ b/sql/time_bucket_ng.sql
@@ -9,18 +9,32 @@
 -- and the interface of this function are subjects to change. There could
 -- be bugs, and the implementation doesn't claim to be complete. Use at
 -- your own risk.
+--
+-- This function is IMMUTABLE when it doesn't accept timestamptz arguments,
+-- and STABLE otherwise. The reason is that occasionally timezones change.
+-- When dealing with timestamptz's from the far future, it's possible that
+-- between now and then the rules for given TZ will change by local laws. Which
+-- makes the function STABLE by the definition [1].
+--
+-- We don't forbid users to work with timestamptz's from the future, nor warn
+-- about this corner case. This behavior is consistent with PostgreSQL
+-- behavior [2].
+--
+-- [1]: https://www.postgresql.org/docs/current/xfunc-volatility.html
+-- [2]: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-TIMEZONES
+--
 CREATE OR REPLACE FUNCTION timescaledb_experimental.time_bucket_ng(bucket_width INTERVAL, ts DATE) RETURNS DATE
-	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng' LANGUAGE C STABLE PARALLEL SAFE STRICT;
+	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng' LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
 CREATE OR REPLACE FUNCTION timescaledb_experimental.time_bucket_ng(bucket_width INTERVAL, ts DATE, origin DATE) RETURNS DATE
-	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng' LANGUAGE C STABLE PARALLEL SAFE STRICT;
+	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng' LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
 -- utility functions
 CREATE OR REPLACE FUNCTION timescaledb_experimental.time_bucket_ng(bucket_width INTERVAL, ts TIMESTAMP) RETURNS TIMESTAMP
-	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng_timestamp' LANGUAGE C STABLE PARALLEL SAFE STRICT;
+	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng_timestamp' LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
 CREATE OR REPLACE FUNCTION timescaledb_experimental.time_bucket_ng(bucket_width INTERVAL, ts TIMESTAMP, origin TIMESTAMP) RETURNS TIMESTAMP
-	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng_timestamp' LANGUAGE C STABLE PARALLEL SAFE STRICT;
+	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng_timestamp' LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
 
 CREATE OR REPLACE FUNCTION timescaledb_experimental.time_bucket_ng(bucket_width INTERVAL, ts TIMESTAMPTZ) RETURNS TIMESTAMPTZ
 	AS '@MODULE_PATHNAME@', 'ts_time_bucket_ng_timestamptz' LANGUAGE C STABLE PARALLEL SAFE STRICT;


### PR DESCRIPTION
```
time_bucket_ng() may be IMMUTABLE depending on arguments

This function is IMMUTABLE when it doesn't accept timestamptz arguments,
and STABLE otherwise. See the comments in sql/time_bucket_ng.sql for
more details.
```