### PR TITLE
Fix bad use of repalloc

### DIFF
--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -75,6 +75,7 @@ chunk_constraints_expand(ChunkConstraints *ccs, int16 new_capacity)
 
 	old = MemoryContextSwitchTo(ccs->mctx);
 	ccs->capacity = new_capacity;
+	Assert(ccs->constraints); /* repalloc() does not work with NULL argument */
 	ccs->constraints = repalloc(ccs->constraints, CHUNK_CONSTRAINTS_SIZE(new_capacity));
 	MemoryContextSwitchTo(old);
 }

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -93,8 +93,13 @@ is_time_bucket_function(Expr *node)
 static void
 ts_setup_append_rel_array(PlannerInfo *root)
 {
-	root->append_rel_array =
-		repalloc(root->append_rel_array, root->simple_rel_array_size * sizeof(AppendRelInfo *));
+	/* repalloc() does not work with NULL argument */
+	if (root->append_rel_array)
+		root->append_rel_array =
+			repalloc(root->append_rel_array, root->simple_rel_array_size * sizeof(AppendRelInfo *));
+	else
+		root->append_rel_array = palloc(root->simple_rel_array_size * sizeof(AppendRelInfo *));
+
 	ListCell *lc;
 	foreach (lc, root->append_rel_list)
 	{

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -46,6 +46,7 @@ ts_tablespaces_add(Tablespaces *tspcs, const FormData_tablespace *form, Oid tspc
 	if (tspcs->num_tablespaces >= tspcs->capacity)
 	{
 		tspcs->capacity += TABLESPACE_DEFAULT_CAPACITY;
+		Assert(tspcs->tablespaces); /* repalloc() does not work with NULL argument */
 		tspcs->tablespaces = repalloc(tspcs->tablespaces, sizeof(Tablespace) * tspcs->capacity);
 	}
 

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -920,6 +920,11 @@ decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, Chunk
 	Oid compressed_relid = compressed_chunk->table_id;
 	RelOptInfo *compressed_rel;
 
+	/* repalloc() does not work with NULL argument */
+	Assert(root->simple_rel_array);
+	Assert(root->simple_rte_array);
+	Assert(root->append_rel_array);
+
 	root->simple_rel_array_size++;
 	root->simple_rel_array =
 		repalloc(root->simple_rel_array, root->simple_rel_array_size * sizeof(RelOptInfo *));


### PR DESCRIPTION
In contrast to `realloc`, the PostgreSQL function `repalloc` does not
accept a NULL pointer to fall back on `palloc`. For that reason it is
necessary to check if the pointer is NULL and either use `palloc` or
`repalloc`.