### PR TITLE
Release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,23 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
-## Unreleased
+## 2.3.1 (2021-07-05)
 
 **Bugfixes**
+* #3279 Add some more randomness to chunk assignment
+* #3288 Fix failed update with parallel workers
+* #3300 Improve trigger handling on distributed hypertables
+* #3304 Remove paths that reference parent relids for compressed chunks
 * #3305 Fix pull_varnos miscomputation of relids set
+* #3310 Generate downgrade script
+* #3314 Fix heap buffer overflow in hypertable expansion
+* #3317 Fix heap buffer overflow in remote connection cache.
 * #3327 Make aggregates in caggs fully qualified
 * #3336 Fix pg_init_privs objsubid handling
 * #3345 Fix SkipScan distinct column identification
+* #3355 Fix heap buffer overflow when renaming compressed hypertable columns.
 * #3367 Improve DecompressChunk qual pushdown
+* #3377 Fix bad use of repalloc
 
 **Thanks**
 * @db-adrian for reporting an issue when accessing cagg view through postgres_fdw

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -25,7 +25,8 @@ set(MOD_FILES
     updates/2.1.0--2.1.1.sql
     updates/2.1.1--2.2.0.sql
     updates/2.2.0--2.2.1.sql
-    updates/2.2.1--2.3.0.sql)
+    updates/2.2.1--2.3.0.sql
+    updates/2.3.0--2.3.1.sql)
 
 # Files for downgrade scripts.
 set(REV_FILES)

--- a/sql/updates/2.3.0--2.3.1.sql
+++ b/sql/updates/2.3.0--2.3.1.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS _timescaledb_internal.refresh_continuous_aggregate;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -2,4 +2,3 @@ CREATE SCHEMA IF NOT EXISTS timescaledb_experimental;
 GRANT USAGE ON SCHEMA timescaledb_experimental TO PUBLIC;
 DROP FUNCTION IF EXISTS _timescaledb_internal.block_new_chunks;
 DROP FUNCTION IF EXISTS _timescaledb_internal.allow_new_chunks;
-DROP FUNCTION IF EXISTS _timescaledb_internal.refresh_continuous_aggregate;

--- a/version.config
+++ b/version.config
@@ -1,4 +1,4 @@
 version = 2.4.0-dev
-update_from_version = 2.3.0
+update_from_version = 2.3.1
 downgrade_to_version = 2.3.0
 


### PR DESCRIPTION
```
**Bugfixes**
* #3279 Add some more randomness to chunk assignment
* #3288 Fix failed update with parallel workers
* #3300 Improve trigger handling on distributed hypertables
* #3304 Remove paths that reference parent relids for compressed chunks
* #3305 Fix pull_varnos miscomputation of relids set
* #3310 Generate downgrade script
* #3314 Fix heap buffer overflow in hypertable expansion
* #3317 Fix heap buffer overflow in remote connection cache.
* #3327 Make aggregate in caggs fully qualified
* #3336 Fix pg_init_privs objsubid handling
* #3345 Fix SkipScan distinct column identification
* #3355 Fix heap buffer overflow when renaming compressed hypertable columns.
* #3367 Improve DecompressChunk qual pushdown
* #3377 Fix bad use of repalloc

**Thanks**
* @db-adrian for reporting an issue when accessing cagg view through postgres_fdw
* @fncaldas and @pgwhalen for reporting an issue accessing caggs when public is not in search_path
* @fvannee, @mglonnro and @ebreijo for reporting an issue with the upgrade script
* @fvannee for reporting a performance regression with SkipScan
```