### PR TITLE
Remove copy_chunk_data from downgrade script

### DIFF
--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -5,7 +5,6 @@ DROP FUNCTION IF EXISTS _timescaledb_internal.create_chunk_table;
 DROP FUNCTION IF EXISTS _timescaledb_internal.create_chunk_replica_table;
 DROP FUNCTION IF EXISTS _timescaledb_internal.chunk_drop_replica;
 DROP FUNCTION IF EXISTS _timescaledb_internal.create_chunk;
-DROP FUNCTION IF EXISTS _timescaledb_internal.copy_chunk_data;
 DROP PROCEDURE IF EXISTS _timescaledb_internal.wait_subscription_sync;
 DROP PROCEDURE IF EXISTS timescaledb_experimental.move_chunk;
 DROP PROCEDURE IF EXISTS timescaledb_experimental.copy_chunk;


### PR DESCRIPTION
The internal function `copy_chunk_data` was removed as part of
refactoring and is no longer necessary to remove in the downgrade
script since the function was never part of a release.