### PR TITLE
Fix segfault for RelOptInfo without fdw_private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## Unreleased
+
+**Bugfixes**
+* #3401 Fix segfault for RelOptInfo without fdw_private
+
+**Thanks**
+* @fvannee for reporting an issue with hypertable expansion in functions
+
 ## 2.3.1 (2021-07-05)
 
 This maintenance release contains bugfixes since the 2.3.0 release. We

--- a/src/planner.c
+++ b/src/planner.c
@@ -394,7 +394,7 @@ classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable **p
 			 * with CACHE_FLAG_CHECK which includes CACHE_FLAG_NOCREATE flag because
 			 * the rel might not be in cache yet.
 			 */
-			ht = get_hypertable(rte->relid, rte->inh ? CACHE_FLAG_MISSING_OK : CACHE_FLAG_CHECK);
+			ht = get_hypertable(rte->relid, CACHE_FLAG_MISSING_OK);
 
 			if (ht != NULL)
 				reltype = TS_REL_HYPERTABLE;

--- a/src/planner.h
+++ b/src/planner.h
@@ -38,9 +38,14 @@ ts_create_private_reloptinfo(RelOptInfo *rel)
 }
 
 static inline TimescaleDBPrivate *
-ts_get_private_reloptinfo(const RelOptInfo *rel)
+ts_get_private_reloptinfo(RelOptInfo *rel)
 {
-	return rel->fdw_private;
+	/* If rel->fdw_private is not set up here it means the rel got missclassified
+	 * and did not get expanded by our code but by postgres native code.
+	 * This is not a problem by itself, but probably an oversight on our part.
+	 */
+	Assert(rel->fdw_private);
+	return rel->fdw_private ? rel->fdw_private : ts_create_private_reloptinfo(rel);
 }
 
 /*

--- a/test/expected/plan_expand_hypertable-12.out
+++ b/test/expected/plan_expand_hypertable-12.out
@@ -2918,4 +2918,81 @@ EXPLAIN (costs off) SELECT * FROM test_f(now());
                Chunks excluded during startup: 4
 (5 rows)
 
+CREATE TABLE t1 (a int, b int NOT NULL);
+SELECT create_hypertable('t1', 'b', chunk_time_interval=>10);
+ create_hypertable 
+-------------------
+ (17,public,t1,t)
+(1 row)
+
+CREATE TABLE t2 (a int, b int NOT NULL);
+SELECT create_hypertable('t2', 'b', chunk_time_interval=>10);
+ create_hypertable 
+-------------------
+ (18,public,t2,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION f_t1(_a int, _b int)
+ RETURNS SETOF t1
+ LANGUAGE SQL
+ STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (a) * FROM t1 WHERE a = _a and b = _b ORDER BY a, b DESC
+$function$
+;
+CREATE OR REPLACE FUNCTION f_t2(_a int, _b int) RETURNS SETOF t2 LANGUAGE sql STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (j.a) j.*
+   FROM
+      f_t1(_a, _b) sc,
+      t2 j
+   WHERE
+      j.b = _b AND
+      j.a = _a
+   ORDER BY j.a, j.b DESC
+$function$
+;
+CREATE OR REPLACE FUNCTION f_t1_2(_b int) RETURNS SETOF t1 LANGUAGE SQL STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (j.a) jt.* FROM t1 j, f_t1(j.a, _b) jt
+$function$;
+EXPLAIN (costs off) SELECT * FROM f_t1_2(10);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Subquery Scan on f_t1_2
+   ->  Unique
+         ->  Sort
+               Sort Key: j.a
+               ->  Nested Loop
+                     ->  Seq Scan on t1 j
+                     ->  Unique
+                           ->  Index Scan using t1_b_idx on t1
+                                 Index Cond: (b = 10)
+                                 Filter: (a = j.a)
+(10 rows)
+
+EXPLAIN (costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Nested Loop
+   ->  Unique
+         ->  Sort
+               Sort Key: j.a
+               ->  Nested Loop
+                     ->  Seq Scan on t1 j
+                     ->  Unique
+                           ->  Index Scan using t1_b_idx on t1
+                                 Index Cond: (b = 10)
+                                 Filter: (a = j.a)
+   ->  Unique
+         ->  Nested Loop
+               ->  Unique
+                     ->  Index Scan using t1_b_idx on t1 t1_1
+                           Index Cond: (b = 10)
+                           Filter: (a = t1.a)
+               ->  Index Scan using t2_b_idx on t2 j_1
+                     Index Cond: (b = 10)
+                     Filter: (a = t1.a)
+(19 rows)
+
 --TEST END--

--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -2918,4 +2918,81 @@ EXPLAIN (costs off) SELECT * FROM test_f(now());
                Chunks excluded during startup: 4
 (5 rows)
 
+CREATE TABLE t1 (a int, b int NOT NULL);
+SELECT create_hypertable('t1', 'b', chunk_time_interval=>10);
+ create_hypertable 
+-------------------
+ (17,public,t1,t)
+(1 row)
+
+CREATE TABLE t2 (a int, b int NOT NULL);
+SELECT create_hypertable('t2', 'b', chunk_time_interval=>10);
+ create_hypertable 
+-------------------
+ (18,public,t2,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION f_t1(_a int, _b int)
+ RETURNS SETOF t1
+ LANGUAGE SQL
+ STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (a) * FROM t1 WHERE a = _a and b = _b ORDER BY a, b DESC
+$function$
+;
+CREATE OR REPLACE FUNCTION f_t2(_a int, _b int) RETURNS SETOF t2 LANGUAGE sql STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (j.a) j.*
+   FROM
+      f_t1(_a, _b) sc,
+      t2 j
+   WHERE
+      j.b = _b AND
+      j.a = _a
+   ORDER BY j.a, j.b DESC
+$function$
+;
+CREATE OR REPLACE FUNCTION f_t1_2(_b int) RETURNS SETOF t1 LANGUAGE SQL STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (j.a) jt.* FROM t1 j, f_t1(j.a, _b) jt
+$function$;
+EXPLAIN (costs off) SELECT * FROM f_t1_2(10);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Subquery Scan on f_t1_2
+   ->  Unique
+         ->  Sort
+               Sort Key: j.a
+               ->  Nested Loop
+                     ->  Seq Scan on t1 j
+                     ->  Unique
+                           ->  Index Scan using t1_b_idx on t1
+                                 Index Cond: (b = 10)
+                                 Filter: (a = j.a)
+(10 rows)
+
+EXPLAIN (costs off) SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Nested Loop
+   ->  Unique
+         ->  Sort
+               Sort Key: j.a
+               ->  Nested Loop
+                     ->  Seq Scan on t1 j
+                     ->  Unique
+                           ->  Index Scan using t1_b_idx on t1
+                                 Index Cond: (b = 10)
+                                 Filter: (a = j.a)
+   ->  Unique
+         ->  Nested Loop
+               ->  Unique
+                     ->  Index Scan using t1_b_idx on t1 t1_1
+                           Index Cond: (b = 10)
+                           Filter: (a = t1.a)
+               ->  Index Scan using t2_b_idx on t2 j_1
+                     Index Cond: (b = 10)
+                     Filter: (a = t1.a)
+(19 rows)
+
 --TEST END--

--- a/test/sql/plan_expand_hypertable.sql.in
+++ b/test/sql/plan_expand_hypertable.sql.in
@@ -67,4 +67,42 @@ $f$;
 -- plan output should be identical to previous session
 :PREFIX SELECT * FROM test_f(now());
 
+
+-- test hypertable expansion in nested function calls
+CREATE TABLE t1 (a int, b int NOT NULL);
+SELECT create_hypertable('t1', 'b', chunk_time_interval=>10);
+
+CREATE TABLE t2 (a int, b int NOT NULL);
+SELECT create_hypertable('t2', 'b', chunk_time_interval=>10);
+
+CREATE OR REPLACE FUNCTION f_t1(_a int, _b int)
+ RETURNS SETOF t1
+ LANGUAGE SQL
+ STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (a) * FROM t1 WHERE a = _a and b = _b ORDER BY a, b DESC
+$function$
+;
+
+CREATE OR REPLACE FUNCTION f_t2(_a int, _b int) RETURNS SETOF t2 LANGUAGE sql STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (j.a) j.*
+   FROM
+      f_t1(_a, _b) sc,
+      t2 j
+   WHERE
+      j.b = _b AND
+      j.a = _a
+   ORDER BY j.a, j.b DESC
+$function$
+;
+
+CREATE OR REPLACE FUNCTION f_t1_2(_b int) RETURNS SETOF t1 LANGUAGE SQL STABLE PARALLEL SAFE
+AS $function$
+   SELECT DISTINCT ON (j.a) jt.* FROM t1 j, f_t1(j.a, _b) jt
+$function$;
+
+:PREFIX SELECT * FROM f_t1_2(10);
+:PREFIX SELECT * FROM f_t1_2(10) sc, f_t2(sc.a, 10);
+
 \qecho '--TEST END--'


### PR DESCRIPTION
In nested function invocations hypertable expansion would not work
correctly and a hypertable would not be expanded by timescaledb
code but by postgres table inheritance leading to fdw_private
not being properly initialized.

Fixes #3391