### PR TITLE
Ignore debug_notice test during sanitizer runs

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -93,7 +93,7 @@ jobs:
         # test seems to fail due to a PostgreSQL bug where AbortStartTime in
         # postmaster.c is not atomic but read/written across signal handlers
         # and ServerLoop.
-        make -k -C build installcheck SKIPS='remote_txn' IGNORES='bgw_db_scheduler' | tee installcheck.log
+        make -k -C build installcheck SKIPS='remote_txn' IGNORES='bgw_db_scheduler debug_notice' | tee installcheck.log
 
     - name: Show regression diffs
       if: always()


### PR DESCRIPTION
This test sometimes fails because it generates extra "rehashing
catalog cache" debug messages, which is not very helpful.