### PR TITLE
Add perl module files to PG install

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -125,3 +125,5 @@ endif(PG_SOURCE_DIR)
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   add_subdirectory(src)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
+
+add_subdirectory(perl)

--- a/test/perl/CMakeLists.txt
+++ b/test/perl/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(PERL_FILES AccessNode.pm DataNode.pm TimescaleNode.pm)
+
+# Check if PostgreSQL was compiled with --enable-tap-tests
+if(EXISTS "${PG_PKGLIBDIR}/pgxs/src/test/perl")
+  install(FILES ${PERL_FILES} DESTINATION "${PG_PKGLIBDIR}/pgxs/src/test/perl")
+endif()

--- a/test/perl/TimescaleNode.pm
+++ b/test/perl/TimescaleNode.pm
@@ -33,7 +33,7 @@ sub init
 	# append into postgresql.conf from Timescale
 	# template config file
 	$self->append_conf('postgresql.conf',
-		TestLib::slurp_file("$ENV{'BUILDIR'}/tsl/test/postgresql.conf"));
+		TestLib::slurp_file("$ENV{'CONFDIR'}/postgresql.conf"));
 }
 
 # helper function to check output from PSQL for a query

--- a/tsl/test/CMakeLists.txt
+++ b/tsl/test/CMakeLists.txt
@@ -56,7 +56,7 @@ if(PG_REGRESS)
       provecheck
       COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/tmp_check
       COMMAND
-        BUILDIR=${CMAKE_BINARY_DIR} PATH="${PG_BINDIR}:$ENV{PATH}"
+        CONFDIR=${CMAKE_BINARY_DIR}/tsl/test PATH="${PG_BINDIR}:$ENV{PATH}"
         PG_REGRESS=${PG_REGRESS} SRC_DIR=${PG_SOURCE_DIR}
         CM_SRC_DIR=${CMAKE_SOURCE_DIR} PG_LIBDIR=${PG_LIBDIR}
         ${PRIMARY_TEST_DIR}/pg_prove.sh


### PR DESCRIPTION
We have added additional functionality in timescaledb extension to
use in tap tests. Install these perl files in the PG installation
directory so that external modules (the current "forge_ext" extension
as an example) can use this functionality without having to have an
additional dependency on the timescaledb extension source code. Note
that these perl files should be installed only if PG installation has
the relevant "${PG_PKGLIBDIR}/pgxs/src/test/perl" subdirectory.

Also rejig the configuration directory variable that's used for the
tap tests so that external modules can specify their own locations by
using their own values for it (the current variable was tightly tied to
timescaledb source code location).