### PR TITLE
Fix targetlist for cagg views

### DIFF
--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -1346,3 +1346,27 @@ SELECT count(*) FROM pg_namespace WHERE nspname = 'test_schema';
 
 DROP TABLESPACE tablespace1;
 DROP TABLESPACE tablespace2;
+-- Check that we can rename a column of a materialized view and still
+-- rebuild it after (#3051, #3405)
+CREATE TABLE conditions (
+       time TIMESTAMPTZ NOT NULL,
+       location TEXT NOT NULL,
+       temperature DOUBLE PRECISION NULL
+);
+SELECT create_hypertable('conditions', 'time');
+    create_hypertable     
+--------------------------
+ (34,public,conditions,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW conditions_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+SELECT location,
+       time_bucket(INTERVAL '1 day', time) AS bucket,
+       AVG(temperature)
+  FROM conditions
+GROUP BY location, bucket;
+NOTICE:  continuous aggregate "conditions_daily" is already up-to-date
+ALTER MATERIALIZED VIEW conditions_daily RENAME COLUMN bucket to "time";
+-- This will rebuild the materialized view and should succeed.
+ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only = false); 


### PR DESCRIPTION
If the names for entries in the targetlist for the direct and partial
views of the continuous aggregate does not match the attribute names in
the tuple descriptor for the result tuple of the user view an error
will be generated. This commit fixes this by setting the targetlist
resource names of the columns in the direct and partial view to the 
corresponding attribute name of the user view relation tuple
descriptor.


Fixes #3051
Fixes #3405