### PR TITLE
Rename on all continuous aggregate objects

### DIFF
--- a/scripts/test_downgrade_from_tag.sh
+++ b/scripts/test_downgrade_from_tag.sh
@@ -241,6 +241,7 @@ echo "Executing setup script on clean"
 docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/setup.databases.sql "postgres"
 docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/pre.testing.sql
 docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/setup.${TEST_VERSION}.sql
+docker_pgscript ${CONTAINER_CLEAN_RERUN} /src/test/sql/updates/setup.post-downgrade.sql
 
 docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc single > /tmp/single.dump"
 docker_exec ${CONTAINER_UPDATED} "pg_dump -h localhost -U postgres -Fc dn1 > /tmp/dn1.dump"

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,2 +1,84 @@
 DROP FUNCTION _timescaledb_internal.time_col_name_for_chunk(name,name);
 DROP FUNCTION _timescaledb_internal.time_col_type_for_chunk(name,name);
+
+-- Handle column renames for continuous aggregates that were not
+-- handled correctly and fix it in the update. We save the information
+-- in a table.
+CREATE UNLOGGED TABLE rename_tables (
+       user_view regclass,
+       new_name text,
+       old_name text,
+       partial_view regclass,
+       direct_view regclass,
+       mat_table regclass,
+       hypertable_id int
+);
+
+-- Compare the user view and the direct view of each continuous
+-- aggregate to figure out what columns that were renamed on the user
+-- view but which did not propagate to the other objects of the
+-- continuous aggregate since this did not work in previous versions.
+WITH
+  objs AS (
+        SELECT format('%I.%I', user_view_schema, user_view_name)::regclass AS user_view,
+               format('%I.%I', direct_view_schema, direct_view_name)::regclass AS direct_view,
+               format('%I.%I', partial_view_schema, partial_view_name)::regclass AS partial_view,
+               format('%I.%I', schema_name, table_name)::regclass AS mat_table,
+               mat_hypertable_id AS mat_id
+          FROM _timescaledb_catalog.continuous_agg
+          JOIN _timescaledb_catalog.hypertable ON mat_hypertable_id = id),
+  user_view AS (
+        SELECT attrelid, attname, attnum, mat_id
+          FROM objs, pg_attribute
+         WHERE attrelid = objs.user_view),
+  direct_view AS (
+        SELECT attrelid, attname, attnum, mat_id
+          FROM objs, pg_attribute
+         WHERE attrelid = objs.direct_view)
+INSERT INTO rename_tables
+SELECT (SELECT user_view FROM objs WHERE uv.attrelid = user_view),
+       uv.attname AS new_name,
+       dv.attname AS old_name,
+       (SELECT partial_view FROM objs WHERE uv.attrelid = user_view),
+       (SELECT direct_view FROM objs WHERE uv.attrelid = user_view),
+       (SELECT mat_table FROM objs WHERE uv.attrelid = user_view),
+       (SELECT mat_id FROM objs WHERE uv.attrelid = user_view)
+  FROM user_view uv JOIN direct_view dv USING (mat_id, attnum)
+ WHERE uv.attname != dv.attname;
+
+CREATE PROCEDURE alter_table_column(cagg regclass, relation regclass, old_column_name name, new_column_name name) AS $$
+BEGIN
+    EXECUTE format('ALTER TABLE %s RENAME COLUMN %I TO %I', relation, old_column_name, new_column_name);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Rename the columns for all the associated objects for continuous
+-- aggregates that have renamed columns. Also rename the column in the
+-- dimension table.
+DO
+$$
+DECLARE
+    user_view regclass;
+    new_name name;
+    old_name name;
+    partial_view regclass;
+    direct_view regclass;
+    mat_table regclass;
+    ht_id int;
+BEGIN
+  FOR user_view, new_name, old_name, partial_view, direct_view, mat_table, ht_id IN
+  SELECT * FROM rename_tables
+  LOOP
+    -- There is no RENAME COLUMN for views, but we can use ALTER TABLE
+    -- to rename a column in a view.
+    CALL alter_table_column(user_view, partial_view, old_name, new_name);
+    CALL alter_table_column(user_view, direct_view, old_name, new_name);
+    CALL alter_table_column(user_view, mat_table, old_name, new_name);
+    UPDATE _timescaledb_catalog.dimension SET column_name = new_name
+     WHERE hypertable_id = ht_id AND column_name = old_name;
+  END LOOP;
+END
+$$;
+
+DROP PROCEDURE alter_table_column;
+DROP TABLE rename_tables;

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -3,7 +3,6 @@ DO $$
 DECLARE
  vname regclass;
  materialized_only bool;
- altercmd text;
  ts_version TEXT;
 BEGIN
     SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
@@ -18,12 +17,10 @@ BEGIN
         -- to have something more generic, but right now it is just
         -- this case.
         IF ts_version < '2.0.0' THEN
-            altercmd := format('ALTER VIEW %s SET (timescaledb.materialized_only=%L) ', vname::text, materialized_only);
+            EXECUTE format('ALTER VIEW %s SET (timescaledb.materialized_only=%L) ', vname::text, materialized_only);
         ELSE
-            altercmd := format('ALTER MATERIALIZED VIEW %s SET (timescaledb.materialized_only=%L) ', vname::text, materialized_only);
+            EXECUTE format('ALTER MATERIALIZED VIEW %s SET (timescaledb.materialized_only=%L) ', vname::text, materialized_only);
         END IF;
-        RAISE INFO 'cmd executed: %', altercmd;
-        EXECUTE altercmd;
     END LOOP;
     EXCEPTION WHEN OTHERS THEN RAISE;
 END

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -881,6 +881,7 @@ typedef struct FormData_continuous_agg
 	int64 bucket_width;
 	NameData direct_view_schema;
 	NameData direct_view_name;
+	bool materialized_only;
 } FormData_continuous_agg;
 
 typedef FormData_continuous_agg *Form_continuous_agg;

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -104,7 +104,7 @@ typedef struct CrossModuleFunctions
 	bool (*process_compress_table)(AlterTableCmd *cmd, Hypertable *ht,
 								   WithClauseResult *with_clause_options);
 	void (*process_altertable_cmd)(Hypertable *ht, const AlterTableCmd *cmd);
-	void (*process_rename_cmd)(Hypertable *ht, const RenameStmt *stmt);
+	void (*process_rename_cmd)(Oid relid, Cache *hcache, const RenameStmt *stmt);
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
 	PGFunction recompress_chunk;

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -51,4 +51,10 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY id, hypertable_id;
 SELECT * FROM _timescaledb_catalog.chunk_constraint ORDER BY chunk_id, dimension_slice_id, constraint_name;
 SELECT index_name FROM _timescaledb_catalog.chunk_index ORDER BY index_name;
 
-\d+ _timescaledb_internal._hyper*
+-- Indices can have different column names between an upgrade and a
+-- restore of a dump, so we only list the tables. This will include
+-- the indexes defined on the tables, but not the exact definition of
+-- the indexes and in particular not the column name in the index
+-- which will be different in a restored database and an updated
+-- database for columns that were renamed before the update.
+\dt+ _timescaledb_internal._hyper*

--- a/test/sql/updates/post.integrity_test.sql
+++ b/test/sql/updates/post.integrity_test.sql
@@ -2,7 +2,11 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\d+ _timescaledb_internal.*
+-- We do not dump the size of the tables here since that might differ
+-- between an updated node and a restored node. For examples, stats
+-- tables can have different sizes, and this is not relevant for an
+-- update test.
+\dt _timescaledb_internal.*
 
 CREATE OR REPLACE FUNCTION timescaledb_integrity_test()
     RETURNS VOID LANGUAGE PLPGSQL STABLE AS

--- a/test/sql/updates/setup.continuous_aggs.v2.sql
+++ b/test/sql/updates/setup.continuous_aggs.v2.sql
@@ -100,6 +100,9 @@ BEGIN
       GROUP BY bucket, location
       HAVING min(location) >= 'NYC' and avg(temperature) > 2;
 
+    -- ALTER VIEW cannot rename columns before PG13, but ALTER TABLE
+    -- works for views.
+    ALTER TABLE rename_cols RENAME COLUMN bucket to "time";
   ELSE
     CREATE MATERIALIZED VIEW rename_cols
     WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
@@ -153,10 +156,10 @@ BEGIN
       GROUP BY bucket, location
       HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
     PERFORM add_continuous_aggregate_policy('mat_before', NULL, '-30 days'::interval, '336 h');
+
+    ALTER MATERIALIZED VIEW rename_cols RENAME COLUMN bucket to "time";
   END IF;
 END $$;
-
-ALTER MATERIALIZED VIEW rename_cols RENAME COLUMN bucket to "time";
 
 \if :WITH_SUPERUSER
 GRANT SELECT ON mat_before TO cagg_user WITH GRANT OPTION;

--- a/test/sql/updates/setup.post-downgrade.sql
+++ b/test/sql/updates/setup.post-downgrade.sql
@@ -1,0 +1,31 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- When running a downgrade tests, the extension is first updated to
+-- the later version and then downgraded to the previous version. This
+-- means that in some cases, changes done by the update is not
+-- reversed by the downgrade. If these changes are harmless, we can
+-- apply changes to the clean rerun to incorporate these changes
+-- directly and prevent a diff between the clean-rerun version and the
+-- upgrade-downgrade version of the database.
+
+SELECT extversion >= '2.0.0' AS has_create_mat_view
+  FROM pg_extension
+ WHERE extname = 'timescaledb' \gset
+
+-- For the renamed continuous aggregate "rename_cols", fix the column
+-- name in the materialized hypertable and in the dimension
+-- table. This will allow the views to be rebuilt with the new name
+-- and prevent a diff when doing an upgrade-downgrade.
+SELECT timescaledb_pre_restore();
+ALTER TABLE _timescaledb_internal._materialized_hypertable_4 RENAME COLUMN bucket TO "time";
+UPDATE _timescaledb_catalog.dimension SET column_name = 'time' WHERE hypertable_id = 4;
+SELECT timescaledb_post_restore();
+
+-- Rebuild the user views based on the renamed views
+\if :has_create_mat_view
+ALTER MATERIALIZED VIEW rename_cols SET (timescaledb.materialized_only = FALSE);
+\else
+ALTER VIEW rename_cols SET (timescaledb.materialized_only = FALSE);
+\endif

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1816,8 +1816,7 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
  * update the view definition of an existing continuous aggregate
  */
 void
-cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht,
-							WithClauseResult *with_clause_options)
+cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 {
 	ListCell *lc1, *lc2;
 	int sec_ctx;
@@ -1854,7 +1853,7 @@ cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht,
 
 	Query *view_query = finalizequery_get_select_query(&fqi, mattblinfo.matcollist, &mataddress);
 
-	if (with_clause_options[ContinuousViewOptionMaterializedOnly].parsed == BoolGetDatum(false))
+	if (!agg->data.materialized_only)
 		view_query = build_union_query(&timebucket_exprinfo,
 									   &mattblinfo,
 									   view_query,

--- a/tsl/src/continuous_aggs/create.h
+++ b/tsl/src/continuous_aggs/create.h
@@ -16,7 +16,6 @@
 DDLResult tsl_process_continuous_agg_viewstmt(Node *stmt, const char *query_string, void *pstmt,
 											  WithClauseResult *with_clause_options);
 
-void cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht,
-								 WithClauseResult *with_clause_options);
+void cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_CREATE_H */

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -73,12 +73,12 @@ continuous_agg_update_options(ContinuousAgg *agg, WithClauseResult *with_clause_
 		Cache *hcache = ts_hypertable_cache_pin();
 		Hypertable *mat_ht =
 			ts_hypertable_cache_get_entry_by_id(hcache, agg->data.mat_hypertable_id);
-		bool materialized_only =
+		agg->data.materialized_only =
 			DatumGetBool(with_clause_options[ContinuousViewOptionMaterializedOnly].parsed);
 		Assert(mat_ht != NULL);
 
-		cagg_update_view_definition(agg, mat_ht, with_clause_options);
-		update_materialized_only(agg, materialized_only);
+		cagg_update_view_definition(agg, mat_ht);
+		update_materialized_only(agg, agg->data.materialized_only);
 		ts_cache_release(hcache);
 	}
 

--- a/tsl/src/process_utility.h
+++ b/tsl/src/process_utility.h
@@ -15,6 +15,6 @@ extern void tsl_ddl_command_start(ProcessUtilityArgs *args);
 extern void tsl_ddl_command_end(EventTriggerData *command);
 extern void tsl_sql_drop(List *dropped_objects);
 extern void tsl_process_altertable_cmd(Hypertable *ht, const AlterTableCmd *cmd);
-extern void tsl_process_rename_cmd(Hypertable *ht, const RenameStmt *stmt);
+extern void tsl_process_rename_cmd(Oid relid, Cache *hcache, const RenameStmt *stmt);
 
 #endif /* TIMESCALEDB_TSL_PROCESS_UTILITY_H */

--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -377,7 +377,7 @@ SELECT * FROM truncate_partitioned;
 \set ON_ERROR_STOP 0
 -- test a variety of ALTER TABLE statements
 ALTER TABLE :drop_chunks_mat_table_u RENAME chunk_id TO bad_name;
-ERROR:  cannot rename column "chunk_id" of materialization table "_materialized_hypertable_7"
+ERROR:  renaming columns on materialization tables is not supported
 ALTER TABLE :drop_chunks_mat_table_u ADD UNIQUE(chunk_id);
 ERROR:  operation not supported on materialization tables
 ALTER TABLE :drop_chunks_mat_table_u SET UNLOGGED;
@@ -1359,14 +1359,102 @@ SELECT create_hypertable('conditions', 'time');
  (34,public,conditions,t)
 (1 row)
 
+INSERT INTO conditions VALUES ( '2018-01-01 09:20:00-08', 'SFO', 55);
+INSERT INTO conditions VALUES ( '2018-01-02 09:30:00-08', 'por', 100);
+INSERT INTO conditions VALUES ( '2018-01-02 09:20:00-08', 'SFO', 65);
+INSERT INTO conditions VALUES ( '2018-01-02 09:10:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 09:20:00-08', 'NYC', 45);
+INSERT INTO conditions VALUES ( '2018-11-01 10:40:00-08', 'NYC', 55);
+INSERT INTO conditions VALUES ( '2018-11-01 11:50:00-08', 'NYC', 65);
+INSERT INTO conditions VALUES ( '2018-11-01 12:10:00-08', 'NYC', 75);
+INSERT INTO conditions VALUES ( '2018-11-01 13:10:00-08', 'NYC', 85);
+INSERT INTO conditions VALUES ( '2018-11-02 09:20:00-08', 'NYC', 10);
+INSERT INTO conditions VALUES ( '2018-11-02 10:30:00-08', 'NYC', 20);
 CREATE MATERIALIZED VIEW conditions_daily
 WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
 SELECT location,
        time_bucket(INTERVAL '1 day', time) AS bucket,
        AVG(temperature)
   FROM conditions
-GROUP BY location, bucket;
-NOTICE:  continuous aggregate "conditions_daily" is already up-to-date
+GROUP BY location, bucket
+WITH NO DATA;
+-- Show both the columns and the view definitions to see that
+-- references are correct in the view as well.
+SELECT * FROM test.show_columns('conditions_daily');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ bucket   | timestamp with time zone | f
+ avg      | double precision         | f
+(3 rows)
+
+SELECT * FROM test.show_columns(' _timescaledb_internal._direct_view_35');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ bucket   | timestamp with time zone | f
+ avg      | double precision         | f
+(3 rows)
+
+SELECT * FROM test.show_columns(' _timescaledb_internal._partial_view_35');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ bucket   | timestamp with time zone | f
+ agg_3_3  | bytea                    | f
+ chunk_id | integer                  | f
+(4 rows)
+
+SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_35');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ bucket   | timestamp with time zone | t
+ agg_3_3  | bytea                    | f
+ chunk_id | integer                  | f
+(4 rows)
+
 ALTER MATERIALIZED VIEW conditions_daily RENAME COLUMN bucket to "time";
+-- Show both the columns and the view definitions to see that
+-- references are correct in the view as well.
+SELECT * FROM test.show_columns(' conditions_daily');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ time     | timestamp with time zone | f
+ avg      | double precision         | f
+(3 rows)
+
+SELECT * FROM test.show_columns(' _timescaledb_internal._direct_view_35');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ time     | timestamp with time zone | f
+ avg      | double precision         | f
+(3 rows)
+
+SELECT * FROM test.show_columns(' _timescaledb_internal._partial_view_35');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ time     | timestamp with time zone | f
+ agg_3_3  | bytea                    | f
+ chunk_id | integer                  | f
+(4 rows)
+
+SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_35');
+  Column  |           Type           | NotNull 
+----------+--------------------------+---------
+ location | text                     | f
+ time     | timestamp with time zone | t
+ agg_3_3  | bytea                    | f
+ chunk_id | integer                  | f
+(4 rows)
+
 -- This will rebuild the materialized view and should succeed.
 ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only = false); 
+-- Refresh the continuous aggregate to check that it works after the
+-- rename.
+\set VERBOSITY verbose
+CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
+\set VERBOSITY terse


### PR DESCRIPTION
When renaming a column on a continuous aggregate, only the user view
column was renamed. This commit changes this by applying the rename on
the materialized table, the user view, the direct view, and the partial
view, as well as the column name in the dimension table.

Since this also changes some of the table definitions, we need to
perform the same rename in the update scripts as well, which is done by
comparing the direct view and the user view to decide what columns that
require a rename and then executing that rename on the direct view,
partial view, and materialization table, as well as updating the column
name in the dimension table.

When renaming columns in tables with indexes, the column in the table
is renamed but not the column in the index, which keeps the same name.
When restoring from a dump, however, the column name of the table is
used, which create a diff in the update test. For that reason, we
change the update tests to not list index definitions as part of the
comparison. The existance of the indexes is still tracked and compared
since the indexes for a hypertable is listed as part of the output.

If a downgrade does not revert some changes, this will cause a diff in
the downgrade test. Since the rename is benign and not easy to revert,
this will cause test failure. Instead, we add a file to do extra
actions during a clean-rerun to prevent these diffs. In this case,
applying the same renames as the update script.

Fixes #3405