### PR TITLE
Fix remote_txn_heal_data_node() for multiple DB's

### DIFF
--- a/tsl/test/expected/remote_txn_resolve.out
+++ b/tsl/test/expected/remote_txn_resolve.out
@@ -184,3 +184,24 @@ SELECT count(*) FROM _timescaledb_catalog.remote_txn;
      0
 (1 row)
 
+-- test that healing function does not conflict with other databases
+--
+-- #3433
+-- create additional database and simulate remote txn activity
+CREATE DATABASE test_an2;
+\c test_an2
+BEGIN;
+CREATE TABLE unused(id int);
+PREPARE TRANSACTION 'ts-1-10-20-30';
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- should not fail
+SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
+ remote_txn_heal_data_node 
+---------------------------
+                         0
+(1 row)
+
+\c test_an2
+ROLLBACK PREPARED 'ts-1-10-20-30';
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE test_an2;


### PR DESCRIPTION
Since pg_prepared_xacts is shared between databases, the healing
function tried to resolve prepared transactions created by other
distributed databases.

This change makes the healing function to work only with current
database.

Fix #3433