### PR TITLE
Fix downgrade files for 2.3.1

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -28,7 +28,8 @@ set(MOD_FILES
     updates/2.2.1--2.3.0.sql
     updates/2.3.0--2.3.1.sql)
 
-# Files for downgrade scripts.
+# Files for downgrade scripts. This should only include files for downgrade to
+# previous version since we do not support skipping versions when downgrading
 set(REV_FILES)
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")

--- a/sql/updates/2.3.1--2.3.0.sql
+++ b/sql/updates/2.3.1--2.3.0.sql
@@ -1,0 +1,28 @@
+-- We need to rewrite all continuous aggregates to make sure that the
+-- queries do not contain qualification. They will be re-written in
+-- the post-update script as well, but the previous version does not
+-- process all continuous aggregates, leaving some with qualification
+-- for the standard functions. To make this work, we need to
+-- temporarily set the update stage to the post-update stage, which
+-- will allow the ALTER MATERIALIZED VIEW to rewrite the query. If
+-- that is not done, the TimescaleDB-specific hooks will not be used
+-- and you will get an error message saying that, for example,
+-- `conditions_summary` is not a materialized view.
+SET timescaledb.update_script_stage TO 'post';
+DO $$
+DECLARE
+ vname regclass;
+ materialized_only bool;
+ altercmd text;
+ ts_version TEXT;
+BEGIN
+    FOR vname, materialized_only IN select format('%I.%I', cagg.user_view_schema, cagg.user_view_name)::regclass, cagg.materialized_only from _timescaledb_catalog.continuous_agg cagg
+    LOOP
+	altercmd := format('ALTER MATERIALIZED VIEW %s SET (timescaledb.materialized_only=%L) ', vname::text, materialized_only);
+        EXECUTE altercmd;
+    END LOOP;
+    EXCEPTION WHEN OTHERS THEN RAISE;
+END
+$$;
+RESET timescaledb.update_script_stage;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -2,32 +2,3 @@ DROP SCHEMA IF EXISTS timescaledb_experimental CASCADE;
 DROP FUNCTION IF EXISTS _timescaledb_internal.block_new_chunks;
 DROP FUNCTION IF EXISTS _timescaledb_internal.allow_new_chunks;
 DROP FUNCTION IF EXISTS _timescaledb_internal.refresh_continuous_aggregate;
-
--- We need to rewrite all continuous aggregates to make sure that the
--- queries do not contain qualification. They will be re-written in
--- the post-update script as well, but the previous version does not
--- process all continuous aggregates, leaving some with qualification
--- for the standard functions. To make this work, we need to
--- temporarily set the update stage to the post-update stage, which
--- will allow the ALTER MATERIALIZED VIEW to rewrite the query. If
--- that is not done, the TimescaleDB-specific hooks will not be used
--- and you will get an error message saying that, for example,
--- `conditions_summary` is not a materialized view.
-SET timescaledb.update_script_stage TO 'post';
-DO $$
-DECLARE
- vname regclass;
- materialized_only bool;
- altercmd text;
- ts_version TEXT;
-BEGIN
-    FOR vname, materialized_only IN select format('%I.%I', cagg.user_view_schema, cagg.user_view_name)::regclass, cagg.materialized_only from _timescaledb_catalog.continuous_agg cagg
-    LOOP
-	altercmd := format('ALTER MATERIALIZED VIEW %s SET (timescaledb.materialized_only=%L) ', vname::text, materialized_only);
-        EXECUTE altercmd;
-    END LOOP;
-    EXCEPTION WHEN OTHERS THEN RAISE;
-END
-$$;
-RESET timescaledb.update_script_stage;
-


### PR DESCRIPTION
The cagg rebuild was required for a fix introduced in 2.3.1 but
was not removed from reverse-dev.sql when that version got released.