### PR TITLE
Skip perl file installation without TAP_CHECKS

### DIFF
--- a/test/perl/CMakeLists.txt
+++ b/test/perl/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(PERL_FILES AccessNode.pm DataNode.pm TimescaleNode.pm)
 
 # Check if PostgreSQL was compiled with --enable-tap-tests
-if(EXISTS "${PG_PKGLIBDIR}/pgxs/src/test/perl")
+if(TAP_CHECKS AND EXISTS "${PG_PKGLIBDIR}/pgxs/src/test/perl")
   install(FILES ${PERL_FILES} DESTINATION "${PG_PKGLIBDIR}/pgxs/src/test/perl")
 endif()


### PR DESCRIPTION
Don't install the TAP-related perl files when TAP checks has been
disabled. Installing this files unconditionally creates problem
when building packages as these files should not be part of the
package.