### PR TITLE
Fix crash while tracking alter table commands

### DIFF
--- a/src/dimension.c
+++ b/src/dimension.c
@@ -1078,7 +1078,9 @@ dimension_add_not_null_on_column(Oid table_relid, char *colname)
 			(errmsg("adding not-null constraint to column \"%s\"", colname),
 			 errdetail("Time dimensions cannot have NULL values.")));
 
+	EventTriggerAlterTableStart((Node *) &cmd);
 	AlterTableInternal(table_relid, list_make1(&cmd), false);
+	EventTriggerAlterTableEnd();
 }
 
 void

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1410,3 +1410,8 @@ SELECT show_chunks('test3.hyperx');
  _timescaledb_internal._hyper_15_40_chunk
 (1 row)
 
+-- Check CTAS behavior when internal ALTER TABLE gets fired
+CREATE TABLE PUBLIC.drop_chunk_test4(time bigint, temp float8, device_id text);
+CREATE TABLE drop_chunks_table_id AS SELECT hypertable_id
+      FROM create_hypertable('public.drop_chunk_test4', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"

--- a/test/sql/chunk_utils.sql
+++ b/test/sql/chunk_utils.sql
@@ -594,3 +594,8 @@ SELECT show_chunks('test3.hyperx');
 SELECT drop_chunks('hyperx', older_than => 100);
 SELECT show_chunks('test2.hyperx');
 SELECT show_chunks('test3.hyperx');
+
+-- Check CTAS behavior when internal ALTER TABLE gets fired
+CREATE TABLE PUBLIC.drop_chunk_test4(time bigint, temp float8, device_id text);
+CREATE TABLE drop_chunks_table_id AS SELECT hypertable_id
+      FROM create_hypertable('public.drop_chunk_test4', 'time', chunk_time_interval => 1);


### PR DESCRIPTION
In this specific case, when we create a hypertable then
we add a "not-null" constraint to the "time" column if it
does not exist. That is done via an internal ALTER TABLE
subcommand in dimension_add_not_null_on_column function. If the
currentEventTriggerState structure is enabled then it's necessary to
set up the command tracking appropriately, otherwise crash ensues. This
has been fixed via this now.

Fixes #3442