### PR TITLE
Fix compiler warning about missing braces

### DIFF
--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -547,8 +547,8 @@ ts_hypertable_scan_with_memory_context(const char *schema, const char *table,
 									   bool tuplock, MemoryContext mctx)
 {
 	ScanKeyData scankey[2];
-	NameData schema_name = { 0 };
-	NameData table_name = { 0 };
+	NameData schema_name = { { 0 } };
+	NameData table_name = { { 0 } };
 
 	if (schema)
 		namestrcpy(&schema_name, schema);


### PR DESCRIPTION
Older gcc versions will throw a warning about missing braces when
a nested struct is initialized with {0}.