### PR TITLE
Improve error message when adding data nodes

### DIFF
--- a/tsl/src/hypertable.c
+++ b/tsl/src/hypertable.c
@@ -133,8 +133,9 @@ List *
 hypertable_get_and_validate_data_nodes(ArrayType *nodearr)
 {
 	bool fail_on_aclcheck = nodearr != NULL;
-	List *data_nodes;
+	List *data_nodes = NIL;
 	int num_data_nodes;
+	List *all_data_nodes = NIL;
 
 	/* If the user explicitly specified a set of data nodes (data_node_arr is
 	 * non-NULL), we validate the given array and fail if the user doesn't
@@ -148,7 +149,7 @@ hypertable_get_and_validate_data_nodes(ArrayType *nodearr)
 		/* No explicit set of data nodes given. Check if there are any data
 		 * nodes that the user cannot use due to lack of permissions and
 		 * raise a NOTICE if some of them cannot be used. */
-		List *all_data_nodes = data_node_get_node_name_list();
+		all_data_nodes = data_node_get_node_name_list();
 		int num_nodes_not_used = list_length(all_data_nodes) - list_length(data_nodes);
 
 		if (num_nodes_not_used > 0)
@@ -160,11 +161,22 @@ hypertable_get_and_validate_data_nodes(ArrayType *nodearr)
 					 errhint("Grant USAGE on data nodes to attach them to a hypertable.")));
 	}
 
+	/*
+	 * In this case, if we couldn't find any valid data nodes to assign, it
+	 * means that they do not have the right permissions on the data nodes or
+	 * that there were no data nodes to assign. Depending on the case, we
+	 * print different error details and hints to aid the user.
+	 */
 	if (num_data_nodes == 0)
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_INSUFFICIENT_NUM_DATA_NODES),
 				 errmsg("no data nodes can be assigned to the hypertable"),
-				 errhint("Add data nodes to the database.")));
+				 errdetail(list_length(all_data_nodes) == 0 ?
+							   "No data nodes where available to assign to the hypertable." :
+							   "Data nodes exist, but none have USAGE privilege."),
+				 errhint(list_length(all_data_nodes) == 0 ?
+							 "Add data nodes to the database." :
+							 "Grant USAGE on data nodes to attach them to the hypertable.")));
 
 	if (num_data_nodes == 1)
 		ereport(WARNING,
@@ -172,7 +184,9 @@ hypertable_get_and_validate_data_nodes(ArrayType *nodearr)
 				 errdetail("A distributed hypertable should have at least two data nodes for best "
 						   "performance."),
 				 errhint(
-					 "Make sure the user has USAGE on enough data nodes or add additional ones.")));
+					 list_length(all_data_nodes) == 1 ?
+						 "Add more data nodes to the database and attach them to the hypertable." :
+						 "Grant USAGE on data nodes and attach them to the hypertable.")));
 
 	if (num_data_nodes > MAX_NUM_HYPERTABLE_DATA_NODES)
 		ereport(ERROR,

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -172,6 +172,21 @@ SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => :'DN
  data_node_3 | localhost | 55432 | db_data_node_3 | t            | t                | t
 (1 row)
 
+SET ROLE :ROLE_1;
+-- Create a distributed hypertable where no nodes can be selected
+-- because there are no data nodes with the right permissions.
+CREATE TABLE disttable(time timestamptz, device int, temp float);
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device');
+NOTICE:  3 of 3 data nodes not used by this hypertable due to lack of permissions
+HINT:  Grant USAGE on data nodes to attach them to a hypertable.
+ERROR:  no data nodes can be assigned to the hypertable
+DETAIL:  Data nodes exist, but none have USAGE privilege.
+HINT:  Grant USAGE on data nodes to attach them to the hypertable.
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
+RESET ROLE;
 -- Allow ROLE_1 to create distributed tables on these data nodes.
 -- We'll test that data_node_3 is properly filtered when ROLE_1
 -- creates a distributed hypertable without explicitly specifying
@@ -204,8 +219,6 @@ ORDER BY object_name, object_type;
 (4 rows)
 
 SET ROLE :ROLE_1;
--- Now create a distributed hypertable using the data nodes
-CREATE TABLE disttable(time timestamptz, device int, temp float);
 -- Test that all data nodes are added to a hypertable and that the
 -- slices in the device dimension equals the number of data nodes.
 BEGIN;

--- a/tsl/test/sql/data_node.sql
+++ b/tsl/test/sql/data_node.sql
@@ -101,6 +101,19 @@ SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => :'DN
 SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => :'DN_DBNAME_2');
 SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => :'DN_DBNAME_3');
 
+SET ROLE :ROLE_1;
+
+-- Create a distributed hypertable where no nodes can be selected
+-- because there are no data nodes with the right permissions.
+CREATE TABLE disttable(time timestamptz, device int, temp float);
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device');
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
+
+RESET ROLE;
+
 -- Allow ROLE_1 to create distributed tables on these data nodes.
 -- We'll test that data_node_3 is properly filtered when ROLE_1
 -- creates a distributed hypertable without explicitly specifying
@@ -121,9 +134,6 @@ GROUP BY object_schema, object_name, object_type
 ORDER BY object_name, object_type;
 
 SET ROLE :ROLE_1;
-
--- Now create a distributed hypertable using the data nodes
-CREATE TABLE disttable(time timestamptz, device int, temp float);
 
 -- Test that all data nodes are added to a hypertable and that the
 -- slices in the device dimension equals the number of data nodes.


### PR DESCRIPTION
When data nodes are added but are missing USAGE privileges, a hint will
be shown suggesting to add more data nodes. This is misleading since
data nodes are added. Instead, if there are data nodes but they are not
used, the hint will be to fix the privileges for the data nodes.

Fixes #3479