### PR TITLE
Use SPI transaction manipulation functions

### DIFF
--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -1641,6 +1641,46 @@ SELECT sum(device) FROM dist_test;
  846
 (1 row)
 
+-- Check that they can be called from inside a procedure without
+-- generating warnings or error messages (#3495).
+CREATE OR REPLACE PROCEDURE copy_wrapper(regclass, text, text)
+AS $$
+BEGIN
+    CALL timescaledb_experimental.copy_chunk($1, $2, $3);
+END
+$$
+LANGUAGE PLPGSQL;
+CREATE OR REPLACE PROCEDURE move_wrapper(regclass, text, text)
+AS $$
+BEGIN
+    CALL timescaledb_experimental.move_chunk($1, $2, $3);
+END
+$$
+LANGUAGE PLPGSQL;
+SELECT chunk_name, replica_nodes, non_replica_nodes
+FROM timescaledb_experimental.chunk_replication_status;
+       chunk_name       |       replica_nodes       |     non_replica_nodes     
+------------------------+---------------------------+---------------------------
+ _dist_hyper_9_12_chunk | {data_node_1,data_node_3} | {data_node_2}
+ _dist_hyper_9_13_chunk | {data_node_2}             | {data_node_1,data_node_3}
+ _dist_hyper_9_14_chunk | {data_node_3}             | {data_node_1,data_node_2}
+ _dist_hyper_9_15_chunk | {data_node_1}             | {data_node_2,data_node_3}
+(4 rows)
+
+CALL copy_wrapper('_timescaledb_internal._dist_hyper_9_14_chunk', 'data_node_3', 'data_node_2');
+CALL move_wrapper('_timescaledb_internal._dist_hyper_9_13_chunk', 'data_node_2', 'data_node_1');
+SELECT chunk_name, replica_nodes, non_replica_nodes
+FROM timescaledb_experimental.chunk_replication_status;
+       chunk_name       |       replica_nodes       |     non_replica_nodes     
+------------------------+---------------------------+---------------------------
+ _dist_hyper_9_12_chunk | {data_node_1,data_node_3} | {data_node_2}
+ _dist_hyper_9_13_chunk | {data_node_1}             | {data_node_2,data_node_3}
+ _dist_hyper_9_14_chunk | {data_node_3,data_node_2} | {data_node_1}
+ _dist_hyper_9_15_chunk | {data_node_1}             | {data_node_2,data_node_3}
+(4 rows)
+
+DROP PROCEDURE copy_wrapper;
+DROP PROCEDURE move_wrapper;
 RESET ROLE;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;


### PR DESCRIPTION
The procedures `copy_chunk` and `move_chunk` internally manipulate the
transaction state using plumbing-level commands such as
`StartTransactionCommand` and `CommitTransactionCommand`. Since these
affect the internal state of the SPI execution context, it generates
warnings when used inside a PL/SQL procedures.

This commit fixes this by switching to using SPI-level commands and
connecting and finishing the SPI properly.

Fixes #3495