### PR TITLE
Run CI against PG snapshots

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -19,7 +19,7 @@ jobs:
       run: python scripts/gh_matrix_builder.py ${{ github.event_name }}
 
   regress:
-    name: PG${{ matrix.pg }} ${{ matrix.name }} ${{ matrix.os }}
+    name: PG${{ matrix.pg }}${{ matrix.snapshot }} ${{ matrix.name }} ${{ matrix.os }}
     needs: matrixbuilder
     runs-on: ${{ matrix.os }}
     strategy:
@@ -58,15 +58,20 @@ jobs:
     # leading to a tainted cache
     - name: Cache PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }}
       id: cache-postgresql
+      if: matrix.snapshot != 'snapshot'
       uses: actions/cache@v2
       with:
         path: ~/${{ env.PG_SRC_DIR }}
         key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ matrix.build_type }}${{ env.CACHE_SUFFIX }}
 
-    - name: Build PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }}
+    - name: Build PostgreSQL ${{ matrix.pg }}${{ matrix.snapshot }} ${{ matrix.build_type }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
-        wget -q -O postgresql.tar.bz2 https://ftp.postgresql.org/pub/source/v${{ matrix.pg }}/postgresql-${{ matrix.pg }}.tar.bz2
+        if [ "${{ matrix.snapshot }}" = "snapshot" ]; then
+          wget -q -O postgresql.tar.bz2 https://ftp.postgresql.org/pub/snapshot/${{ matrix.pg }}/postgresql-${{ matrix.pg }}-snapshot.tar.bz2
+        else
+          wget -q -O postgresql.tar.bz2 https://ftp.postgresql.org/pub/source/v${{ matrix.pg }}/postgresql-${{ matrix.pg }}.tar.bz2
+        fi
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
         cd ~/$PG_SRC_DIR

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -140,6 +140,11 @@ if event_type != "pull_request":
   m["include"].append(build_apache_config({"pg":PG12_LATEST}))
   m["include"].append(build_apache_config({"pg":PG13_LATEST}))
 
+  # to discover issues with upcoming releases we run CI against
+  # the stable branches of supported PG releases
+  m["include"].append(build_debug_config({"pg":12,"snapshot":"snapshot"}))
+  m["include"].append(build_debug_config({"pg":13,"snapshot":"snapshot"}))
+
 # generate command to set github action variable
 print(str.format("::set-output name=matrix::{0}",json.dumps(m)))
 


### PR DESCRIPTION
Run CI against PG snapshots to discover potential issues with
upcoming PG releases earlier.