### PR TITLE
Modify compression bgw chunk selection logic

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4084,6 +4084,13 @@ ts_chunk_is_compressed(const Chunk *chunk)
 	return ts_flags_are_set_32(chunk->fd.status, CHUNK_STATUS_COMPRESSED);
 }
 
+bool
+ts_chunk_is_uncompressed_or_unordered(const Chunk *chunk)
+{
+	return (ts_flags_are_set_32(chunk->fd.status, CHUNK_STATUS_COMPRESSED_UNORDERED) ||
+			!ts_flags_are_set_32(chunk->fd.status, CHUNK_STATUS_COMPRESSED));
+}
+
 Datum
 ts_chunk_show(PG_FUNCTION_ARGS)
 {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -174,6 +174,8 @@ ts_chunk_find_or_create_without_cuts(const Hypertable *ht, Hypercube *hc, const 
 extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_unordered(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_compressed(const Chunk *chunk);
+extern TSDLLEXPORT bool ts_chunk_is_uncompressed_or_unordered(const Chunk *chunk);
+
 extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(const Chunk *chunk);
 extern TSDLLEXPORT ChunkCompressionStatus ts_chunk_get_compression_status(int32 chunk_id);
 extern TSDLLEXPORT Datum ts_chunk_id_from_relid(PG_FUNCTION_ARGS);

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -80,9 +80,9 @@ extern TSDLLEXPORT int
 ts_dimension_slice_oldest_valid_chunk_for_reorder(int32 job_id, int32 dimension_id,
 												  StrategyNumber start_strategy, int64 start_value,
 												  StrategyNumber end_strategy, int64 end_value);
-extern TSDLLEXPORT int32 ts_dimension_slice_get_chunkid_to_compress(
+extern TSDLLEXPORT List *ts_dimension_slice_get_chunkids_to_compress(
 	int32 dimension_id, StrategyNumber start_strategy, int64 start_value,
-	StrategyNumber end_strategy, int64 end_value, bool compress, bool recompress);
+	StrategyNumber end_strategy, int64 end_value, bool compress, bool recompress, int32 numchunks);
 #define dimension_slice_insert(slice) ts_dimension_slice_insert_multi(&(slice), 1)
 
 #define dimension_slice_scan(dimension_id, coordinate, tuplock)                                    \

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -42,6 +42,7 @@
 #define CONFIG_KEY_COMPRESS_AFTER "compress_after"
 #define CONFIG_KEY_RECOMPRESS_AFTER "recompress_after"
 #define CONFIG_KEY_RECOMPRESS "recompress"
+#define CONFIG_KEY_MAXCHUNKS_TO_COMPRESS "maxchunks_to_compress"
 
 bool
 policy_compression_get_recompress(const Jsonb *config)
@@ -50,6 +51,23 @@ policy_compression_get_recompress(const Jsonb *config)
 	bool recompress = ts_jsonb_get_bool_field(config, CONFIG_KEY_RECOMPRESS, &found);
 
 	return found ? recompress : true;
+}
+
+int32
+policy_compression_get_maxchunks_per_job(const Jsonb *config)
+{
+	bool found;
+	int32 maxchunks = ts_jsonb_get_int32_field(config, CONFIG_KEY_MAXCHUNKS_TO_COMPRESS, &found);
+	return (found && maxchunks > 0) ? maxchunks : 0;
+}
+
+bool
+policy_compression_get_verbose_log(const Jsonb *config)
+{
+	bool found;
+	bool verbose_log = ts_jsonb_get_bool_field(config, CONFIG_KEY_VERBOSE_LOG, &found);
+
+	return found ? verbose_log : false;
 }
 
 int32

--- a/tsl/src/bgw_policy/compression_api.h
+++ b/tsl/src/bgw_policy/compression_api.h
@@ -22,7 +22,9 @@ int32 policy_compression_get_hypertable_id(const Jsonb *config);
 int64 policy_compression_get_compress_after_int(const Jsonb *config);
 Interval *policy_compression_get_compress_after_interval(const Jsonb *config);
 bool policy_compression_get_recompress(const Jsonb *config);
+int32 policy_compression_get_maxchunks_per_job(const Jsonb *config);
 int64 policy_recompression_get_recompress_after_int(const Jsonb *config);
 Interval *policy_recompression_get_recompress_after_interval(const Jsonb *config);
+bool policy_compression_get_verbose_log(const Jsonb *config);
 
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_COMPRESSION_API_H */

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -15,6 +15,9 @@
 #include "continuous_aggs/materialize.h"
 #include "bgw_policy/chunk_stats.h"
 
+/* Add config keys common across job types here */
+#define CONFIG_KEY_VERBOSE_LOG "verbose_log" /*used only by compression now*/
+
 typedef struct PolicyReorderData
 {
 	Hypertable *hypertable;

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -43,10 +43,18 @@ select * from alter_job(:compressjob_id, schedule_interval=>'1s');
    1000 | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | t         | {"hypertable_id": 1, "compress_after": "@ 60 days"} | -infinity
 (1 row)
 
+--enable maxchunks to 1 so that only 1 chunk is compressed by the job
+SELECT alter_job(id,config:=jsonb_set(config,'{maxchunks_to_compress}', '1'))
+ FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+                                                                 alter_job                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------
+ (1000,"@ 1 sec","@ 0",-1,"@ 1 hour",t,"{""hypertable_id"": 1, ""compress_after"": ""@ 60 days"", ""maxchunks_to_compress"": 1}",-infinity)
+(1 row)
+
 select * from _timescaledb_config.bgw_job where id >= 1000 ORDER BY id;
-  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                       config                        
-------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-----------------------------------------------------
- 1000 | Compression Policy [1000] | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             1 | {"hypertable_id": 1, "compress_after": "@ 60 days"}
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                                     config                                      
+------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+---------------------------------------------------------------------------------
+ 1000 | Compression Policy [1000] | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             1 | {"hypertable_id": 1, "compress_after": "@ 60 days", "maxchunks_to_compress": 1}
 (1 row)
 
 insert into conditions
@@ -142,7 +150,7 @@ select * from _timescaledb_config.bgw_job where id=:compressjob_id;
 (1 row)
 
 \gset
-CALL run_job(:compressjob_id);
+--will compress all chunks that need compression
 CALL run_job(:compressjob_id);
 select chunk_name, before_compression_total_bytes, after_compression_total_bytes
 from chunk_compression_stats('test_table_int') where compression_status like 'Compressed' order by chunk_name;
@@ -220,9 +228,41 @@ SELECT COUNT(*) AS dropped_chunks_count
                    14
 (1 row)
 
+SELECT count(*) FROM timescaledb_information.chunks
+WHERE hypertable_name = 'conditions' and is_compressed = true;
+ count 
+-------
+     0
+(1 row)
+
 SELECT add_compression_policy AS job_id
   FROM add_compression_policy('conditions', INTERVAL '1 day') \gset
+-- job compresses only 1 chunk at a time --
+SELECT alter_job(id,config:=jsonb_set(config,'{maxchunks_to_compress}', '1'))
+ FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+                                                                  alter_job                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ (1002,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""hypertable_id"": 7, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
+(1 row)
+
+SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
+ FROM _timescaledb_config.bgw_job WHERE id = :job_id;
+                                                                             alter_job                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (1002,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""verbose_log"": true, ""hypertable_id"": 7, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
+(1 row)
+
+set client_min_messages TO LOG;
 CALL run_job(:job_id);
+LOG:  job 1002 completed compressing chunk _timescaledb_internal._hyper_7_26_chunk
+set client_min_messages TO NOTICE;
+SELECT count(*) FROM timescaledb_information.chunks
+WHERE hypertable_name = 'conditions' and is_compressed = true;
+ count 
+-------
+     1
+(1 row)
+
 \i include/recompress_basic.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -346,6 +386,7 @@ SELECT add_compression_policy AS job_id
   FROM add_compression_policy('test2', '30d'::interval) \gset
 CALL run_job(:job_id);
 CALL run_job(:job_id);
+psql:include/recompress_basic.sql:85: NOTICE:  no chunks for hypertable public.test2 that satisfy compress chunk policy
 -- status should be compressed ---
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
@@ -479,7 +520,7 @@ SELECT delete_job(:JOB_COMPRESS);
  
 (1 row)
 
-SELECT add_job('_timescaledb_internal.policy_recompression','1w','{"hypertable_id": 12, "recompress_after": "@ 7 days"}') AS "JOB_RECOMPRESS" \gset
+SELECT add_job('_timescaledb_internal.policy_recompression','1w','{"hypertable_id": 12, "recompress_after": "@ 7 days", "maxchunks_to_compress": 1 }') AS "JOB_RECOMPRESS" \gset
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -662,6 +662,14 @@ select * from _timescaledb_config.bgw_job where id >= 1000 ORDER BY id;
  1000 | Compression Policy [1000] | @ 1 sec           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | test_role_1 | t         |             2 | {"hypertable_id": 2, "compress_after": "@ 60 days"}
 (1 row)
 
+-- we want only 1 chunk to be compressed --
+SELECT alter_job(id,config:=jsonb_set(config,'{maxchunks_to_compress}', '1'))
+FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+                                                                 alter_job                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------
+ (1000,"@ 1 sec","@ 0",-1,"@ 1 hour",t,"{""hypertable_id"": 2, ""compress_after"": ""@ 60 days"", ""maxchunks_to_compress"": 1}",-infinity)
+(1 row)
+
 insert into conditions
 select now()::timestamp, 'TOK', 'sony', 55, 75;
 -- TEST3 --
@@ -759,6 +767,7 @@ select * from _timescaledb_config.bgw_job where id=:compressjob_id;
 \gset
 CALL run_job(:compressjob_id);
 CALL run_job(:compressjob_id);
+NOTICE:  no chunks for hypertable public.test_table_int that satisfy compress chunk policy
 select chunk_name, node_name, before_compression_total_bytes, after_compression_total_bytes
 from chunk_compression_stats('test_table_int') where compression_status like 'Compressed' order by chunk_name;
        chunk_name       |       node_name       | before_compression_total_bytes | after_compression_total_bytes 

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -234,6 +234,10 @@ select add_compression_policy('conditions', '60d'::interval) AS compressjob_id
 select * from _timescaledb_config.bgw_job where id = :compressjob_id;
 select * from alter_job(:compressjob_id, schedule_interval=>'1s');
 select * from _timescaledb_config.bgw_job where id >= 1000 ORDER BY id;
+-- we want only 1 chunk to be compressed --
+SELECT alter_job(id,config:=jsonb_set(config,'{maxchunks_to_compress}', '1'))
+FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+
 insert into conditions
 select now()::timestamp, 'TOK', 'sony', 55, 75;
 

--- a/tsl/test/sql/include/recompress_basic.sql
+++ b/tsl/test/sql/include/recompress_basic.sql
@@ -163,7 +163,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 SELECT delete_job(:JOB_COMPRESS);
 
-SELECT add_job('_timescaledb_internal.policy_recompression','1w','{"hypertable_id": 12, "recompress_after": "@ 7 days"}') AS "JOB_RECOMPRESS" \gset
+SELECT add_job('_timescaledb_internal.policy_recompression','1w','{"hypertable_id": 12, "recompress_after": "@ 7 days", "maxchunks_to_compress": 1 }') AS "JOB_RECOMPRESS" \gset
 
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';


### PR DESCRIPTION
To reviewers:
The PR has multiple commits to help with reviewing the changes. I'll combine them into a single commit before merging.

Commit 1: change  logic for picking chunks to process
Commit 2: add a new parameter to limit the number of chunks that are chosen by the compression job
Commit 3: Test file changes ( needed as the new algorithm processes all pending chunks and the old way processes exactly ONE chunk).
