### PR TITLE
Blind attempt to repair the build on AppVeyor

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -65,35 +65,12 @@
  * behavior of the new version we simply adopt the new version's name.
  */
 
-#if PG12
-#define ExecComputeStoredGeneratedCompat(rri, estate, slot, cmd_type)                              \
-	ExecComputeStoredGenerated(estate, slot)
-#elif PG13
-#define ExecComputeStoredGeneratedCompat(rri, estate, slot, cmd_type)                              \
+#if PG13_GE
+#define ExecComputeStoredGeneratedCompat(estate, slot, cmd_type)                                   \
 	ExecComputeStoredGenerated(estate, slot, cmd_type)
 #else
-#define ExecComputeStoredGeneratedCompat(rri, estate, slot, cmd_type)                              \
-	ExecComputeStoredGenerated(rri, estate, slot, cmd_type)
-#endif
-
-#if PG14_LT
-#define ExecInsertIndexTuplesCompat(rri,                                                           \
-									slot,                                                          \
-									estate,                                                        \
-									update,                                                        \
-									noDupErr,                                                      \
-									specConflict,                                                  \
-									arbiterIndexes)                                                \
-	ExecInsertIndexTuples(slot, estate, noDupErr, specConflict, arbiterIndexes)
-#else
-#define ExecInsertIndexTuplesCompat(rri,                                                           \
-									slot,                                                          \
-									estate,                                                        \
-									update,                                                        \
-									noDupErr,                                                      \
-									specConflict,                                                  \
-									arbiterIndexes)                                                \
-	ExecInsertIndexTuples(rri, slot, estate, update, noDupErr, specConflict, arbiterIndexes)
+#define ExecComputeStoredGeneratedCompat(estate, slot, cmd_type)                                   \
+	ExecComputeStoredGenerated(estate, slot)
 #endif
 
 /* PG14 fixes a bug in miscomputation of relids set in pull_varnos. The bugfix
@@ -102,30 +79,22 @@
  * the modified functions get added under different name in PG12 and PG13.
  * We add a compatibility macro that uses the modified functions when compiling
  * against a postgres version that has them available.
- * PG14 also adds PlannerInfo as argument to make_restrictinfo,
- * make_simple_restrictinfo and pull_varnos.
  *
  * https://github.com/postgres/postgres/commit/1cce024fd2
  * https://github.com/postgres/postgres/commit/73fc2e5bab
- * https://github.com/postgres/postgres/commit/55dc86eca7
  */
 
-#if (PG12 && PG_VERSION_NUM < 120006) || (PG13 && PG_VERSION_NUM < 130002)
+#if (PG12 && PG_VERSION_NUM < 120006) || (PG13 && PG_VERSION_NUM < 130002) || PG14
 #define pull_varnos_compat(root, expr) pull_varnos(expr)
 #define make_simple_restrictinfo_compat(root, expr) make_simple_restrictinfo(expr)
 #define make_restrictinfo_compat(root, a, b, c, d, e, f, g, h)                                     \
 	make_restrictinfo(a, b, c, d, e, f, g, h)
-#elif PG14_LT
+#else
 #define pull_varnos_compat(root, expr) pull_varnos_new(root, expr)
 #define make_simple_restrictinfo_compat(root, expr)                                                \
 	make_restrictinfo_new(root, expr, true, false, false, 0, NULL, NULL, NULL)
 #define make_restrictinfo_compat(root, a, b, c, d, e, f, g, h)                                     \
 	make_restrictinfo_new(root, a, b, c, d, e, f, g, h)
-#else
-#define pull_varnos_compat(root, expr) pull_varnos(root, expr)
-#define make_simple_restrictinfo_compat(root, clause) make_simple_restrictinfo(root, clause)
-#define make_restrictinfo_compat(root, a, b, c, d, e, f, g, h)                                     \
-	make_restrictinfo(root, a, b, c, d, e, f, g, h)
 #endif
 
 /* PG14 renames predefined roles

--- a/src/copy.c
+++ b/src/copy.c
@@ -370,7 +370,7 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 			/* Compute stored generated columns */
 			if (check_resultRelInfo->ri_RelationDesc->rd_att->constr &&
 				check_resultRelInfo->ri_RelationDesc->rd_att->constr->has_generated_stored)
-				ExecComputeStoredGeneratedCompat(check_resultRelInfo, estate, myslot, CMD_INSERT);
+				ExecComputeStoredGeneratedCompat(estate, myslot, CMD_INSERT);
 
 			/*
 			 * If the target is a plain table, check the constraints of
@@ -393,13 +393,7 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 								   ti_options,
 								   bistate);
 				if (resultRelInfo->ri_NumIndices > 0)
-					recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
-																 compress_slot,
-																 estate,
-																 false,
-																 false,
-																 NULL,
-																 NIL);
+					recheckIndexes = ExecInsertIndexTuples(compress_slot, estate, false, NULL, NIL);
 			}
 			else
 			{
@@ -411,13 +405,7 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 								   bistate);
 
 				if (resultRelInfo->ri_NumIndices > 0)
-					recheckIndexes = ExecInsertIndexTuplesCompat(resultRelInfo,
-																 myslot,
-																 estate,
-																 false,
-																 false,
-																 NULL,
-																 NIL);
+					recheckIndexes = ExecInsertIndexTuples(myslot, estate, false, NULL, NIL);
 			}
 
 			/* AFTER ROW INSERT Triggers */

--- a/src/nodes/chunk_dispatch_state.c
+++ b/src/nodes/chunk_dispatch_state.c
@@ -136,10 +136,7 @@ chunk_dispatch_exec(CustomScanState *node)
 		}
 
 		if (cis->rel->rd_att->constr && cis->rel->rd_att->constr->has_generated_stored)
-			ExecComputeStoredGeneratedCompat(cis->orig_result_relation_info,
-											 estate,
-											 slot,
-											 CMD_INSERT);
+			ExecComputeStoredGeneratedCompat(estate, slot, CMD_INSERT);
 
 		if (cis->rel->rd_att->constr)
 			ExecConstraints(cis->orig_result_relation_info, slot, estate);

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -1471,7 +1471,7 @@ propagate_join_quals(PlannerInfo *root, RelOptInfo *rel, CollectQualCtx *ctx)
 
 			if (new_qual)
 			{
-				Relids relids = pull_varnos_compat(ctx->root, (Node *) propagated);
+				Relids relids = pull_varnos_compat(root, (Node *) propagated);
 				RestrictInfo *restrictinfo;
 
 				restrictinfo = make_restrictinfo_compat(root,

--- a/tsl/src/nodes/data_node_copy.c
+++ b/tsl/src/nodes/data_node_copy.c
@@ -182,7 +182,7 @@ data_node_copy_exec(CustomScanState *node)
 
 			if (NULL != rri_chunk->ri_projectReturning && rri_desc->constr &&
 				rri_desc->constr->has_generated_stored)
-				ExecComputeStoredGeneratedCompat(rri_chunk, estate, slot, CMD_INSERT);
+				ExecComputeStoredGeneratedCompat(estate, slot, CMD_INSERT);
 
 			ResetPerTupleExprContext(estate);
 			oldmctx = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));

--- a/tsl/src/nodes/data_node_dispatch.c
+++ b/tsl/src/nodes/data_node_dispatch.c
@@ -709,7 +709,7 @@ handle_read(DataNodeDispatchState *sds)
 
 			if (NULL != rri->ri_projectReturning && rri_desc->constr &&
 				rri_desc->constr->has_generated_stored)
-				ExecComputeStoredGeneratedCompat(rri, estate, slot, CMD_INSERT);
+				ExecComputeStoredGeneratedCompat(estate, slot, CMD_INSERT);
 
 			Assert(NULL != cis);
 


### PR DESCRIPTION
The following tests fail on AppVeyor:

```
test remote_txn_id                ... FAILED
test remote_txn_resolve           ... FAILED
test reorder                      ... FAILED
```

It looks like we have a segfault during the execution of `remote_txn` test (which is ignored on Windows), which makes the following tests (which are not ignored) fail:

```
[00:12:47] diff -u /timescaledb/tsl/test/expected/remote_txn.out /timescaledb/build/tsl/test/results/remote_txn.out
[00:12:47] --- /timescaledb/tsl/test/expected/remote_txn.out	2021-09-07 14:12:59.025148105 +0000
[00:12:47] +++ /timescaledb/build/tsl/test/results/remote_txn.out	2021-09-07 14:19:45.428937438 +0000
[00:12:47] @@ -213,7 +213,10 @@
[00:12:47]  COMMIT;
[00:12:47]  WARNING:  kill event: pre-commit
[00:12:47]  WARNING:  transaction rollback on data node "loopback" failed
[00:12:47] -ERROR:  [loopback]: terminating connection due to administrator command
[00:12:47] +ERROR:  [loopback]: server closed the connection unexpectedly
[00:12:47] +	This probably means the server terminated abnormally
[00:12:47] +	before or while processing the request.
[00:12:47] +
```
By reverting recent commits one by one I was able to pinpoint the one that caused this problem. This PR reverts this commit.