### PR TITLE
Adjust FuncnameGetCandidates calls to PG14 changes

### DIFF
--- a/src/catalog.c
+++ b/src/catalog.c
@@ -473,6 +473,9 @@ ts_catalog_get(void)
 								  def.args,
 								  NULL,
 								  false,
+#if PG14_GE
+								  false, /* include_out_arguments */
+#endif
 								  false,
 								  false);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -569,7 +569,15 @@ ts_get_function_oid(const char *funcname, const char *schema_name, int nargs, Oi
 		list_make2(makeString(pstrdup(schema_name)), makeString(pstrdup(funcname)));
 	FuncCandidateList func_candidates;
 
-	func_candidates = FuncnameGetCandidates(qualified_funcname, nargs, NIL, false, false, false);
+	func_candidates = FuncnameGetCandidates(qualified_funcname,
+											nargs,
+											NIL,
+											false,
+#if PG14_GE
+											false, /* include_out_arguments */
+#endif
+											false,
+											false);
 	while (func_candidates != NULL)
 	{
 		if (func_candidates->nargs == nargs &&


### PR DESCRIPTION
PG14 adds an include_out_arguments parameter to FuncnameGetCandidates.

https://github.com/postgres/postgres/commit/e56bce5d