### PR TITLE
Optimize approximate_row_count

### DIFF
--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -368,43 +368,30 @@ $BODY$;
 -- Estimated number of rows according to catalog tables
 CREATE OR REPLACE FUNCTION approximate_row_count(relation REGCLASS)
 RETURNS BIGINT
-LANGUAGE PLPGSQL VOLATILE STRICT AS
+LANGUAGE SQL VOLATILE STRICT AS
 $BODY$
-DECLARE
-	table_name       NAME;
-	schema_name      NAME;
-	row_count_parent BIGINT;
-	row_count        BIGINT;
-BEGIN
-	SELECT relname, nspname, CASE WHEN c.reltuples > 0 THEN c.reltuples::bigint ELSE 0 END
-	INTO table_name, schema_name, row_count_parent
-	FROM pg_class c
-	INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
-	WHERE c.OID = relation;
-
-	WITH RECURSIVE inherited_id AS
-	(
-		SELECT i.inhrelid AS oid
-		FROM pg_inherits i
-		JOIN pg_class base ON i.inhparent = base.oid
-		JOIN pg_namespace base_ns ON base.relnamespace = base_ns.oid
-		WHERE base_ns.nspname = schema_name AND base.relname = table_name
-		UNION
-		SELECT i.inhrelid AS oid
-		FROM pg_inherits i
-		JOIN inherited_id b ON i.inhparent = b.oid
-	)
-	SELECT sum(CASE WHEN child.reltuples > 0 THEN child.reltuples ELSE 0 END)::bigint
-	INTO row_count
-	FROM inherited_id i
-	JOIN pg_class child ON i.oid = child.oid
-	JOIN pg_namespace child_ns ON child.relnamespace = child_ns.oid;
-
-	IF row_count IS NULL THEN
-		RETURN row_count_parent;
-	END IF;
-	RETURN row_count_parent + row_count;
-END
+  WITH RECURSIVE inherited_id AS
+  (
+    SELECT i.inhrelid AS oid
+    FROM pg_inherits i
+    WHERE i.inhparent = relation
+    UNION
+    SELECT i.inhrelid AS oid
+    FROM pg_inherits i
+    JOIN inherited_id b ON i.inhparent = b.oid
+  ),
+  parent AS
+  (
+    -- reltuples for partitioned tables is the sum of it's children in pg14 so we need to filter those out
+    SELECT CASE WHEN c.reltuples > 0 AND c.relkind <> 'p' THEN c.reltuples::bigint ELSE 0 END AS reltuples
+    FROM pg_class c
+    WHERE c.oid = relation
+  )
+  SELECT
+    (SELECT reltuples FROM parent) +
+    COALESCE(sum(CASE WHEN reltuples > 0 AND relkind <> 'p' THEN reltuples ELSE 0 END)::bigint,0)
+  FROM inherited_id i
+    JOIN pg_class child ON child.oid = i.oid;
 $BODY$;
 
 -------- stats related to compression ------

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -289,7 +289,7 @@ SELECT * FROM approximate_row_count('approx_count_c');
 
 DROP TABLE approx_count CASCADE;
 NOTICE:  drop cascades to 3 other objects
--- Regular table with declarative partitioning
+-- table with declarative partitioning
 --
 CREATE TABLE approx_count_dp(time TIMESTAMP, value int) PARTITION BY RANGE(time);
 CREATE TABLE approx_count_dp0 PARTITION OF approx_count_dp
@@ -361,6 +361,55 @@ SELECT * FROM approximate_row_count('approx_count_dp2');
 -----------------------
                      3
 (1 row)
+
+CREATE TABLE approx_count_dp_nested(time TIMESTAMP, device_id int, value int) PARTITION BY RANGE(time);
+CREATE TABLE approx_count_dp_nested_0 PARTITION OF approx_count_dp_nested FOR VALUES FROM ('2004-01-01 00:00:00') TO ('2005-01-01 00:00:00') PARTITION BY RANGE (device_id);
+CREATE TABLE approx_count_dp_nested_0_0 PARTITION OF approx_count_dp_nested_0 FOR VALUES FROM (0) TO (10);
+CREATE TABLE approx_count_dp_nested_0_1 PARTITION OF approx_count_dp_nested_0 FOR VALUES FROM (10) TO (20);
+CREATE TABLE approx_count_dp_nested_1 PARTITION OF approx_count_dp_nested FOR VALUES FROM ('2005-01-01 00:00:00') TO ('2006-01-01 00:00:00') PARTITION BY RANGE (device_id);
+CREATE TABLE approx_count_dp_nested_1_0 PARTITION OF approx_count_dp_nested_1 FOR VALUES FROM (0) TO (10);
+CREATE TABLE approx_count_dp_nested_1_1 PARTITION OF approx_count_dp_nested_1 FOR VALUES FROM (10) TO (20);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 1, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 2, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 3, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 11, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 12, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 13, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 1, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 2, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 3, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 11, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 12, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 13, 1);
+SELECT * FROM approximate_row_count('approx_count_dp_nested');
+ approximate_row_count 
+-----------------------
+                     0
+(1 row)
+
+ANALYZE approx_count_dp_nested;
+SELECT
+  (SELECT count(*) FROM approx_count_dp_nested) AS dp_nested,
+  (SELECT count(*) FROM approx_count_dp_nested_0) AS dp_nested_0,
+  (SELECT count(*) FROM approx_count_dp_nested_0_0) AS dp_nested_0_0,
+  (SELECT count(*) FROM approx_count_dp_nested_0_1) AS dp_nested_0_1,
+  (SELECT count(*) FROM approx_count_dp_nested_1) AS dp_nested_1,
+  (SELECT count(*) FROM approx_count_dp_nested_1_0) AS dp_nested_1_0,
+  (SELECT count(*) FROM approx_count_dp_nested_1_1) AS dp_nested_1_1
+UNION ALL
+SELECT
+  approximate_row_count('approx_count_dp_nested'),
+  approximate_row_count('approx_count_dp_nested_0'),
+  approximate_row_count('approx_count_dp_nested_0_0'),
+  approximate_row_count('approx_count_dp_nested_0_1'),
+  approximate_row_count('approx_count_dp_nested_1'),
+  approximate_row_count('approx_count_dp_nested_1_0'),
+  approximate_row_count('approx_count_dp_nested_1_1');
+ dp_nested | dp_nested_0 | dp_nested_0_0 | dp_nested_0_1 | dp_nested_1 | dp_nested_1_0 | dp_nested_1_1 
+-----------+-------------+---------------+---------------+-------------+---------------+---------------
+        12 |           6 |             3 |             3 |           6 |             3 |             3
+        12 |           6 |             3 |             3 |           6 |             3 |             3
+(2 rows)
 
 -- Hypertable
 --

--- a/test/sql/size_utils.sql
+++ b/test/sql/size_utils.sql
@@ -103,7 +103,7 @@ SELECT * FROM approximate_row_count('approx_count_c');
 
 DROP TABLE approx_count CASCADE;
 
--- Regular table with declarative partitioning
+-- table with declarative partitioning
 --
 
 CREATE TABLE approx_count_dp(time TIMESTAMP, value int) PARTITION BY RANGE(time);
@@ -138,6 +138,48 @@ SELECT * FROM approximate_row_count('approx_count_dp');
 SELECT * FROM approximate_row_count('approx_count_dp0');
 SELECT * FROM approximate_row_count('approx_count_dp1');
 SELECT * FROM approximate_row_count('approx_count_dp2');
+
+CREATE TABLE approx_count_dp_nested(time TIMESTAMP, device_id int, value int) PARTITION BY RANGE(time);
+CREATE TABLE approx_count_dp_nested_0 PARTITION OF approx_count_dp_nested FOR VALUES FROM ('2004-01-01 00:00:00') TO ('2005-01-01 00:00:00') PARTITION BY RANGE (device_id);
+CREATE TABLE approx_count_dp_nested_0_0 PARTITION OF approx_count_dp_nested_0 FOR VALUES FROM (0) TO (10);
+CREATE TABLE approx_count_dp_nested_0_1 PARTITION OF approx_count_dp_nested_0 FOR VALUES FROM (10) TO (20);
+CREATE TABLE approx_count_dp_nested_1 PARTITION OF approx_count_dp_nested FOR VALUES FROM ('2005-01-01 00:00:00') TO ('2006-01-01 00:00:00') PARTITION BY RANGE (device_id);
+CREATE TABLE approx_count_dp_nested_1_0 PARTITION OF approx_count_dp_nested_1 FOR VALUES FROM (0) TO (10);
+CREATE TABLE approx_count_dp_nested_1_1 PARTITION OF approx_count_dp_nested_1 FOR VALUES FROM (10) TO (20);
+
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 1, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 2, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 3, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 11, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 12, 1);
+INSERT INTO approx_count_dp_nested VALUES('2004-01-01 10:00:00', 13, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 1, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 2, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 3, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 11, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 12, 1);
+INSERT INTO approx_count_dp_nested VALUES('2005-01-01 10:00:00', 13, 1);
+
+SELECT * FROM approximate_row_count('approx_count_dp_nested');
+ANALYZE approx_count_dp_nested;
+
+SELECT
+  (SELECT count(*) FROM approx_count_dp_nested) AS dp_nested,
+  (SELECT count(*) FROM approx_count_dp_nested_0) AS dp_nested_0,
+  (SELECT count(*) FROM approx_count_dp_nested_0_0) AS dp_nested_0_0,
+  (SELECT count(*) FROM approx_count_dp_nested_0_1) AS dp_nested_0_1,
+  (SELECT count(*) FROM approx_count_dp_nested_1) AS dp_nested_1,
+  (SELECT count(*) FROM approx_count_dp_nested_1_0) AS dp_nested_1_0,
+  (SELECT count(*) FROM approx_count_dp_nested_1_1) AS dp_nested_1_1
+UNION ALL
+SELECT
+  approximate_row_count('approx_count_dp_nested'),
+  approximate_row_count('approx_count_dp_nested_0'),
+  approximate_row_count('approx_count_dp_nested_0_0'),
+  approximate_row_count('approx_count_dp_nested_0_1'),
+  approximate_row_count('approx_count_dp_nested_1'),
+  approximate_row_count('approx_count_dp_nested_1_0'),
+  approximate_row_count('approx_count_dp_nested_1_1');
 
 -- Hypertable
 --


### PR DESCRIPTION
Rewrite approximate_row_count to SQL instead of PLpgSQL and remove
superfluous JOINs against pg_namespace. Adjust tuple calculation
for PG14 since in PG14 reltuples for partitioned tables is the sum
of it's children so we need to exclude those from calculation to
not doublecount.