### PR TITLE
Backport ec member function for PG v13.2 or less

### DIFF
--- a/src/import/planner.c
+++ b/src/import/planner.c
@@ -38,7 +38,7 @@
 #include "compat/compat.h"
 #include "planner.h"
 
-#if PG12
+#if (PG_VERSION_NUM < 133000)
 static EquivalenceMember *find_ec_member_matching_expr(EquivalenceClass *ec, Expr *expr,
 													   Relids relids);
 static EquivalenceMember *find_computable_ec_member(PlannerInfo *root, EquivalenceClass *ec,
@@ -367,7 +367,7 @@ ts_get_variable_range(PlannerInfo *root, VariableStatData *vardata, Oid sortop, 
 	return have_data;
 }
 
-#if PG12
+#if (PG_VERSION_NUM < 133000)
 /*
  * find_ec_member_matching_expr
  *		Locate an EquivalenceClass member matching the given expr, if any;


### PR DESCRIPTION
A couple of planner functions related to equivalance members were
introduced in PG 13.3, but was only backported to PG 12 or less. This
meant that builds for PG 13.2 broke.

Fix this by backporting to all versions < PG 13.3.