### PR TITLE
Call cleanup functions on backend exit

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -5,6 +5,7 @@
  */
 #include <postgres.h>
 #include <access/xact.h>
+#include <storage/ipc.h>
 
 #include "cache.h"
 #include "compat/compat.h"
@@ -369,6 +370,7 @@ _cache_init(void)
 void
 _cache_fini(void)
 {
+	release_all_pinned_caches();
 	MemoryContextDelete(pinned_caches_mctx);
 	pinned_caches_mctx = NULL;
 	pinned_caches = NIL;


### PR DESCRIPTION
A number of cleanup functions for various data structures (e.g.,
caches) are designed to be called when the extension library is
unloaded (via `_PG_fini`). But unloading is disabled in PostgreSQL and
the library is also not unloaded when the backend exits. Therefore,
cleanup functions are never called in practice.

In most cases this is not a problem since memory is released in any
case. However, in the case of the connection cache, connections need
to be closed before memory is released or otherwise the DNs will emit
"Connection reset by peer" log entries when the AN backend exits.

Add proper cleanup of caches and other data structures by adding a
callback via `on_proc_exit`, which gets called when the backend exits.
The closing of AN to DN backend connections are also logged on
the AN if `log_connections=true`.