### PR TITLE
Update connection cache on role changes

### DIFF
--- a/tsl/src/remote/connection_cache.h
+++ b/tsl/src/remote/connection_cache.h
@@ -24,6 +24,7 @@ extern bool remote_connection_cache_remove(TSConnectionId id);
 
 extern void remote_connection_cache_invalidate_callback(Datum arg, int cacheid, uint32 hashvalue);
 extern void remote_connection_cache_dropped_db_callback(const char *dbname);
+extern void remote_connection_cache_dropped_role_callback(const char *rolename);
 extern Datum remote_connection_cache_show(PG_FUNCTION_ARGS);
 extern void _remote_connection_cache_init(void);
 extern void _remote_connection_cache_fini(void);

--- a/tsl/test/expected/remote_connection_cache.out
+++ b/tsl/test/expected/remote_connection_cache.out
@@ -28,5 +28,46 @@ SELECT _timescaledb_internal.test_remote_connection_cache();
  
 (1 row)
 
+-- Test that connection cache entries for a role gets invalidated when
+-- we rename the role
+GRANT USAGE ON FOREIGN SERVER loopback_1, loopback_2 TO :ROLE_1;
+SET ROLE :ROLE_1;
+CREATE TABLE testtable (time timestamptz, location int, temp float);
+SELECT * FROM create_distributed_hypertable('testtable', 'time', 'location');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | testtable  | t
+(1 row)
+
+INSERT INTO testtable VALUES ('2021-09-19', 1, 13.2);
+-- Should show valid connections for ROLE_1
+SELECT node_name, user_name, invalidated
+FROM _timescaledb_internal.show_connection_cache()
+WHERE user_name=:'ROLE_1'
+ORDER BY 1,2;
+ node_name  |  user_name  | invalidated 
+------------+-------------+-------------
+ loopback_1 | test_role_1 | f
+ loopback_2 | test_role_1 | f
+(2 rows)
+
+RESET ROLE;
+BEGIN;
+-- Renaming the role should invalidate the connection cache entries
+-- for ROLE_1/bob. The connections will be recreated on next cache
+-- fetch.
+ALTER ROLE :ROLE_1 RENAME TO bob;
+SELECT node_name, user_name, invalidated
+FROM _timescaledb_internal.show_connection_cache()
+WHERE user_name='bob'
+ORDER BY 1,2;
+ node_name  | user_name | invalidated 
+------------+-----------+-------------
+ loopback_1 | bob       | t
+ loopback_2 | bob       | t
+(2 rows)
+
+ROLLBACK;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;

--- a/tsl/test/sql/remote_connection_cache.sql
+++ b/tsl/test/sql/remote_connection_cache.sql
@@ -30,5 +30,32 @@ $d$;
 
 SELECT _timescaledb_internal.test_remote_connection_cache();
 
+-- Test that connection cache entries for a role gets invalidated when
+-- we rename the role
+GRANT USAGE ON FOREIGN SERVER loopback_1, loopback_2 TO :ROLE_1;
+SET ROLE :ROLE_1;
+
+CREATE TABLE testtable (time timestamptz, location int, temp float);
+SELECT * FROM create_distributed_hypertable('testtable', 'time', 'location');
+INSERT INTO testtable VALUES ('2021-09-19', 1, 13.2);
+
+-- Should show valid connections for ROLE_1
+SELECT node_name, user_name, invalidated
+FROM _timescaledb_internal.show_connection_cache()
+WHERE user_name=:'ROLE_1'
+ORDER BY 1,2;
+RESET ROLE;
+BEGIN;
+
+-- Renaming the role should invalidate the connection cache entries
+-- for ROLE_1/bob. The connections will be recreated on next cache
+-- fetch.
+ALTER ROLE :ROLE_1 RENAME TO bob;
+SELECT node_name, user_name, invalidated
+FROM _timescaledb_internal.show_connection_cache()
+WHERE user_name='bob'
+ORDER BY 1,2;
+ROLLBACK;
+
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;

--- a/tsl/test/t/003_connections.pl
+++ b/tsl/test/t/003_connections.pl
@@ -1,0 +1,68 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+# test a simple multi node cluster creation and basic operations
+use strict;
+use warnings;
+use AccessNode;
+use DataNode;
+use TestLib;
+use Test::More tests => 1;
+
+#Initialize all the multi-node instances
+my $an  = AccessNode->create('an');
+my $dn1 = DataNode->create('dn1');
+my $dn2 = DataNode->create('dn2');
+
+$an->add_data_node($dn1);
+$an->add_data_node($dn2);
+
+$dn1->append_conf('postgresql.conf', 'log_connections=true');
+$dn2->append_conf('postgresql.conf', 'log_connections=true');
+
+my $output = $an->safe_psql(
+	'postgres',
+	qq[
+	CREATE ROLE alice;
+	CALL distributed_exec('CREATE ROLE alice LOGIN');
+	GRANT USAGE ON FOREIGN SERVER dn1,dn2 TO alice;
+	SET ROLE alice;
+	CREATE TABLE conditions (time timestamptz, location int, temp float);
+	SELECT create_distributed_hypertable('conditions', 'time', 'location');
+	INSERT INTO conditions VALUES ('2021-09-20 00:00:00+02', 1, 23.4);
+    ]);
+
+
+my ($cmdret, $stdout, $stderr) = $an->psql(
+	'postgres',
+	qq[
+	SET ROLE alice;
+	SELECT time AT TIME ZONE 'America/New_York', location, temp FROM conditions;
+	SELECT node_name, user_name, invalidated
+   	FROM _timescaledb_internal.show_connection_cache()
+	WHERE user_name='alice';
+	RESET ROLE;
+	DROP TABLE conditions;
+	REVOKE USAGE ON FOREIGN SERVER dn1,dn2 FROM alice;
+	DROP ROLE ALICE;
+	SELECT node_name, user_name, invalidated
+   	FROM _timescaledb_internal.show_connection_cache()
+	WHERE user_name='alice';
+	
+]);
+
+# Expected output:
+#
+# * First row is from the SELECT query that creates the connections
+# * for alice.
+#
+# * Second row is the output from the connection cache after SELECT
+#   and prior to dropping alice. The entry has invalidated=false, so
+#   the entry is still valid.
+#
+# * There is no row for the third connection cache query since the
+# * connections for alice have been purged.
+is( $stdout,
+	q[2021-09-19 18:00:00|1|23.4
+dn1|alice|f]);

--- a/tsl/test/t/CMakeLists.txt
+++ b/tsl/test/t/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PROVE_TEST_FILES 001_simple_multinode.pl)
+set(PROVE_TEST_FILES 001_simple_multinode.pl 003_connections.pl)
 set(PROVE_DEBUG_TEST_FILES 002_chunk_copy_move.pl)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
The access node maintains a cache of connections to its data
nodes. Each entry in the cache is a connection for a user and remote
data node pair. Currently, a cache entry is invalidated when a foreign
server object representing a data node is changed (e.g., the port
could have been updated). The connection will remain in the cache for
the duration of the current command, but will be remade with the
updated parameters the next time it is fetched from the cache.

This change invalidates a connection cache entry if the connection's
role/user changes and drops an entry if the role is dropped. One
reason for invalidating a connection is that a role rename invalidates
the certificate the connection is using in case client certificate
authentication is used. Thus, connections that have been
authenticated with a certificate that is no longer valid will be
remade. In some cases, this extra invalidation leads to purging
connections when not strictly necessary. However, this is not a big
problem in practice since role objects don't change often.
