### PR TITLE
Show details on compressed chunk error

### DIFF
--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -663,10 +663,17 @@ ERROR:  "trigger_test" is a table
 -- AFTER INSERT ROW trigger not supported on compressed chunk
 CREATE TRIGGER t4_ar AFTER INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION stmt_trig_info();
 \set ON_ERROR_STOP 0
+\set VERBOSITY default
 INSERT INTO trigger_test SELECT '2000-01-01',1,0;
 ERROR:  after insert row trigger on compressed chunk not supported
+DETAIL:  Triggers: t4_ar
+HINT:  Decompress the chunk first before inserting into it.
 COPY trigger_test FROM STDIN DELIMITER ',';
 ERROR:  after insert row trigger on compressed chunk not supported
+DETAIL:  Triggers: t4_ar
+HINT:  Decompress the chunk first before inserting into it.
+CONTEXT:  COPY trigger_test, line 1: "2000-01-01 01:00:00-05,1,0"
+\set VERBOSITY terse
 \set ON_ERROR_STOP 1
 -- should not insert rows. count is 1
 SELECT count(*) FROM trigger_test;

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -663,10 +663,17 @@ ERROR:  "trigger_test" is a table
 -- AFTER INSERT ROW trigger not supported on compressed chunk
 CREATE TRIGGER t4_ar AFTER INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION stmt_trig_info();
 \set ON_ERROR_STOP 0
+\set VERBOSITY default
 INSERT INTO trigger_test SELECT '2000-01-01',1,0;
 ERROR:  after insert row trigger on compressed chunk not supported
+DETAIL:  Triggers: t4_ar
+HINT:  Decompress the chunk first before inserting into it.
 COPY trigger_test FROM STDIN DELIMITER ',';
 ERROR:  after insert row trigger on compressed chunk not supported
+DETAIL:  Triggers: t4_ar
+HINT:  Decompress the chunk first before inserting into it.
+CONTEXT:  COPY trigger_test, line 1: "2000-01-01 01:00:00-05,1,0"
+\set VERBOSITY terse
 \set ON_ERROR_STOP 1
 -- should not insert rows. count is 1
 SELECT count(*) FROM trigger_test;

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -459,10 +459,12 @@ CREATE TRIGGER t4_instead INSTEAD OF INSERT ON trigger_test FOR EACH STATEMENT E
 CREATE TRIGGER t4_ar AFTER INSERT ON trigger_test FOR EACH ROW EXECUTE FUNCTION stmt_trig_info();
 
 \set ON_ERROR_STOP 0
+\set VERBOSITY default
 INSERT INTO trigger_test SELECT '2000-01-01',1,0;
 COPY trigger_test FROM STDIN DELIMITER ',';
 2000-01-01 01:00:00-05,1,0
 \.
+\set VERBOSITY terse
 \set ON_ERROR_STOP 1
 
 -- should not insert rows. count is 1


### PR DESCRIPTION
If insertion is attempted into a chunk that is compressed, the error
message is very brief. This commit adds a hint that the chunk should be
decompressed before inserting into it and also list the triggers on the
chunk so that it is easy to debug.