### PR TITLE
Improve error message when chunk not found

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -118,6 +118,15 @@ typedef struct ChunkScanEntry
 	ChunkStub *stub;
 } ChunkScanEntry;
 
+/*
+ * Information to be able to display a scan key details for error messages.
+ */
+typedef struct DisplayKeyData
+{
+	const char *name;
+	const char *(*as_string)(Datum);
+} DisplayKeyData;
+
 extern Chunk *ts_chunk_create_from_point(const Hypertable *ht, const Point *p, const char *schema,
 										 const char *prefix);
 

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -856,3 +856,27 @@ NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
                ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 
+-- Create a hypertable and add a rogue inherited table to it. 
+CREATE TABLE i165 (time timestamptz PRIMARY KEY);
+SELECT create_hypertable('i165','time');
+ create_hypertable  
+--------------------
+ (15,public,i165,t)
+(1 row)
+
+ALTER TABLE i165 SET (timescaledb.compress);
+SELECT compress_chunk(show_chunks('i165'));
+ compress_chunk 
+----------------
+(0 rows)
+
+CREATE TABLE extras (more_magic bool) INHERITS (i165);
+INSERT INTO i165 (time) VALUES
+       (generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'));
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SELECT * FROM i165;
+ERROR:  chunk not found
+DETAIL:  schema_name: public, table_name: extras
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -856,3 +856,27 @@ NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
                ->  Seq Scan on compress_hyper_14_23_chunk
 (10 rows)
 
+-- Create a hypertable and add a rogue inherited table to it. 
+CREATE TABLE i165 (time timestamptz PRIMARY KEY);
+SELECT create_hypertable('i165','time');
+ create_hypertable  
+--------------------
+ (15,public,i165,t)
+(1 row)
+
+ALTER TABLE i165 SET (timescaledb.compress);
+SELECT compress_chunk(show_chunks('i165'));
+ compress_chunk 
+----------------
+(0 rows)
+
+CREATE TABLE extras (more_magic bool) INHERITS (i165);
+INSERT INTO i165 (time) VALUES
+       (generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'));
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SELECT * FROM i165;
+ERROR:  chunk not found
+DETAIL:  schema_name: public, table_name: extras
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -550,3 +550,17 @@ SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timesc
 
 -- should be ordered append
 :PREFIX SELECT * FROM test_ordering ORDER BY 1;
+
+-- Create a hypertable and add a rogue inherited table to it. 
+CREATE TABLE i165 (time timestamptz PRIMARY KEY);
+SELECT create_hypertable('i165','time');
+ALTER TABLE i165 SET (timescaledb.compress);
+SELECT compress_chunk(show_chunks('i165'));
+CREATE TABLE extras (more_magic bool) INHERITS (i165);
+INSERT INTO i165 (time) VALUES
+       (generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'));
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SELECT * FROM i165;
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
When a chunk is not found, we print a generic error message that does
not hint at what we are looking for, which means that it is very hard
to locate the problem.

This commit adds details to the error message printing out values used
for the scan key when searching for the chunk.

Related-To: #2344
Related-To: #3400
Related-To: #153