### PR TITLE
Make ssl_dir/passfile gucs accessible for read

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -325,7 +325,7 @@ _guc_init(void)
 							   &ts_guc_ssl_dir,
 							   NULL,
 							   PGC_SIGHUP,
-							   GUC_SUPERUSER_ONLY,
+							   0,
 							   NULL,
 							   NULL,
 							   NULL);
@@ -337,7 +337,7 @@ _guc_init(void)
 							   &ts_guc_passfile,
 							   NULL,
 							   PGC_SIGHUP,
-							   GUC_SUPERUSER_ONLY,
+							   0,
 							   NULL,
 							   NULL,
 							   NULL);

--- a/tsl/test/expected/dist_util.out
+++ b/tsl/test/expected/dist_util.out
@@ -843,6 +843,15 @@ SELECT * FROM hypertable_index_size('nondisttable_pkey');
                  40960
 (1 row)
 
+-- Make sure timescaledb.ssl_dir and passfile gucs can be read by a non-superuser
+\c :TEST_DBNAME :ROLE_1
+\unset ECHO
+\set ON_ERROR_STOP 0
+SET timescaledb.ssl_dir TO 'ssldir';
+ERROR:  parameter "timescaledb.ssl_dir" cannot be changed now
+SET timescaledb.passfile TO 'passfile';
+ERROR:  parameter "timescaledb.passfile" cannot be changed now
+\set ON_ERROR_STOP 1
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 SET client_min_messages TO ERROR;
 DROP DATABASE backend_1_1;

--- a/tsl/test/sql/dist_util.sql
+++ b/tsl/test/sql/dist_util.sql
@@ -278,6 +278,19 @@ SELECT * FROM chunk_compression_stats('nondisttable') ORDER BY chunk_schema, chu
 SELECT * FROM hypertable_index_size('disttable_pkey');
 SELECT * FROM hypertable_index_size('nondisttable_pkey');
 
+-- Make sure timescaledb.ssl_dir and passfile gucs can be read by a non-superuser
+\c :TEST_DBNAME :ROLE_1
+\unset ECHO
+\o /dev/null
+SHOW timescaledb.ssl_dir;
+SHOW timescaledb.passfile;
+\o
+\set ECHO all
+\set ON_ERROR_STOP 0
+SET timescaledb.ssl_dir TO 'ssldir';
+SET timescaledb.passfile TO 'passfile';
+\set ON_ERROR_STOP 1
+
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 SET client_min_messages TO ERROR;
 DROP DATABASE backend_1_1;


### PR DESCRIPTION
`timescaledb.ssl_dir/passfile` GUC's is currently only visible for superusers. This makes it impossible for non superusers to read GUC value which might be useful in some cases (eg. troubleshooting or building multinode automation).

Since this GUC's does not contain any sensitive information it makes sense to make it public.

Fixes #3608