### PR TITLE
Update refresh procedure to read invalidation logs from data nodes for distributed hypertables

### DIFF
--- a/cmake/ScriptFiles.cmake
+++ b/cmake/ScriptFiles.cmake
@@ -61,7 +61,8 @@ set(SOURCE_FILES
     restoring.sql
     job_api.sql
     policy_api.sql
-    policy_internal.sql)
+    policy_internal.sql
+    cagg_utils.sql)
 
 # These files should be pre-pended to update scripts so that they are executed
 # before anything else during updates

--- a/sql/cagg_utils.sql
+++ b/sql/cagg_utils.sql
@@ -1,0 +1,74 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Adds the initial materialization invalidation log entry to all data nodes that comprise the
+-- underlying distributed hypertable when creating a CAGG. This invalidation entry and is set
+-- to [-infinity, +infinity].
+--
+-- mat_hypertable_id - The hypertable ID of the CAGG materialized hypertable in the Access Node
+CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_cagg_log_add_initial_entry(
+    mat_hypertable_id INTEGER
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_invalidation_cagg_log_add_initial_entry' LANGUAGE C STRICT VOLATILE;
+
+-- Processes the hypertable invalidation log in a data node for all the CAGGs that belong to the
+-- distributed hypertable with hypertable ID 'raw_hypertable_id' in the Access Node. The
+-- invalidations are cut, merged and moved to the materialization invalidation log.
+--
+-- mat_hypertable_id - The hypertable ID of the CAGG materialized hypertable in the Access Node
+--                     that is currently being refreshed
+-- raw_hypertable_id - The hypertable ID of the original distributed hypertable in the Access Node
+-- dimtype - The OID of the type of the time dimension for this CAGG
+-- last_mat_hypertable_id - The hypertable ID of the last CAGG materialized hypertable in the
+--                          Access Node from the 'mat_hypertable_ids' array
+-- mat_hypertable_ids - The array of hypertable IDs for all CAGG materialized hypertables in the
+--                      Access Node that belong to 'raw_hypertable_id'
+-- bucket_widths - The array of time bucket widths for all the CAGGs that belong to
+--                 'raw_hypertable_id'
+-- max_bucket_widths - The array of the maximum time bucket widths for all the CAGGs that belong
+--                     to 'raw_hypertable_id'
+CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_process_hypertable_log(
+    mat_hypertable_id INTEGER,
+    raw_hypertable_id INTEGER,
+    dimtype REGCLASS,
+    last_mat_hypertable_id INTEGER,
+    mat_hypertable_ids INTEGER[],
+    bucket_widths BIGINT[],
+    max_bucket_widths BIGINT[]
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_invalidation_process_hypertable_log' LANGUAGE C STRICT VOLATILE;
+
+-- Processes the materialization invalidation log in a data node for the CAGG being refreshed that
+-- belongs to the distributed hypertable with hypertable ID 'raw_hypertable_id' in the Access Node.
+-- The invalidations are cut, merged and returned as a single refresh window.
+--
+-- mat_hypertable_id - The hypertable ID of the CAGG materialized hypertable in the Access Node
+--                     that is currently being refreshed.
+-- raw_hypertable_id - The hypertable ID of the original distributed hypertable in the Access Node
+-- dimtype - The OID of the type of the time dimension for this CAGG
+-- window_start - The starting time of the CAGG refresh window
+-- window_end - The ending time of the CAGG refresh window
+-- last_mat_hypertable_id - The hypertable ID of the last CAGG materialized hypertable in the
+--                          Access Node from the 'mat_hypertable_ids' array
+-- mat_hypertable_ids - The array of hypertable IDs for all CAGG materialized hypertables in the
+--                      Access Node that belong to 'raw_hypertable_id'
+-- bucket_widths - The array of time bucket widths for all the CAGGs that belong to
+--                 'raw_hypertable_id'
+-- max_bucket_widths - The array of the maximum time bucket widths for all the CAGGs that belong
+--                     to 'raw_hypertable_id'
+--
+-- Returns a tuple of:
+-- ret_window_start - The merged refresh window starting time
+-- ret_window_end - The merged refresh window ending time
+CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_process_cagg_log(
+    mat_hypertable_id INTEGER,
+    raw_hypertable_id INTEGER,
+    dimtype REGCLASS,
+    window_start BIGINT,
+    window_end BIGINT,
+    last_mat_hypertable_id INTEGER,
+    mat_hypertable_ids INTEGER[],
+    bucket_widths BIGINT[],
+    max_bucket_widths BIGINT[],
+    OUT ret_window_start BIGINT,
+    OUT ret_window_end BIGINT
+) RETURNS RECORD AS '@MODULE_PATHNAME@', 'ts_invalidation_process_cagg_log' LANGUAGE C STRICT VOLATILE;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -60,6 +60,28 @@ typedef struct ContinuousAggMatOptions
 									   cover this point */
 } ContinuousAggMatOptions;
 
+typedef struct CaggsInfoData
+{
+	List *mat_hypertable_ids; /* (int32) elements */
+	List *bucket_widths;	  /* (int64 *) elements */
+	List *max_bucket_widths;  /* (int64 *) elements */
+	int32 last_mat_hypertable_id;
+} CaggsInfo;
+
+extern TSDLLEXPORT CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
+extern TSDLLEXPORT CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
+extern TSDLLEXPORT void populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids,
+														ArrayType *bucket_widths,
+														ArrayType *max_bucket_widths,
+														CaggsInfo *all_caggs);
+extern TSDLLEXPORT void create_arrayexprs_from_caggs_info(CaggsInfo *all_caggs,
+														  ArrayExpr **mat_hypertable_ids,
+														  ArrayExpr **bucket_widths,
+														  ArrayExpr **max_bucket_widths);
+TSDLLEXPORT void create_arrays_from_caggs_info(CaggsInfo *all_caggs, ArrayType **mat_hypertable_ids,
+											   ArrayType **bucket_widths,
+											   ArrayType **max_bucket_widths);
+
 extern TSDLLEXPORT ContinuousAgg *
 ts_continuous_agg_find_by_mat_hypertable_id(int32 mat_hypertable_id);
 

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -74,6 +74,9 @@ CROSSMODULE_WRAPPER(recompress_chunk);
 CROSSMODULE_WRAPPER(continuous_agg_invalidation_trigger);
 CROSSMODULE_WRAPPER(continuous_agg_refresh);
 CROSSMODULE_WRAPPER(continuous_agg_refresh_chunk);
+CROSSMODULE_WRAPPER(invalidation_cagg_log_add_initial_entry);
+CROSSMODULE_WRAPPER(invalidation_process_hypertable_log);
+CROSSMODULE_WRAPPER(invalidation_process_cagg_log);
 
 CROSSMODULE_WRAPPER(data_node_ping);
 CROSSMODULE_WRAPPER(data_node_block_new_chunks);
@@ -349,6 +352,9 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.continuous_agg_refresh_chunk = error_no_default_fn_pg_community,
 	.continuous_agg_invalidate = continuous_agg_invalidate_all_default,
 	.continuous_agg_update_options = continuous_agg_update_options_default,
+	.invalidation_cagg_log_add_initial_entry = error_no_default_fn_pg_community,
+	.invalidation_process_hypertable_log = error_no_default_fn_pg_community,
+	.invalidation_process_cagg_log = error_no_default_fn_pg_community,
 
 	/* compression */
 	.compressed_data_send = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -85,6 +85,8 @@ typedef struct CrossModuleFunctions
 	void (*ddl_command_start)(ProcessUtilityArgs *args);
 	void (*ddl_command_end)(EventTriggerData *command);
 	void (*sql_drop)(List *dropped_objects);
+
+	/* Continuous Aggregates */
 	PGFunction partialize_agg;
 	PGFunction finalize_agg_sfunc;
 	PGFunction finalize_agg_ffunc;
@@ -96,6 +98,9 @@ typedef struct CrossModuleFunctions
 	void (*continuous_agg_invalidate)(const Hypertable *ht, int64 start, int64 end);
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);
+	PGFunction invalidation_cagg_log_add_initial_entry;
+	PGFunction invalidation_process_hypertable_log;
+	PGFunction invalidation_process_cagg_log;
 
 	PGFunction compressed_data_send;
 	PGFunction compressed_data_recv;

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -40,9 +40,32 @@ typedef struct Hypertable Hypertable;
 extern void invalidation_cagg_log_add_entry(int32 cagg_hyper_id, int64 start, int64 end);
 extern void invalidation_hyper_log_add_entry(int32 hyper_id, int64 start, int64 end);
 extern void invalidation_add_entry(const Hypertable *ht, int64 start, int64 end);
-extern void invalidation_process_hypertable_log(const ContinuousAgg *cagg, Oid dimtype);
-extern InvalidationStore *invalidation_process_cagg_log(const ContinuousAgg *cagg,
-														const InternalTimeRange *refresh_window);
+
+extern Datum tsl_invalidation_cagg_log_add_initial_entry(PG_FUNCTION_ARGS);
+void remote_invalidation_cagg_log_add_initial_entry(int32 mat_hypertable_id,
+													int32 raw_hypertable_id);
+
+extern void invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
+												Oid dimtype, CaggsInfo *all_caggs_info);
+extern void invoke_invalidation_process_hypertable_log(int32 mat_hypertable_id,
+													   int32 raw_hypertable_id, Oid dimtype,
+													   CaggsInfo *all_caggs);
+extern void remote_invalidation_process_hypertable_log(int32 mat_hypertable_id,
+													   int32 raw_hypertable_id, Oid dimtype,
+													   CaggsInfo *all_caggs);
+extern Datum tsl_invalidation_process_hypertable_log(PG_FUNCTION_ARGS);
+
+extern InvalidationStore *
+invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
+							  const InternalTimeRange *refresh_window, CaggsInfo *all_caggs_info,
+							  const long max_materializations, bool *do_merged_refresh,
+							  InternalTimeRange *ret_merged_refresh_window);
+extern Datum tsl_invalidation_process_cagg_log(PG_FUNCTION_ARGS);
+extern void remote_invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
+												 const InternalTimeRange *refresh_window,
+												 CaggsInfo *all_caggs, bool *do_merged_refresh,
+												 InternalTimeRange *ret_merged_refresh_window);
+
 extern void invalidation_store_free(InvalidationStore *store);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_INVALIDATION_H */

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -334,6 +334,89 @@ materialization_per_refresh_window(void)
 	return max_materializations;
 }
 
+typedef void (*scan_refresh_ranges_funct_t)(const InternalTimeRange *bucketed_refresh_window,
+											const long iteration, /* 0 is first range */
+											void *arg1, void *arg2);
+
+static void
+continuous_agg_refresh_execute_wrapper(const InternalTimeRange *bucketed_refresh_window,
+									   const long iteration, void *arg1_refresh,
+									   void *arg2_chunk_id)
+{
+	const CaggRefreshState *refresh = (const CaggRefreshState *) arg1_refresh;
+	const int32 chunk_id = *(const int32 *) arg2_chunk_id;
+	(void) iteration;
+
+	log_refresh_window(DEBUG1, &refresh->cagg, bucketed_refresh_window, "invalidation refresh on");
+	continuous_agg_refresh_execute(refresh, bucketed_refresh_window, chunk_id);
+}
+
+static void
+update_merged_refresh_window(const InternalTimeRange *bucketed_refresh_window, const long iteration,
+							 void *arg1_merged_refresh_window, void *arg2)
+{
+	InternalTimeRange *merged_refresh_window = (InternalTimeRange *) arg1_merged_refresh_window;
+	(void) arg2;
+
+	if (iteration == 0)
+		*merged_refresh_window = *bucketed_refresh_window;
+	else
+	{
+		if (bucketed_refresh_window->start < merged_refresh_window->start)
+			merged_refresh_window->start = bucketed_refresh_window->start;
+
+		if (bucketed_refresh_window->end > merged_refresh_window->end)
+			merged_refresh_window->end = bucketed_refresh_window->end;
+	}
+}
+
+static long
+continuous_agg_scan_refresh_window_ranges(const InternalTimeRange *refresh_window,
+										  const InvalidationStore *invalidations,
+										  const int64 max_bucket_width,
+										  scan_refresh_ranges_funct_t exec_func, void *func_arg1,
+										  void *func_arg2)
+{
+	TupleTableSlot *slot;
+	long count = 0;
+
+	slot = MakeSingleTupleTableSlot(invalidations->tupdesc, &TTSOpsMinimalTuple);
+
+	while (tuplestore_gettupleslot(invalidations->tupstore,
+								   true /* forward */,
+								   false /* copy */,
+								   slot))
+	{
+		bool isnull;
+		Datum start = slot_getattr(
+			slot,
+			Anum_continuous_aggs_materialization_invalidation_log_lowest_modified_value,
+			&isnull);
+		Datum end = slot_getattr(
+			slot,
+			Anum_continuous_aggs_materialization_invalidation_log_greatest_modified_value,
+			&isnull);
+		InternalTimeRange invalidation = {
+			.type = refresh_window->type,
+			.start = DatumGetInt64(start),
+			/* Invalidations are inclusive at the end, while refresh windows
+			 * aren't, so add one to the end of the invalidated region */
+			.end = ts_time_saturating_add(DatumGetInt64(end), 1, refresh_window->type),
+		};
+
+		InternalTimeRange bucketed_refresh_window =
+			compute_circumscribed_bucketed_refresh_window(&invalidation, max_bucket_width);
+
+		(*exec_func)(&bucketed_refresh_window, count, func_arg1, func_arg2);
+
+		count++;
+	}
+
+	ExecDropSingleTupleTableSlot(slot);
+
+	return count;
+}
+
 /*
  * Execute refreshes based on the processed invalidations.
  *
@@ -363,75 +446,16 @@ materialization_per_refresh_window(void)
 static void
 continuous_agg_refresh_with_window(const ContinuousAgg *cagg,
 								   const InternalTimeRange *refresh_window,
-								   const InvalidationStore *invalidations, const int32 chunk_id)
+								   const InvalidationStore *invalidations,
+								   const int64 max_bucket_width, const int32 chunk_id,
+								   const bool is_raw_ht_distributed, const bool do_merged_refresh,
+								   const InternalTimeRange merged_refresh_window)
 {
 	CaggRefreshState refresh;
-	TupleTableSlot *slot;
-	bool do_merged_refresh = false;
-	InternalTimeRange merged_refresh_window;
-	long count = 0;
 
 	continuous_agg_refresh_init(&refresh, cagg, refresh_window);
 
-	/*
-	 * If there are many individual invalidation ranges to refresh, then
-	 * revert to a merged refresh across the range decided by lowest and
-	 * highest invalidated value.
-	 */
-	if (tuplestore_tuple_count(invalidations->tupstore) > materialization_per_refresh_window())
-		do_merged_refresh = true;
-
-	slot = MakeSingleTupleTableSlot(invalidations->tupdesc, &TTSOpsMinimalTuple);
-
-	while (tuplestore_gettupleslot(invalidations->tupstore,
-								   true /* forward */,
-								   false /* copy */,
-								   slot))
-	{
-		bool isnull;
-		Datum start = slot_getattr(
-			slot,
-			Anum_continuous_aggs_materialization_invalidation_log_lowest_modified_value,
-			&isnull);
-		Datum end = slot_getattr(
-			slot,
-			Anum_continuous_aggs_materialization_invalidation_log_greatest_modified_value,
-			&isnull);
-		InternalTimeRange invalidation = {
-			.type = refresh_window->type,
-			.start = DatumGetInt64(start),
-			/* Invalidations are inclusive at the end, while refresh windows
-			 * aren't, so add one to the end of the invalidated region */
-			.end = ts_time_saturating_add(DatumGetInt64(end), 1, refresh_window->type),
-		};
-
-		int64 max_bucket_width = ts_continuous_agg_max_bucket_width(cagg);
-		InternalTimeRange bucketed_refresh_window =
-			compute_circumscribed_bucketed_refresh_window(&invalidation, max_bucket_width);
-
-		if (do_merged_refresh)
-		{
-			if (count == 0)
-				merged_refresh_window = bucketed_refresh_window;
-			else
-			{
-				if (bucketed_refresh_window.start < merged_refresh_window.start)
-					merged_refresh_window.start = bucketed_refresh_window.start;
-
-				if (bucketed_refresh_window.end > merged_refresh_window.end)
-					merged_refresh_window.end = bucketed_refresh_window.end;
-			}
-		}
-		else
-		{
-			log_refresh_window(DEBUG1, cagg, &bucketed_refresh_window, "invalidation refresh on");
-			continuous_agg_refresh_execute(&refresh, &bucketed_refresh_window, chunk_id);
-		}
-
-		count++;
-	}
-
-	if (do_merged_refresh && count > 0)
+	if (do_merged_refresh)
 	{
 		Assert(merged_refresh_window.type == refresh_window->type);
 		Assert(merged_refresh_window.start >= refresh_window->start);
@@ -440,11 +464,20 @@ continuous_agg_refresh_with_window(const ContinuousAgg *cagg,
 		log_refresh_window(DEBUG1,
 						   cagg,
 						   &merged_refresh_window,
-						   psprintf("merged %ld invalidations for refresh on", count));
+						   "merged invalidations for refresh on");
 		continuous_agg_refresh_execute(&refresh, &merged_refresh_window, chunk_id);
 	}
-
-	ExecDropSingleTupleTableSlot(slot);
+	else
+	{
+		long count;
+		count = continuous_agg_scan_refresh_window_ranges(refresh_window,
+														  invalidations,
+														  max_bucket_width,
+														  continuous_agg_refresh_execute_wrapper,
+														  (void *) &refresh /* arg1 */,
+														  (void *) &chunk_id /* arg2 */);
+		Assert(count);
+	}
 }
 
 static ContinuousAgg *
@@ -525,6 +558,22 @@ emit_up_to_date_notice(const ContinuousAgg *cagg, const CaggRefreshCallContext c
 	}
 }
 
+void
+continuous_agg_calculate_merged_refresh_window(const InternalTimeRange *refresh_window,
+											   const InvalidationStore *invalidations,
+											   const int64 max_bucket_width,
+											   InternalTimeRange *merged_refresh_window)
+{
+	long count;
+	count = continuous_agg_scan_refresh_window_ranges(refresh_window,
+													  invalidations,
+													  max_bucket_width,
+													  update_merged_refresh_window,
+													  (void *) merged_refresh_window,
+													  NULL /* arg2 */);
+	Assert(count);
+}
+
 static bool
 process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 									   const InternalTimeRange *refresh_window,
@@ -532,6 +581,9 @@ process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 {
 	InvalidationStore *invalidations;
 	Oid hyper_relid = ts_hypertable_id_to_relid(cagg->data.mat_hypertable_id);
+	bool do_merged_refresh = false;
+	InternalTimeRange merged_refresh_window;
+	long max_materializations;
 
 	/* Lock the continuous aggregate's materialized hypertable to protect
 	 * against concurrent refreshes. Only concurrent reads will be
@@ -542,9 +594,34 @@ process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 	 * windows.
 	 */
 	LockRelationOid(hyper_relid, ExclusiveLock);
-	invalidations = invalidation_process_cagg_log(cagg, refresh_window);
+	Hypertable *ht = cagg_get_hypertable_or_fail(cagg->data.raw_hypertable_id);
+	bool is_raw_ht_distributed = hypertable_is_distributed(ht);
+	CaggsInfo all_caggs_info = ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
+	if (is_raw_ht_distributed)
+	{
+		invalidations = NULL;
+		/* Force to always merge the refresh ranges in the distributed raw HyperTable case */
+		max_materializations = 0;
+		remote_invalidation_process_cagg_log(cagg->data.mat_hypertable_id,
+											 cagg->data.raw_hypertable_id,
+											 refresh_window,
+											 &all_caggs_info,
+											 &do_merged_refresh,
+											 &merged_refresh_window);
+	}
+	else
+	{
+		max_materializations = materialization_per_refresh_window();
+		invalidations = invalidation_process_cagg_log(cagg->data.mat_hypertable_id,
+													  cagg->data.raw_hypertable_id,
+													  refresh_window,
+													  &all_caggs_info,
+													  max_materializations,
+													  &do_merged_refresh,
+													  &merged_refresh_window);
+	}
 
-	if (invalidations != NULL)
+	if (invalidations != NULL || do_merged_refresh)
 	{
 		if (callctx == CAGG_REFRESH_CREATION)
 		{
@@ -554,8 +631,16 @@ process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 					 errhint("Use WITH NO DATA if you do not want to refresh the continuous "
 							 "aggregate on creation.")));
 		}
-		continuous_agg_refresh_with_window(cagg, refresh_window, invalidations, chunk_id);
-		invalidation_store_free(invalidations);
+		continuous_agg_refresh_with_window(cagg,
+										   refresh_window,
+										   invalidations,
+										   ts_continuous_agg_max_bucket_width(cagg),
+										   chunk_id,
+										   is_raw_ht_distributed,
+										   do_merged_refresh,
+										   merged_refresh_window);
+		if (invalidations)
+			invalidation_store_free(invalidations);
 		return true;
 	}
 
@@ -573,6 +658,7 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	int64 computed_invalidation_threshold;
 	int64 invalidation_threshold;
 	int64 max_bucket_width;
+	bool is_raw_ht_distributed;
 
 	/* Like regular materialized views, require owner to refresh. */
 	if (!pg_class_ownercheck(cagg->relid, GetUserId()))
@@ -590,6 +676,9 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	 * still take a long time and it is probably best for consistency to always
 	 * prevent transaction blocks.  */
 	PreventInTransactionBlock(true, REFRESH_FUNCTION_NAME);
+
+	Hypertable *ht = cagg_get_hypertable_or_fail(cagg->data.raw_hypertable_id);
+	is_raw_ht_distributed = hypertable_is_distributed(ht);
 
 	max_bucket_width = ts_continuous_agg_max_bucket_width(cagg);
 	refresh_window =
@@ -655,7 +744,22 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	}
 
 	/* Process invalidations in the hypertable invalidation log */
-	invalidation_process_hypertable_log(cagg, refresh_window.type);
+	CaggsInfo all_caggs_info = ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
+	if (is_raw_ht_distributed)
+	{
+		(void) invoke_invalidation_process_hypertable_log; /* TODO: remove me? */
+		remote_invalidation_process_hypertable_log(cagg->data.mat_hypertable_id,
+												   cagg->data.raw_hypertable_id,
+												   refresh_window.type,
+												   &all_caggs_info);
+	}
+	else
+	{
+		invalidation_process_hypertable_log(cagg->data.mat_hypertable_id,
+											cagg->data.raw_hypertable_id,
+											refresh_window.type,
+											&all_caggs_info);
+	}
 
 	/* Start a new transaction. Note that this invalidates previous memory
 	 * allocations (and locks). */
@@ -713,7 +817,11 @@ continuous_agg_refresh_chunk(PG_FUNCTION_ARGS)
 					AccessExclusiveLock);
 	invalidation_threshold_set_or_get(chunk->fd.hypertable_id, refresh_window.end);
 
-	invalidation_process_hypertable_log(cagg, refresh_window.type);
+	CaggsInfo all_caggs_info = ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
+	invalidation_process_hypertable_log(cagg->data.mat_hypertable_id,
+										cagg->data.raw_hypertable_id,
+										refresh_window.type,
+										&all_caggs_info);
 	/* Must make invalidation processing visible */
 	CommandCounterIncrement();
 	process_cagg_invalidations_and_refresh(cagg, &refresh_window, CAGG_REFRESH_CHUNK, chunk->fd.id);

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -11,6 +11,7 @@
 #include "continuous_aggs/materialize.h"
 
 #include "materialize.h"
+#include "invalidation.h"
 
 typedef enum CaggRefreshCallContext
 {
@@ -22,6 +23,9 @@ typedef enum CaggRefreshCallContext
 
 extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern Datum continuous_agg_refresh_chunk(PG_FUNCTION_ARGS);
+extern void continuous_agg_calculate_merged_refresh_window(
+	const InternalTimeRange *refresh_window, const InvalidationStore *invalidations,
+	const int64 max_bucket_width, InternalTimeRange *merged_refresh_window);
 extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,
 											const CaggRefreshCallContext callctx);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -122,15 +122,21 @@ CrossModuleFunctions tsl_cm_functions = {
 	.move_chunk_proc = tsl_move_chunk_proc,
 	.copy_chunk_proc = tsl_copy_chunk_proc,
 	.copy_chunk_cleanup_proc = tsl_copy_chunk_cleanup_proc,
+
+	/* Continuous Aggregates */
 	.partialize_agg = tsl_partialize_agg,
 	.finalize_agg_sfunc = tsl_finalize_agg_sfunc,
 	.finalize_agg_ffunc = tsl_finalize_agg_ffunc,
 	.process_cagg_viewstmt = tsl_process_continuous_agg_viewstmt,
 	.continuous_agg_invalidation_trigger = continuous_agg_trigfn,
-	.continuous_agg_update_options = continuous_agg_update_options,
 	.continuous_agg_refresh = continuous_agg_refresh,
 	.continuous_agg_refresh_chunk = continuous_agg_refresh_chunk,
 	.continuous_agg_invalidate = invalidation_add_entry,
+	.continuous_agg_update_options = continuous_agg_update_options,
+	.invalidation_cagg_log_add_initial_entry = tsl_invalidation_cagg_log_add_initial_entry,
+	.invalidation_process_hypertable_log = tsl_invalidation_process_hypertable_log,
+	.invalidation_process_cagg_log = tsl_invalidation_process_cagg_log,
+
 	.compressed_data_decompress_forward = tsl_compressed_data_decompress_forward,
 	.compressed_data_decompress_reverse = tsl_compressed_data_decompress_reverse,
 	.compressed_data_send = tsl_compressed_data_send,


### PR DESCRIPTION
For the `refresh_continuous_aggregate()` operation:
    
Support Continuous Aggregates over distributed hypertables by moving
1. hypertable log invalidation processing
2. materialization log invalidation processing
3. refresh window tuplestore processing
to the Data-Nodes.
    
This processing remains local for normal hypertables.
    
Refresh window tuplestore entries are not transferred over the network in the distributed case. In this case, refresh window merging is forced to limit the amount of network traffic per refresh operation.
