### PR TITLE
Fix execution of refresh_caggs from user actions

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -279,7 +279,8 @@ BEGIN
     LOOP
     SELECT total_successes, total_failures FROM _timescaledb_internal.bgw_job_stat WHERE job_id=job_param_id INTO r;
     IF (r.total_failures > 0) THEN
-        EXIT;
+        RAISE INFO 'wait_for_job_to_run: job execution failed';
+        RETURN false;
     ELSEIF (r.total_successes = expected_runs) THEN
         RETURN true;
     ELSEIF (r.total_successes > expected_runs) THEN
@@ -288,6 +289,7 @@ BEGIN
         PERFORM pg_sleep(0.1);
     END IF;
     END LOOP;
+    RAISE INFO 'wait_for_job_to_run: timeout after % tries', spins;
     RETURN false;
 END
 $BODY$;
@@ -320,6 +322,12 @@ BEGIN
     RAISE EXCEPTION 'forced exception';
     INSERT INTO custom_log VALUES($1, $2, 'custom_proc4 3 ABORT');
     COMMIT;
+END
+$$;
+CREATE OR REPLACE PROCEDURE custom_proc5(job_id int, args jsonb) LANGUAGE PLPGSQL AS
+$$
+BEGIN
+    CALL refresh_continuous_aggregate('conditions_summary_daily', '2021-08-01 00:00', '2021-08-31 00:00');
 END
 $$;
 -- Remove any default jobs, e.g., telemetry
@@ -378,6 +386,7 @@ TRUNCATE custom_log;
 -- Forced Exception
 SELECT add_job('custom_proc4', '1h', config := '{"type":"procedure"}'::jsonb, initial_start := now()) AS job_id_3 \gset
 SELECT wait_for_job_to_run(:job_id_3, 1);
+INFO:  wait_for_job_to_run: job execution failed
  wait_for_job_to_run 
 ---------------------
  f
@@ -398,12 +407,12 @@ SELECT delete_job(:job_id_3);
 (1 row)
 
 CREATE TABLE conditions (
-  time TIMESTAMPTZ NOT NULL,
+  time TIMESTAMP NOT NULL,
   location TEXT NOT NULL,
   location2 char(10) NOT NULL,
   temperature DOUBLE PRECISION NULL,
   humidity DOUBLE PRECISION NULL
-);
+) WITH (autovacuum_enabled = FALSE);
 SELECT create_hypertable('conditions', 'time', chunk_time_interval := '15 days'::interval);
     create_hypertable    
 -------------------------
@@ -443,6 +452,34 @@ SELECT * FROM _timescaledb_internal.compressed_chunk_stats ORDER BY chunk_name;
  public            | conditions      | _timescaledb_internal | _hyper_1_2_chunk | Compressed         |                   8192 |                   16384 |                    8192 |                   32768 |                 8192 |                 16384 |                  8192 |                 32768
  public            | conditions      | _timescaledb_internal | _hyper_1_3_chunk | Compressed         |                   8192 |                   16384 |                    8192 |                   32768 |                 8192 |                 16384 |                  8192 |                 32768
 (3 rows)
+
+-- Decompress chunks before create the cagg
+SELECT decompress_chunk(c) FROM show_chunks('conditions') c;
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+(3 rows)
+
+-- Continuous Aggregate
+CREATE MATERIALIZED VIEW conditions_summary_daily
+WITH (timescaledb.continuous) AS
+SELECT location,
+   time_bucket(INTERVAL '1 day', time) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature)
+FROM conditions
+GROUP BY location, bucket
+WITH NO DATA;
+-- Refresh Continous Aggregate by Job
+SELECT add_job('custom_proc5', '1h', config := '{"type":"procedure"}'::jsonb, initial_start := now()) AS job_id_5 \gset
+SELECT wait_for_job_to_run(:job_id_5, 1);
+ wait_for_job_to_run 
+---------------------
+ t
+(1 row)
 
 -- Stop Background Workers
 SELECT _timescaledb_internal.stop_background_workers();


### PR DESCRIPTION
When calling the `refresh_continous_aggregate` from a user defined
action (jobs) causes segmentation fault.

Fixed it by adding the `SPI_connect_ext/SPI finish` during the
execution because there are underlying SPI calls that lead us to a
nonexistent `_SPI_current` global variable.