### PR TITLE
Add shared dependencies when creating chunk

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -13,9 +13,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v2
-
-    - id: set-matrix
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Build matrix
+      id: set-matrix
       run: python scripts/gh_matrix_builder.py ${{ github.event_name }}
 
   regress:
@@ -43,6 +44,7 @@ jobs:
     - name: Install macOS Dependencies using Perl
       if: runner.os == 'macOS'
       run: |
+        brew install openssl
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'IPC::Run')"
         sudo perl -MCPAN -e "CPAN::Shell->notest('install', 'Test::Most')"
 

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -90,3 +90,104 @@ CREATE database test_drop_owned;
 DROP OWNED BY :ROLE_SUPERUSER;
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE test_drop_owned;
+-- Test that dependencies on roles are added to chunks when creating
+-- new chunks. If that is not done, DROP OWNED BY will not revoke the
+-- privilege on the chunk.
+CREATE TABLE sensor_data(time timestamptz not null, cpu double precision null);
+SELECT * FROM create_hypertable('sensor_data','time');
+ hypertable_id | schema_name | table_name  | created 
+---------------+-------------+-------------+---------
+             3 | public      | sensor_data | t
+(1 row)
+
+INSERT INTO sensor_data
+SELECT time + (INTERVAL '1 minute' * random()) AS time,
+       random() AS cpu
+FROM generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 week', INTERVAL '10 minute') AS g1(time);
+\dp sensor_data
+                                Access privileges
+ Schema |    Name     | Type  | Access privileges | Column privileges | Policies 
+--------+-------------+-------+-------------------+-------------------+----------
+ public | sensor_data | table |                   |                   | 
+(1 row)
+
+\dp _timescaledb_internal._hyper_3*
+                                          Access privileges
+        Schema         |       Name       | Type  | Access privileges | Column privileges | Policies 
+-----------------------+------------------+-------+-------------------+-------------------+----------
+ _timescaledb_internal | _hyper_3_3_chunk | table |                   |                   | 
+ _timescaledb_internal | _hyper_3_4_chunk | table |                   |                   | 
+ _timescaledb_internal | _hyper_3_5_chunk | table |                   |                   | 
+ _timescaledb_internal | _hyper_3_6_chunk | table |                   |                   | 
+ _timescaledb_internal | _hyper_3_7_chunk | table |                   |                   | 
+(5 rows)
+
+GRANT SELECT ON sensor_data TO :ROLE_DEFAULT_PERM_USER;
+\dp sensor_data
+                                      Access privileges
+ Schema |    Name     | Type  |       Access privileges        | Column privileges | Policies 
+--------+-------------+-------+--------------------------------+-------------------+----------
+ public | sensor_data | table | super_user=arwdDxt/super_user +|                   | 
+        |             |       | default_perm_user=r/super_user |                   | 
+(1 row)
+
+\dp _timescaledb_internal._hyper_3*
+                                                Access privileges
+        Schema         |       Name       | Type  |       Access privileges        | Column privileges | Policies 
+-----------------------+------------------+-------+--------------------------------+-------------------+----------
+ _timescaledb_internal | _hyper_3_3_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_4_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_5_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_6_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_7_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+(5 rows)
+
+-- Insert more chunks after adding the user to the hypertable. These
+-- will now get the privileges of the hypertable.
+INSERT INTO sensor_data
+SELECT time + (INTERVAL '1 minute' * random()) AS time, random() AS cpu
+  FROM generate_series(now() - INTERVAL '1 week', now(), INTERVAL '10 minute') AS g1(time);
+\dp _timescaledb_internal._hyper_3*
+                                                Access privileges
+        Schema         |       Name       | Type  |       Access privileges        | Column privileges | Policies 
+-----------------------+------------------+-------+--------------------------------+-------------------+----------
+ _timescaledb_internal | _hyper_3_3_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_4_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_5_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_6_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_7_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+ _timescaledb_internal | _hyper_3_8_chunk | table | super_user=arwdDxt/super_user +|                   | 
+                       |                  |       | default_perm_user=r/super_user |                   | 
+(6 rows)
+
+-- This should revoke the privileges on both the hypertable and the chunks.
+DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
+\dp sensor_data
+                                      Access privileges
+ Schema |    Name     | Type  |       Access privileges       | Column privileges | Policies 
+--------+-------------+-------+-------------------------------+-------------------+----------
+ public | sensor_data | table | super_user=arwdDxt/super_user |                   | 
+(1 row)
+
+\dp _timescaledb_internal._hyper_3*
+                                                Access privileges
+        Schema         |       Name       | Type  |       Access privileges       | Column privileges | Policies 
+-----------------------+------------------+-------+-------------------------------+-------------------+----------
+ _timescaledb_internal | _hyper_3_3_chunk | table | super_user=arwdDxt/super_user |                   | 
+ _timescaledb_internal | _hyper_3_4_chunk | table | super_user=arwdDxt/super_user |                   | 
+ _timescaledb_internal | _hyper_3_5_chunk | table | super_user=arwdDxt/super_user |                   | 
+ _timescaledb_internal | _hyper_3_6_chunk | table | super_user=arwdDxt/super_user |                   | 
+ _timescaledb_internal | _hyper_3_7_chunk | table | super_user=arwdDxt/super_user |                   | 
+ _timescaledb_internal | _hyper_3_8_chunk | table | super_user=arwdDxt/super_user |                   | 
+(6 rows)
+


### PR DESCRIPTION
When a new chunk is created, the ACL is copied from the hypertable, but
the shared dependencies are not set at all. Since there is no shared
dependency, a `DROP OWNED BY` will not find the chunk and revoke the
privileges for the user from the chunk. When the user is later dropped,
the ACL for the chunk will contain a non-existent user.

This commit fixes this by adding shared dependencies of the hypertable
to the chunk when the chunk is created.

Fixes #3614