### PR TITLE
Fix memory context bug executing TRUNCATE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ accidentally triggering the load of a previous DB version.**
 ## Unreleased
 
 **Bugfixes**
+* #3580 Fix memory context bug executing TRUNCATE
 * #3654 Fix index attnum mapping in reorder_chunk
+
+**Thanks**
+* @hardikm10, @DavidPavlicek and @pafiti for reporting bugs on TRUNCATE
 
 ## 2.4.2 (2021-09-21)
 

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -152,6 +152,58 @@ SELECT * FROM truncate_normal;
      1
 (1 row)
 
+-- fix for bug #3580
+\set ON_ERROR_STOP 0
+TRUNCATE nonexistentrelation;
+ERROR:  relation "nonexistentrelation" does not exist
+\set ON_ERROR_STOP 1
+CREATE TABLE truncate_nested (color int);
+INSERT INTO truncate_nested VALUES (2);
+SELECT * FROM truncate_normal, truncate_nested;
+ color | color 
+-------+-------
+     1 |     2
+(1 row)
+
+CREATE FUNCTION fn_truncate_nested()
+RETURNS trigger LANGUAGE plpgsql
+AS $$
+BEGIN
+    TRUNCATE truncate_nested;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER tg_truncate_nested
+    BEFORE TRUNCATE ON truncate_normal
+    FOR EACH STATEMENT EXECUTE FUNCTION fn_truncate_nested();
+TRUNCATE truncate_normal;
+SELECT * FROM truncate_normal, truncate_nested;
+ color | color 
+-------+-------
+(0 rows)
+
+INSERT INTO truncate_normal VALUES (3);
+INSERT INTO truncate_nested VALUES (4);
+SELECT * FROM truncate_normal, truncate_nested;
+ color | color 
+-------+-------
+     3 |     4
+(1 row)
+
+TRUNCATE truncate_normal;
+SELECT * FROM truncate_normal, truncate_nested;
+ color | color 
+-------+-------
+(0 rows)
+
+INSERT INTO truncate_normal VALUES (5);
+INSERT INTO truncate_nested VALUES (6);
+SELECT * FROM truncate_normal, truncate_nested;
+ color | color 
+-------+-------
+     5 |     6
+(1 row)
+
 SELECT * FROM test.show_subtables('"two_Partitions"');
                  Child                  | Tablespace 
 ----------------------------------------+------------
@@ -174,8 +226,8 @@ SELECT * FROM "two_Partitions";
 ------------+-----------+----------+----------+----------+-------------
 (0 rows)
 
-SELECT * FROM truncate_normal;
- color 
--------
+SELECT * FROM truncate_normal, truncate_nested;
+ color | color 
+-------+-------
 (0 rows)
 

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -552,7 +552,6 @@ _timescaledb_internal._dist_hyper_2_5_chunk|        4|f         |          0|   
 -- Clean up
 RESET ROLE;
 TRUNCATE disttable;
-TRUNCATE costtable;
 SELECT * FROM delete_data_node('data_node_1', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
 NOTICE:  the number of partitions in dimension "device" was decreased to 1

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -254,7 +254,6 @@ $$);
 -- Clean up
 RESET ROLE;
 TRUNCATE disttable;
-TRUNCATE costtable;
 SELECT * FROM delete_data_node('data_node_1', force => true);
 SELECT * FROM delete_data_node('data_node_2', force => true);
 DROP DATABASE :DN_DBNAME_1;


### PR DESCRIPTION
Inside the `process_truncate` function is created a new relations list
removing the distributed hypertables and this new list is assigned to
the current statement relation list. This new list is allocated into
the `PortalContext` that is destroyed at the end of the statement
execution.

The problem arise on the subsequent `TRUNCATE` call because the
compiled plpgsql code is cached into another memory context and the
elements of the relations inside this cache is pointing to an invalid
memory area because the `PortalContext` is destroyed.

Fixed it by allocating the new relations list to the same memory
context of the original list.

Fixes #3580, fixes #3622, fixes #3182