### PR TITLE
Fix flaky drop_owned test

### DIFF
--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -101,9 +101,9 @@ SELECT * FROM create_hypertable('sensor_data','time');
 (1 row)
 
 INSERT INTO sensor_data
-SELECT time + (INTERVAL '1 minute' * random()) AS time,
+SELECT time,
        random() AS cpu
-FROM generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 week', INTERVAL '10 minute') AS g1(time);
+FROM generate_series('2020-01-01'::timestamptz, '2020-01-24'::timestamptz, INTERVAL '10 minute') AS g1(time);
 \dp sensor_data
                                 Access privileges
  Schema |    Name     | Type  | Access privileges | Column privileges | Policies 
@@ -150,8 +150,9 @@ GRANT SELECT ON sensor_data TO :ROLE_DEFAULT_PERM_USER;
 -- Insert more chunks after adding the user to the hypertable. These
 -- will now get the privileges of the hypertable.
 INSERT INTO sensor_data
-SELECT time + (INTERVAL '1 minute' * random()) AS time, random() AS cpu
-  FROM generate_series(now() - INTERVAL '1 week', now(), INTERVAL '10 minute') AS g1(time);
+SELECT time,
+       random() AS cpu
+FROM generate_series('2020-01-20'::timestamptz, '2020-02-05'::timestamptz, INTERVAL '10 minute') AS g1(time);
 \dp _timescaledb_internal._hyper_3*
                                                 Access privileges
         Schema         |       Name       | Type  |       Access privileges        | Column privileges | Policies 

--- a/test/sql/drop_owned.sql
+++ b/test/sql/drop_owned.sql
@@ -51,9 +51,9 @@ CREATE TABLE sensor_data(time timestamptz not null, cpu double precision null);
 SELECT * FROM create_hypertable('sensor_data','time');
 
 INSERT INTO sensor_data
-SELECT time + (INTERVAL '1 minute' * random()) AS time,
+SELECT time,
        random() AS cpu
-FROM generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 week', INTERVAL '10 minute') AS g1(time);
+FROM generate_series('2020-01-01'::timestamptz, '2020-01-24'::timestamptz, INTERVAL '10 minute') AS g1(time);
 
 \dp sensor_data
 \dp _timescaledb_internal._hyper_3*
@@ -66,8 +66,9 @@ GRANT SELECT ON sensor_data TO :ROLE_DEFAULT_PERM_USER;
 -- Insert more chunks after adding the user to the hypertable. These
 -- will now get the privileges of the hypertable.
 INSERT INTO sensor_data
-SELECT time + (INTERVAL '1 minute' * random()) AS time, random() AS cpu
-  FROM generate_series(now() - INTERVAL '1 week', now(), INTERVAL '10 minute') AS g1(time);
+SELECT time,
+       random() AS cpu
+FROM generate_series('2020-01-20'::timestamptz, '2020-02-05'::timestamptz, INTERVAL '10 minute') AS g1(time);
 
 \dp _timescaledb_internal._hyper_3*
 


### PR DESCRIPTION
Using now() in regression tests will result in flaky tests as this
can result in creating different number of chunks depending on
alignment of now() relative to chunk boundaries.