### PR TITLE
Switch appveyor to preview image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Previous Visual Studio 2019
+image: Visual Studio 2019 Preview
 services:
   - postgresql12
   - docker


### PR DESCRIPTION
Since there is an issue with the current appveyor image we switch
appveyor to the preview image which runs CI fine.