### PR TITLE
[>=2.6.x] Rename continuous_aggs_invalidation_threshold.watermark to .threshold

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -282,7 +282,7 @@ SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_agg'
 
 CREATE TABLE IF NOT EXISTS _timescaledb_catalog.continuous_aggs_invalidation_threshold (
   hypertable_id integer PRIMARY KEY REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE,
-  watermark bigint NOT NULL
+  threshold bigint NOT NULL
 );
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_invalidation_threshold', '');

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -3,3 +3,5 @@ DROP FUNCTION IF EXISTS _timescaledb_internal.time_col_type_for_chunk(name,name)
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.subtract_integer_from_now( hypertable_relid REGCLASS, lag INT8 )
 RETURNS INT8 AS '@MODULE_PATHNAME@', 'ts_subtract_integer_from_now' LANGUAGE C STABLE STRICT;
+
+ALTER TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold RENAME COLUMN watermark TO threshold;

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -976,7 +976,7 @@ typedef enum Anum_continuous_aggs_hypertable_invalidation_log_idx
 typedef enum Anum_continuous_aggs_invalidation_threshold
 {
 	Anum_continuous_aggs_invalidation_threshold_hypertable_id = 1,
-	Anum_continuous_aggs_invalidation_threshold_watermark,
+	Anum_continuous_aggs_invalidation_threshold_threshold,
 	_Anum_continuous_aggs_invalidation_threshold_max,
 } Anum_continuous_aggs_invalidation_threshold;
 

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -353,7 +353,7 @@ invalidation_tuple_found(TupleInfo *ti, void *min)
 {
 	bool isnull;
 	Datum watermark =
-		slot_getattr(ti->slot, Anum_continuous_aggs_invalidation_threshold_watermark, &isnull);
+		slot_getattr(ti->slot, Anum_continuous_aggs_invalidation_threshold_threshold, &isnull);
 
 	Assert(!isnull);
 

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -165,7 +165,7 @@ invalidation_threshold_set_or_get(int32 raw_hypertable_id, int64 invalidation_th
 
 		values[AttrNumberGetAttrOffset(Anum_continuous_aggs_invalidation_threshold_hypertable_id)] =
 			Int32GetDatum(raw_hypertable_id);
-		values[AttrNumberGetAttrOffset(Anum_continuous_aggs_invalidation_threshold_watermark)] =
+		values[AttrNumberGetAttrOffset(Anum_continuous_aggs_invalidation_threshold_threshold)] =
 			Int64GetDatum(invalidation_threshold);
 
 		ts_catalog_insert_values(rel, desc, values, nulls);
@@ -181,7 +181,7 @@ invalidation_threshold_tuple_found(TupleInfo *ti, void *data)
 	int64 *threshold = data;
 	bool isnull;
 	Datum datum =
-		slot_getattr(ti->slot, Anum_continuous_aggs_invalidation_threshold_watermark, &isnull);
+		slot_getattr(ti->slot, Anum_continuous_aggs_invalidation_threshold_threshold, &isnull);
 
 	Assert(!isnull);
 	*threshold = DatumGetInt64(datum);

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -144,7 +144,7 @@ SELECT materialization_id AS cagg_id,
 -- set:
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
 (0 rows)
 
@@ -162,7 +162,7 @@ SELECT * FROM cagg_invals;
 CALL refresh_continuous_aggregate('cond_10', 1, 50);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        50
 (1 row)
@@ -193,7 +193,7 @@ CALL refresh_continuous_aggregate('cond_10', 20, 49);
 NOTICE:  continuous aggregate "cond_10" is already up-to-date
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        50
 (1 row)
@@ -213,7 +213,7 @@ SELECT * FROM cagg_invals;
 CALL refresh_continuous_aggregate('measure_10', 0, 30);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        50
              2 |        30
@@ -234,7 +234,7 @@ SELECT * FROM cagg_invals;
 CALL refresh_continuous_aggregate('cond_20', 60, 100);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |       100
              2 |        30
@@ -306,7 +306,7 @@ CALL refresh_continuous_aggregate('cond_10', 20, 60);
 -- Invalidation threshold remains at 100:
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |       100
              2 |        30
@@ -855,7 +855,7 @@ WHERE user_view_name = 'thresh_2' \gset
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
 (0 rows)
 
@@ -867,7 +867,7 @@ NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
- hypertable_id |  watermark  
+ hypertable_id |  threshold  
 ---------------+-------------
              7 | -2147483648
 (1 row)
@@ -881,7 +881,7 @@ CALL refresh_continuous_aggregate('thresh_2', 0, 5);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              7 |         4
 (1 row)
@@ -890,11 +890,11 @@ ORDER BY 1,2;
 -- max data value
 CALL refresh_continuous_aggregate('thresh_2', 14, NULL);
 NOTICE:  continuous aggregate "thresh_2" is already up-to-date
-SELECT watermark AS thresh_hyper_id_watermark
+SELECT threshold AS thresh_hyper_id_threshold
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id \gset
--- Refresh where we start from the current watermark to infinity
-CALL refresh_continuous_aggregate('thresh_2', :thresh_hyper_id_watermark, NULL);
+-- Refresh where we start from the current invalidation threshold to infinity
+CALL refresh_continuous_aggregate('thresh_2', :thresh_hyper_id_threshold, NULL);
 NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 -- Now refresh with max end of the window to test that the
 -- invalidation threshold is capped at the last bucket of data
@@ -902,7 +902,7 @@ CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              7 |        12
 (1 row)
@@ -980,7 +980,7 @@ ORDER BY 1;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              7 |        12
 (1 row)
@@ -1010,7 +1010,7 @@ ORDER BY 1;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              7 |        16
 (1 row)

--- a/tsl/test/expected/continuous_aggs_multi.out
+++ b/tsl/test/expected/continuous_aggs_multi.out
@@ -86,7 +86,7 @@ select * from cagg_2 order by 1,2;
 (5 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        18
 (1 row)
@@ -96,7 +96,7 @@ SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
 INSERT INTO continuous_agg_test VALUES
     (10, -4, 10), (11, - 3, 50), (11, - 3, 70), (10, - 4, 10);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        18
 (1 row)
@@ -294,7 +294,7 @@ select * from cagg_2 order by 1;
 
 SET ROLE :ROLE_SUPERUSER;
 select * from _timescaledb_catalog.continuous_aggs_invalidation_threshold order by 1;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              4 |        18
 (1 row)

--- a/tsl/test/expected/continuous_aggs_query-13.out
+++ b/tsl/test/expected/continuous_aggs_query-13.out
@@ -803,7 +803,7 @@ SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:
 
 -- The watermark should, in this case, be the same as the invalidation
 -- threshold
-SELECT _timescaledb_internal.to_timestamp(watermark)
+SELECT _timescaledb_internal.to_timestamp(threshold)
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :raw_id;
          to_timestamp         
@@ -853,7 +853,7 @@ SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:
 
 -- Since we removed the last chunk, the invalidation threshold doesn't
 -- move back, while the watermark does.
-SELECT _timescaledb_internal.to_timestamp(watermark)
+SELECT _timescaledb_internal.to_timestamp(threshold)
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :raw_id;
          to_timestamp         

--- a/tsl/test/expected/continuous_aggs_watermark.out
+++ b/tsl/test/expected/continuous_aggs_watermark.out
@@ -18,7 +18,7 @@ SELECT set_integer_now_func('continuous_agg_test', 'integer_now_test1');
 
 -- watermark tabels start out empty
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
 (0 rows)
 
@@ -30,7 +30,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 -- inserting into a table that does not have continuous_agg_insert_trigger doesn't change the watermark
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
 (0 rows)
 
@@ -60,7 +60,7 @@ CREATE TRIGGER continuous_agg_insert_trigger
 -- entire table anyway.
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
 (0 rows)
 
@@ -75,7 +75,7 @@ INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2), (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -89,7 +89,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 -- INSERTs only above the continuous_aggs_invalidation_threshold won't change the continuous_aggs_hypertable_invalidation_log
 INSERT INTO continuous_agg_test VALUES (21, 3), (22, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -103,7 +103,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 -- INSERTs only below the continuous_aggs_invalidation_threshold will change the continuous_aggs_hypertable_invalidation_log
 INSERT INTO continuous_agg_test VALUES (10, 1), (11, 2);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -118,7 +118,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 -- test INSERTing other values
 INSERT INTO continuous_agg_test VALUES (1, 7), (12, 6), (24, 5), (51, 4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -135,7 +135,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 ALTER TABLE continuous_agg_test DROP COLUMN data;
 INSERT INTO continuous_agg_test VALUES (-1), (-2), (-3), (-4);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -151,7 +151,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
 INSERT INTO continuous_agg_test VALUES (100);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -169,7 +169,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 ALTER TABLE continuous_agg_test ADD COLUMN d BOOLEAN;
 INSERT INTO continuous_agg_test VALUES (-6, true), (-7, false), (-3, true), (-4, false);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -186,7 +186,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
 INSERT INTO continuous_agg_test VALUES (120, false), (200, true);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              1 |        15
 (1 row)
@@ -233,7 +233,7 @@ CREATE MATERIALIZED VIEW cit_view
         GROUP BY 1 WITH NO DATA;
 INSERT INTO ca_inval_test SELECT generate_series(0, 5);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
 (0 rows)
 
@@ -247,7 +247,7 @@ INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 INSERT INTO ca_inval_test SELECT generate_series(5, 15);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              3 |        15
 (1 row)
@@ -260,7 +260,7 @@ SELECT * from _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log;
 
 INSERT INTO ca_inval_test SELECT generate_series(16, 20);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              3 |        15
 (1 row)
@@ -283,7 +283,7 @@ UPDATE ca_inval_test SET time = 12 WHERE time = 16;
 UPDATE ca_inval_test SET time = 19 WHERE time = 18;
 UPDATE ca_inval_test SET time = 17 WHERE time = 19;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              3 |        15
 (1 row)
@@ -328,7 +328,7 @@ CREATE MATERIALIZED VIEW continuous_view
         FROM ts_continuous_test
         GROUP BY 1 WITH NO DATA;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
 (0 rows)
 
@@ -342,7 +342,7 @@ INSERT INTO _timescaledb_catalog.continuous_aggs_invalidation_threshold VALUES (
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 INSERT INTO ts_continuous_test VALUES (1, 1);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              5 |         2
 (1 row)
@@ -358,7 +358,7 @@ BEGIN;
     INSERT INTO ts_continuous_test VALUES (-20, -20);
 ABORT;
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold;
- hypertable_id | watermark 
+ hypertable_id | threshold 
 ---------------+-----------
              5 |         2
 (1 row)

--- a/tsl/test/sql/continuous_aggs_invalidation.sql
+++ b/tsl/test/sql/continuous_aggs_invalidation.sql
@@ -494,12 +494,12 @@ ORDER BY 1,2;
 -- max data value
 CALL refresh_continuous_aggregate('thresh_2', 14, NULL);
 
-SELECT watermark AS thresh_hyper_id_watermark
+SELECT threshold AS thresh_hyper_id_threshold
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id \gset
 
--- Refresh where we start from the current watermark to infinity
-CALL refresh_continuous_aggregate('thresh_2', :thresh_hyper_id_watermark, NULL);
+-- Refresh where we start from the current invalidation threshold to infinity
+CALL refresh_continuous_aggregate('thresh_2', :thresh_hyper_id_threshold, NULL);
 
 -- Now refresh with max end of the window to test that the
 -- invalidation threshold is capped at the last bucket of data

--- a/tsl/test/sql/continuous_aggs_query.sql.in
+++ b/tsl/test/sql/continuous_aggs_query.sql.in
@@ -243,7 +243,7 @@ SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:
 
 -- The watermark should, in this case, be the same as the invalidation
 -- threshold
-SELECT _timescaledb_internal.to_timestamp(watermark)
+SELECT _timescaledb_internal.to_timestamp(threshold)
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :raw_id;
 
@@ -268,7 +268,7 @@ SELECT _timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(:
 
 -- Since we removed the last chunk, the invalidation threshold doesn't
 -- move back, while the watermark does.
-SELECT _timescaledb_internal.to_timestamp(watermark)
+SELECT _timescaledb_internal.to_timestamp(threshold)
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :raw_id;
 


### PR DESCRIPTION
The continuous_aggs_invalidation_threshold catalog table uses a column name
`watermark`, which is a wrong term. This patch renames it to `threshold` to
avoid any confusion by the developers, especially new ones.

A watermark is a timestamp determinate as a border between the materialized
and "hot" data. Watermark is used by the CAGG views. See \d+ of any CAGG and
the definition of _timescaledb_internal.cagg_watermark() function.

What is stored in this table is called `invalidation threshold`. It is used by
the invalidation trigger to determine whether a record should be made to the
hypertable invalidation log.

These are different values. The invalidation threshold is updated immediately
after step 1 of the refresh of given CAGG. It can't be used by the views the
same way as `watermark`, because the data is not materialized until step 2
of the refresh finishes.