### PR TITLE
Fix SkipScan path generation with constant DISTINCT column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #3580 Fix memory context bug executing TRUNCATE
 * #3654 Fix index attnum mapping in reorder_chunk
+* #3661 Fix SkipScan path generation with constant DISTINCT column
+
+**Thanks**
+* @binakot and @sebvett for reporting an issue with DISTINCT queries
 
 **Thanks**
 * @hardikm10, @DavidPavlicek and @pafiti for reporting bugs on TRUNCATE

--- a/tsl/test/expected/plan_skip_scan-12.out
+++ b/tsl/test/expected/plan_skip_scan-12.out
@@ -3917,3 +3917,35 @@ EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_n
                      Index Cond: (dev_name > NULL::text)
 (15 rows)
 
+-- #3629 skipscan with constant skipscan column in where clause
+CREATE TABLE i3629(a int, time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('i3629', 'time');
+ table_name 
+------------
+ i3629
+(1 row)
+
+INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
+EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+                   QUERY PLAN                   
+------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: _hyper_3_6_chunk."time" DESC
+         ->  Append
+               ->  Seq Scan on _hyper_3_6_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_7_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_8_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_9_chunk
+                     Filter: (a = 2)
+(12 rows)
+
+SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+ a |             time             
+---+------------------------------
+ 2 | Fri Mar 20 00:00:00 2020 PDT
+(1 row)
+

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -3909,3 +3909,35 @@ EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_n
                      Index Cond: (dev_name > NULL::text)
 (15 rows)
 
+-- #3629 skipscan with constant skipscan column in where clause
+CREATE TABLE i3629(a int, time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('i3629', 'time');
+ table_name 
+------------
+ i3629
+(1 row)
+
+INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
+EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+                   QUERY PLAN                   
+------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: _hyper_3_6_chunk."time" DESC
+         ->  Append
+               ->  Seq Scan on _hyper_3_6_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_7_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_8_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_9_chunk
+                     Filter: (a = 2)
+(12 rows)
+
+SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+ a |             time             
+---+------------------------------
+ 2 | Fri Mar 20 00:00:00 2020 PDT
+(1 row)
+

--- a/tsl/test/expected/plan_skip_scan-14.out
+++ b/tsl/test/expected/plan_skip_scan-14.out
@@ -3909,3 +3909,35 @@ EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_n
                      Index Cond: (dev_name > NULL::text)
 (15 rows)
 
+-- #3629 skipscan with constant skipscan column in where clause
+CREATE TABLE i3629(a int, time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('i3629', 'time');
+ table_name 
+------------
+ i3629
+(1 row)
+
+INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
+EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+                   QUERY PLAN                   
+------------------------------------------------
+ Unique
+   ->  Sort
+         Sort Key: _hyper_3_6_chunk."time" DESC
+         ->  Append
+               ->  Seq Scan on _hyper_3_6_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_7_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_8_chunk
+                     Filter: (a = 2)
+               ->  Seq Scan on _hyper_3_9_chunk
+                     Filter: (a = 2)
+(12 rows)
+
+SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+ a |             time             
+---+------------------------------
+ 2 | Fri Mar 20 00:00:00 2020 PDT
+(1 row)
+

--- a/tsl/test/sql/plan_skip_scan.sql.in
+++ b/tsl/test/sql/plan_skip_scan.sql.in
@@ -18,3 +18,11 @@
 -- try one query with EXPLAIN only for coverage
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan;
 EXPLAIN (costs off, timing off, summary off) SELECT DISTINCT ON (dev_name) dev_name FROM skip_scan_ht;
+
+-- #3629 skipscan with constant skipscan column in where clause
+CREATE TABLE i3629(a int, time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('i3629', 'time');
+INSERT INTO i3629 SELECT i, '2020-04-01'::date-10-i from generate_series(1,20) i;
+EXPLAIN (SUMMARY OFF, COSTS OFF) SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
+


### PR DESCRIPTION
When a DISTINCT query has a WHERE clause that constifies the
DISTINCT column the query might use an index that does not have
include the DISTINCT column even though it is referenced in the
ORDER BY clause. The skipscan path generation would error on any
path with such a configuration. This patch changes the path
generation code to skip generating SkipScan path under these
circumstances.

Fixes #3629