### PR TITLE
Don't use VACUUM VERBOSE in vacuum tests

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -113,7 +113,7 @@ pg14_debug_latest = {
   "pg": PG14_LATEST,
   "tsdb_build_args": "-DWARNINGS_AS_ERRORS=OFF -DEXPERIMENTAL=ON",
   "coverage": False,
-  "installcheck_args": "IGNORES='dist_hypertable-14 dist_partial_agg dist_query dist_triggers insert-14 partition upsert vacuum vacuum_parallel'"
+  "installcheck_args": "IGNORES='dist_hypertable-14 dist_partial_agg dist_query dist_triggers insert-14 partition upsert'"
 }
 m["include"].append(build_debug_config(pg14_debug_latest))
 

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -31,27 +31,7 @@ ORDER BY tablename, attname, array_to_string(histogram_bounds, ',');
 -----------+---------+------------------+------------
 (0 rows)
 
-VACUUM (VERBOSE, ANALYZE) vacuum_test;
-INFO:  vacuuming "_timescaledb_internal._hyper_1_1_chunk"
-INFO:  "_hyper_1_1_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_1_1_chunk"
-INFO:  "_hyper_1_1_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "_timescaledb_internal._hyper_1_2_chunk"
-INFO:  "_hyper_1_2_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_1_2_chunk"
-INFO:  "_hyper_1_2_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "_timescaledb_internal._hyper_1_3_chunk"
-INFO:  "_hyper_1_3_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_1_3_chunk"
-INFO:  "_hyper_1_3_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "public.vacuum_test"
-INFO:  "vacuum_test": found 0 removable, 0 nonremovable row versions in 0 out of 0 pages
-INFO:  analyzing "public.vacuum_test"
-INFO:  "vacuum_test": scanned 0 of 0 pages, containing 0 live rows and 0 dead rows; 0 rows in sample, 0 estimated total rows
-INFO:  analyzing "public.vacuum_test" inheritance tree
-INFO:  "_hyper_1_1_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  "_hyper_1_2_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  "_hyper_1_3_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+VACUUM ANALYZE vacuum_test;
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'
@@ -153,11 +133,7 @@ INSERT INTO vacuum_norm VALUES ('2017-01-20T09:00:01', 17.5),
                                ('2017-04-21T09:00:01', 17.1),
                                ('2017-06-20T09:00:01', 18.5),
                                ('2017-06-21T09:00:01', 11.0);
-VACUUM (VERBOSE, ANALYZE) vacuum_norm;
-INFO:  vacuuming "public.vacuum_norm"
-INFO:  "vacuum_norm": found 0 removable, 6 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "public.vacuum_norm"
-INFO:  "vacuum_norm": scanned 1 of 1 pages, containing 6 live rows and 0 dead rows; 6 rows in sample, 6 estimated total rows
+VACUUM ANALYZE vacuum_norm;
 DROP TABLE vacuum_norm;
 --Similar to normal vacuum tests, but PG11 introduced ability to vacuum multiple tables at once, we make sure that works for hypertables as well.
 CREATE TABLE vacuum_test(time timestamp, temp float);
@@ -211,51 +187,7 @@ ORDER BY tablename, attname, array_to_string(histogram_bounds, ',');
 -----------+---------+------------------+------------
 (0 rows)
 
-VACUUM (VERBOSE, ANALYZE) vacuum_norm, vacuum_test, analyze_test;
-INFO:  vacuuming "_timescaledb_internal._hyper_3_7_chunk"
-INFO:  "_hyper_3_7_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_3_7_chunk"
-INFO:  "_hyper_3_7_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "_timescaledb_internal._hyper_3_8_chunk"
-INFO:  "_hyper_3_8_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_3_8_chunk"
-INFO:  "_hyper_3_8_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "_timescaledb_internal._hyper_3_9_chunk"
-INFO:  "_hyper_3_9_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_3_9_chunk"
-INFO:  "_hyper_3_9_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "_timescaledb_internal._hyper_4_10_chunk"
-INFO:  "_hyper_4_10_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_4_10_chunk"
-INFO:  "_hyper_4_10_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "_timescaledb_internal._hyper_4_11_chunk"
-INFO:  "_hyper_4_11_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_4_11_chunk"
-INFO:  "_hyper_4_11_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "_timescaledb_internal._hyper_4_12_chunk"
-INFO:  "_hyper_4_12_chunk": found 0 removable, 2 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "_timescaledb_internal._hyper_4_12_chunk"
-INFO:  "_hyper_4_12_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "public.vacuum_norm"
-INFO:  "vacuum_norm": found 0 removable, 6 nonremovable row versions in 1 out of 1 pages
-INFO:  analyzing "public.vacuum_norm"
-INFO:  "vacuum_norm": scanned 1 of 1 pages, containing 6 live rows and 0 dead rows; 6 rows in sample, 6 estimated total rows
-INFO:  vacuuming "public.vacuum_test"
-INFO:  "vacuum_test": found 0 removable, 0 nonremovable row versions in 0 out of 0 pages
-INFO:  analyzing "public.vacuum_test"
-INFO:  "vacuum_test": scanned 0 of 0 pages, containing 0 live rows and 0 dead rows; 0 rows in sample, 0 estimated total rows
-INFO:  analyzing "public.vacuum_test" inheritance tree
-INFO:  "_hyper_3_7_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  "_hyper_3_8_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  "_hyper_3_9_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  vacuuming "public.analyze_test"
-INFO:  "analyze_test": found 0 removable, 0 nonremovable row versions in 0 out of 0 pages
-INFO:  analyzing "public.analyze_test"
-INFO:  "analyze_test": scanned 0 of 0 pages, containing 0 live rows and 0 dead rows; 0 rows in sample, 0 estimated total rows
-INFO:  analyzing "public.analyze_test" inheritance tree
-INFO:  "_hyper_4_10_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  "_hyper_4_11_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
-INFO:  "_hyper_4_12_chunk": scanned 1 of 1 pages, containing 2 live rows and 0 dead rows; 2 rows in sample, 2 estimated total rows
+VACUUM ANALYZE vacuum_norm, vacuum_test, analyze_test;
 -- stats should exist for all 6 chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = '_timescaledb_internal' AND tablename LIKE '_hyper_%_chunk'

--- a/test/expected/vacuum_parallel.out
+++ b/test/expected/vacuum_parallel.out
@@ -34,37 +34,5 @@ CREATE INDEX ON _hyper_1_3_chunk(temp2);
 -- INSERT only will not trigger vacuum on indexes for PG13.3+
 UPDATE vacuum_test SET time = time + '1s'::interval, temp1 = random(), temp2 = random();
 -- we should see two parallel workers for each chunk
-VACUUM (PARALLEL 3, VERBOSE) vacuum_test;
-INFO:  vacuuming "public._hyper_1_1_chunk"
-INFO:  launched 2 parallel vacuum workers for index vacuuming (planned: 2)
-INFO:  scanned index "_hyper_1_1_chunk_time_idx" to remove 41 row versions
-INFO:  scanned index "_hyper_1_1_chunk_temp1_idx" to remove 41 row versions
-INFO:  scanned index "_hyper_1_1_chunk_temp2_idx" to remove 41 row versions
-INFO:  "_hyper_1_1_chunk": removed 41 row versions in 1 pages
-INFO:  index "_hyper_1_1_chunk_time_idx" now contains 41 row versions in 2 pages
-INFO:  index "_hyper_1_1_chunk_temp1_idx" now contains 41 row versions in 2 pages
-INFO:  index "_hyper_1_1_chunk_temp2_idx" now contains 41 row versions in 2 pages
-INFO:  "_hyper_1_1_chunk": found 41 removable, 41 nonremovable row versions in 1 out of 1 pages
-INFO:  vacuuming "public._hyper_1_2_chunk"
-INFO:  launched 2 parallel vacuum workers for index vacuuming (planned: 2)
-INFO:  scanned index "_hyper_1_2_chunk_time_idx" to remove 42 row versions
-INFO:  scanned index "_hyper_1_2_chunk_temp1_idx" to remove 42 row versions
-INFO:  scanned index "_hyper_1_2_chunk_temp2_idx" to remove 42 row versions
-INFO:  "_hyper_1_2_chunk": removed 42 row versions in 1 pages
-INFO:  index "_hyper_1_2_chunk_time_idx" now contains 42 row versions in 2 pages
-INFO:  index "_hyper_1_2_chunk_temp1_idx" now contains 42 row versions in 2 pages
-INFO:  index "_hyper_1_2_chunk_temp2_idx" now contains 42 row versions in 2 pages
-INFO:  "_hyper_1_2_chunk": found 42 removable, 42 nonremovable row versions in 1 out of 1 pages
-INFO:  vacuuming "public._hyper_1_3_chunk"
-INFO:  launched 2 parallel vacuum workers for index vacuuming (planned: 2)
-INFO:  scanned index "_hyper_1_3_chunk_time_idx" to remove 17 row versions
-INFO:  scanned index "_hyper_1_3_chunk_temp1_idx" to remove 17 row versions
-INFO:  scanned index "_hyper_1_3_chunk_temp2_idx" to remove 17 row versions
-INFO:  "_hyper_1_3_chunk": removed 17 row versions in 1 pages
-INFO:  index "_hyper_1_3_chunk_time_idx" now contains 17 row versions in 2 pages
-INFO:  index "_hyper_1_3_chunk_temp1_idx" now contains 17 row versions in 2 pages
-INFO:  index "_hyper_1_3_chunk_temp2_idx" now contains 17 row versions in 2 pages
-INFO:  "_hyper_1_3_chunk": found 17 removable, 17 nonremovable row versions in 1 out of 1 pages
-INFO:  vacuuming "public.vacuum_test"
-INFO:  "vacuum_test": found 0 removable, 0 nonremovable row versions in 0 out of 0 pages
+VACUUM (PARALLEL 3) vacuum_test;
 DROP TABLE vacuum_test;

--- a/test/sql/vacuum.sql
+++ b/test/sql/vacuum.sql
@@ -23,7 +23,7 @@ SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public' AND tablename LIKE 'vacuum_test'
 ORDER BY tablename, attname, array_to_string(histogram_bounds, ',');
 
-VACUUM (VERBOSE, ANALYZE) vacuum_test;
+VACUUM ANALYZE vacuum_test;
 
 -- stats should exist for all three chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
@@ -81,7 +81,7 @@ INSERT INTO vacuum_norm VALUES ('2017-01-20T09:00:01', 17.5),
                                ('2017-06-20T09:00:01', 18.5),
                                ('2017-06-21T09:00:01', 11.0);
 
-VACUUM (VERBOSE, ANALYZE) vacuum_norm;
+VACUUM ANALYZE vacuum_norm;
 DROP TABLE vacuum_norm;
 
 --Similar to normal vacuum tests, but PG11 introduced ability to vacuum multiple tables at once, we make sure that works for hypertables as well.
@@ -124,7 +124,7 @@ SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats
 WHERE schemaname = 'public'
 ORDER BY tablename, attname, array_to_string(histogram_bounds, ',');
 
-VACUUM (VERBOSE, ANALYZE) vacuum_norm, vacuum_test, analyze_test;
+VACUUM ANALYZE vacuum_norm, vacuum_test, analyze_test;
 
 -- stats should exist for all 6 chunks
 SELECT tablename, attname, histogram_bounds, n_distinct FROM pg_stats

--- a/test/sql/vacuum_parallel.sql
+++ b/test/sql/vacuum_parallel.sql
@@ -36,6 +36,6 @@ CREATE INDEX ON _hyper_1_3_chunk(temp2);
 UPDATE vacuum_test SET time = time + '1s'::interval, temp1 = random(), temp2 = random();
 
 -- we should see two parallel workers for each chunk
-VACUUM (PARALLEL 3, VERBOSE) vacuum_test;
+VACUUM (PARALLEL 3) vacuum_test;
 
 DROP TABLE vacuum_test;


### PR DESCRIPTION
VACUUM VERBOSE is the source for flaky tests and we don't gain much
by including the verbose output in the test. Additionally removing
the verbose option prevents us from having to make the vacuum tests
pg-version specific as PG14 slightly changes the formatting of the
VACUUM VERBOSE output.