### PR TITLE
Fix distributed hypertable DROP within a procedure

### DIFF
--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -567,10 +567,8 @@ dist_ddl_start(ProcessUtilityArgs *args)
 	 * Do not process nested DDL operations made by external
 	 * event triggers.
 	 */
-	if (args->context != PROCESS_UTILITY_TOPLEVEL)
+	if (dist_ddl_scheduled_for_execution())
 		return;
-
-	Assert(dist_ddl_state.remote_commands == NIL);
 
 	dist_ddl_state.mctx = CurrentMemoryContext;
 

--- a/tsl/test/expected/ddl_hook.out
+++ b/tsl/test/expected/ddl_hook.out
@@ -240,6 +240,34 @@ DROP TABLE non_htable;
 NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TABLE non_htable;
 NOTICE:  test_sql_drop: table: public.non_htable
 NOTICE:  test_ddl_command_end: DROP TABLE
+-- DROP TABLE within procedure
+CREATE TABLE test (time timestamp, v int);
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE test (time timestamp, v int);
+NOTICE:  test_ddl_command_end: CREATE TABLE
+SELECT create_hypertable('test','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_hypertable 
+-------------------
+ (2,public,test,t)
+(1 row)
+
+CREATE PROCEDURE test_drop() LANGUAGE PLPGSQL AS $$
+BEGIN
+    DROP TABLE test;
+END
+$$;
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE PROCEDURE test_drop() LANGUAGE PLPGSQL AS $$
+BEGIN
+    DROP TABLE test;
+END
+$$;
+CALL test_drop();
+NOTICE:  test_ddl_command_start: 0 hypertables, query: CALL test_drop();
+NOTICE:  test_ddl_command_start: 0 hypertables, query: DROP TABLE test
+NOTICE:  test_sql_drop: index
+NOTICE:  test_sql_drop: table: public.test
+NOTICE:  test_sql_drop: trigger
+NOTICE:  test_ddl_command_end: DROP TABLE
 -- DROP CASCADE cases
 -- DROP schema
 CREATE TABLE htable_schema.non_htable (id int);
@@ -252,7 +280,7 @@ SELECT * FROM create_hypertable('htable_schema.htable', 'time');
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id |  schema_name  | table_name | created 
 ---------------+---------------+------------+---------
-             2 | htable_schema | htable     | t
+             3 | htable_schema | htable     | t
 (1 row)
 
 DROP SCHEMA htable_schema CASCADE;
@@ -272,7 +300,7 @@ SELECT * FROM create_hypertable('htable', 'time');
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-             3 | public      | htable     | t
+             4 | public      | htable     | t
 (1 row)
 
 CREATE INDEX htable_device_idx ON htable (device);
@@ -302,7 +330,7 @@ SELECT * FROM create_hypertable('htable', 'time');
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-             4 | public      | htable     | t
+             5 | public      | htable     | t
 (1 row)
 
 DROP TABLE non_htable CASCADE;

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -5220,6 +5220,33 @@ SELECT * FROM disttable ORDER BY 1;
  Fri Sep 01 06:01:00 2017 PDT |      5 |     40 |    104
 (1 row)
 
+-- Check distributed hypertable within procedure properly drops remote tables
+--
+-- #3663 
+--
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (29,public,test,t)
+(1 row)
+
+CREATE PROCEDURE test_drop() LANGUAGE PLPGSQL AS $$
+BEGIN
+    DROP TABLE test;
+END
+$$;
+CALL test_drop();
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (30,public,test,t)
+(1 row)
+
+DROP TABLE test;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;
 DROP DATABASE :DATA_NODE_3;

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -5219,6 +5219,33 @@ SELECT * FROM disttable ORDER BY 1;
  Fri Sep 01 06:01:00 2017 PDT |      5 |     40 |    104
 (1 row)
 
+-- Check distributed hypertable within procedure properly drops remote tables
+--
+-- #3663 
+--
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (29,public,test,t)
+(1 row)
+
+CREATE PROCEDURE test_drop() LANGUAGE PLPGSQL AS $$
+BEGIN
+    DROP TABLE test;
+END
+$$;
+CALL test_drop();
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (30,public,test,t)
+(1 row)
+
+DROP TABLE test;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;
 DROP DATABASE :DATA_NODE_3;

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -5219,6 +5219,33 @@ SELECT * FROM disttable ORDER BY 1;
  Fri Sep 01 06:01:00 2017 PDT |      5 |     40 |    104
 (1 row)
 
+-- Check distributed hypertable within procedure properly drops remote tables
+--
+-- #3663 
+--
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (29,public,test,t)
+(1 row)
+
+CREATE PROCEDURE test_drop() LANGUAGE PLPGSQL AS $$
+BEGIN
+    DROP TABLE test;
+END
+$$;
+CALL test_drop();
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (30,public,test,t)
+(1 row)
+
+DROP TABLE test;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;
 DROP DATABASE :DATA_NODE_3;

--- a/tsl/test/sql/ddl_hook.sql
+++ b/tsl/test/sql/ddl_hook.sql
@@ -97,6 +97,16 @@ DROP INDEX htable_descr_idx;
 DROP TABLE htable;
 DROP TABLE non_htable;
 
+-- DROP TABLE within procedure
+CREATE TABLE test (time timestamp, v int);
+SELECT create_hypertable('test','time');
+CREATE PROCEDURE test_drop() LANGUAGE PLPGSQL AS $$
+BEGIN
+    DROP TABLE test;
+END
+$$;
+CALL test_drop();
+
 -- DROP CASCADE cases
 
 -- DROP schema

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -1748,6 +1748,22 @@ INSERT INTO disttable VALUES ('2017-09-01 06:01', 5, 40.0) RETURNING *;
 -- Generated columns with SELECT
 SELECT * FROM disttable ORDER BY 1;
 
+-- Check distributed hypertable within procedure properly drops remote tables
+--
+-- #3663 
+--
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+CREATE PROCEDURE test_drop() LANGUAGE PLPGSQL AS $$
+BEGIN
+    DROP TABLE test;
+END
+$$;
+CALL test_drop();
+CREATE TABLE test (time timestamp, v int);
+SELECT create_distributed_hypertable('test','time');
+DROP TABLE test;
+
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;
 DROP DATABASE :DATA_NODE_3;


### PR DESCRIPTION
When DROP being executed inside procedure ddl_command_start
was not handled which lead to ignoring this operation on the
data nodes.

Fix #3663