### PR TITLE
Add handling of new ALTER TABLE options in PG14

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -111,7 +111,7 @@ m["include"].append(build_debug_config({"pg":PG13_LATEST}))
 
 pg14_debug_latest = {
   "pg": PG14_LATEST,
-  "tsdb_build_args": "-DWARNINGS_AS_ERRORS=OFF -DEXPERIMENTAL=ON",
+  "tsdb_build_args": "-DEXPERIMENTAL=ON",
   "coverage": False,
   "installcheck_args": "IGNORES='dist_hypertable-14 dist_partial_agg dist_query'"
 }

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -149,6 +149,10 @@ check_chunk_alter_table_operation_allowed(Oid relid, AlterTableStmt *stmt)
 				case AT_EnableRowSecurity:
 				case AT_DisableRowSecurity:
 				case AT_SetTableSpace:
+#if PG14_GE
+				case AT_ReAddStatistics:
+				case AT_SetCompression:
+#endif
 					/* allowed on chunks */
 					break;
 				default:
@@ -227,6 +231,10 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 				/* this is passed down in `process_altertable_set_tablespace_end` */
 			case AT_SetStatistics: /* should this be pushed down in some way? */
 			case AT_AddColumn:	 /* this is passed down */
+#if PG14_GE
+			case AT_ReAddStatistics:
+			case AT_SetCompression:
+#endif
 				continue;
 				/*
 				 * BLOCKED:
@@ -3389,6 +3397,10 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_DropOids:
 		case AT_SetOptions:
 		case AT_ResetOptions:
+#if PG14_GE
+		case AT_ReAddStatistics:
+		case AT_SetCompression:
+#endif
 			/* Avoid running this command for distributed hypertable chunks
 			 * since PostgreSQL currently does not allow to alter
 			 * storage options for a foreign table. */
@@ -3470,6 +3482,9 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 											* process_altertable_start_table but also
 											* here as failsafe */
 		case AT_DetachPartition:
+#if PG14_GE
+		case AT_DetachPartitionFinalize:
+#endif
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("operation not supported on hypertables %d", cmd->subtype)));

--- a/test/expected/ddl_extra.out
+++ b/test/expected/ddl_extra.out
@@ -1,0 +1,87 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+CREATE OR REPLACE FUNCTION show_columns_ext(rel regclass)
+RETURNS TABLE("Column" name,
+              "Type" text,
+              "NotNull" boolean,
+              "Compression" text) LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT a.attname,
+    format_type(t.oid, t.typtypmod),
+    a.attnotnull,
+    (CASE WHEN a.attcompression = 'l' THEN 'lz4' WHEN a.attcompression = 'p' THEN 'pglz' ELSE '' END)
+    FROM pg_attribute a, pg_type t
+    WHERE a.attrelid = rel
+    AND a.atttypid = t.oid
+    AND a.attnum >= 0
+    ORDER BY a.attnum;
+$BODY$;
+CREATE TABLE conditions (
+  time TIMESTAMP NOT NULL,
+  location TEXT NOT NULL,
+  temperature DOUBLE PRECISION NULL,
+  humidity DOUBLE PRECISION NULL
+);
+SELECT create_hypertable('conditions', 'time', chunk_time_interval := '1 day'::interval);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions
+SELECT generate_series('2021-10-10 00:00'::timestamp, '2021-10-11 00:00'::timestamp, '1 day'), 'POR', 55, 75;
+CREATE VIEW t AS
+    SELECT 'conditions'::regclass AS r
+    UNION ALL
+    SELECT * FROM show_chunks('conditions');
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+                   r                    |  Column  | Type | NotNull | Compression 
+----------------------------------------+----------+------+---------+-------------
+ conditions                             | location | text | t       | 
+ _timescaledb_internal._hyper_1_1_chunk | location | text | t       | 
+ _timescaledb_internal._hyper_1_2_chunk | location | text | t       | 
+(3 rows)
+
+ALTER TABLE conditions ALTER COLUMN location SET COMPRESSION pglz;
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+                   r                    |  Column  | Type | NotNull | Compression 
+----------------------------------------+----------+------+---------+-------------
+ conditions                             | location | text | t       | pglz
+ _timescaledb_internal._hyper_1_1_chunk | location | text | t       | pglz
+ _timescaledb_internal._hyper_1_2_chunk | location | text | t       | pglz
+(3 rows)
+
+INSERT INTO conditions VALUES ('2021-10-12 00:00'::timestamp, 'BRA', 66, 77);
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+                   r                    |  Column  | Type | NotNull | Compression 
+----------------------------------------+----------+------+---------+-------------
+ conditions                             | location | text | t       | pglz
+ _timescaledb_internal._hyper_1_1_chunk | location | text | t       | pglz
+ _timescaledb_internal._hyper_1_2_chunk | location | text | t       | pglz
+ _timescaledb_internal._hyper_1_3_chunk | location | text | t       | pglz
+(4 rows)
+
+ALTER TABLE conditions ALTER COLUMN location SET COMPRESSION default;
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+                   r                    |  Column  | Type | NotNull | Compression 
+----------------------------------------+----------+------+---------+-------------
+ conditions                             | location | text | t       | 
+ _timescaledb_internal._hyper_1_1_chunk | location | text | t       | 
+ _timescaledb_internal._hyper_1_2_chunk | location | text | t       | 
+ _timescaledb_internal._hyper_1_3_chunk | location | text | t       | 
+(4 rows)
+
+\set ON_ERROR_STOP 0
+-- failing test because compression is not allowed in "non-TOASTable" datatypes
+ALTER TABLE conditions ALTER COLUMN temperature SET COMPRESSION pglz;
+ERROR:  column data type double precision does not support compression
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'temperature' ORDER BY 1, 2;
+                   r                    |   Column    |       Type       | NotNull | Compression 
+----------------------------------------+-------------+------------------+---------+-------------
+ conditions                             | temperature | double precision | f       | 
+ _timescaledb_internal._hyper_1_1_chunk | temperature | double precision | f       | 
+ _timescaledb_internal._hyper_1_2_chunk | temperature | double precision | f       | 
+ _timescaledb_internal._hyper_1_3_chunk | temperature | double precision | f       | 
+(4 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -102,6 +102,10 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "13"))
   list(APPEND TEST_FILES trusted_extension.sql vacuum_parallel.sql)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
+  list(APPEND TEST_FILES ddl_extra.sql)
+endif()
+
 # only test custom type if we are in 64-bit architecture
 if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
   list(APPEND TEST_FILES custom_type.sql)

--- a/test/sql/ddl_extra.sql
+++ b/test/sql/ddl_extra.sql
@@ -1,0 +1,54 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE OR REPLACE FUNCTION show_columns_ext(rel regclass)
+RETURNS TABLE("Column" name,
+              "Type" text,
+              "NotNull" boolean,
+              "Compression" text) LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT a.attname,
+    format_type(t.oid, t.typtypmod),
+    a.attnotnull,
+    (CASE WHEN a.attcompression = 'l' THEN 'lz4' WHEN a.attcompression = 'p' THEN 'pglz' ELSE '' END)
+    FROM pg_attribute a, pg_type t
+    WHERE a.attrelid = rel
+    AND a.atttypid = t.oid
+    AND a.attnum >= 0
+    ORDER BY a.attnum;
+$BODY$;
+
+CREATE TABLE conditions (
+  time TIMESTAMP NOT NULL,
+  location TEXT NOT NULL,
+  temperature DOUBLE PRECISION NULL,
+  humidity DOUBLE PRECISION NULL
+);
+
+SELECT create_hypertable('conditions', 'time', chunk_time_interval := '1 day'::interval);
+
+INSERT INTO conditions
+SELECT generate_series('2021-10-10 00:00'::timestamp, '2021-10-11 00:00'::timestamp, '1 day'), 'POR', 55, 75;
+
+CREATE VIEW t AS
+    SELECT 'conditions'::regclass AS r
+    UNION ALL
+    SELECT * FROM show_chunks('conditions');
+
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+
+ALTER TABLE conditions ALTER COLUMN location SET COMPRESSION pglz;
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+
+INSERT INTO conditions VALUES ('2021-10-12 00:00'::timestamp, 'BRA', 66, 77);
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+
+ALTER TABLE conditions ALTER COLUMN location SET COMPRESSION default;
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'location' ORDER BY 1, 2;
+
+\set ON_ERROR_STOP 0
+-- failing test because compression is not allowed in "non-TOASTable" datatypes
+ALTER TABLE conditions ALTER COLUMN temperature SET COMPRESSION pglz;
+
+SELECT * FROM t, LATERAL show_columns_ext(r) WHERE "Column" = 'temperature' ORDER BY 1, 2;


### PR DESCRIPTION
PG14 introduced new `ALTER TABLE` sub-commands:

* `.. ALTER COLUMN .. SET COMPRESSION`: handled it properly on
  `process_utility` hook code and added related regression tests

* `.. DETACH PARTITION .. {CONCURRENTLY | FINALIZE}`: handled it
  properly on `process_utility` hook code but there's no need to add
  regression tests because we don't rely to native partitioning in
  hypertables.