### PR TITLE
Fix two "unused function" errors

### DIFF
--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -302,18 +302,6 @@ adjust_chunk_colnos(List *colnos, ResultRelInfo *chunk_rri)
 }
 #endif
 
-static inline ResultRelInfo *
-get_chunk_rri(ChunkInsertState *state)
-{
-	return state->result_relation_info;
-}
-
-static inline ResultRelInfo *
-get_hyper_rri(ChunkDispatch *dispatch)
-{
-	return dispatch->hypertable_result_rel_info;
-}
-
 /*
  * Setup ON CONFLICT state for a chunk.
  *


### PR DESCRIPTION
When building on MacOS with Clang 11 the build fails with:

error: unused function 'get_chunk_rri'
error: unused function 'get_hyper_rri'
      [-Werror,-Wunused-function]

This PR fixes it.