### PR TITLE
Fix chunk_get_relstats Datum handling

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -29,7 +29,7 @@ jobs:
             ignores: append-13 debug_notice transparent_decompression-13 pg_dump
             pg_major: 13
           - pg: "14.0"
-            ignores: append-14 chunk_api debug_notice transparent_decompression-14
+            ignores: append-14 debug_notice transparent_decompression-14 pg_dump
             pg_major: 14
 
     steps:

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -555,7 +555,7 @@ chunk_get_single_stats_tuple(Chunk *chunk, TupleDesc tupdesc)
 	Form_pg_class pgcform;
 	Datum values[_Anum_chunk_relstats_max];
 	bool nulls[_Anum_chunk_relstats_max] = { false };
-	float reltuples = 0;
+	Datum reltuples;
 
 	ctup = SearchSysCache1(RELOID, ObjectIdGetDatum(chunk->table_id));
 
@@ -572,8 +572,8 @@ chunk_get_single_stats_tuple(Chunk *chunk, TupleDesc tupdesc)
 		Int32GetDatum(chunk->fd.hypertable_id);
 	values[AttrNumberGetAttrOffset(Anum_chunk_relstats_num_pages)] =
 		Int32GetDatum(pgcform->relpages);
-	reltuples = Float4GetDatum(pgcform->reltuples);
-	values[AttrNumberGetAttrOffset(Anum_chunk_relstats_num_tuples)] = reltuples > 0 ? reltuples : 0;
+	reltuples = Float4GetDatum(pgcform->reltuples > 0 ? pgcform->reltuples : 0);
+	values[AttrNumberGetAttrOffset(Anum_chunk_relstats_num_tuples)] = reltuples;
 	values[AttrNumberGetAttrOffset(Anum_chunk_relstats_num_allvisible)] =
 		Int32GetDatum(pgcform->relallvisible);
 


### PR DESCRIPTION
The code in chunk_get_single_stats_tuple was using Datum getter
wrongly on FormData class which already holds primitive datatypes
and did not correctly convert to Datum when setting the value for
the tuple. Since most of the Datum macros are noops on amd64 this
only lead to failing tests on 32bit.