### PR TITLE
Fix wrong assert in cagg_update_view_definition

### DIFF
--- a/tsl/test/expected/continuous_aggs_ddl.out
+++ b/tsl/test/expected/continuous_aggs_ddl.out
@@ -1458,3 +1458,24 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only = fa
 \set VERBOSITY verbose
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 \set VERBOSITY terse
+-- #3696 assertion failure when referencing columns not present in result
+CREATE TABLE i3696(time timestamptz NOT NULL, search_query text, cnt integer, cnt2 integer);
+SELECT table_name FROM create_hypertable('i3696','time');
+ table_name 
+------------
+ i3696
+(1 row)
+
+CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous)
+AS
+ SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
+ FROM i3696 GROUP BY cnt +cnt2 , bucket, search_query;
+NOTICE:  continuous aggregate "i3696_cagg1" is already up-to-date
+ALTER MATERIALIZED VIEW i3696_cagg1 SET (timescaledb.materialized_only = 'true');
+CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous)
+AS
+ SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
+ FROM i3696 GROUP BY cnt + cnt2, bucket, search_query
+ HAVING cnt + cnt2 + sum(cnt) > 2 or count(cnt2) > 10;
+NOTICE:  continuous aggregate "i3696_cagg2" is already up-to-date
+ALTER MATERIALIZED VIEW i3696_cagg2 SET (timescaledb.materialized_only = 'true');

--- a/tsl/test/sql/continuous_aggs_ddl.sql
+++ b/tsl/test/sql/continuous_aggs_ddl.sql
@@ -950,3 +950,23 @@ ALTER MATERIALIZED VIEW conditions_daily SET (timescaledb.materialized_only = fa
 \set VERBOSITY verbose
 CALL refresh_continuous_aggregate('conditions_daily', NULL, NULL);
 \set VERBOSITY terse
+
+-- #3696 assertion failure when referencing columns not present in result
+CREATE TABLE i3696(time timestamptz NOT NULL, search_query text, cnt integer, cnt2 integer);
+SELECT table_name FROM create_hypertable('i3696','time');
+
+CREATE MATERIALIZED VIEW i3696_cagg1 WITH (timescaledb.continuous)
+AS
+ SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
+ FROM i3696 GROUP BY cnt +cnt2 , bucket, search_query;
+
+ALTER MATERIALIZED VIEW i3696_cagg1 SET (timescaledb.materialized_only = 'true');
+
+CREATE MATERIALIZED VIEW i3696_cagg2 WITH (timescaledb.continuous)
+AS
+ SELECT  search_query,count(search_query) as count, sum(cnt), time_bucket(INTERVAL '1 minute', time) AS bucket
+ FROM i3696 GROUP BY cnt + cnt2, bucket, search_query
+ HAVING cnt + cnt2 + sum(cnt) > 2 or count(cnt2) > 10;
+
+ALTER MATERIALIZED VIEW i3696_cagg2 SET (timescaledb.materialized_only = 'true');
+


### PR DESCRIPTION
When the view query has references to columns not selected in the
resultset those columns will be at the end of the view query
targetlist as junk columns. So the length of the targetlist of
those queries might be different but they should always have
the same amount of nonjunk columns.

Fixes #3696 