### PR TITLE
Combine remote and local cagg invalidation

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3842,14 +3842,11 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 			 * modified. The invalidation will allow the refresh command on a
 			 * continuous aggregate to see that this region was dropped and
 			 * and will therefore be able to refresh accordingly.*/
-			if (hypertable_is_distributed(ht))
-				ts_cm_functions->remote_invalidation_log_add_entry(ht,
-																   HypertableIsRawTable,
-																   ht->fd.id,
-																   start,
-																   end);
-			else
-				ts_cm_functions->continuous_agg_invalidate(ht, start, end);
+			ts_cm_functions->continuous_agg_invalidate(ht,
+													   HypertableIsRawTable,
+													   ht->fd.id,
+													   start,
+													   end);
 		}
 	}
 

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -221,7 +221,9 @@ continuous_agg_update_options_default(ContinuousAgg *cagg, WithClauseResult *wit
 }
 
 static void
-continuous_agg_invalidate_all_default(const Hypertable *ht, int64 start, int64 end)
+continuous_agg_invalidate_all_default(const Hypertable *ht,
+									  ContinuousAggHypertableStatus caggstatus, int32 entry_id,
+									  int64 start, int64 end)
 {
 	error_no_default_fn_community();
 	pg_unreachable();
@@ -279,14 +281,6 @@ func_call_on_data_nodes_default(FunctionCallInfo finfo, List *data_node_oids)
 
 static void
 update_compressed_chunk_relstats_default(Oid uncompressed_relid, Oid compressed_relid)
-{
-	error_no_default_fn_community();
-}
-
-static void
-remote_invalidation_log_add_entry_default(Hypertable *raw_ht,
-										  ContinuousAggHypertableStatus caggstatus, int32 entry_id,
-										  int64 start, int64 end)
 {
 	error_no_default_fn_community();
 }
@@ -362,7 +356,6 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.continuous_agg_update_options = continuous_agg_update_options_default,
 	.invalidation_cagg_log_add_entry = error_no_default_fn_pg_community,
 	.invalidation_hyper_log_add_entry = error_no_default_fn_pg_community,
-	.remote_invalidation_log_add_entry = remote_invalidation_log_add_entry_default,
 	.remote_invalidation_log_delete = NULL,
 	.drop_dist_ht_invalidation_trigger = error_no_default_fn_pg_community,
 	.remote_drop_dist_ht_invalidation_trigger = NULL,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -94,14 +94,13 @@ typedef struct CrossModuleFunctions
 	PGFunction continuous_agg_invalidation_trigger;
 	PGFunction continuous_agg_refresh;
 	PGFunction continuous_agg_refresh_chunk;
-	void (*continuous_agg_invalidate)(const Hypertable *ht, int64 start, int64 end);
+	void (*continuous_agg_invalidate)(const Hypertable *ht,
+									  ContinuousAggHypertableStatus caggstatus, int32 entry_id,
+									  int64 start, int64 end);
 	void (*continuous_agg_update_options)(ContinuousAgg *cagg,
 										  WithClauseResult *with_clause_options);
 	PGFunction invalidation_cagg_log_add_entry;
 	PGFunction invalidation_hyper_log_add_entry;
-	void (*remote_invalidation_log_add_entry)(Hypertable *raw_ht,
-											  ContinuousAggHypertableStatus caggstatus,
-											  int32 entry_id, int64 start, int64 end);
 	void (*remote_invalidation_log_delete)(int32 raw_hypertable_id,
 										   ContinuousAggHypertableStatus caggstatus);
 	PGFunction drop_dist_ht_invalidation_trigger;

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -963,17 +963,11 @@ process_truncate(ProcessUtilityArgs *args)
 						 * longer has any data */
 						raw_ht = ts_hypertable_get_by_id(cagg->data.raw_hypertable_id);
 						Assert(raw_ht != NULL);
-						if (hypertable_is_distributed(raw_ht))
-							ts_cm_functions
-								->remote_invalidation_log_add_entry(raw_ht,
-																	HypertableIsMaterialization,
-																	mat_ht->fd.id,
-																	TS_TIME_NOBEGIN,
-																	TS_TIME_NOEND);
-						else
-							ts_cm_functions->continuous_agg_invalidate(mat_ht,
-																	   TS_TIME_NOBEGIN,
-																	   TS_TIME_NOEND);
+						ts_cm_functions->continuous_agg_invalidate(raw_ht,
+																   HypertableIsMaterialization,
+																   mat_ht->fd.id,
+																   TS_TIME_NOBEGIN,
+																   TS_TIME_NOEND);
 
 						/* mark list as changed because we'll add the materialization hypertable */
 						list_changed = true;
@@ -1007,17 +1001,11 @@ process_truncate(ProcessUtilityArgs *args)
 						if (agg_status == HypertableIsRawTable)
 						{
 							/* The truncation invalidates all associated continuous aggregates */
-							if (hypertable_is_distributed(ht))
-								ts_cm_functions
-									->remote_invalidation_log_add_entry(ht,
-																		HypertableIsRawTable,
-																		ht->fd.id,
-																		TS_TIME_NOBEGIN,
-																		TS_TIME_NOEND);
-							else
-								ts_cm_functions->continuous_agg_invalidate(ht,
-																		   TS_TIME_NOBEGIN,
-																		   TS_TIME_NOEND);
+							ts_cm_functions->continuous_agg_invalidate(ht,
+																	   HypertableIsRawTable,
+																	   ht->fd.id,
+																	   TS_TIME_NOBEGIN,
+																	   TS_TIME_NOEND);
 						}
 
 						if (!relation_should_recurse(rv))
@@ -1162,14 +1150,11 @@ process_drop_chunk(ProcessUtilityArgs *args, DropStmt *stmt)
 
 				Assert(hyperspace_get_open_dimension(ht->space, 0)->fd.id ==
 					   chunk->cube->slices[0]->fd.dimension_id);
-				if (hypertable_is_distributed(ht))
-					ts_cm_functions->remote_invalidation_log_add_entry(ht,
-																	   HypertableIsRawTable,
-																	   ht->fd.id,
-																	   start,
-																	   end);
-				else
-					ts_cm_functions->continuous_agg_invalidate(ht, start, end);
+				ts_cm_functions->continuous_agg_invalidate(ht,
+														   HypertableIsRawTable,
+														   ht->fd.id,
+														   start,
+														   end);
 			}
 		}
 	}

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -39,12 +39,14 @@ typedef struct Hypertable Hypertable;
 
 extern void invalidation_cagg_log_add_entry(int32 cagg_hyper_id, int64 start, int64 end);
 extern void invalidation_hyper_log_add_entry(int32 hyper_id, int64 start, int64 end);
-extern void invalidation_add_entry(const Hypertable *ht, int64 start, int64 end);
+extern void invalidation_add_entry(const Hypertable *ht, ContinuousAggHypertableStatus caggstatus,
+								   int32 entry_id, int64 start, int64 end);
 
 extern Datum tsl_invalidation_cagg_log_add_entry(PG_FUNCTION_ARGS);
 extern Datum tsl_invalidation_hyper_log_add_entry(PG_FUNCTION_ARGS);
-void remote_invalidation_log_add_entry(Hypertable *raw_ht, ContinuousAggHypertableStatus caggstatus,
-									   int32 entry_id, int64 start, int64 end);
+void remote_invalidation_log_add_entry(const Hypertable *raw_ht,
+									   ContinuousAggHypertableStatus caggstatus, int32 entry_id,
+									   int64 start, int64 end);
 
 extern void invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
 												Oid dimtype, CaggsInfo *all_caggs_info);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -135,7 +135,6 @@ CrossModuleFunctions tsl_cm_functions = {
 	.continuous_agg_update_options = continuous_agg_update_options,
 	.invalidation_cagg_log_add_entry = tsl_invalidation_cagg_log_add_entry,
 	.invalidation_hyper_log_add_entry = tsl_invalidation_hyper_log_add_entry,
-	.remote_invalidation_log_add_entry = remote_invalidation_log_add_entry,
 	.remote_invalidation_log_delete = remote_invalidation_log_delete,
 	.drop_dist_ht_invalidation_trigger = tsl_drop_dist_ht_invalidation_trigger,
 	.remote_drop_dist_ht_invalidation_trigger = remote_drop_dist_ht_invalidation_trigger,

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -1226,13 +1226,7 @@ WHERE cagg_id = :cond_10_id;
 (4 rows)
 
 -- should trigger two individual refreshes
-SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  refreshing continuous aggregate "cond_10" in window [ 0, 200 ]
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  invalidation refresh on "cond_10" in window [ 0, 30 ]
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  invalidation refresh on "cond_10" in window [ 40, 50 ]
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  invalidation refresh on "cond_10" in window [ 60, 200 ]
-RESET client_min_messages;
 -- Allow at most 5 individual invalidations per refreshe
 SET timescaledb.materializations_per_refresh_window=5;
 -- Insert into every second bucket
@@ -1243,12 +1237,7 @@ INSERT INTO conditions VALUES (80, 1, 1.0);
 INSERT INTO conditions VALUES (100, 1, 1.0);
 INSERT INTO conditions VALUES (120, 1, 1.0);
 INSERT INTO conditions VALUES (140, 1, 1.0);
-SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  refreshing continuous aggregate "cond_10" in window [ 0, 200 ]
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 200 200
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  merged invalidations for refresh on "cond_10" in window [ 20, 150 ]
-RESET client_min_messages;
 \set VERBOSITY default
 -- Test acceptable values for materializations per refresh
 SET timescaledb.materializations_per_refresh_window=' 5 ';
@@ -1262,16 +1251,16 @@ CALL refresh_continuous_aggregate('cond_10', 0, 200);
 SET timescaledb.materializations_per_refresh_window='foo';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:773: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:769: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "foo".
 SET timescaledb.materializations_per_refresh_window='2bar';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:776: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:772: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "2bar".
 SET timescaledb.materializations_per_refresh_window='-';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:780: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:776: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "-".
 \set VERBOSITY terse

--- a/tsl/test/expected/continuous_aggs_invalidation_dist_ht.out
+++ b/tsl/test/expected/continuous_aggs_invalidation_dist_ht.out
@@ -1289,14 +1289,7 @@ WHERE cagg_id = :cond_10_id;
 (7 rows)
 
 -- should trigger two individual refreshes
-SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  refreshing continuous aggregate "cond_10" in window [ 0, 200 ]
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  merged invalidations for refresh on [10, 200] from db_continuous_aggs_invalidation_dist_ht_1
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  merged invalidations for refresh on [0, 200] from db_continuous_aggs_invalidation_dist_ht_2
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  merged invalidations for refresh on [0, 200] from db_continuous_aggs_invalidation_dist_ht_3
-psql:include/continuous_aggs_invalidation_common.sql:741: DEBUG:  merged invalidations for refresh on "cond_10" in window [ 0, 200 ]
-RESET client_min_messages;
 -- Allow at most 5 individual invalidations per refreshe
 SET timescaledb.materializations_per_refresh_window=5;
 -- Insert into every second bucket
@@ -1307,15 +1300,7 @@ INSERT INTO conditions VALUES (80, 1, 1.0);
 INSERT INTO conditions VALUES (100, 1, 1.0);
 INSERT INTO conditions VALUES (120, 1, 1.0);
 INSERT INTO conditions VALUES (140, 1, 1.0);
-SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  refreshing continuous aggregate "cond_10" in window [ 0, 200 ]
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 200 200
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  merged invalidations for refresh on [20, 150] from db_continuous_aggs_invalidation_dist_ht_1
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  merged invalidations for refresh on [20, 150] from db_continuous_aggs_invalidation_dist_ht_2
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  merged invalidations for refresh on [40, 130] from db_continuous_aggs_invalidation_dist_ht_3
-psql:include/continuous_aggs_invalidation_common.sql:757: DEBUG:  merged invalidations for refresh on "cond_10" in window [ 20, 150 ]
-RESET client_min_messages;
 \set VERBOSITY default
 -- Test acceptable values for materializations per refresh
 SET timescaledb.materializations_per_refresh_window=' 5 ';
@@ -1329,16 +1314,16 @@ CALL refresh_continuous_aggregate('cond_10', 0, 200);
 SET timescaledb.materializations_per_refresh_window='foo';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:773: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:769: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "foo".
 SET timescaledb.materializations_per_refresh_window='2bar';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:776: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:772: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "2bar".
 SET timescaledb.materializations_per_refresh_window='-';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:780: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:776: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "-".
 \set VERBOSITY terse

--- a/tsl/test/sql/include/continuous_aggs_invalidation_common.sql
+++ b/tsl/test/sql/include/continuous_aggs_invalidation_common.sql
@@ -737,9 +737,7 @@ SELECT * FROM cagg_invals
 WHERE cagg_id = :cond_10_id;
 
 -- should trigger two individual refreshes
-SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-RESET client_min_messages;
 
 -- Allow at most 5 individual invalidations per refreshe
 SET timescaledb.materializations_per_refresh_window=5;
@@ -753,9 +751,7 @@ INSERT INTO conditions VALUES (100, 1, 1.0);
 INSERT INTO conditions VALUES (120, 1, 1.0);
 INSERT INTO conditions VALUES (140, 1, 1.0);
 
-SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-RESET client_min_messages;
 
 \set VERBOSITY default
 -- Test acceptable values for materializations per refresh


### PR DESCRIPTION
Continuous aggregates are invalidated using a single cross-module
function instead of two.