### PR TITLE
Support transparent decompression on individual chunks

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -23,13 +23,13 @@ jobs:
         build_type: [ Debug ]
         include:
           - pg: "12.8"
-            ignores: append-12 debug_notice transparent_decompression-12 plan_skip_scan-12 pg_dump
+            ignores: append-12 debug_notice transparent_decompression-12 transparent_decompress_chunk-12 plan_skip_scan-12 pg_dump
             pg_major: 12
           - pg: "13.4"
-            ignores: append-13 debug_notice transparent_decompression-13 pg_dump
+            ignores: append-13 debug_notice transparent_decompression-13 transparent_decompress_chunk-13 pg_dump
             pg_major: 13
           - pg: "14.0"
-            ignores: append-14 debug_notice transparent_decompression-14 pg_dump
+            ignores: append-14 debug_notice transparent_decompression-14 transparent_decompress_chunk-14 pg_dump
             pg_major: 14
 
     steps:

--- a/src/planner.h
+++ b/src/planner.h
@@ -28,6 +28,7 @@ typedef struct TimescaleDBPrivate
 } TimescaleDBPrivate;
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte, bool *isdistributed);
+extern TSDLLEXPORT bool ts_rte_is_marked_for_expansion(const RangeTblEntry *rte);
 
 static inline TimescaleDBPrivate *
 ts_create_private_reloptinfo(RelOptInfo *rel)

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -19,6 +19,8 @@
 #include <utils/lsyscache.h>
 #include <utils/typcache.h>
 
+#include <planner.h>
+
 #include "hypertable_compression.h"
 #include "import/planner.h"
 #include "compression/create.h"
@@ -279,8 +281,18 @@ build_compressioninfo(PlannerInfo *root, Hypertable *ht, RelOptInfo *chunk_rel)
 	info->chunk_rel = chunk_rel;
 	info->chunk_rte = planner_rt_fetch(chunk_rel->relid, root);
 
-	appinfo = ts_get_appendrelinfo(root, chunk_rel->relid, false);
-	info->ht_rte = planner_rt_fetch(appinfo->parent_relid, root);
+	if (chunk_rel->reloptkind == RELOPT_OTHER_MEMBER_REL)
+	{
+		appinfo = ts_get_appendrelinfo(root, chunk_rel->relid, false);
+		info->ht_rte = planner_rt_fetch(appinfo->parent_relid, root);
+	}
+	else
+	{
+		Assert(chunk_rel->reloptkind == RELOPT_BASEREL);
+		info->single_chunk = true;
+		info->ht_rte = info->chunk_rte;
+	}
+
 	info->hypertable_id = ht->fd.id;
 
 	info->hypertable_compression_info = ts_hypertable_compression_get(ht->fd.id);
@@ -325,12 +337,16 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 								   Chunk *chunk)
 {
 	RelOptInfo *compressed_rel;
-	RelOptInfo *hypertable_rel;
 	ListCell *lc;
 	double new_row_estimate;
+	Index ht_relid = 0;
 
 	CompressionInfo *info = build_compressioninfo(root, ht, chunk_rel);
-	Index ht_index;
+
+	/* double check we don't end up here on single chunk queries with ONLY */
+	Assert(info->chunk_rel->reloptkind == RELOPT_OTHER_MEMBER_REL ||
+		   (info->chunk_rel->reloptkind == RELOPT_BASEREL &&
+			ts_rte_is_marked_for_expansion(info->chunk_rte)));
 
 	/*
 	 * since we rely on parallel coordination from the scan below
@@ -338,13 +354,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 	 * than a single worker per chunk
 	 */
 	int parallel_workers = 1;
-	AppendRelInfo *chunk_info = ts_get_appendrelinfo(root, chunk_rel->relid, false);
 	SortInfo sort_info = build_sortinfo(chunk, chunk_rel, info, root->query_pathkeys);
-
-	Assert(chunk_info != NULL);
-	Assert(chunk_info->parent_reloid == ht->main_table_relid);
-	ht_index = chunk_info->parent_relid;
-	hypertable_rel = root->simple_rel_array[ht_index];
 
 	Assert(chunk->fd.compressed_chunk_id > 0);
 
@@ -360,8 +370,17 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 	pushdown_quals(root, chunk_rel, compressed_rel, info->hypertable_compression_info);
 	set_baserel_size_estimates(root, compressed_rel);
 	new_row_estimate = compressed_rel->rows * DECOMPRESS_CHUNK_BATCH_SIZE;
-	/* adjust the parent's estimate by the diff of new and old estimate */
-	hypertable_rel->rows += (new_row_estimate - chunk_rel->rows);
+
+	if (!info->single_chunk)
+	{
+		/* adjust the parent's estimate by the diff of new and old estimate */
+		AppendRelInfo *chunk_info = ts_get_appendrelinfo(root, chunk_rel->relid, false);
+		Assert(chunk_info->parent_reloid == ht->main_table_relid);
+		ht_relid = chunk_info->parent_relid;
+		RelOptInfo *hypertable_rel = root->simple_rel_array[ht_relid];
+		hypertable_rel->rows += (new_row_estimate - chunk_rel->rows);
+	}
+
 	chunk_rel->rows = new_row_estimate;
 	create_compressed_scan_paths(root,
 								 compressed_rel,
@@ -370,7 +389,10 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 								 &sort_info);
 
 	/* compute parent relids of the chunk and use it to filter paths*/
-	Relids parent_relids = find_childrel_parents(root, chunk_rel);
+	Relids parent_relids = NULL;
+	if (!info->single_chunk)
+		parent_relids = find_childrel_parents(root, chunk_rel);
+
 	/* create non-parallel paths */
 	foreach (lc, compressed_rel->pathlist)
 	{
@@ -455,7 +477,8 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 			DecompressChunkPath *path;
 			if (child_path->param_info != NULL &&
 				(bms_is_member(chunk_rel->relid, child_path->param_info->ppi_req_outer) ||
-				 bms_is_member(ht_index, child_path->param_info->ppi_req_outer)))
+				 (!info->single_chunk &&
+				  bms_is_member(ht_relid, child_path->param_info->ppi_req_outer))))
 				continue;
 			path = decompress_chunk_path_create(root, info, parallel_workers, child_path);
 			add_partial_path(chunk_rel, &path->cpath.path);
@@ -920,20 +943,7 @@ decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, Chunk
 	Oid compressed_relid = compressed_chunk->table_id;
 	RelOptInfo *compressed_rel;
 
-	/* repalloc() does not work with NULL argument */
-	Assert(root->simple_rel_array);
-	Assert(root->simple_rte_array);
-	Assert(root->append_rel_array);
-
-	root->simple_rel_array_size++;
-	root->simple_rel_array =
-		repalloc(root->simple_rel_array, root->simple_rel_array_size * sizeof(RelOptInfo *));
-	root->simple_rte_array =
-		repalloc(root->simple_rte_array, root->simple_rel_array_size * sizeof(RangeTblEntry *));
-	root->append_rel_array =
-		repalloc(root->append_rel_array, root->simple_rel_array_size * sizeof(AppendRelInfo *));
-	root->append_rel_array[compressed_index] = NULL;
-
+	expand_planner_arrays(root, 1);
 	info->compressed_rte = decompress_chunk_make_rte(compressed_relid, AccessShareLock);
 	root->simple_rte_array[compressed_index] = info->compressed_rte;
 
@@ -948,7 +958,7 @@ decompress_chunk_add_plannerinfo(PlannerInfo *root, CompressionInfo *info, Chunk
 	 * in generate_join_implied_equalities (called by
 	 * get_baserel_parampathinfo <- create_index_paths)
 	 */
-	Assert(chunk_rel->top_parent_relids != NULL);
+	Assert(info->single_chunk || chunk_rel->top_parent_relids != NULL);
 	compressed_rel->top_parent_relids = bms_copy(chunk_rel->top_parent_relids);
 
 	root->simple_rel_array[compressed_index] = compressed_rel;
@@ -1130,25 +1140,6 @@ get_column_compressioninfo(List *hypertable_compression_info, char *column_name)
 	elog(ERROR, "No compression information for column \"%s\" found.", column_name);
 
 	pg_unreachable();
-}
-
-/*
- * find matching column attno for compressed chunk based on hypertable attno
- *
- * since we dont want aliasing to interfere we lookup directly in catalog
- * instead of using RangeTblEntry
- */
-AttrNumber
-get_compressed_attno(CompressionInfo *info, AttrNumber ht_attno)
-{
-	AttrNumber compressed_attno;
-	char *chunk_col = get_attname(info->ht_rte->relid, ht_attno, false);
-	compressed_attno = get_attnum(info->compressed_rte->relid, chunk_col);
-
-	if (compressed_attno == InvalidAttrNumber)
-		elog(ERROR, "No matching column in compressed chunk found.");
-
-	return compressed_attno;
 }
 
 /*

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -34,6 +34,8 @@ typedef struct CompressionInfo
 	/* compressed chunk attribute numbers for columns that are compressed */
 	Bitmapset *compressed_chunk_compressed_attnos;
 
+	bool single_chunk; /* query on explicit chunk */
+
 } CompressionInfo;
 
 typedef struct DecompressChunkPath
@@ -57,6 +59,5 @@ void ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *rel, Hype
 
 FormData_hypertable_compression *get_column_compressioninfo(List *hypertable_compression_info,
 															char *column_name);
-AttrNumber get_compressed_attno(CompressionInfo *info, AttrNumber chunk_attno);
 
 #endif /* TIMESCALEDB_DECOMPRESS_CHUNK_H */

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -878,6 +878,15 @@ SELECT count(*) from test_recomp_int;
      9
 (1 row)
 
+-- check with per datanode queries disabled
+SET timescaledb.enable_per_data_node_queries TO false;
+SELECT count(*) from test_recomp_int;
+ count 
+-------
+     9
+(1 row)
+
+RESET timescaledb.enable_per_data_node_queries;
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
@@ -936,9 +945,9 @@ SELECT * from test_recomp_int_chunk_status ORDER BY 1;
  _dist_hyper_4_16_chunk |            3
 (3 rows)
 
-SELECT time_bucket(20, time ), count(*)
+SELECT time_bucket(20, time), count(*)
 FROM test_recomp_int
-GROUP BY time_bucket( 20, time) ORDER BY 1;
+GROUP BY time_bucket(20, time) ORDER BY 1;
  time_bucket | count 
 -------------+-------
            0 |    14
@@ -946,6 +955,19 @@ GROUP BY time_bucket( 20, time) ORDER BY 1;
          100 |     5
 (3 rows)
 
+-- check with per datanode queries disabled
+SET timescaledb.enable_per_data_node_queries TO false;
+SELECT time_bucket(20, time), count(*)
+FROM test_recomp_int
+GROUP BY time_bucket(20, time) ORDER BY 1;
+ time_bucket | count 
+-------------+-------
+           0 |    14
+          60 |     3
+         100 |     5
+(3 rows)
+
+RESET timescaledb.enable_per_data_node_queries;
 --check compression_status afterwards--
 SELECT recompress_chunk(chunk, true) FROM
 ( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 2)q;

--- a/tsl/test/isolation/expected/compression_ddl.out
+++ b/tsl/test/isolation/expected/compression_ddl.out
@@ -35,10 +35,15 @@ _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
 step Cc: COMMIT;
-step SC1: SELECT count(*) from _timescaledb_internal._hyper_1_1_chunk;
+step SC1: SELECT count(*) AS only FROM ONLY _timescaledb_internal._hyper_1_1_chunk; SELECT count(*) FROM _timescaledb_internal._hyper_1_1_chunk;
+only
+----
+   0
+(1 row)
+
 count
 -----
-    0
+   11
 (1 row)
 
 step S1: SELECT count(*) from ts_device_table;

--- a/tsl/test/isolation/specs/compression_ddl.spec
+++ b/tsl/test/isolation/specs/compression_ddl.spec
@@ -33,7 +33,7 @@ step "SChunkStat" {  SELECT status from _timescaledb_catalog.chunk
 
 session "S"
 step "S1" { SELECT count(*) from ts_device_table; }
-step "SC1" { SELECT count(*) from _timescaledb_internal._hyper_1_1_chunk; }
+step "SC1" { SELECT count(*) AS only FROM ONLY _timescaledb_internal._hyper_1_1_chunk; SELECT count(*) FROM _timescaledb_internal._hyper_1_1_chunk; }
 step "SH" { SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table'); }
 
 session "LCT"
@@ -43,7 +43,7 @@ step "LockChunkTuple" {
   WHERE id = ( select min(ch.id) FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table') FOR UPDATE;
   }
 step "UnlockChunkTuple"   { ROLLBACK; }
-   
+
 session "LC"
 step "LockChunk1" {
   BEGIN;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-12.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-12.out
@@ -1,0 +1,1108 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
+SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
+-- this should use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(7 rows)
+
+-- must not use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   Output: "time", device_id, v0, v1, v2, v3
+   ->  Sort (actual rows=0 loops=1)
+         Output: "time", device_id, v0, v1, v2, v3
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+               Output: "time", device_id, v0, v1, v2, v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+(9 rows)
+
+-- test expressions
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    t AS "RECORD"
+FROM :TEST_TABLE t
+WHERE device_id IN (1, 2)
+ORDER BY time, device_id;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Sort (actual rows=7196 loops=1)
+   Sort Key: t."time", t.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Filter: (device_id = ANY ('{1,2}'::integer[]))
+               Rows Removed by Filter: 12
+(7 rows)
+
+-- test empty targetlist
+:PREFIX SELECT FROM :TEST_TABLE;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(2 rows)
+
+-- test empty resultset
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Filter: (device_id < 0)
+         Rows Removed by Filter: 20
+(4 rows)
+
+-- test targetlist not referencing columns
+:PREFIX SELECT 1 FROM :TEST_TABLE;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(2 rows)
+
+-- test constraints not present in targetlist
+:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3598 loops=1)
+   Sort Key: _hyper_X_X_chunk.v1
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(6 rows)
+
+-- test order not present in targetlist
+:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3598 loops=1)
+   Sort Key: _hyper_X_X_chunk.v1
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(6 rows)
+
+-- test column with all NULL
+:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Index Cond: (device_id = 1)
+(3 rows)
+
+--
+-- test qual pushdown
+--
+-- v3 is not segment by or order by column so should not be pushed down
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+                                                                                                                          QUERY PLAN                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+         Rows Removed by Filter: 17990
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+(10 rows)
+
+-- device_id constraint should be pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+-- test IS NULL / IS NOT NULL
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (device_id IS NOT NULL)
+(7 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id IS NULL)
+(7 rows)
+
+-- test IN (Const,Const)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     Rows Removed by Filter: 12
+(8 rows)
+
+-- test cast pushdown
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+--test var op var
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (device_id = v0)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: (device_id < v1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+-- test expressions
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 3)
+(4 rows)
+
+-- test function calls
+-- not yet pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+               Filter: (device_id = length("substring"(version(), 1, 3)))
+               Rows Removed by Filter: 14392
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--
+-- test segment meta pushdown
+--
+-- order by column and const
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
+         Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         Rows Removed by Filter: 2985
+         ->  Sort (actual rows=5 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=150 loops=1)
+               Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 2840
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=155 loops=1)
+               Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 2835
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17840 loops=1)
+               Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 150
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17835 loops=1)
+               Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 155
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17835 loops=1)
+               Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+               Rows Removed by Filter: 155
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+--pushdowns between order by and segment by columns
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 < 1)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 < device_id)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: (device_id < v0)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v1 = device_id)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--pushdown between two order by column (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 = v1)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--pushdown of quals on order by and segment by cols anded together
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         Rows Removed by Filter: 31
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+               Filter: (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(10 rows)
+
+--pushdown of quals on order by and segment by cols or together (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17866 loops=1)
+               Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+               Rows Removed by Filter: 124
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--functions not yet optimized
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: ("time" < now())
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+-- test sort optimization interaction
+:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(6 rows)
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(6 rows)
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(3 rows)
+
+-- test aggregate
+:PREFIX SELECT count(*) FROM :TEST_TABLE;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(3 rows)
+
+-- test aggregate with GROUP BY
+:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Sort (actual rows=5 loops=1)
+   Sort Key: _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+-- test window functions with GROUP BY
+:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort (actual rows=5 loops=1)
+   Sort Key: _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  WindowAgg (actual rows=5 loops=1)
+         ->  HashAggregate (actual rows=5 loops=1)
+               Group Key: _hyper_X_X_chunk.device_id
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+-- test CTE
+:PREFIX WITH q AS (
+  SELECT v1 FROM :TEST_TABLE ORDER BY time
+)
+SELECT * FROM q ORDER BY v1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort (actual rows=17990 loops=1)
+   Sort Key: q.v1
+   Sort Method: quicksort 
+   ->  Subquery Scan on q (actual rows=17990 loops=1)
+         ->  Sort (actual rows=17990 loops=1)
+               Sort Key: _hyper_X_X_chunk."time"
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(9 rows)
+
+-- test CTE join
+:PREFIX WITH q1 AS (
+  SELECT time, v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time
+),
+q2 AS (
+  SELECT time, v2 FROM :TEST_TABLE WHERE device_id = 2 ORDER BY time
+)
+SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=3598 loops=1)
+   Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+   ->  Materialize (actual rows=3598 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     Index Cond: (device_id = 2)
+(9 rows)
+
+--
+-- test indexes
+--
+SET enable_seqscan TO FALSE;
+-- IndexScans should work
+:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- globs should not plan IndexOnlyScans
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                                                                                QUERY PLAN                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- whole row reference should work
+:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                                                                                QUERY PLAN                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
+   Output: test_table.*, test_table.device_id, test_table."time"
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- even when we select only a segmentby column, we still need count
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   Output: count(*)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(6 rows)
+
+--ensure that we can get a nested loop
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+--with multiple values can get a nested loop.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=7196 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         ->  Sort (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(16 rows)
+
+RESET enable_hashjoin;
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+--with multiple values can get a semi-join or nested loop depending on seq_page_cost.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=7196 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         ->  Sort (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(16 rows)
+
+SET seq_page_cost = 100;
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique
+         Output: "*VALUES*".column1
+         ->  Sort
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               ->  Values Scan on "*VALUES*"
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(15 rows)
+
+RESET seq_page_cost;
+-- test view
+CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
+:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+DROP VIEW compressed_view;
+-- test INNER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=17990 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=17990 loops=1)
+               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
+                     ->  Hash Join (actual rows=17990 loops=1)
+                           Hash Cond: (m1."time" = m3."time")
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           ->  Hash (actual rows=3598 loops=1)
+                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
+                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
+                                             Index Cond: (device_id = 3)
+(19 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                           Index Cond: (device_id = 2)
+(10 rows)
+
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=100 loops=1)
+               Order: m1."time"
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
+                     Index Cond: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
+                     Index Cond: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
+                     Index Cond: (device_id = 1)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
+                     Order: m2."time"
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_1 (actual rows=100 loops=1)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_2 (never executed)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_3 (never executed)
+                           Index Cond: (device_id = 2)
+(20 rows)
+
+-- test OUTER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=17990 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Sort (actual rows=100 loops=1)
+         Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=17990 loops=1)
+               Hash Cond: (m1."time" = m2."time")
+               Join Filter: (m1.device_id = 1)
+               Rows Removed by Join Filter: 14392
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=3598 loops=1)
+                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                                 Index Cond: (device_id = 2)
+(15 rows)
+
+SET parallel_leader_participation TO false;
+-- test implicit self-join
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=20 loops=1)
+   ->  Sort (actual rows=20 loops=1)
+         Sort Key: m1."time", m1.device_id, m2.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=89950 loops=1)
+               Hash Cond: (m1."time" = m2."time")
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+-- test self-join with sub-query
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id, m2.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=89950 loops=1)
+               Hash Cond: (m1."time" = m2."time")
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+RESET parallel_leader_participation;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 17
+(9 rows)
+
+-- test prepared statement
+SET plan_cache_mode TO force_generic_plan;
+PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+:PREFIX EXECUTE prep;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+DEALLOCATE prep;
+-- test prepared statement with params pushdown
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+:PREFIX EXECUTE param_prep (1);
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Index Cond: (device_id = $1)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 4
+(10 rows)
+
+:PREFIX EXECUTE param_prep (2);
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Index Cond: (device_id = $1)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 4
+(10 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (2);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (2);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+DEALLOCATE param_prep;
+RESET plan_cache_mode;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -1,0 +1,1120 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
+SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
+-- this should use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(7 rows)
+
+-- must not use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   Output: "time", device_id, v0, v1, v2, v3
+   ->  Sort (actual rows=0 loops=1)
+         Output: "time", device_id, v0, v1, v2, v3
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+               Output: "time", device_id, v0, v1, v2, v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+(9 rows)
+
+-- test expressions
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    t AS "RECORD"
+FROM :TEST_TABLE t
+WHERE device_id IN (1, 2)
+ORDER BY time, device_id;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Sort (actual rows=7196 loops=1)
+   Sort Key: t."time", t.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Filter: (device_id = ANY ('{1,2}'::integer[]))
+               Rows Removed by Filter: 12
+(7 rows)
+
+-- test empty targetlist
+:PREFIX SELECT FROM :TEST_TABLE;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(2 rows)
+
+-- test empty resultset
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Filter: (device_id < 0)
+         Rows Removed by Filter: 20
+(4 rows)
+
+-- test targetlist not referencing columns
+:PREFIX SELECT 1 FROM :TEST_TABLE;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(2 rows)
+
+-- test constraints not present in targetlist
+:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3598 loops=1)
+   Sort Key: _hyper_X_X_chunk.v1
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(6 rows)
+
+-- test order not present in targetlist
+:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3598 loops=1)
+   Sort Key: _hyper_X_X_chunk.v1
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(6 rows)
+
+-- test column with all NULL
+:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Index Cond: (device_id = 1)
+(3 rows)
+
+--
+-- test qual pushdown
+--
+-- v3 is not segment by or order by column so should not be pushed down
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+                                                                                                                          QUERY PLAN                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+         Rows Removed by Filter: 17990
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+(10 rows)
+
+-- device_id constraint should be pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+-- test IS NULL / IS NOT NULL
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (device_id IS NOT NULL)
+(7 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id IS NULL)
+(7 rows)
+
+-- test IN (Const,Const)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     Rows Removed by Filter: 12
+(8 rows)
+
+-- test cast pushdown
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+--test var op var
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (device_id = v0)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: (device_id < v1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+-- test expressions
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 3)
+(4 rows)
+
+-- test function calls
+-- not yet pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+               Filter: (device_id = length("substring"(version(), 1, 3)))
+               Rows Removed by Filter: 14392
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--
+-- test segment meta pushdown
+--
+-- order by column and const
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
+         Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         Rows Removed by Filter: 2985
+         ->  Sort (actual rows=5 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=150 loops=1)
+               Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 2840
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=155 loops=1)
+               Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 2835
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17840 loops=1)
+               Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 150
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17835 loops=1)
+               Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 155
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17835 loops=1)
+               Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+               Rows Removed by Filter: 155
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+--pushdowns between order by and segment by columns
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 < 1)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 < device_id)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: (device_id < v0)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v1 = device_id)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--pushdown between two order by column (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 = v1)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--pushdown of quals on order by and segment by cols anded together
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         Rows Removed by Filter: 31
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+               Filter: (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(10 rows)
+
+--pushdown of quals on order by and segment by cols or together (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17866 loops=1)
+               Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+               Rows Removed by Filter: 124
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--functions not yet optimized
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: ("time" < now())
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+-- test sort optimization interaction
+:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(6 rows)
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(6 rows)
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(3 rows)
+
+-- test aggregate
+:PREFIX SELECT count(*) FROM :TEST_TABLE;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(3 rows)
+
+-- test aggregate with GROUP BY
+:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Sort (actual rows=5 loops=1)
+   Sort Key: _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         Batches: 1 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+-- test window functions with GROUP BY
+:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort (actual rows=5 loops=1)
+   Sort Key: _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  WindowAgg (actual rows=5 loops=1)
+         ->  HashAggregate (actual rows=5 loops=1)
+               Group Key: _hyper_X_X_chunk.device_id
+               Batches: 1 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(9 rows)
+
+-- test CTE
+:PREFIX WITH q AS (
+  SELECT v1 FROM :TEST_TABLE ORDER BY time
+)
+SELECT * FROM q ORDER BY v1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort (actual rows=17990 loops=1)
+   Sort Key: q.v1
+   Sort Method: quicksort 
+   ->  Subquery Scan on q (actual rows=17990 loops=1)
+         ->  Sort (actual rows=17990 loops=1)
+               Sort Key: _hyper_X_X_chunk."time"
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(9 rows)
+
+-- test CTE join
+:PREFIX WITH q1 AS (
+  SELECT time, v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time
+),
+q2 AS (
+  SELECT time, v2 FROM :TEST_TABLE WHERE device_id = 2 ORDER BY time
+)
+SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=3598 loops=1)
+   Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+   ->  Materialize (actual rows=3598 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     Index Cond: (device_id = 2)
+(9 rows)
+
+--
+-- test indexes
+--
+SET enable_seqscan TO FALSE;
+-- IndexScans should work
+:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- globs should not plan IndexOnlyScans
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                                                                                QUERY PLAN                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- whole row reference should work
+:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                                                                                QUERY PLAN                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
+   Output: test_table.*, test_table.device_id, test_table."time"
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- even when we select only a segmentby column, we still need count
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   Output: count(*)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(6 rows)
+
+--ensure that we can get a nested loop
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+--with multiple values can get a nested loop.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=7196 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         ->  Sort (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(16 rows)
+
+RESET enable_hashjoin;
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+--with multiple values can get a semi-join or nested loop depending on seq_page_cost.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=7196 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         ->  Sort (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(16 rows)
+
+SET seq_page_cost = 100;
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique
+         Output: "*VALUES*".column1
+         ->  Sort
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               ->  Values Scan on "*VALUES*"
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(15 rows)
+
+RESET seq_page_cost;
+-- test view
+CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
+:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+DROP VIEW compressed_view;
+-- test INNER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=17990 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=17990 loops=1)
+               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
+                     ->  Hash Join (actual rows=17990 loops=1)
+                           Hash Cond: (m1."time" = m3."time")
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           ->  Hash (actual rows=3598 loops=1)
+                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
+                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
+                                             Index Cond: (device_id = 3)
+(19 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                           Index Cond: (device_id = 2)
+(10 rows)
+
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=100 loops=1)
+               Order: m1."time"
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
+                     Index Cond: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
+                     Index Cond: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
+                     Index Cond: (device_id = 1)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
+                     Order: m2."time"
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_1 (actual rows=100 loops=1)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_2 (never executed)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_3 (never executed)
+                           Index Cond: (device_id = 2)
+(20 rows)
+
+-- test OUTER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=17990 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Sort (actual rows=100 loops=1)
+         Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=17990 loops=1)
+               Hash Cond: (m1."time" = m2."time")
+               Join Filter: (m1.device_id = 1)
+               Rows Removed by Join Filter: 14392
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=3598 loops=1)
+                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                                 Index Cond: (device_id = 2)
+(15 rows)
+
+SET parallel_leader_participation TO false;
+-- test implicit self-join
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=20 loops=1)
+   ->  Incremental Sort (actual rows=20 loops=1)
+         Sort Key: m1."time", m1.device_id, m2.device_id
+         Presorted Key: m1."time"
+         Full-sort Groups: 1  Sort Method: quicksort 
+         ->  Merge Join (actual rows=26 loops=1)
+               Merge Cond: (m1."time" = m2."time")
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: m1."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=26 loops=1)
+                     Sort Key: m2."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(17 rows)
+
+-- test self-join with sub-query
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Incremental Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id, m2.device_id
+         Presorted Key: m1."time"
+         Full-sort Groups: 1  Sort Method: top-N heapsort 
+         ->  Merge Join (actual rows=26 loops=1)
+               Merge Cond: (m1."time" = m2."time")
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: m1."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=26 loops=1)
+                     Sort Key: m2."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(17 rows)
+
+RESET parallel_leader_participation;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 17
+(9 rows)
+
+-- test prepared statement
+SET plan_cache_mode TO force_generic_plan;
+PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+:PREFIX EXECUTE prep;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+DEALLOCATE prep;
+-- test prepared statement with params pushdown
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+:PREFIX EXECUTE param_prep (1);
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Index Cond: (device_id = $1)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 4
+(10 rows)
+
+:PREFIX EXECUTE param_prep (2);
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Index Cond: (device_id = $1)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 4
+(10 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (2);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (2);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+DEALLOCATE param_prep;
+RESET plan_cache_mode;

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -1,0 +1,1120 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
+SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
+-- this should use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=5 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(7 rows)
+
+-- must not use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   Output: "time", device_id, v0, v1, v2, v3
+   ->  Sort (actual rows=0 loops=1)
+         Output: "time", device_id, v0, v1, v2, v3
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: quicksort 
+         ->  Seq Scan on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+               Output: "time", device_id, v0, v1, v2, v3
+               Filter: (_hyper_X_X_chunk.device_id = 1)
+(9 rows)
+
+-- test expressions
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    t AS "RECORD"
+FROM :TEST_TABLE t
+WHERE device_id IN (1, 2)
+ORDER BY time, device_id;
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Sort (actual rows=7196 loops=1)
+   Sort Key: t."time", t.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Filter: (device_id = ANY ('{1,2}'::integer[]))
+               Rows Removed by Filter: 12
+(7 rows)
+
+-- test empty targetlist
+:PREFIX SELECT FROM :TEST_TABLE;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(2 rows)
+
+-- test empty resultset
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Filter: (device_id < 0)
+         Rows Removed by Filter: 20
+(4 rows)
+
+-- test targetlist not referencing columns
+:PREFIX SELECT 1 FROM :TEST_TABLE;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(2 rows)
+
+-- test constraints not present in targetlist
+:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3598 loops=1)
+   Sort Key: _hyper_X_X_chunk.v1
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(6 rows)
+
+-- test order not present in targetlist
+:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=3598 loops=1)
+   Sort Key: _hyper_X_X_chunk.v1
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(6 rows)
+
+-- test column with all NULL
+:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
+                                                                 QUERY PLAN                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Index Cond: (device_id = 1)
+(3 rows)
+
+--
+-- test qual pushdown
+--
+-- v3 is not segment by or order by column so should not be pushed down
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+                                                                                                                          QUERY PLAN                                                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=0 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         Filter: (_hyper_X_X_chunk.v3 > '10'::double precision)
+         Rows Removed by Filter: 17990
+         ->  Seq Scan on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+(10 rows)
+
+-- device_id constraint should be pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+-- test IS NULL / IS NOT NULL
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (device_id IS NOT NULL)
+(7 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id IS NULL)
+(7 rows)
+
+-- test IN (Const,Const)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     Rows Removed by Filter: 12
+(8 rows)
+
+-- test cast pushdown
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+--test var op var
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (device_id = v0)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: (device_id < v1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+-- test expressions
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 3)
+(4 rows)
+
+-- test function calls
+-- not yet pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time"
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+               Filter: (device_id = length("substring"(version(), 1, 3)))
+               Rows Removed by Filter: 14392
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--
+-- test segment meta pushdown
+--
+-- order by column and const
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
+         Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         Rows Removed by Filter: 2985
+         ->  Sort (actual rows=5 loops=1)
+               Sort Key: compress_hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=150 loops=1)
+               Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 2840
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=155 loops=1)
+               Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 2835
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+                     Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 15
+(10 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17840 loops=1)
+               Filter: ("time" >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 150
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17835 loops=1)
+               Filter: ("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+               Rows Removed by Filter: 155
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17835 loops=1)
+               Filter: ('Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone < "time")
+               Rows Removed by Filter: 155
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(9 rows)
+
+--pushdowns between order by and segment by columns
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 < 1)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 < device_id)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: (device_id < v0)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v1 = device_id)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--pushdown between two order by column (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Limit (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: quicksort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+               Filter: (v0 = v1)
+               Rows Removed by Filter: 17990
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--pushdown of quals on order by and segment by cols anded together
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=10 loops=1)
+         Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+         Filter: (_hyper_X_X_chunk."time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+         Rows Removed by Filter: 31
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+               Filter: (compress_hyper_X_X_chunk._ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+(10 rows)
+
+--pushdown of quals on order by and segment by cols or together (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17866 loops=1)
+               Filter: (("time" > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) OR (device_id = 1))
+               Rows Removed by Filter: 124
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+--functions not yet optimized
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               Filter: ("time" < now())
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(7 rows)
+
+-- test sort optimization interaction
+:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(6 rows)
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+         Sort Method: top-N heapsort 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(6 rows)
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(3 rows)
+
+-- test aggregate
+:PREFIX SELECT count(*) FROM :TEST_TABLE;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(3 rows)
+
+-- test aggregate with GROUP BY
+:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Sort (actual rows=5 loops=1)
+   Sort Key: _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         Batches: 1 
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(8 rows)
+
+-- test window functions with GROUP BY
+:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort (actual rows=5 loops=1)
+   Sort Key: _hyper_X_X_chunk.device_id
+   Sort Method: quicksort 
+   ->  WindowAgg (actual rows=5 loops=1)
+         ->  HashAggregate (actual rows=5 loops=1)
+               Group Key: _hyper_X_X_chunk.device_id
+               Batches: 1 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(9 rows)
+
+-- test CTE
+:PREFIX WITH q AS (
+  SELECT v1 FROM :TEST_TABLE ORDER BY time
+)
+SELECT * FROM q ORDER BY v1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Sort (actual rows=17990 loops=1)
+   Sort Key: q.v1
+   Sort Method: quicksort 
+   ->  Subquery Scan on q (actual rows=17990 loops=1)
+         ->  Sort (actual rows=17990 loops=1)
+               Sort Key: _hyper_X_X_chunk."time"
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(9 rows)
+
+-- test CTE join
+:PREFIX WITH q1 AS (
+  SELECT time, v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time
+),
+q2 AS (
+  SELECT time, v2 FROM :TEST_TABLE WHERE device_id = 2 ORDER BY time
+)
+SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Merge Join (actual rows=3598 loops=1)
+   Merge Cond: (_hyper_X_X_chunk."time" = _hyper_X_X_chunk_1."time")
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+   ->  Materialize (actual rows=3598 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=3598 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     Index Cond: (device_id = 2)
+(9 rows)
+
+--
+-- test indexes
+--
+SET enable_seqscan TO FALSE;
+-- IndexScans should work
+:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- globs should not plan IndexOnlyScans
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                                                                                QUERY PLAN                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id, _hyper_X_X_chunk.v0, _hyper_X_X_chunk.v1, _hyper_X_X_chunk.v2, _hyper_X_X_chunk.v3
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- whole row reference should work
+:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
+                                                                                                                                                QUERY PLAN                                                                                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk test_table (actual rows=3598 loops=1)
+   Output: test_table.*, test_table.device_id, test_table."time"
+   ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk._ts_meta_sequence_num, compress_hyper_X_X_chunk."time", compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk.v0, compress_hyper_X_X_chunk.v1, compress_hyper_X_X_chunk.v2, compress_hyper_X_X_chunk.v3
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+-- even when we select only a segmentby column, we still need count
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   Output: count(*)
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(6 rows)
+
+--ensure that we can get a nested loop
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+--with multiple values can get a nested loop.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=7196 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         ->  Sort (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(16 rows)
+
+RESET enable_hashjoin;
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=1)
+         Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+         Index Cond: (compress_hyper_X_X_chunk.device_id = 1)
+(5 rows)
+
+--with multiple values can get a semi-join or nested loop depending on seq_page_cost.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+                                                                               QUERY PLAN                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=7196 loops=1)
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique (actual rows=2 loops=1)
+         Output: "*VALUES*".column1
+         ->  Sort (actual rows=2 loops=1)
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               Sort Method: quicksort 
+               ->  Values Scan on "*VALUES*" (actual rows=2 loops=1)
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk (actual rows=3598 loops=2)
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk (actual rows=4 loops=2)
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(16 rows)
+
+SET seq_page_cost = 100;
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   Output: _hyper_X_X_chunk.device_id
+   ->  Unique
+         Output: "*VALUES*".column1
+         ->  Sort
+               Output: "*VALUES*".column1
+               Sort Key: "*VALUES*".column1
+               ->  Values Scan on "*VALUES*"
+                     Output: "*VALUES*".column1
+   ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_X_X_chunk
+         Output: _hyper_X_X_chunk.device_id
+         Filter: ("*VALUES*".column1 = _hyper_X_X_chunk.device_id)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on _timescaledb_internal.compress_hyper_X_X_chunk
+               Output: compress_hyper_X_X_chunk._ts_meta_count, compress_hyper_X_X_chunk.device_id
+               Index Cond: (compress_hyper_X_X_chunk.device_id = "*VALUES*".column1)
+(15 rows)
+
+RESET seq_page_cost;
+-- test view
+CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
+:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+DROP VIEW compressed_view;
+-- test INNER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=17990 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=17990 loops=1)
+               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
+                     ->  Hash Join (actual rows=17990 loops=1)
+                           Hash Cond: (m1."time" = m3."time")
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                           ->  Hash (actual rows=3598 loops=1)
+                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
+                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
+                                             Index Cond: (device_id = 3)
+(19 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=100 loops=1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=100 loops=1)
+                     ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=1 loops=1)
+                           Index Cond: (device_id = 2)
+(10 rows)
+
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: (m1."time" = m2."time")
+         ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=100 loops=1)
+               Order: m1."time"
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_1 (actual rows=100 loops=1)
+                     Index Cond: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_2 (never executed)
+                     Index Cond: (device_id = 1)
+               ->  Index Scan Backward using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk m1_3 (never executed)
+                     Index Cond: (device_id = 1)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=100 loops=1)
+                     Order: m2."time"
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_1 (actual rows=100 loops=1)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_2 (never executed)
+                           Index Cond: (device_id = 2)
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_space_device_id_time_idx on _hyper_X_X_chunk m2_3 (never executed)
+                           Index Cond: (device_id = 2)
+(20 rows)
+
+-- test OUTER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=17990 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=17990 loops=1)
+                     Buckets: 32768  Batches: 1 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(12 rows)
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+                                                                                           QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=100 loops=1)
+   ->  Sort (actual rows=100 loops=1)
+         Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=17990 loops=1)
+               Hash Cond: (m1."time" = m2."time")
+               Join Filter: (m1.device_id = 1)
+               Rows Removed by Join Filter: 14392
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Hash (actual rows=3598 loops=1)
+                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                                 Index Cond: (device_id = 2)
+(15 rows)
+
+SET parallel_leader_participation TO false;
+-- test implicit self-join
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=20 loops=1)
+   ->  Incremental Sort (actual rows=20 loops=1)
+         Sort Key: m1."time", m1.device_id, m2.device_id
+         Presorted Key: m1."time"
+         Full-sort Groups: 1  Sort Method: quicksort 
+         ->  Merge Join (actual rows=26 loops=1)
+               Merge Cond: (m1."time" = m2."time")
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: m1."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=26 loops=1)
+                     Sort Key: m2."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(17 rows)
+
+-- test self-join with sub-query
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10 loops=1)
+   ->  Incremental Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id, m2.device_id
+         Presorted Key: m1."time"
+         Full-sort Groups: 1  Sort Method: top-N heapsort 
+         ->  Merge Join (actual rows=26 loops=1)
+               Merge Cond: (m1."time" = m2."time")
+               ->  Sort (actual rows=6 loops=1)
+                     Sort Key: m1."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=26 loops=1)
+                     Sort Key: m2."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(17 rows)
+
+RESET parallel_leader_participation;
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 17
+(9 rows)
+
+-- test prepared statement
+SET plan_cache_mode TO force_generic_plan;
+PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+:PREFIX EXECUTE prep;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate (actual rows=1 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               Index Cond: (device_id = 1)
+(4 rows)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+EXECUTE prep;
+ count 
+-------
+  3598
+(1 row)
+
+DEALLOCATE prep;
+-- test prepared statement with params pushdown
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+:PREFIX EXECUTE param_prep (1);
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Index Cond: (device_id = $1)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 4
+(10 rows)
+
+:PREFIX EXECUTE param_prep (2);
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Nested Loop (actual rows=5 loops=1)
+   ->  Function Scan on generate_series g (actual rows=32 loops=1)
+   ->  Limit (actual rows=0 loops=32)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=0 loops=32)
+               Filter: ("time" = g."time")
+               Rows Removed by Filter: 81
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=32)
+                     Index Cond: (device_id = $1)
+                     Filter: ((_ts_meta_min_1 <= g."time") AND (_ts_meta_max_1 >= g."time"))
+                     Rows Removed by Filter: 4
+(10 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (2);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (2);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+EXECUTE param_prep (1);
+             time             |             time             
+------------------------------+------------------------------
+ Sat Jan 01 00:00:00 2000 PST | Sat Jan 01 00:00:00 2000 PST
+ Sun Jan 02 00:00:00 2000 PST | Sun Jan 02 00:00:00 2000 PST
+ Mon Jan 03 00:00:00 2000 PST | Mon Jan 03 00:00:00 2000 PST
+ Tue Jan 04 00:00:00 2000 PST | Tue Jan 04 00:00:00 2000 PST
+ Wed Jan 05 00:00:00 2000 PST | Wed Jan 05 00:00:00 2000 PST
+(5 rows)
+
+DEALLOCATE param_prep;
+RESET plan_cache_mode;

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -15,8 +15,9 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES_SHARED timestamp_limits.sql with_clause_parser.sql)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
-set(TEST_TEMPLATES_SHARED gapfill.sql.in generated_columns.sql.in
-                          ordered_append.sql.in ordered_append_join.sql.in)
+set(TEST_TEMPLATES_SHARED
+    gapfill.sql.in generated_columns.sql.in transparent_decompress_chunk.sql.in
+    ordered_append.sql.in ordered_append_join.sql.in)
 
 # Regression tests that vary with PostgreSQL version. Generated test files are
 # put in the original source directory since all tests must be in the same

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -1,0 +1,326 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set PREFIX 'EXPLAIN (analyze, costs off, timing off, summary off)'
+\set PREFIX_VERBOSE 'EXPLAIN (analyze, costs off, timing off, summary off, verbose)'
+\set PREFIX_NO_ANALYZE 'EXPLAIN (verbose, costs off)'
+
+SELECT show_chunks('metrics_compressed') AS "TEST_TABLE" ORDER BY 1::text LIMIT 1 \gset
+
+-- this should use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+
+-- must not use DecompressChunk node
+:PREFIX_VERBOSE
+SELECT * FROM ONLY :TEST_TABLE WHERE device_id = 1 ORDER BY time LIMIT 5;
+
+-- test expressions
+:PREFIX
+SELECT time_bucket ('1d', time),
+    v1 + v2 AS "sum",
+    COALESCE(NULL, v1, v2) AS "coalesce",
+    NULL AS "NULL",
+    'text' AS "text",
+    t AS "RECORD"
+FROM :TEST_TABLE t
+WHERE device_id IN (1, 2)
+ORDER BY time, device_id;
+
+-- test empty targetlist
+:PREFIX SELECT FROM :TEST_TABLE;
+
+-- test empty resultset
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
+
+-- test targetlist not referencing columns
+:PREFIX SELECT 1 FROM :TEST_TABLE;
+
+-- test constraints not present in targetlist
+:PREFIX SELECT v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+
+-- test order not present in targetlist
+:PREFIX SELECT v2 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY v1;
+
+-- test column with all NULL
+:PREFIX SELECT v3 FROM :TEST_TABLE WHERE device_id = 1;
+
+--
+-- test qual pushdown
+--
+-- v3 is not segment by or order by column so should not be pushed down
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE v3 > 10.0 ORDER BY time, device_id;
+
+-- device_id constraint should be pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
+
+-- test IS NULL / IS NOT NULL
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
+
+-- test IN (Const,Const)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IN (1, 2) ORDER BY time, device_id LIMIT 10;
+
+-- test cast pushdown
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
+
+--test var op var
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
+
+-- test expressions
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
+
+-- test function calls
+-- not yet pushed down
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
+
+--
+-- test segment meta pushdown
+--
+-- order by column and const
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+
+--pushdowns between order by and segment by columns
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
+
+--pushdown between two order by column (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+
+--pushdown of quals on order by and segment by cols anded together
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
+
+--pushdown of quals on order by and segment by cols or together (not pushed down)
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
+
+--functions not yet optimized
+:PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+
+-- test sort optimization interaction
+:PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+
+:PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
+
+-- test aggregate
+:PREFIX SELECT count(*) FROM :TEST_TABLE;
+
+-- test aggregate with GROUP BY
+:PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+
+-- test window functions with GROUP BY
+:PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
+
+-- test CTE
+:PREFIX WITH q AS (
+  SELECT v1 FROM :TEST_TABLE ORDER BY time
+)
+SELECT * FROM q ORDER BY v1;
+
+-- test CTE join
+:PREFIX WITH q1 AS (
+  SELECT time, v1 FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time
+),
+q2 AS (
+  SELECT time, v2 FROM :TEST_TABLE WHERE device_id = 2 ORDER BY time
+)
+SELECT * FROM q1 INNER JOIN q2 ON q1.time = q2.time ORDER BY q1.time;
+
+--
+-- test indexes
+--
+SET enable_seqscan TO FALSE;
+
+-- IndexScans should work
+:PREFIX_VERBOSE SELECT time, device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+
+-- globs should not plan IndexOnlyScans
+:PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id, time;
+
+-- whole row reference should work
+:PREFIX_VERBOSE SELECT test_table FROM :TEST_TABLE AS test_table WHERE device_id = 1 ORDER BY device_id, time;
+
+-- even when we select only a segmentby column, we still need count
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id = 1 ORDER BY device_id;
+
+:PREFIX_VERBOSE SELECT count(*) FROM :TEST_TABLE WHERE device_id = 1;
+
+--ensure that we can get a nested loop
+SET enable_seqscan TO TRUE;
+SET enable_hashjoin TO FALSE;
+
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1));
+
+--with multiple values can get a nested loop.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN ( VALUES (1), (2));
+
+RESET enable_hashjoin;
+
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1));
+
+--with multiple values can get a semi-join or nested loop depending on seq_page_cost.
+:PREFIX_VERBOSE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+
+SET seq_page_cost = 100;
+
+-- loop/row counts of this query is different on windows so we run it without analyze
+:PREFIX_NO_ANALYZE SELECT device_id FROM :TEST_TABLE WHERE device_id IN (VALUES (1), (2));
+
+RESET seq_page_cost;
+
+-- test view
+CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :TEST_TABLE;
+
+:PREFIX SELECT * FROM compressed_view WHERE device_id = 1 ORDER BY time DESC LIMIT 10;
+
+DROP VIEW compressed_view;
+
+-- test INNER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = m2.device_id
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    INNER JOIN :TEST_TABLE m3 ON m2.time = m3.time
+        AND m1.device_id = m2.device_id
+        AND m3.device_id = 3
+    ORDER BY m1.time,
+        m1.device_id
+    LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    INNER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+
+:PREFIX
+SELECT *
+FROM metrics m1
+    INNER JOIN metrics_space m2 ON m1.time = m2.time
+        AND m1.device_id = 1
+        AND m2.device_id = 2
+    ORDER BY m1.time,
+        m1.device_id,
+        m2.time,
+        m2.device_id
+    LIMIT 100;
+
+-- test OUTER JOIN
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = m2.device_id
+ORDER BY m1.time,
+    m1.device_id
+LIMIT 10;
+
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1
+    LEFT OUTER JOIN :TEST_TABLE m2 ON m1.time = m2.time
+    AND m1.device_id = 1
+    AND m2.device_id = 2
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 100;
+
+SET parallel_leader_participation TO false;
+-- test implicit self-join
+:PREFIX
+SELECT *
+FROM :TEST_TABLE m1,
+    :TEST_TABLE m2
+WHERE m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.time,
+    m2.device_id
+LIMIT 20;
+
+-- test self-join with sub-query
+:PREFIX
+SELECT *
+FROM (
+    SELECT *
+    FROM :TEST_TABLE m1) m1
+    INNER JOIN (
+        SELECT *
+        FROM :TEST_TABLE m2) m2 ON m1.time = m2.time
+ORDER BY m1.time,
+    m1.device_id,
+    m2.device_id
+LIMIT 10;
+RESET parallel_leader_participation;
+
+:PREFIX
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+            LIMIT 1) m1 ON TRUE;
+
+
+-- test prepared statement
+SET plan_cache_mode TO force_generic_plan;
+PREPARE prep AS SELECT count(time) FROM :TEST_TABLE WHERE device_id = 1;
+
+:PREFIX EXECUTE prep;
+EXECUTE prep;
+EXECUTE prep;
+EXECUTE prep;
+EXECUTE prep;
+EXECUTE prep;
+EXECUTE prep;
+DEALLOCATE prep;
+
+-- test prepared statement with params pushdown
+PREPARE param_prep (int) AS
+SELECT *
+FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g (time)
+        INNER JOIN LATERAL (
+            SELECT time
+            FROM :TEST_TABLE m1
+            WHERE m1.time = g.time
+                AND device_id = $1
+            LIMIT 1) m1 ON TRUE;
+
+:PREFIX EXECUTE param_prep (1);
+:PREFIX EXECUTE param_prep (2);
+EXECUTE param_prep (1);
+EXECUTE param_prep (2);
+EXECUTE param_prep (1);
+EXECUTE param_prep (2);
+EXECUTE param_prep (1);
+DEALLOCATE param_prep;
+RESET plan_cache_mode;

--- a/tsl/test/sql/dist_compression.sql
+++ b/tsl/test/sql/dist_compression.sql
@@ -348,6 +348,12 @@ SELECT * from test_recomp_int_chunk_status ORDER BY 1;
 --run the compression policy job, it will recompress chunks that are unordered
 CALL run_job(:compressjob_id);
 SELECT count(*) from test_recomp_int;
+
+-- check with per datanode queries disabled
+SET timescaledb.enable_per_data_node_queries TO false;
+SELECT count(*) from test_recomp_int;
+RESET timescaledb.enable_per_data_node_queries;
+
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
 
 ---run copy tests
@@ -387,9 +393,16 @@ COPY test_recomp_int  FROM STDIN WITH DELIMITER ',';
 \.
 
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
-SELECT time_bucket(20, time ), count(*)
+SELECT time_bucket(20, time), count(*)
 FROM test_recomp_int
-GROUP BY time_bucket( 20, time) ORDER BY 1;
+GROUP BY time_bucket(20, time) ORDER BY 1;
+
+-- check with per datanode queries disabled
+SET timescaledb.enable_per_data_node_queries TO false;
+SELECT time_bucket(20, time), count(*)
+FROM test_recomp_int
+GROUP BY time_bucket(20, time) ORDER BY 1;
+RESET timescaledb.enable_per_data_node_queries;
 
 --check compression_status afterwards--
 SELECT recompress_chunk(chunk, true) FROM


### PR DESCRIPTION
In queries on distributed hypertables with per datanode queries
disabled transparent decompression would not work because the
query sent to the data node was for individual chunks. To support
queries on distributed hypertables with per datanode queries
disabled this patch adds support for transparent decompression
in queries on individual chunks.

Fixes #3714 