### PR TITLE
Initial release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,30 @@
 # Release pipeline
 #
-# This release pipeline does a release with the contents of the
-# branch that you select when running the workflow. 
-
+# This release pipeline does a release with the contents of the branch
+# that you select when running the workflow. Right now it only tags
+# the release and triggers the release procedure in the other
+# repositories and expect that you have added a changelog already.
+#
+# We could trigger this on a tagging event, but since this is still
+# experimental, we will trigger it manually for now. This will allow
+# us to do a dry-run first, check that it looks good, and then trigger
+# a real release.
+#
+# The release can be triggered either through the GitHub web interface
+# or using the GitHub CLI. To release 2.1.5 using the 2.1.x branch,
+# you would have to do.
+#
+#     gh workflow run --ref 2.1.x version=2.1.5 publish=true release.yaml
+#
+# The following secrets are used in the workflow.
+#
+# SLACK_BOT_TOKEN
+#    OAuth token for the application that will write the message.
+# SLACK_CHANNEL_RELEASE
+#    Channel identifier for channel where the release thread should be
+#    created.
+# SLACK_CHANNEL_FEED_EXPERIMENTAL
+#    Experimental Slack channel
 name: Release TimescaleDB
 on:
   workflow_dispatch:
@@ -10,16 +32,21 @@ on:
       version:
         description: 'Version to release'
         required: true
-      publish-artifacts:
-        description: 'Publish all artifacts'
+      publish:
+        description: 'Publish artifacts'
         required: false
         default: false
 jobs:
   # This is just a simple check but does not do anything sensible at
   # this point except printing some status information about the
-  # branch.
+  # branch and checking that the version.config contains the correct
+  # information.
+  #
+  # Intention is to add more checks later to make sure that releases
+  # are not started accidentally or when not needed, e.g., if there
+  # are no commits in the branch.
   check-release:
-    name: Check Release
+    name: Check Release Status
     runs-on: ubuntu-latest
     steps:
       - name: Checkout TimescaleDB
@@ -35,4 +62,99 @@ jobs:
         shell: bash -x {0}
         run: |
           tag=$(git describe --tags --abbrev=0 $GITHUB_REF)
-          git log $tag..
+          git log --oneline --decorate $tag..
+
+      - name: Check version configuration
+        shell: perl {0} version.config
+        run: |
+          my $expected = q/${{ github.event.inputs.version }}/;
+          while (<>) {
+            die "Version was $1, expected $expected"
+              if /\bversion\s*=\s*(\S+)/ && $1 != $expected
+          }
+
+  tag-release:
+    name: Tag release
+    needs: check-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout TimescaleDB
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get some info
+        run: |
+          whoami
+          echo "${{ toJSON(github) }}"
+          echo "GITHUB_ACTOR: ${GITHUB_ACTOR}"
+          echo "GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}"
+
+      - name: Tag version
+        run: |
+          git config --local user.email "release@timescale.com"
+          git config --local user.name "TimescaleDB Release"
+          git tag -a ${{ github.event.inputs.version }}  -m "${{ github.event.inputs.version }}"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true
+
+  homebrew-release:
+    name: Release Homebrew
+    needs: tag-release
+    uses: timescale/release-build-scripts/.github/workflows/timescaledb-homebrew.yaml@v1
+    with:
+      version: ${{ github.event.inputs.version }}
+      upload-artifacts: ${{ github.event.inputs.publish }}
+
+  debian-release:
+    name: Release Debian
+    needs: tag-release
+    uses: timescale/release-build-scripts/.github/workflows/timescaledb-debian.yaml@v1
+    with:
+      version: ${{ github.event.inputs.version }}
+      upload-artifacts: ${{ github.event.inputs.publish }}
+
+  rpm-release:
+    name: Release RPM
+    needs: tag-release
+    runs-on: ubuntu-latest
+    uses: timescale/release-build-scripts/.github/workflows/timescaledb-rpm.yaml@v1
+    with:
+      version: ${{ github.event.inputs.version }}
+      upload-artifacts: ${{ github.event.inputs.publish }}
+
+  ubuntu-release:
+    name: Release Ubuntu
+    needs: tag-release
+    runs-on: ubuntu-latest
+    uses: timescale/release-build-scripts/.github/workflows/timescaledb-ubuntu.yaml@v1
+    with:
+      version: ${{ github.event.inputs.version }}
+      upload-artifacts: ${{ github.event.inputs.publish }}
+
+  docker-release:
+    name: Release Docker Image
+    needs: tag-release
+    runs-on: ubuntu-latest
+    uses: timescale/timescaledb-docker/.github/workflows/docker-image.yaml@v1
+    with:
+      version: ${{ github.event.inputs.version }}
+      upload-artifacts: ${{ github.event.inputs.publish }}
+
+  notify:
+    needs: [release-homebrew, release-docker, release-rpm,  release-ubuntu]
+    steps:
+      - name: Notify that release was done
+        id: slack
+        uses: slackapi/slack-github-action@v1.14.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_FEED_EXPERIMENTAL }}
+          slack-message: 'Release of TimescaleDB ${{ github.event.inputs.version }} complete!'
+          


### PR DESCRIPTION
Initial version of a pipeline that will perform a release based
on a set of commits in a specific branch. The workflow will tag the
release and trigger the release procedure in other repositories, so the
assumption is that the commits for the release and the changelog is up
to date.

You can trigger this workflow either explicitly in the GitHub
interface, or using the CLI with something like:

    gh workflow run release.yaml --ref 2.1.x version=2.1.5
