### PR TITLE
Fix DirectFunctionCall crash in distributed_exec

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -21,9 +21,6 @@
 
 #include "export.h"
 
-#define TS_PREVENT_FUNC_IF_READ_ONLY()                                                             \
-	(PreventCommandIfReadOnly(psprintf("%s()", get_func_name(FC_FN_OID(fcinfo)))))
-
 #define is_supported_pg_version_12(version) ((version >= 120000) && (version < 130000))
 #define is_supported_pg_version_13(version) ((version >= 130002) && (version < 140000))
 #define is_supported_pg_version_14(version) ((version >= 140000) && (version < 150000))

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,6 +15,19 @@
 
 #include "compat/compat.h"
 
+/*
+ * Get the function name in a PG_FUNCTION.
+ *
+ * The function name is resolved from the function Oid in the functioncall
+ * data. However, this information is not present in case of a direct function
+ * call, so fall back to the C-function name.
+ */
+#define TS_FUNCNAME()                                                                              \
+	(psprintf("%s()", fcinfo->flinfo ? get_func_name(FC_FN_OID(fcinfo)) : __func__))
+
+#define TS_PREVENT_FUNC_IF_READ_ONLY() PreventCommandIfReadOnly(TS_FUNCNAME())
+#define TS_PREVENT_IN_TRANSACTION_BLOCK(toplevel) PreventInTransactionBlock(toplevel, TS_FUNCNAME())
+
 #define MAX(x, y) ((x) > (y) ? x : y)
 #define MIN(x, y) ((x) < (y) ? x : y)
 

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -712,7 +712,7 @@ data_node_add_internal(PG_FUNCTION_ARGS, bool set_distid)
 	 * cannot run in a transaction block, we cannot run the function in a
 	 * transaction block either.
 	 */
-	PreventInTransactionBlock(true, "add_data_node");
+	TS_PREVENT_IN_TRANSACTION_BLOCK(true);
 
 	/* Try to create the foreign server, or get the existing one in case of
 	 * if_not_exists true. */

--- a/tsl/src/remote/dist_commands.c
+++ b/tsl/src/remote/dist_commands.c
@@ -12,6 +12,8 @@
 #include <utils/lsyscache.h>
 #include <utils/syscache.h>
 
+#include <utils.h>
+
 #include "dist_commands.h"
 #include "dist_txn.h"
 #include "connection_cache.h"
@@ -95,7 +97,10 @@ ts_dist_multi_cmds_params_invoke_on_data_nodes(const char **sql, StmtParams **pa
 	DistCmdResult *results;
 
 	if (data_nodes == NIL)
-		elog(ERROR, "target data nodes must be specified for ts_dist_cmd_invoke_on_data_nodes");
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("no data nodes to execute command on"),
+				 errhint("Add data nodes before executing a distributed command.")));
 
 	switch (nodeTag(data_nodes))
 	{
@@ -400,7 +405,10 @@ ts_dist_cmd_prepare_command(const char *sql, size_t n_params, List *node_names)
 	AsyncResponseResult *async_resp;
 
 	if (node_names == NIL)
-		elog(ERROR, "target data nodes must be specified for ts_dist_cmd_prepare_command");
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid data nodes list"),
+				 errdetail("Must specify a non-empty list of data nodes.")));
 
 	foreach (lc, node_names)
 	{
@@ -474,7 +482,7 @@ ts_dist_cmd_exec(PG_FUNCTION_ARGS)
 	const char *search_path;
 
 	if (!transactional)
-		PreventInTransactionBlock(true, get_func_name(FC_FN_OID(fcinfo)));
+		TS_PREVENT_IN_TRANSACTION_BLOCK(true);
 
 	if (NULL == query)
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("empty command string")));
@@ -487,8 +495,40 @@ ts_dist_cmd_exec(PG_FUNCTION_ARGS)
 	if (data_nodes == NULL)
 		data_node_list = data_node_get_node_name_list();
 	else
-		data_node_list = data_node_array_to_node_name_list(data_nodes);
+	{
+		int ndatanodes;
 
+		if (ARR_NDIM(data_nodes) > 1)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid data nodes list"),
+					 errdetail("The array of data nodes cannot be multi-dimensional.")));
+
+		if (ARR_HASNULL(data_nodes))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid data nodes list"),
+					 errdetail("The array of data nodes cannot contain null values.")));
+
+		ndatanodes = ArrayGetNItems(ARR_NDIM(data_nodes), ARR_DIMS(data_nodes));
+
+		if (ndatanodes == 0)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("invalid data nodes list"),
+					 errdetail("The array of data nodes cannot be empty.")));
+
+		data_node_list = data_node_array_to_node_name_list(data_nodes);
+	}
+
+	/* Assert that the data node list is not empty. Since we checked that the
+	 * function is run on an access node above, the list of data nodes must
+	 * per definition be non-empty for the case when not specifying an
+	 * explicit list of data nodes. For the case of explicitly specifying data
+	 * nodes, we already checked for a non-empty array, and then validated all
+	 * the specified data nodes. If there was a node in the list that is not a
+	 * data node, we would already have thrown an error. */
+	Assert(data_node_list != NIL);
 	search_path = GetConfigOption("search_path", false, false);
 	result = ts_dist_cmd_invoke_on_data_nodes_using_search_path(query,
 																search_path,

--- a/tsl/test/expected/data_node_bootstrap.out
+++ b/tsl/test/expected/data_node_bootstrap.out
@@ -382,7 +382,7 @@ DROP DATABASE access_node;
 BEGIN;
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('bootstrap_test', host => 'localhost', database => 'bootstrap_test');
-ERROR:  add_data_node cannot run inside a transaction block
+ERROR:  add_data_node() cannot run inside a transaction block
 \set ON_ERROR_STOP 1
 COMMIT;
 SELECT * FROM show_data_nodes();

--- a/tsl/test/expected/dist_commands.out
+++ b/tsl/test/expected/dist_commands.out
@@ -212,11 +212,45 @@ t
 (1 row)
 
 -- Test distributed_exec()
+-- Test calling distributed exec via direct function call
+RESET ROLE;
+CREATE OR REPLACE PROCEDURE distributed_exec_direct_function_call(
+       query TEXT,
+       node_list name[] = NULL,
+       transactional BOOLEAN = TRUE)
+AS :TSL_MODULE_PATHNAME, 'ts_test_direct_function_call' LANGUAGE C;
+SET ROLE :ROLE_1;
+-- Invalid input
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+BEGIN;
+-- Not allowed in transcation block if transactional=false
+CALL distributed_exec_direct_function_call('CREATE TABLE dist_test(id int)', NULL, false);
+ERROR:  ts_dist_cmd_exec() cannot run inside a transaction block
+ROLLBACK;
+-- multi-dimensional array of data nodes
+CALL distributed_exec('CREATE TABLE dist_test(id int)', '{{data_node_1}}');
+ERROR:  invalid data nodes list
+DETAIL:  The array of data nodes cannot be multi-dimensional.
+-- Specified, but empty data node array
+CALL distributed_exec('CREATE TABLE dist_test(id int)', '{}');
+ERROR:  invalid data nodes list
+DETAIL:  The array of data nodes cannot be empty.
+-- Specified, but contains null values
+CALL distributed_exec('CREATE TABLE dist_test(id int)', '{data_node_1, NULL}');
+ERROR:  invalid data nodes list
+DETAIL:  The array of data nodes cannot contain null values.
+-- Specified, but not a data node
+CALL distributed_exec('CREATE TABLE dist_test(id int)', '{data_node_1928}');
+ERROR:  server "data_node_1928" does not exist
+\set VERBOSITY terse
+\set ON_ERROR_STOP 1
 -- Make sure dist session is properly set
 CALL distributed_exec('DO $$ BEGIN ASSERT(SELECT is_frontend_session()) = true; END; $$;');
 -- Test creating and dropping a table
 CALL distributed_exec('CREATE TABLE dist_test (id int)');
 CALL distributed_exec('INSERT INTO dist_test values (7)');
+-- Test INSERTING data using empty array of data nodes (same behavior as not specifying).
 SELECT * FROM test.remote_exec(NULL, $$ SELECT * from dist_test; $$);
 NOTICE:  [data_node_1]:  SELECT * from dist_test
 NOTICE:  [data_node_1]:
@@ -326,6 +360,13 @@ SELECT * FROM delete_data_node('data_node_3');
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;
 DROP DATABASE :DN_DBNAME_3;
+\set ON_ERROR_STOP 0
+-- Calling distributed_exec without data nodes should fail
+CALL distributed_exec('SELECT 1');
+ERROR:  function must be run on the access node only
+CALL distributed_exec('SELECT 1', '{data_node_1}');
+ERROR:  function must be run on the access node only
+\set ON_ERROR_STOP 1
 -- Test TS execution on non-TSDB server
 CREATE EXTENSION postgres_fdw;
 CREATE SERVER myserver FOREIGN DATA WRAPPER postgres_fdw
@@ -447,7 +488,7 @@ CALL distributed_exec(
      $$ INSERT INTO my_table VALUES (3, 'baz') $$,
      transactional => FALSE
 );
-ERROR:  distributed_exec cannot run inside a transaction block
+ERROR:  distributed_exec() cannot run inside a transaction block
 COMMIT;
 \set ON_ERROR_STOP 1
 -- We should see no changes

--- a/tsl/test/src/CMakeLists.txt
+++ b/tsl/test/src/CMakeLists.txt
@@ -5,7 +5,8 @@ set(SOURCES
     test_compression.c
     test_continuous_agg.c
     test_ddl_hook.c
-    test_dist_util.c)
+    test_dist_util.c
+    test_dist_commands.c)
 
 include(${PROJECT_SOURCE_DIR}/tsl/src/build-defs.cmake)
 
@@ -18,6 +19,8 @@ set_target_properties(${TSL_TESTS_LIB_NAME} PROPERTIES POSITION_INDEPENDENT_CODE
                                                        ON)
 target_include_directories(${TSL_TESTS_LIB_NAME}
                            PRIVATE ${CMAKE_SOURCE_DIR}/test/src)
+target_include_directories(${TSL_TESTS_LIB_NAME}
+                           PRIVATE ${CMAKE_SOURCE_DIR}/tsl/src/remote)
 target_include_directories(${TSL_TESTS_LIB_NAME} PRIVATE ${PG_INCLUDEDIR})
 target_compile_definitions(${TSL_TESTS_LIB_NAME} PUBLIC TS_SUBMODULE)
 

--- a/tsl/test/src/test_dist_commands.c
+++ b/tsl/test/src/test_dist_commands.c
@@ -1,0 +1,38 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+#include <postgres.h>
+#include <dist_commands.h>
+
+TS_FUNCTION_INFO_V1(ts_test_direct_function_call);
+
+/*
+ * Test that calling distribute_exec via a direct function call works. Covers
+ * a bug that was hit when the third argument was transactional=false and the
+ * fcinfo didn't have the full metadata from the parsing stage (which is
+ * typical when using direct function calls).
+ */
+Datum
+ts_test_direct_function_call(PG_FUNCTION_ARGS)
+{
+	LOCAL_FCINFO(fcinfo2, 3);
+	Datum result;
+
+	/* Fill in FunctionCallInfo similar to DirectFunctionCall, but copy info
+	 * from wrapper. */
+	InitFunctionCallInfoData(*fcinfo2, NULL, 3, InvalidOid, NULL, NULL);
+
+	fcinfo2->args[0].value = PG_GETARG_DATUM(0);
+	fcinfo2->args[0].isnull = PG_ARGISNULL(0);
+	fcinfo2->args[1].value = PG_GETARG_DATUM(1);
+	fcinfo2->args[1].isnull = PG_ARGISNULL(1);
+	fcinfo2->args[2].value = PG_GETARG_DATUM(2);
+	fcinfo2->args[2].isnull = PG_ARGISNULL(2);
+
+	result = ts_dist_cmd_exec(fcinfo2);
+	Assert(!fcinfo2->isnull);
+
+	return result;
+}

--- a/tsl/test/src/test_dist_util.c
+++ b/tsl/test/src/test_dist_util.c
@@ -10,6 +10,7 @@
 #include <export.h>
 #include <access/htup_details.h>
 
+#include <dist_commands.h>
 #include "dist_util.h"
 
 TS_FUNCTION_INFO_V1(ts_test_compatible_version);


### PR DESCRIPTION
This change fixes a crash that occurred when calling
`distributed_exec` via a direct function call.

The crash was triggered by a dynamic lookup of the function name via
the function Oid in the `FunctionCallInfo` struct in order to generate
error messages for read-only and transaction block checks. However,
this information is provided by the parsing stage, which is not
executed when doing direct function calls, thus leading to a
segmentation fault when trying to dereference a pointer in the
`FunctionCallInfo` that wasn't set.

Note that this problem is not limited to `distributed_exec`; it is
present in all SQL-callable functions that use the same pattern and
macros.

To fix the problem, update the macros and patterns used for checking
for read-only mode and transaction blocks to avoid doing the function
name lookup when the pointer is not set. Instead fall back to the C
function name in that case (via C macro `__func__`).

A test case is added in C code to call `distributed_exec` via a direct
function call within a transaction block in order to hit the
previously crashing error message.

The `distributed_exec` function has also been updated with better
handling of input parameters, like empty arrays of data nodes, or
arrays containing NULL elements.