### PR TITLE
Fix flaky pg_dump

### DIFF
--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
+\set TEST_DBNAME_EXTRA :TEST_DBNAME _extra
 \o /dev/null
 \ir include/insert_two_partitions.sql
 -- This file and its contents are licensed under the Apache License 2.0.
@@ -35,6 +36,10 @@ INSERT INTO "two_Partitions"("timeCustom", device_id, series_0, series_1) VALUES
 \set QUIET on
 \o
 \c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION bgw_wait(database TEXT, timeout INT)
+RETURNS VOID
+AS :MODULE_PATHNAME, 'ts_bgw_wait'
+LANGUAGE C VOLATILE;
 CREATE SCHEMA test_schema AUTHORIZATION :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME
 ALTER TABLE PUBLIC."two_Partitions" SET SCHEMA "test_schema";
@@ -591,24 +596,52 @@ SELECT get_sqlstate('SELECT timescaledb_post_restore()');
 (1 row)
 
 drop function get_sqlstate(TEXT);
-\c postgres :ROLE_SUPERUSER
---need to shutdown workers to use db as template
--- there should be no sessions for that database
--- columns are explicit so the output is the same on PG12 and PG13 since PG13 has extra column leader_pid
-SELECT datid,datname,pid,usesysid,usename,application_name,client_addr,client_hostname,client_port,backend_start,xact_start,query_start,state_change,wait_event_type,wait_event,state,backend_xid,backend_xmin,query,backend_type FROM pg_stat_activity WHERE datname = :'TEST_DBNAME';
- datid | datname | pid | usesysid | usename | application_name | client_addr | client_hostname | client_port | backend_start | xact_start | query_start | state_change | wait_event_type | wait_event | state | backend_xid | backend_xmin | query | backend_type 
--------+---------+-----+----------+---------+------------------+-------------+-----------------+-------------+---------------+------------+-------------+--------------+-----------------+------------+-------+-------------+--------------+-------+--------------
-(0 rows)
-
-CREATE DATABASE db_dump_error WITH TEMPLATE :TEST_DBNAME;
---now test functions for permission errors
-\c  db_dump_error :ROLE_DEFAULT_PERM_USER_2
-\set ON_ERROR_STOP 0
-SELECT timescaledb_pre_restore();
-ERROR:  must be owner of database db_dump_error
-SELECT timescaledb_post_restore();
-ERROR:  must be owner of database db_dump_error
-\set ON_ERROR_STOP 1
---drop db
+-- Check that the extension can be copied from an existing database
+-- without explicitly installing it. Stop background workers since we
+-- cannot have any backends connected to the database when cloning it.
 \c :TEST_DBNAME :ROLE_SUPERUSER
-DROP DATABASE db_dump_error;
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+(1 row)
+
+SELECT bgw_wait(:'TEST_DBNAME', 60);
+ bgw_wait 
+----------
+ 
+(1 row)
+
+CREATE DATABASE :TEST_DBNAME_EXTRA WITH TEMPLATE :TEST_DBNAME;
+-- Connect to the database and do some basic stuff to check that the
+-- extension works.
+\c :TEST_DBNAME_EXTRA :ROLE_DEFAULT_PERM_USER
+CREATE TABLE test_tz(time timestamptz not null, temp float8, device text);
+SELECT create_hypertable('test_tz', 'time', 'device', 2);
+  create_hypertable   
+----------------------
+ (2,public,test_tz,t)
+(1 row)
+
+SELECT id, schema_name, table_name FROM _timescaledb_catalog.hypertable;
+ id | schema_name |   table_name   
+----+-------------+----------------
+  1 | test_schema | two_Partitions
+  2 | public      | test_tz
+(2 rows)
+
+INSERT INTO test_tz VALUES('Mon Mar 20 09:17:00.936242 2017', 23.4, 'dev1');
+INSERT INTO test_tz VALUES('Mon Mar 20 09:27:00.936242 2017', 22, 'dev2');
+INSERT INTO test_tz VALUES('Mon Mar 20 09:28:00.936242 2017', 21.2, 'dev1');
+INSERT INTO test_tz VALUES('Mon Mar 20 09:37:00.936242 2017', 30, 'dev3');
+SELECT * FROM test_tz ORDER BY time;
+                time                 | temp | device 
+-------------------------------------+------+--------
+ Mon Mar 20 09:17:00.936242 2017 PDT | 23.4 | dev1
+ Mon Mar 20 09:27:00.936242 2017 PDT |   22 | dev2
+ Mon Mar 20 09:28:00.936242 2017 PDT | 21.2 | dev1
+ Mon Mar 20 09:37:00.936242 2017 PDT |   30 | dev3
+(4 rows)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE :TEST_DBNAME_EXTRA;

--- a/test/expected/test_utils.out
+++ b/test/expected/test_utils.out
@@ -15,13 +15,13 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- failing conditions
 \set ON_ERROR_STOP 0
 SELECT test.condition();
-ERROR:  TestFailure @ test_utils.c ts_test_utils_condition:28 | (true_value == false_value)
+ERROR:  TestFailure @ test_utils.c ts_test_utils_condition:30 | (true_value == false_value)
 SELECT test.int64_eq();
-ERROR:  TestFailure @ test_utils.c ts_test_utils_int64_eq:38 | (big == small) [32532978 == 3242234]
+ERROR:  TestFailure @ test_utils.c ts_test_utils_int64_eq:40 | (big == small) [32532978 == 3242234]
 SELECT test.ptr_eq();
-ERROR:  TestFailure @ test_utils.c ts_test_utils_ptr_eq:52 | (true_ptr == false_ptr)
+ERROR:  TestFailure @ test_utils.c ts_test_utils_ptr_eq:54 | (true_ptr == false_ptr)
 SELECT test.double_eq();
-ERROR:  TestFailure @ test_utils.c ts_test_utils_double_eq:63 | (big_double == small_double) [923423478.324200 == 324.300000]
+ERROR:  TestFailure @ test_utils.c ts_test_utils_double_eq:65 | (big_double == small_double) [923423478.324200 == 324.300000]
 \set ON_ERROR_STOP 1
 -- Test debug points
 --

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -30,7 +30,6 @@ set(TEST_FILES
     parallel.sql
     partition.sql
     partitioning.sql
-    pg_dump.sql
     pg_dump_unprivileged.sql
     pg_join.sql
     plain.sql
@@ -93,6 +92,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     metadata.sql
     multi_transaction_index.sql
     net.sql
+    pg_dump.sql
     symbol_conflict.sql
     telemetry.sql
     test_utils.sql)

--- a/test/src/test_utils.c
+++ b/test/src/test_utils.c
@@ -6,6 +6,8 @@
 #include <postgres.h>
 #include <fmgr.h>
 #include <utils/builtins.h>
+#include <storage/procarray.h>
+#include <commands/dbcommands.h>
 
 #include "test_utils.h"
 #include "debug_point.h"
@@ -71,4 +73,41 @@ ts_test_error_injection(PG_FUNCTION_ARGS)
 	text *name = PG_GETARG_TEXT_PP(0);
 	DEBUG_ERROR_INJECTION(text_to_cstring(name));
 	PG_RETURN_VOID();
+}
+
+TS_FUNCTION_INFO_V1(ts_bgw_wait);
+Datum
+ts_bgw_wait(PG_FUNCTION_ARGS)
+{
+	text *datname = PG_GETARG_TEXT_PP(0);
+	/* The timeout is given in seconds, so we compute the number of iterations
+	 * necessary to get a coverage of that time */
+	uint32 iterations = PG_ARGISNULL(1) ? 5 : (PG_GETARG_UINT32(1) + 4) / 5;
+	Oid dboid = get_database_oid(text_to_cstring(datname), false);
+
+	/* This function contains a timeout of 5 seconds, so we iterate a few
+	 * times to make sure that it really has terminated. */
+	int notherbackends;
+	int npreparedxacts;
+	while (iterations-- > 0)
+	{
+		if (!CountOtherDBBackends(dboid, &notherbackends, &npreparedxacts))
+			PG_RETURN_NULL();
+		ereport(NOTICE,
+				(errmsg("source database \"%s\" is being accessed by other users",
+						text_to_cstring(datname)),
+				 errdetail("There are %d other session(s) and %d prepared transaction(s) using the "
+						   "database.",
+						   notherbackends,
+						   npreparedxacts)));
+	}
+	ereport(ERROR,
+			(errcode(ERRCODE_OBJECT_IN_USE),
+			 errmsg("source database \"%s\" is being accessed by other users",
+					text_to_cstring(datname)),
+			 errdetail("There are %d other session(s) and %d prepared transaction(s) using the "
+					   "database.",
+					   notherbackends,
+					   npreparedxacts)));
+	pg_unreachable();
 }


### PR DESCRIPTION
Calling `CREATE DATABASE` we cannot have any backends connected to the
source database, except the current one. Since background workers
connect to any database that has installed the extension, they can
linger and cause a flaky error.

The test changed to just check that the extension can be implicitly
installed, but this require waiting for backends to be unregistered
from `procArray` in `procarray.c`, which the function
`pg_terminate_backend` does not handle properly and hence results in a
flaky test. This happen because `pg_terminate_backend` only signals the
process to terminate, but does not wait for it to actually terminate.

Instead, we add an explicit function that checks the `procArray` and
waits for it to not have any backends for a database and uses that to
wait for termination.
