### PR TITLE
Fix compression policy on tables using INTEGER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #3766 Fix segfault in ts_hist_sfunc
+* #3739 Fix compression policy on tables using INTEGER
 
 **Thanks**
 * @cbisnett for reporting and fixing a typo in an error message
+* @CaptainCuddleCube for reporting bug on compression policy procedure on tables using INTEGER on time dimension
 
 ## 2.5.0 (2021-10-28)
 

--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -19,163 +19,125 @@ AS '@MODULE_PATHNAME@', 'ts_policy_refresh_cagg_proc'
 LANGUAGE C;
 
 CREATE OR REPLACE PROCEDURE
-_timescaledb_internal.policy_compression_interval( job_id INTEGER, 
-   htid INTEGER,
-   lag INTERVAL,
-   maxchunks INTEGER,
-   verbose_log BOOLEAN,
-   recompress_enabled BOOLEAN)
+_timescaledb_internal.policy_compression_execute(
+  job_id              INTEGER,
+  htid                INTEGER,
+  lag                 ANYELEMENT,
+  maxchunks           INTEGER,
+  verbose_log         BOOLEAN,
+  recompress_enabled  BOOLEAN)
 AS $$
 DECLARE
-  htoid regclass;
-  chunk_rec record;
-  numchunks integer := 1;
+  htoid       REGCLASS;
+  chunk_rec   RECORD;
+  numchunks   INTEGER := 1;
 BEGIN
 
-  SELECT format('%I.%I',schema_name, table_name) INTO htoid
+  SELECT format('%I.%I', schema_name, table_name) INTO htoid
   FROM _timescaledb_catalog.hypertable
   WHERE id = htid;
 
-  FOR chunk_rec IN
-    SELECT show.oid, ch.schema_name, ch.table_name, ch.status
-    FROM show_chunks( htoid, older_than => lag) as show(oid)
-      INNER JOIN pg_class pgc ON pgc.oid = show.oid
-      INNER JOIN pg_namespace pgns ON pgc.relnamespace = pgns.oid
-      INNER JOIN _timescaledb_catalog.chunk ch ON ch.table_name = pgc.relname and ch.schema_name = pgns.nspname and ch.hypertable_id = htid
-    WHERE ch.dropped is false and  (ch.status = 0 OR ch.status = 3)
-  LOOP
-    IF chunk_rec.status = 0 THEN
-       PERFORM compress_chunk( chunk_rec.oid );
-    ELSIF chunk_rec.status = 3 AND recompress_enabled = 'true' THEN
-       PERFORM recompress_chunk( chunk_rec.oid );
-    END IF;
-    COMMIT;
-    IF verbose_log THEN
-       RAISE LOG 'job % completed processing chunk %.%', job_id, chunk_rec.schema_name, chunk_rec.table_name;
-    END IF;
-    numchunks := numchunks + 1;
-    IF maxchunks > 0 AND numchunks >= maxchunks THEN  
-         EXIT; 
-    END IF;  
-  END LOOP;
-END;
-$$ LANGUAGE PLPGSQL;
-
-CREATE OR REPLACE PROCEDURE
-_timescaledb_internal.policy_compression_integer( job_id INTEGER, 
-   htid INTEGER,
-   lag BIGINT,
-   maxchunks INTEGER,
-   verbose_log BOOLEAN,
-   recompress_enabled BOOLEAN)
-AS $$
-DECLARE
-  htoid regclass;
-  chunk_rec record;
-  numchunks integer := 0;
-  lag_integer BIGINT;
-BEGIN
-
-  SELECT format('%I.%I',schema_name, table_name) INTO htoid
-  FROM _timescaledb_catalog.hypertable
-  WHERE id = htid;
-
-  --for the integer case , we have to compute the lag w.r.t 
+  -- for the integer cases, we have to compute the lag w.r.t
   -- the integer_now function and then pass on to show_chunks
-  lag_integer := _timescaledb_internal.subtract_integer_from_now( htoid, lag);
+  IF pg_typeof(lag) IN ('BIGINT'::regtype, 'INTEGER'::regtype, 'SMALLINT'::regtype) THEN
+    lag := _timescaledb_internal.subtract_integer_from_now(htoid, lag::BIGINT);
+  END IF;
 
   FOR chunk_rec IN
-    SELECT show.oid, ch.schema_name, ch.table_name, ch.status
-    FROM show_chunks( htoid, older_than => lag_integer) SHOW (oid)
+    SELECT
+      show.oid, ch.schema_name, ch.table_name, ch.status
+    FROM
+      show_chunks(htoid, older_than => lag) AS show(oid)
       INNER JOIN pg_class pgc ON pgc.oid = show.oid
       INNER JOIN pg_namespace pgns ON pgc.relnamespace = pgns.oid
-      INNER JOIN _timescaledb_catalog.chunk ch ON ch.table_name = pgc.relname and ch.schema_name = pgns.nspname and ch.hypertable_id = htid
-    WHERE ch.dropped is false and  (ch.status = 0 OR ch.status = 3)
+      INNER JOIN _timescaledb_catalog.chunk ch ON ch.table_name = pgc.relname AND ch.schema_name = pgns.nspname AND ch.hypertable_id = htid
+    WHERE
+      ch.dropped IS FALSE
+      AND (ch.status = 0 OR ch.status = 3)
   LOOP
     IF chunk_rec.status = 0 THEN
        PERFORM compress_chunk( chunk_rec.oid );
-    ELSIF chunk_rec.status = 3 AND recompress_enabled = 'true' THEN
+    ELSIF chunk_rec.status = 3 AND recompress_enabled IS TRUE THEN
        PERFORM recompress_chunk( chunk_rec.oid );
     END IF;
     COMMIT;
     IF verbose_log THEN
        RAISE LOG 'job % completed processing chunk %.%', job_id, chunk_rec.schema_name, chunk_rec.table_name;
     END IF;
-
     numchunks := numchunks + 1;
-    IF maxchunks > 0 AND numchunks >= maxchunks THEN  
-         EXIT; 
-    END IF;  
+    IF maxchunks > 0 AND numchunks >= maxchunks THEN
+         EXIT;
+    END IF;
   END LOOP;
 END;
 $$ LANGUAGE PLPGSQL;
 
 CREATE OR REPLACE PROCEDURE
-_timescaledb_internal.policy_compression( job_id INTEGER, config JSONB)
+_timescaledb_internal.policy_compression(job_id INTEGER, config JSONB)
 AS $$
 DECLARE
-  dimtype regtype;
-  compress_after text;
-  lag_interval interval;
-  lag_integer bigint;
-  htid integer;
-  htoid regclass;
-  chunk_rec record;
-  verbose_log bool;
-  maxchunks integer := 0;
-  numchunks integer := 1;
-  recompress_enabled bool;
+  dimtype             REGTYPE;
+  dimtypeinput        REGPROC;
+  compress_after      TEXT;
+  lag_value           TEXT;
+  htid                INTEGER;
+  htoid               REGCLASS;
+  chunk_rec           RECORD;
+  verbose_log         BOOL;
+  maxchunks           INTEGER := 0;
+  numchunks           INTEGER := 1;
+  recompress_enabled  BOOL;
 BEGIN
   IF config IS NULL THEN
     RAISE EXCEPTION 'job % has null config', job_id;
   END IF;
- 
-  htid := jsonb_object_field_text (config, 'hypertable_id')::integer;
+
+  htid := jsonb_object_field_text(config, 'hypertable_id')::INTEGER;
   IF htid is NULL THEN
     RAISE EXCEPTION 'job % config must have hypertable_id', job_id;
   END IF;
-  
-  verbose_log := jsonb_object_field_text (config, 'verbose_log')::boolean;
-  IF verbose_log is NULL THEN
-     verbose_log = 'false';
-  END IF;
-  
-  maxchunks := jsonb_object_field_text (config, 'maxchunks_to_compress')::integer;
-  IF maxchunks IS NULL THEN
-    maxchunks = 0;
-  END IF;
-  
-  recompress_enabled := jsonb_object_field_text (config, 'recompress')::boolean;
-  IF recompress_enabled IS NULL THEN
-    recompress_enabled = 'true';
-  END IF;
-  
-  compress_after := jsonb_object_field_text(config, 'compress_after');
+
+  verbose_log         := COALESCE(jsonb_object_field_text(config, 'verbose_log')::BOOLEAN, FALSE);
+  maxchunks           := COALESCE(jsonb_object_field_text(config, 'maxchunks_to_compress')::INTEGER, 0);
+  recompress_enabled  := COALESCE(jsonb_object_field_text(config, 'recompress')::BOOLEAN, TRUE);
+  compress_after      := jsonb_object_field_text(config, 'compress_after');
+
   IF compress_after IS NULL THEN
     RAISE EXCEPTION 'job % config must have compress_after', job_id;
   END IF;
 
   -- find primary dimension type --
-  SELECT column_type INTO STRICT dimtype
-  FROM ( SELECT ht.schema_name, ht.table_name, dim.column_name, dim.column_type,
-         row_number() over(partition by ht.id order by dim.id) as rn
-         FROM  _timescaledb_catalog.hypertable ht , 
-               _timescaledb_catalog.dimension dim 
-         WHERE ht.id = dim.hypertable_id and ht.id = htid ) q 
-  WHERE rn = 1; 
- 
-  CASE WHEN (dimtype = 'TIMESTAMP'::regtype
-      OR dimtype = 'TIMESTAMPTZ'::regtype
-      OR dimtype = 'DATE'::regtype) THEN
-      lag_interval := jsonb_object_field_text(config, 'compress_after')::interval ;
-      CALL _timescaledb_internal.policy_compression_interval( 
-           job_id, htid, lag_interval, 
-           maxchunks, verbose_log, recompress_enabled);
-  ELSE
-      lag_integer := jsonb_object_field_text(config, 'compress_after')::bigint;
-      CALL _timescaledb_internal.policy_compression_integer( 
-            job_id, htid, lag_integer, 
-            maxchunks, verbose_log, recompress_enabled );
+  SELECT dim.column_type INTO dimtype
+  FROM  _timescaledb_catalog.hypertable ht
+        JOIN _timescaledb_catalog.dimension dim ON ht.id = dim.hypertable_id
+  WHERE ht.id = htid
+  ORDER BY dim.id
+  LIMIT 1;
+
+  lag_value := jsonb_object_field_text(config, 'compress_after');
+
+  -- execute the properly type casts for the lag value
+  CASE dimtype
+    WHEN 'TIMESTAMP'::regtype, 'TIMESTAMPTZ'::regtype, 'DATE'::regtype THEN
+      CALL _timescaledb_internal.policy_compression_execute(
+        job_id, htid, lag_value::INTERVAL,
+        maxchunks, verbose_log, recompress_enabled
+      );
+    WHEN 'BIGINT'::regtype THEN
+      CALL _timescaledb_internal.policy_compression_execute(
+        job_id, htid, lag_value::BIGINT,
+        maxchunks, verbose_log, recompress_enabled
+      );
+    WHEN 'INTEGER'::regtype THEN
+      CALL _timescaledb_internal.policy_compression_execute(
+        job_id, htid, lag_value::INTEGER,
+        maxchunks, verbose_log, recompress_enabled
+      );
+    WHEN 'SMALLINT'::regtype THEN
+      CALL _timescaledb_internal.policy_compression_execute(
+        job_id, htid, lag_value::SMALLINT,
+        maxchunks, verbose_log, recompress_enabled
+      );
   END CASE;
 END;
 $$ LANGUAGE PLPGSQL;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,3 @@
+-- Remove old compression policy procedures
+DROP PROCEDURE IF EXISTS _timescaledb_internal.policy_compression_interval(INTEGER, INTEGER, INTERVAL, INTEGER, BOOLEAN, BOOLEAN);
+DROP PROCEDURE IF EXISTS _timescaledb_internal.policy_compression_integer(INTEGER, INTEGER, BIGINT, INTEGER, BOOLEAN, BOOLEAN);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,2 @@
+-- Remove old compression policy procedures
+DROP PROCEDURE IF EXISTS _timescaledb_internal.policy_compression_execute(INTEGER, INTEGER, ANYELEMENT, INTEGER, BOOLEAN, BOOLEAN);

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -123,41 +123,116 @@ ERROR:  job 1000 not found
 DROP TABLE IF EXISTS conditions CASCADE;
 NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_2_4_chunk
 --TEST 7
---compression policy for integer based partition hypertable
-CREATE TABLE test_table_int(time bigint, val int);
-SELECT create_hypertable('test_table_int', 'time', chunk_time_interval => 1);
+--compression policy for smallint, integer or bigint based partition hypertable
+--smallint test
+CREATE TABLE test_table_smallint(time SMALLINT, val SMALLINT);
+SELECT create_hypertable('test_table_smallint', 'time', chunk_time_interval => 1);
 NOTICE:  adding not-null constraint to column "time"
-      create_hypertable      
------------------------------
- (3,public,test_table_int,t)
+        create_hypertable         
+----------------------------------
+ (3,public,test_table_smallint,t)
 (1 row)
 
-create or replace function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
-select set_integer_now_func('test_table_int', 'dummy_now');
+CREATE OR REPLACE FUNCTION dummy_now_smallint() RETURNS SMALLINT LANGUAGE SQL IMMUTABLE AS 'SELECT 5::SMALLINT';
+SELECT set_integer_now_func('test_table_smallint', 'dummy_now_smallint');
  set_integer_now_func 
 ----------------------
  
 (1 row)
 
-insert into test_table_int select generate_series(1,5), 10;
-alter table test_table_int set (timescaledb.compress);
-select add_compression_policy('test_table_int', 2::int) AS compressjob_id
-\gset
-select * from _timescaledb_config.bgw_job where id=:compressjob_id;
+INSERT INTO test_table_smallint SELECT generate_series(1,5), 10;
+ALTER TABLE test_table_smallint SET (timescaledb.compress);
+SELECT add_compression_policy('test_table_smallint', 2::SMALLINT) AS compressjob_id \gset
+SELECT * FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
   id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                  config                   
 ------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-------------------------------------------
  1001 | Compression Policy [1001] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             3 | {"hypertable_id": 3, "compress_after": 2}
 (1 row)
 
-\gset
 --will compress all chunks that need compression
 CALL run_job(:compressjob_id);
-select chunk_name, before_compression_total_bytes, after_compression_total_bytes
-from chunk_compression_stats('test_table_int') where compression_status like 'Compressed' order by chunk_name;
+SELECT chunk_name, before_compression_total_bytes, after_compression_total_bytes
+FROM chunk_compression_stats('test_table_smallint')
+WHERE compression_status LIKE 'Compressed'
+ORDER BY chunk_name;
     chunk_name    | before_compression_total_bytes | after_compression_total_bytes 
 ------------------+--------------------------------+-------------------------------
  _hyper_3_5_chunk |                          24576 |                         16384
  _hyper_3_6_chunk |                          24576 |                         16384
+(2 rows)
+
+--integer tests
+CREATE TABLE test_table_integer(time INTEGER, val INTEGER);
+SELECT create_hypertable('test_table_integer', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (5,public,test_table_integer,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION dummy_now_integer() RETURNS INTEGER LANGUAGE SQL IMMUTABLE AS 'SELECT 5::INTEGER';
+SELECT set_integer_now_func('test_table_integer', 'dummy_now_integer');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO test_table_integer SELECT generate_series(1,5), 10;
+ALTER TABLE test_table_integer SET (timescaledb.compress);
+SELECT add_compression_policy('test_table_integer', 2::INTEGER) AS compressjob_id \gset
+SELECT * FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                  config                   
+------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-------------------------------------------
+ 1002 | Compression Policy [1002] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             5 | {"hypertable_id": 5, "compress_after": 2}
+(1 row)
+
+--will compress all chunks that need compression
+CALL run_job(:compressjob_id);
+SELECT chunk_name, before_compression_total_bytes, after_compression_total_bytes
+FROM chunk_compression_stats('test_table_integer')
+WHERE compression_status LIKE 'Compressed'
+ORDER BY chunk_name;
+    chunk_name     | before_compression_total_bytes | after_compression_total_bytes 
+-------------------+--------------------------------+-------------------------------
+ _hyper_5_12_chunk |                          24576 |                         16384
+ _hyper_5_13_chunk |                          24576 |                         16384
+(2 rows)
+
+--bigint test
+CREATE TABLE test_table_bigint(time BIGINT, val BIGINT);
+SELECT create_hypertable('test_table_bigint', 'time', chunk_time_interval => 1);
+NOTICE:  adding not-null constraint to column "time"
+       create_hypertable        
+--------------------------------
+ (7,public,test_table_bigint,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION dummy_now_bigint() RETURNS BIGINT LANGUAGE SQL IMMUTABLE AS 'SELECT 5::BIGINT';
+SELECT set_integer_now_func('test_table_bigint', 'dummy_now_bigint');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO test_table_bigint SELECT generate_series(1,5), 10;
+ALTER TABLE test_table_bigint SET (timescaledb.compress);
+SELECT add_compression_policy('test_table_bigint', 2::BIGINT) AS compressjob_id \gset
+SELECT * FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |       owner       | scheduled | hypertable_id |                  config                   
+------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------------+-----------+---------------+-------------------------------------------
+ 1003 | Compression Policy [1003] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | default_perm_user | t         |             7 | {"hypertable_id": 7, "compress_after": 2}
+(1 row)
+
+--will compress all chunks that need compression
+CALL run_job(:compressjob_id);
+SELECT chunk_name, before_compression_total_bytes, after_compression_total_bytes
+FROM chunk_compression_stats('test_table_bigint')
+WHERE compression_status LIKE 'Compressed'
+ORDER BY chunk_name;
+    chunk_name     | before_compression_total_bytes | after_compression_total_bytes 
+-------------------+--------------------------------+-------------------------------
+ _hyper_7_19_chunk |                          24576 |                         16384
+ _hyper_7_20_chunk |                          24576 |                         16384
 (2 rows)
 
 --TEST 8
@@ -168,10 +243,10 @@ SELECT create_hypertable('test_table_nologin', 'time', chunk_time_interval => 1)
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
- (5,public,test_table_nologin,t)
+ (9,public,test_table_nologin,t)
 (1 row)
 
-SELECT set_integer_now_func('test_table_nologin', 'dummy_now');
+SELECT set_integer_now_func('test_table_nologin', 'dummy_now_bigint');
  set_integer_now_func 
 ----------------------
  
@@ -194,7 +269,7 @@ SELECT * FROM create_hypertable('conditions', 'time',
                                 chunk_time_interval => '1 day'::interval);
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-             7 | public      | conditions | t
+            11 | public      | conditions | t
 (1 row)
 
 INSERT INTO conditions
@@ -240,21 +315,21 @@ SELECT add_compression_policy AS job_id
 -- job compresses only 1 chunk at a time --
 SELECT alter_job(id,config:=jsonb_set(config,'{maxchunks_to_compress}', '1'))
  FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-                                                                  alter_job                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
- (1002,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""hypertable_id"": 7, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
+                                                                  alter_job                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------
+ (1004,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""hypertable_id"": 11, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
 (1 row)
 
 SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
  FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-                                                                             alter_job                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
- (1002,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""verbose_log"": true, ""hypertable_id"": 7, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
+                                                                              alter_job                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (1004,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""verbose_log"": true, ""hypertable_id"": 11, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
 (1 row)
 
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
-LOG:  job 1002 completed processing chunk _timescaledb_internal._hyper_7_26_chunk
+LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
 set client_min_messages TO NOTICE;
 SELECT count(*) FROM timescaledb_information.chunks
 WHERE hypertable_name = 'conditions' and is_compressed = true;
@@ -273,7 +348,7 @@ SELECT
    h.table_name AS hypertable_name,
    c.schema_name as chunk_schema,
    c.table_name as chunk_name,
-   c.status as chunk_status, 
+   c.status as chunk_status,
    comp.schema_name as compressed_chunk_schema,
    comp.table_name as compressed_chunk_name
 FROM
@@ -291,22 +366,22 @@ SELECT table_name from create_hypertable('test2', 'timec', chunk_time_interval=>
 (1 row)
 
 INSERT INTO test2 SELECT q, 10, 11, 'hello' FROM generate_series( '2020-01-03 10:00:00+00', '2020-01-03 12:00:00+00' , '5 min'::interval) q;
-ALTER TABLE test2 set (timescaledb.compress, 
-timescaledb.compress_segmentby = 'b', 
+ALTER TABLE test2 set (timescaledb.compress,
+timescaledb.compress_segmentby = 'b',
 timescaledb.compress_orderby = 'timec DESC');
 SELECT compress_chunk(c)
 FROM show_chunks('test2') c;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_10_48_chunk
+ _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
 ---insert into the middle of the range ---
-INSERT INTO test2 values ( '2020-01-03 10:01:00+00', 20, 11, '2row'); 
-INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 11, '3row'); 
-INSERT INTO test2 values ( '2020-01-03 12:01:00+00', 20, 11, '4row'); 
+INSERT INTO test2 values ( '2020-01-03 10:01:00+00', 20, 11, '2row');
+INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 11, '3row');
+INSERT INTO test2 values ( '2020-01-03 12:01:00+00', 20, 11, '4row');
 --- insert a new segment  by ---
-INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 12, '12row'); 
+INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 12, '12row');
 SELECT time_bucket(INTERVAL '2 hour', timec), b, count(*)
 FROM test2
 GROUP BY time_bucket(INTERVAL '2 hour', timec), b
@@ -318,20 +393,19 @@ ORDER BY 1, 2;
  Fri Jan 03 04:00:00 2020 PST | 11 |     2
 (3 rows)
 
- 
 --check status for chunk --
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
-            3 | _hyper_10_48_chunk
+            3 | _hyper_14_62_chunk
 (1 row)
 
 SELECT compressed_chunk_schema || '.' || compressed_chunk_name as "COMP_CHUNK_NAME",
         chunk_schema || '.' || chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' \gset
 SELECT count(*) from test2;
  count 
@@ -339,26 +413,26 @@ SELECT count(*) from test2;
     29
 (1 row)
 
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass); 
+SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
              recompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_10_48_chunk
+ _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
-            1 | _hyper_10_48_chunk
+            1 | _hyper_14_62_chunk
 (1 row)
 
 --- insert into a compressed chunk again + a new chunk--
-INSERT INTO test2 values ( '2020-01-03 11:01:03+00', 20, 11, '33row'), 
-                         ( '2020-01-03 11:01:06+00', 20, 11, '36row'), 
-                         ( '2020-01-03 11:02:00+00', 20, 12, '12row'), 
-                         ( '2020-04-03 00:02:00+00', 30, 13, '3013row'); 
+INSERT INTO test2 values ( '2020-01-03 11:01:03+00', 20, 11, '33row'),
+                         ( '2020-01-03 11:01:06+00', 20, 11, '36row'),
+                         ( '2020-01-03 11:02:00+00', 20, 12, '12row'),
+                         ( '2020-04-03 00:02:00+00', 30, 13, '3013row');
 SELECT time_bucket(INTERVAL '2 hour', timec), b, count(*)
 FROM test2
 GROUP BY time_bucket(INTERVAL '2 hour', timec), b
@@ -374,12 +448,12 @@ ORDER BY 1, 2;
 --chunk status should be unordered for the previously compressed chunk
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
-            3 | _hyper_10_48_chunk
-            0 | _hyper_10_51_chunk
+            3 | _hyper_14_62_chunk
+            0 | _hyper_14_65_chunk
 (2 rows)
 
 SELECT add_compression_policy AS job_id
@@ -389,30 +463,30 @@ CALL run_job(:job_id);
 -- status should be compressed ---
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
  chunk_status |     CHUNK_NAME     
 --------------+--------------------
-            1 | _hyper_10_48_chunk
-            1 | _hyper_10_51_chunk
+            1 | _hyper_14_62_chunk
+            1 | _hyper_14_65_chunk
 (2 rows)
 
 \set ON_ERROR_STOP 0
 -- call recompress_chunk when status is not unordered
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, true); 
-psql:include/recompress_basic.sql:95: NOTICE:  nothing to recompress in chunk "_hyper_10_48_chunk" 
+SELECT recompress_chunk(:'CHUNK_NAME'::regclass, true);
+psql:include/recompress_basic.sql:95: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk" 
  recompress_chunk 
 ------------------
  
 (1 row)
 
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, false); 
-psql:include/recompress_basic.sql:96: ERROR:  nothing to recompress in chunk "_hyper_10_48_chunk" 
---now decompress it , then try and recompress 
+SELECT recompress_chunk(:'CHUNK_NAME'::regclass, false);
+psql:include/recompress_basic.sql:96: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk" 
+--now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_10_48_chunk
+ _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
 SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
@@ -420,17 +494,12 @@ psql:include/recompress_basic.sql:100: ERROR:  call compress_chunk instead of re
 \set ON_ERROR_STOP 1
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);
-SELECT create_hypertable('metrics','time');
-   create_hypertable   
------------------------
- (12,public,metrics,t)
-(1 row)
-
+SELECT hypertable_id AS "HYPERTABLE_ID", schema_name, table_name, created FROM create_hypertable('metrics','time') \gset
 ALTER TABLE metrics SET (timescaledb.compress);
 -- create chunk with some data and compress
 INSERT INTO metrics SELECT '2000-01-01' FROM generate_series(1,10);
 -- create custom compression job without recompress boolean
-SELECT add_job('_timescaledb_internal.policy_compression','1w','{"hypertable_id": 12, "compress_after": "@ 7 days"}') AS "JOB_COMPRESS" \gset
+SELECT add_job('_timescaledb_internal.policy_compression','1w',('{"hypertable_id": '||:'HYPERTABLE_ID'||', "compress_after": "@ 7 days"}')::jsonb) AS "JOB_COMPRESS" \gset
 -- first call should compress
 CALL run_job(:JOB_COMPRESS);
 -- 2nd call should do nothing
@@ -464,7 +533,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 SELECT alter_job(id,config:=jsonb_set(config,'{recompress}','false')) FROM _timescaledb_config.bgw_job WHERE id = :JOB_COMPRESS;
                                                               alter_job                                                               
 --------------------------------------------------------------------------------------------------------------------------------------
- (1004,"@ 7 days","@ 0",-1,"@ 5 mins",t,"{""recompress"": false, ""hypertable_id"": 12, ""compress_after"": ""@ 7 days""}",-infinity)
+ (1006,"@ 7 days","@ 0",-1,"@ 5 mins",t,"{""recompress"": false, ""hypertable_id"": 16, ""compress_after"": ""@ 7 days""}",-infinity)
 (1 row)
 
 -- nothing to do
@@ -498,7 +567,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 SELECT alter_job(id,config:=jsonb_set(config,'{recompress}','true')) FROM _timescaledb_config.bgw_job WHERE id = :JOB_COMPRESS;
                                                               alter_job                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
- (1004,"@ 7 days","@ 0",-1,"@ 5 mins",t,"{""recompress"": true, ""hypertable_id"": 12, ""compress_after"": ""@ 7 days""}",-infinity)
+ (1006,"@ 7 days","@ 0",-1,"@ 5 mins",t,"{""recompress"": true, ""hypertable_id"": 16, ""compress_after"": ""@ 7 days""}",-infinity)
 (1 row)
 
 -- should recompress now
@@ -516,7 +585,7 @@ SELECT delete_job(:JOB_COMPRESS);
  
 (1 row)
 
-SELECT add_job('_timescaledb_internal.policy_recompression','1w','{"hypertable_id": 12, "recompress_after": "@ 7 days", "maxchunks_to_compress": 1 }') AS "JOB_RECOMPRESS" \gset
+SELECT add_job('_timescaledb_internal.policy_recompression','1w',('{"hypertable_id": '||:'HYPERTABLE_ID'||', "recompress_after": "@ 7 days", "maxchunks_to_compress": 1}')::jsonb) AS "JOB_RECOMPRESS" \gset
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -458,7 +458,7 @@ SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
 --should fail
 CALL run_job(:compressjob_id);
 ERROR:  job 1000 config must have compress_after
-CONTEXT:  PL/pgSQL function _timescaledb_internal.policy_compression(integer,jsonb) line 41 at RAISE
+CONTEXT:  PL/pgSQL function _timescaledb_internal.policy_compression(integer,jsonb) line 30 at RAISE
 SELECT remove_compression_policy('test_table_int');
  remove_compression_policy 
 ---------------------------

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -197,7 +197,7 @@ ORDER BY chunk_name, node_name;
  _timescaledb_internal | _dist_hyper_1_3_chunk | Uncompressed       |                                |                                |                                |                                |                               |                               |                               |                               | db_dist_compression_3
 (6 rows)
 
-select * from hypertable_compression_stats('compressed'); 
+select * from hypertable_compression_stats('compressed');
  total_chunks | number_compressed_chunks | before_compression_table_bytes | before_compression_index_bytes | before_compression_toast_bytes | before_compression_total_bytes | after_compression_table_bytes | after_compression_index_bytes | after_compression_toast_bytes | after_compression_total_bytes |       node_name       
 --------------+--------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------------------
             2 |                        1 |                           8192 |                          32768 |                              0 |                          40960 |                          8192 |                         16384 |                          8192 |                         32768 | db_dist_compression_1
@@ -370,7 +370,7 @@ replication_factor  | 2
 data_nodes          | {db_dist_compression_1,db_dist_compression_2,db_dist_compression_3}
 tablespaces         | 
 
-SELECT * from timescaledb_information.chunks 
+SELECT * from timescaledb_information.chunks
 ORDER BY hypertable_name, chunk_name;
 -[ RECORD 1 ]----------+----------------------------------------------
 hypertable_schema      | public
@@ -415,7 +415,7 @@ is_compressed          | f
 chunk_tablespace       | 
 data_nodes             | {db_dist_compression_1,db_dist_compression_3}
 
-SELECT * from timescaledb_information.dimensions 
+SELECT * from timescaledb_information.dimensions
 ORDER BY hypertable_name, dimension_number;
 -[ RECORD 1 ]-----+-------------------------
 hypertable_schema | public
@@ -441,7 +441,7 @@ integer_now_func  |
 num_partitions    | 3
 
 \x
-SELECT * FROM chunks_detailed_size('compressed'::regclass) 
+SELECT * FROM chunks_detailed_size('compressed'::regclass)
 ORDER BY chunk_name, node_name;
      chunk_schema      |      chunk_name       | table_bytes | index_bytes | toast_bytes | total_bytes |       node_name       
 -----------------------+-----------------------+-------------+-------------+-------------+-------------+-----------------------
@@ -536,8 +536,8 @@ SELECT count(*) from compressed where new_coli is not null;
      0
 (1 row)
 
---insert data into new chunk  
-INSERT INTO compressed 
+--insert data into new chunk
+INSERT INTO compressed
 SELECT '2019-08-01 00:00',  100, 100, 1, 'newcolv' ;
 SELECT COUNT(*) AS count_compressed
 FROM
@@ -562,13 +562,13 @@ SELECT * from compressed where new_coli is not null;
 -- Test ALTER TABLE rename column on distributed hypertables
 ALTER TABLE compressed RENAME new_coli TO new_intcol  ;
 ALTER TABLE compressed RENAME device TO device_id  ;
-SELECT * FROM test.remote_exec( NULL, 
+SELECT * FROM test.remote_exec( NULL,
     $$ SELECT * FROM _timescaledb_catalog.hypertable_compression
-       WHERE attname = 'device_id' OR attname = 'new_intcol'  and 
+       WHERE attname = 'device_id' OR attname = 'new_intcol'  and
        hypertable_id = (SELECT id from _timescaledb_catalog.hypertable
                        WHERE table_name = 'compressed' ) ORDER BY attname; $$ );
 NOTICE:  [db_dist_compression_1]:  SELECT * FROM _timescaledb_catalog.hypertable_compression
-       WHERE attname = 'device_id' OR attname = 'new_intcol'  and 
+       WHERE attname = 'device_id' OR attname = 'new_intcol'  and
        hypertable_id = (SELECT id from _timescaledb_catalog.hypertable
                        WHERE table_name = 'compressed' ) ORDER BY attname
 NOTICE:  [db_dist_compression_1]:
@@ -580,7 +580,7 @@ hypertable_id|attname   |compression_algorithm_id|segmentby_column_index|orderby
 
 
 NOTICE:  [db_dist_compression_2]:  SELECT * FROM _timescaledb_catalog.hypertable_compression
-       WHERE attname = 'device_id' OR attname = 'new_intcol'  and 
+       WHERE attname = 'device_id' OR attname = 'new_intcol'  and
        hypertable_id = (SELECT id from _timescaledb_catalog.hypertable
                        WHERE table_name = 'compressed' ) ORDER BY attname
 NOTICE:  [db_dist_compression_2]:
@@ -592,7 +592,7 @@ hypertable_id|attname   |compression_algorithm_id|segmentby_column_index|orderby
 
 
 NOTICE:  [db_dist_compression_3]:  SELECT * FROM _timescaledb_catalog.hypertable_compression
-       WHERE attname = 'device_id' OR attname = 'new_intcol'  and 
+       WHERE attname = 'device_id' OR attname = 'new_intcol'  and
        hypertable_id = (SELECT id from _timescaledb_catalog.hypertable
                        WHERE table_name = 'compressed' ) ORDER BY attname
 NOTICE:  [db_dist_compression_3]:
@@ -609,7 +609,7 @@ hypertable_id|attname   |compression_algorithm_id|segmentby_column_index|orderby
 (1 row)
 
 -- TEST insert data into compressed chunk
-INSERT INTO compressed 
+INSERT INTO compressed
 SELECT '2019-08-01 01:00',  300, 300, 3, 'newcolv' ;
 SELECT * from compressed where new_intcol = 3;
              time             | device_id | temp | new_intcol | new_colv 
@@ -739,40 +739,41 @@ ERROR:  job 1000 not found
 -- We're done with the table, so drop it.
 DROP TABLE IF EXISTS conditions CASCADE;
 --TEST 7
---compression policy for integer based partition hypertable
-CREATE TABLE test_table_int(time bigint, val int);
-SELECT create_distributed_hypertable('test_table_int', 'time', chunk_time_interval => 1, replication_factor => 2);
+--compression policy for smallint, integer or bigint based partition hypertable
+--smallint tests
+CREATE TABLE test_table_smallint(time smallint, val int);
+SELECT create_distributed_hypertable('test_table_smallint', 'time', chunk_time_interval => 1, replication_factor => 2);
 NOTICE:  adding not-null constraint to column "time"
- create_distributed_hypertable 
--------------------------------
- (3,public,test_table_int,t)
+  create_distributed_hypertable   
+----------------------------------
+ (3,public,test_table_smallint,t)
 (1 row)
 
-CREATE OR REPLACE FUNCTION dummy_now() RETURNS BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
+CREATE OR REPLACE FUNCTION dummy_now_smallint() RETURNS SMALLINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::SMALLINT';
 CALL distributed_exec($$
-CREATE OR REPLACE FUNCTION dummy_now() RETURNS BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT'
+CREATE OR REPLACE FUNCTION dummy_now_smallint() RETURNS SMALLINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::SMALLINT'
 $$);
-select set_integer_now_func('test_table_int', 'dummy_now');
+SELECT set_integer_now_func('test_table_smallint', 'dummy_now_smallint');
  set_integer_now_func 
 ----------------------
  
 (1 row)
 
-insert into test_table_int select generate_series(1,5), 10;
-alter table test_table_int set (timescaledb.compress);
-select add_compression_policy('test_table_int', 2::int) AS compressjob_id
-\gset
-select * from _timescaledb_config.bgw_job where id=:compressjob_id;
+INSERT INTO test_table_smallint SELECT generate_series(1,5), 10;
+ALTER TABLE test_table_smallint SET (timescaledb.compress);
+SELECT add_compression_policy('test_table_smallint', 2::int) AS compressjob_id \gset
+SELECT * FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
   id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |    owner    | scheduled | hypertable_id |                  config                   
 ------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------+-----------+---------------+-------------------------------------------
  1001 | Compression Policy [1001] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | test_role_1 | t         |             3 | {"hypertable_id": 3, "compress_after": 2}
 (1 row)
 
-\gset
 CALL run_job(:compressjob_id);
 CALL run_job(:compressjob_id);
-select chunk_name, node_name, before_compression_total_bytes, after_compression_total_bytes
-from chunk_compression_stats('test_table_int') where compression_status like 'Compressed' order by chunk_name;
+SELECT chunk_name, node_name, before_compression_total_bytes, after_compression_total_bytes
+FROM chunk_compression_stats('test_table_smallint')
+WHERE compression_status LIKE 'Compressed'
+ORDER BY chunk_name;
        chunk_name       |       node_name       | before_compression_total_bytes | after_compression_total_bytes 
 ------------------------+-----------------------+--------------------------------+-------------------------------
  _dist_hyper_3_10_chunk | db_dist_compression_2 |                          24576 |                         16384
@@ -781,13 +782,97 @@ from chunk_compression_stats('test_table_int') where compression_status like 'Co
  _dist_hyper_3_9_chunk  | db_dist_compression_2 |                          24576 |                         16384
 (4 rows)
 
+--integer tests
+CREATE TABLE test_table_integer(time int, val int);
+SELECT create_distributed_hypertable('test_table_integer', 'time', chunk_time_interval => 1, replication_factor => 2);
+NOTICE:  adding not-null constraint to column "time"
+  create_distributed_hypertable  
+---------------------------------
+ (4,public,test_table_integer,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION dummy_now_integer() RETURNS INTEGER LANGUAGE SQL IMMUTABLE as  'SELECT 5::INTEGER';
+CALL distributed_exec($$
+CREATE OR REPLACE FUNCTION dummy_now_integer() RETURNS INTEGER LANGUAGE SQL IMMUTABLE as  'SELECT 5::INTEGER'
+$$);
+SELECT set_integer_now_func('test_table_integer', 'dummy_now_integer');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO test_table_integer SELECT generate_series(1,5), 10;
+ALTER TABLE test_table_integer SET (timescaledb.compress);
+SELECT add_compression_policy('test_table_integer', 2::int) AS compressjob_id \gset
+SELECT * FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |    owner    | scheduled | hypertable_id |                  config                   
+------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------+-----------+---------------+-------------------------------------------
+ 1002 | Compression Policy [1002] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | test_role_1 | t         |             4 | {"hypertable_id": 4, "compress_after": 2}
+(1 row)
+
+CALL run_job(:compressjob_id);
+CALL run_job(:compressjob_id);
+SELECT chunk_name, node_name, before_compression_total_bytes, after_compression_total_bytes
+FROM chunk_compression_stats('test_table_integer')
+WHERE compression_status LIKE 'Compressed'
+ORDER BY chunk_name;
+       chunk_name       |       node_name       | before_compression_total_bytes | after_compression_total_bytes 
+------------------------+-----------------------+--------------------------------+-------------------------------
+ _dist_hyper_4_14_chunk | db_dist_compression_2 |                          24576 |                         16384
+ _dist_hyper_4_14_chunk | db_dist_compression_3 |                          24576 |                         16384
+ _dist_hyper_4_15_chunk | db_dist_compression_1 |                          24576 |                         16384
+ _dist_hyper_4_15_chunk | db_dist_compression_3 |                          24576 |                         16384
+(4 rows)
+
+--bigint tests
+CREATE TABLE test_table_bigint(time bigint, val int);
+SELECT create_distributed_hypertable('test_table_bigint', 'time', chunk_time_interval => 1, replication_factor => 2);
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable  
+--------------------------------
+ (5,public,test_table_bigint,t)
+(1 row)
+
+CREATE OR REPLACE FUNCTION dummy_now_bigint() RETURNS BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
+CALL distributed_exec($$
+CREATE OR REPLACE FUNCTION dummy_now_bigint() RETURNS BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT'
+$$);
+SELECT set_integer_now_func('test_table_bigint', 'dummy_now_bigint');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+INSERT INTO test_table_bigint SELECT generate_series(1,5), 10;
+ALTER TABLE test_table_bigint SET (timescaledb.compress);
+SELECT add_compression_policy('test_table_bigint', 2::int) AS compressjob_id \gset
+SELECT * FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+  id  |     application_name      | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |     proc_name      |    owner    | scheduled | hypertable_id |                  config                   
+------+---------------------------+-------------------+-------------+-------------+--------------+-----------------------+--------------------+-------------+-----------+---------------+-------------------------------------------
+ 1003 | Compression Policy [1003] | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression | test_role_1 | t         |             5 | {"hypertable_id": 5, "compress_after": 2}
+(1 row)
+
+CALL run_job(:compressjob_id);
+CALL run_job(:compressjob_id);
+SELECT chunk_name, node_name, before_compression_total_bytes, after_compression_total_bytes
+FROM chunk_compression_stats('test_table_bigint')
+WHERE compression_status LIKE 'Compressed'
+ORDER BY chunk_name;
+       chunk_name       |       node_name       | before_compression_total_bytes | after_compression_total_bytes 
+------------------------+-----------------------+--------------------------------+-------------------------------
+ _dist_hyper_5_19_chunk | db_dist_compression_1 |                          24576 |                         16384
+ _dist_hyper_5_19_chunk | db_dist_compression_3 |                          24576 |                         16384
+ _dist_hyper_5_20_chunk | db_dist_compression_1 |                          24576 |                         16384
+ _dist_hyper_5_20_chunk | db_dist_compression_2 |                          24576 |                         16384
+(4 rows)
+
 --TEST8 insert into compressed chunks on dist. hypertable
 CREATE TABLE test_recomp_int(time bigint, val int);
 SELECT create_distributed_hypertable('test_recomp_int', 'time', chunk_time_interval => 20);
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
- (4,public,test_recomp_int,t)
+ (6,public,test_recomp_int,t)
 (1 row)
 
 CREATE OR REPLACE FUNCTION dummy_now() RETURNS BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 100::BIGINT';
@@ -806,22 +891,22 @@ CREATE VIEW test_recomp_int_chunk_status as
 SELECT
    c.table_name as chunk_name,
    c.status as chunk_status
-FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c 
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'test_recomp_int';
---compress chunks 
+--compress chunks
 SELECT compress_chunk(chunk)
 FROM show_chunks('test_recomp_int') AS chunk
 ORDER BY chunk;
                 compress_chunk                
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_4_14_chunk
+ _timescaledb_internal._dist_hyper_6_24_chunk
 (1 row)
 
---check the status 
+--check the status
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            1
+ _dist_hyper_6_24_chunk |            1
 (1 row)
 
 -- insert into compressed chunks of test_recomp_int (using same value for val)--
@@ -836,25 +921,25 @@ SELECT count(*) from test_recomp_int where val = 10;
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            3
+ _dist_hyper_6_24_chunk |            3
 (1 row)
 
 SELECT
 c.schema_name || '.' || c.table_name as "CHUNK_NAME"
-FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c 
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'test_recomp_int' \gset
 --call recompress_chunk directly on distributed chunk
 SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
                recompress_chunk               
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_4_14_chunk
+ _timescaledb_internal._dist_hyper_6_24_chunk
 (1 row)
 
 --check chunk status now, should be compressed
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            1
+ _dist_hyper_6_24_chunk |            1
 (1 row)
 
 SELECT count(*) from test_recomp_int;
@@ -871,7 +956,7 @@ insert into test_recomp_int select generate_series(5,7), 10;
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            3
+ _dist_hyper_6_24_chunk |            3
 (1 row)
 
 --run the compression policy job, it will recompress chunks that are unordered
@@ -894,7 +979,7 @@ RESET timescaledb.enable_per_data_node_queries;
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            1
+ _dist_hyper_6_24_chunk |            1
 (1 row)
 
 ---run copy tests
@@ -914,9 +999,9 @@ INSERT INTO test_recomp_int VALUES( 65, 10);
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            3
- _dist_hyper_4_15_chunk |            0
- _dist_hyper_4_16_chunk |            0
+ _dist_hyper_6_24_chunk |            3
+ _dist_hyper_6_25_chunk |            0
+ _dist_hyper_6_26_chunk |            0
 (3 rows)
 
 --compress all 3 chunks ---
@@ -926,17 +1011,17 @@ FROM show_chunks('test_recomp_int') AS chunk
 ORDER BY chunk;
                 compress_chunk                
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_4_14_chunk
- _timescaledb_internal._dist_hyper_4_15_chunk
- _timescaledb_internal._dist_hyper_4_16_chunk
+ _timescaledb_internal._dist_hyper_6_24_chunk
+ _timescaledb_internal._dist_hyper_6_25_chunk
+ _timescaledb_internal._dist_hyper_6_26_chunk
 (3 rows)
 
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            3
- _dist_hyper_4_15_chunk |            1
- _dist_hyper_4_16_chunk |            1
+ _dist_hyper_6_24_chunk |            3
+ _dist_hyper_6_25_chunk |            1
+ _dist_hyper_6_26_chunk |            1
 (3 rows)
 
 --interleave copy into 3 different chunks and check status--
@@ -944,9 +1029,9 @@ COPY test_recomp_int  FROM STDIN WITH DELIMITER ',';
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            3
- _dist_hyper_4_15_chunk |            3
- _dist_hyper_4_16_chunk |            3
+ _dist_hyper_6_24_chunk |            3
+ _dist_hyper_6_25_chunk |            3
+ _dist_hyper_6_26_chunk |            3
 (3 rows)
 
 SELECT time_bucket(20, time), count(*)
@@ -977,25 +1062,25 @@ SELECT recompress_chunk(chunk, true) FROM
 ( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 2)q;
                recompress_chunk               
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_4_14_chunk
- _timescaledb_internal._dist_hyper_4_15_chunk
+ _timescaledb_internal._dist_hyper_6_24_chunk
+ _timescaledb_internal._dist_hyper_6_25_chunk
 (2 rows)
 
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            1
- _dist_hyper_4_15_chunk |            1
- _dist_hyper_4_16_chunk |            3
+ _dist_hyper_6_24_chunk |            1
+ _dist_hyper_6_25_chunk |            1
+ _dist_hyper_6_26_chunk |            3
 (3 rows)
 
 CALL run_job(:compressjob_id);
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
- _dist_hyper_4_14_chunk |            1
- _dist_hyper_4_15_chunk |            1
- _dist_hyper_4_16_chunk |            1
+ _dist_hyper_6_24_chunk |            1
+ _dist_hyper_6_25_chunk |            1
+ _dist_hyper_6_26_chunk |            1
 (3 rows)
 
 --verify that there are no errors if the policy/recompress_chunk is executed again
@@ -1003,9 +1088,9 @@ SELECT * from test_recomp_int_chunk_status ORDER BY 1;
 CALL run_job(:compressjob_id);
 SELECT recompress_chunk(chunk, true) FROM
 ( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk )q;
-NOTICE:  nothing to recompress in chunk "_dist_hyper_4_14_chunk" 
-NOTICE:  nothing to recompress in chunk "_dist_hyper_4_15_chunk" 
-NOTICE:  nothing to recompress in chunk "_dist_hyper_4_16_chunk" 
+NOTICE:  nothing to recompress in chunk "_dist_hyper_6_24_chunk" 
+NOTICE:  nothing to recompress in chunk "_dist_hyper_6_25_chunk" 
+NOTICE:  nothing to recompress in chunk "_dist_hyper_6_26_chunk" 
  recompress_chunk 
 ------------------
  
@@ -1019,7 +1104,7 @@ SELECT decompress_chunk(chunk, true) FROM
 ( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 1 )q;
                decompress_chunk               
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_4_14_chunk
+ _timescaledb_internal._dist_hyper_6_24_chunk
 (1 row)
 
 SELECT recompress_chunk(chunk)  FROM
@@ -1028,7 +1113,11 @@ ERROR:  call compress_chunk instead of recompress_chunk
 \set ON_ERROR_STOP 1
 -- test alter column type with distributed hypertable
 \set ON_ERROR_STOP 0
-ALTER TABLE test_table_int ALTER COLUMN val TYPE float;
+ALTER TABLE test_table_smallint ALTER COLUMN val TYPE float;
+ERROR:  operation not supported on hypertables that have compression enabled
+ALTER TABLE test_table_integer ALTER COLUMN val TYPE float;
+ERROR:  operation not supported on hypertables that have compression enabled
+ALTER TABLE test_table_bigint ALTER COLUMN val TYPE float;
 ERROR:  operation not supported on hypertables that have compression enabled
 \set ON_ERROR_STOP 1
 --create a cont agg view on the ht as well then the drop should nuke everything
@@ -1041,7 +1130,7 @@ AS SELECT time_bucket(BIGINT '5', "time"), SUM(val)
 SELECT add_continuous_aggregate_policy('test_recomp_int_cont_view', NULL, BIGINT '5', '1 day'::interval);
  add_continuous_aggregate_policy 
 ---------------------------------
-                            1003
+                            1005
 (1 row)
 
 CALL refresh_continuous_aggregate('test_recomp_int_cont_view', NULL, NULL);
@@ -1086,13 +1175,13 @@ SELECT * FROM test_recomp_int_cont_view ORDER BY 1;
 
 DROP TABLE test_recomp_int CASCADE;
 NOTICE:  drop cascades to 2 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_5_17_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_7_27_chunk
 -- test compression default handling
 CREATE TABLE test_defaults(time timestamptz NOT NULL, device_id int);
 SELECT create_distributed_hypertable('test_defaults','time');
  create_distributed_hypertable 
 -------------------------------
- (6,public,test_defaults,t)
+ (8,public,test_defaults,t)
 (1 row)
 
 ALTER TABLE test_defaults SET (timescaledb.compress,timescaledb.compress_segmentby='device_id');
@@ -1103,7 +1192,7 @@ INSERT INTO test_defaults SELECT '2001-01-01', 1;
 SELECT compress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
                compressed_chunk               
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_6_18_chunk
+ _timescaledb_internal._dist_hyper_8_28_chunk
 (1 row)
 
 SELECT * FROM test_defaults ORDER BY 1;
@@ -1135,7 +1224,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
 SELECT recompress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
                compressed_chunk               
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_6_18_chunk
+ _timescaledb_internal._dist_hyper_8_28_chunk
 (1 row)
 
 SELECT * FROM test_defaults ORDER BY 1,2;
@@ -1152,7 +1241,7 @@ SELECT create_distributed_hypertable('test_drop','time');
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
- (7,public,test_drop,t)
+ (9,public,test_drop,t)
 (1 row)
 
 ALTER TABLE test_drop SET (timescaledb.compress,timescaledb.compress_segmentby='device',timescaledb.compress_orderby='o1,o2');

--- a/tsl/test/sql/include/recompress_basic.sql
+++ b/tsl/test/sql/include/recompress_basic.sql
@@ -8,7 +8,7 @@ SELECT
    h.table_name AS hypertable_name,
    c.schema_name as chunk_schema,
    c.table_name as chunk_name,
-   c.status as chunk_status, 
+   c.status as chunk_status,
    comp.schema_name as compressed_chunk_schema,
    comp.table_name as compressed_chunk_name
 FROM
@@ -23,50 +23,50 @@ CREATE TABLE test2 (timec timestamptz NOT NULL, i integer ,
 SELECT table_name from create_hypertable('test2', 'timec', chunk_time_interval=> INTERVAL '7 days');
 
 INSERT INTO test2 SELECT q, 10, 11, 'hello' FROM generate_series( '2020-01-03 10:00:00+00', '2020-01-03 12:00:00+00' , '5 min'::interval) q;
-ALTER TABLE test2 set (timescaledb.compress, 
-timescaledb.compress_segmentby = 'b', 
+ALTER TABLE test2 set (timescaledb.compress,
+timescaledb.compress_segmentby = 'b',
 timescaledb.compress_orderby = 'timec DESC');
 
 SELECT compress_chunk(c)
 FROM show_chunks('test2') c;
 
 ---insert into the middle of the range ---
-INSERT INTO test2 values ( '2020-01-03 10:01:00+00', 20, 11, '2row'); 
-INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 11, '3row'); 
-INSERT INTO test2 values ( '2020-01-03 12:01:00+00', 20, 11, '4row'); 
+INSERT INTO test2 values ( '2020-01-03 10:01:00+00', 20, 11, '2row');
+INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 11, '3row');
+INSERT INTO test2 values ( '2020-01-03 12:01:00+00', 20, 11, '4row');
 --- insert a new segment  by ---
-INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 12, '12row'); 
+INSERT INTO test2 values ( '2020-01-03 11:01:00+00', 20, 12, '12row');
 
 SELECT time_bucket(INTERVAL '2 hour', timec), b, count(*)
 FROM test2
 GROUP BY time_bucket(INTERVAL '2 hour', timec), b
 ORDER BY 1, 2;
- 
+
 --check status for chunk --
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 SELECT compressed_chunk_schema || '.' || compressed_chunk_name as "COMP_CHUNK_NAME",
         chunk_schema || '.' || chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' \gset
 
 SELECT count(*) from test2;
 
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass); 
+SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
 
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 --- insert into a compressed chunk again + a new chunk--
-INSERT INTO test2 values ( '2020-01-03 11:01:03+00', 20, 11, '33row'), 
-                         ( '2020-01-03 11:01:06+00', 20, 11, '36row'), 
-                         ( '2020-01-03 11:02:00+00', 20, 12, '12row'), 
-                         ( '2020-04-03 00:02:00+00', 30, 13, '3013row'); 
+INSERT INTO test2 values ( '2020-01-03 11:01:03+00', 20, 11, '33row'),
+                         ( '2020-01-03 11:01:06+00', 20, 11, '36row'),
+                         ( '2020-01-03 11:02:00+00', 20, 12, '12row'),
+                         ( '2020-04-03 00:02:00+00', 30, 13, '3013row');
 
 SELECT time_bucket(INTERVAL '2 hour', timec), b, count(*)
 FROM test2
@@ -76,7 +76,7 @@ ORDER BY 1, 2;
 --chunk status should be unordered for the previously compressed chunk
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 SELECT add_compression_policy AS job_id
@@ -87,29 +87,29 @@ CALL run_job(:job_id);
 -- status should be compressed ---
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
-FROM compressed_chunk_info_view 
+FROM compressed_chunk_info_view
 WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 \set ON_ERROR_STOP 0
 -- call recompress_chunk when status is not unordered
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, true); 
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, false); 
+SELECT recompress_chunk(:'CHUNK_NAME'::regclass, true);
+SELECT recompress_chunk(:'CHUNK_NAME'::regclass, false);
 
---now decompress it , then try and recompress 
+--now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
 SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
 \set ON_ERROR_STOP 1
 
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);
-SELECT create_hypertable('metrics','time');
+SELECT hypertable_id AS "HYPERTABLE_ID", schema_name, table_name, created FROM create_hypertable('metrics','time') \gset
 ALTER TABLE metrics SET (timescaledb.compress);
 
 -- create chunk with some data and compress
 INSERT INTO metrics SELECT '2000-01-01' FROM generate_series(1,10);
 
 -- create custom compression job without recompress boolean
-SELECT add_job('_timescaledb_internal.policy_compression','1w','{"hypertable_id": 12, "compress_after": "@ 7 days"}') AS "JOB_COMPRESS" \gset
+SELECT add_job('_timescaledb_internal.policy_compression','1w',('{"hypertable_id": '||:'HYPERTABLE_ID'||', "compress_after": "@ 7 days"}')::jsonb) AS "JOB_COMPRESS" \gset
 
 -- first call should compress
 CALL run_job(:JOB_COMPRESS);
@@ -163,7 +163,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 SELECT delete_job(:JOB_COMPRESS);
 
-SELECT add_job('_timescaledb_internal.policy_recompression','1w','{"hypertable_id": 12, "recompress_after": "@ 7 days", "maxchunks_to_compress": 1 }') AS "JOB_RECOMPRESS" \gset
+SELECT add_job('_timescaledb_internal.policy_recompression','1w',('{"hypertable_id": '||:'HYPERTABLE_ID'||', "recompress_after": "@ 7 days", "maxchunks_to_compress": 1}')::jsonb) AS "JOB_RECOMPRESS" \gset
 
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';


### PR DESCRIPTION
Commit fffd6c2350f5b3237486f3d49d7167105e72a55b fixes problem
related to PortalContext using PL/pgSQL procedure to execute the policy.
Unfortunately this new implementation introduced a problem when we use
INTEGER and not BIGINT for the time dimension.

Fixed it by dealing correclty with the integer types: SMALLINT, INTEGER
and BIGINT.

Also refatored the policy compression procedure replacing the two
procedures `policy_compression_{interval|integer}` by a simple
`policy_compression_execute` casting dimension type dynamically.

Fixes #3773