### PR TITLE
Fix compiler warnings

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -122,14 +122,14 @@ if event_type != "pull_request":
   # chunk_utils is ignored because of a use after free bug in postgres 12.0 which one of our tests hit
   pg12_debug_earliest = {
     "pg": PG12_EARLIEST,
-    "installcheck_args": "IGNORES='chunk_utils cluster-12 compression_ddl continuous_aggs_concurrent_refresh continuous_aggs_concurrent_refresh_dist_ht continuous_aggs_insert continuous_aggs_multi continuous_aggs_multi_dist_ht deadlock_drop_chunks_compress deadlock_dropchunks_select dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback'"
+    "installcheck_args": "IGNORES='chunk_utils cluster-12 compression_ddl continuous_aggs_concurrent_refresh continuous_aggs_concurrent_refresh_dist_ht continuous_aggs_insert continuous_aggs_multi continuous_aggs_multi_dist_ht deadlock_drop_chunks_compress deadlock_dropchunks_select dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback continuous_aggs_drop_chunks'"
   }
   m["include"].append(build_debug_config(pg12_debug_earliest))
 
   # add debug test for first supported PG13 version
   pg13_debug_earliest = {
     "pg": PG13_EARLIEST,
-    "installcheck_args": "IGNORES='compression_ddl continuous_aggs_concurrent_refresh continuous_aggs_concurrent_refresh_dist_ht continuous_aggs_insert continuous_aggs_multi continuous_aggs_multi_dist_ht deadlock_drop_chunks_compress deadlock_dropchunks_select dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback'"
+    "installcheck_args": "IGNORES='compression_ddl continuous_aggs_concurrent_refresh continuous_aggs_concurrent_refresh_dist_ht continuous_aggs_insert continuous_aggs_multi continuous_aggs_multi_dist_ht deadlock_drop_chunks_compress deadlock_dropchunks_select dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback continuous_aggs_drop_chunks'"
   }
   m["include"].append(build_debug_config(pg13_debug_earliest))
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1614,7 +1614,7 @@ process_drop_start(ProcessUtilityArgs *args)
 	{
 		case OBJECT_TABLE:
 			process_drop_hypertable(args, stmt);
-			/* FALL-THROUGH */
+			TS_FALLTHROUGH;
 		case OBJECT_FOREIGN_TABLE:
 			/* Chunks can be either normal tables, or foreign tables in the case of a distributed
 			 * hypertable */

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1006,6 +1006,7 @@ invalidation_state_init(CaggInvalidationState *state, int32 mat_hypertable_id,
 						int32 raw_hypertable_id, Oid dimtype, CaggsInfo *all_caggs)
 {
 	ListCell *lc1, *lc2, *lc3;
+	bool PG_USED_FOR_ASSERTS_ONLY found = false;
 
 	state->mat_hypertable_id = mat_hypertable_id;
 	state->raw_hypertable_id = raw_hypertable_id;
@@ -1033,9 +1034,11 @@ invalidation_state_init(CaggInvalidationState *state, int32 mat_hypertable_id,
 
 			state->bucket_width = bucket_width;
 			state->max_bucket_width = max_bucket_width;
+			found = true;
 			break;
 		}
 	}
+	Assert(found);
 }
 
 static void


### PR DESCRIPTION
Fix compiler warnings for MacOS 10.15 build.

See https://github.com/timescale/timescaledb/runs/4001786573?check_suite_focus=true