### PR TITLE
Fix ANALYZE crash with custom types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ accidentally triggering the load of a previous DB version.**
 * #3708 Fix crash in get_aggsplit
 * #3709 Fix ordered append pathkey check
 * #3728 Fix SkipScan with varchar column
+* #3733 Fix ANALYZE crash with custom statistics for custom types
 
 **Thanks**
 * @binakot and @sebvett for reporting an issue with DISTINCT queries
 * @hardikm10, @DavidPavlicek and @pafiti for reporting bugs on TRUNCATE
 * @mjf for reporting an issue with ordered append and JOINs
 * @phemmer for reporting the issues on multinode with aggregate queries and evaluation of now()
+* @tanglebones for reporting the ANALYZE crash with custom types on multinode
 
 ## 2.4.2 (2021-09-21)
 

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -757,7 +757,14 @@ collect_colstat_slots(const HeapTuple tuple, const Form_pg_statistic formdata, D
 		slot_collation[i] = ObjectIdGetDatum(((Oid *) &formdata->stacoll1)[i]);
 
 		slotkind[i] = ObjectIdGetDatum(kind);
-		if (kind == InvalidOid)
+
+		/*
+		 * As per comments in pg_statistic_d.h, "kind" codes from 0 - 99 are reserved
+		 * for assignment by the core PostgreSQL project. Beyond that are for PostGIS
+		 * and other projects
+		 */
+#define PG_STATS_KINDS_MAX 99
+		if (kind == InvalidOid || kind > PG_STATS_KINDS_MAX)
 		{
 			nulls[numbers_idx] = true;
 			nulls[values_idx] = true;
@@ -1175,7 +1182,12 @@ chunk_process_remote_colstats_row(StatsProcessContext *ctx, TupleFactory *tf, Tu
 		value_arrays[i] = NULL;
 		valtype_oids[i] = InvalidOid;
 
-		if (slot_kinds[i] == InvalidOid)
+		/*
+		 * As per comments in pg_statistic_d.h, "kind" codes from 0 - 99 are reserved
+		 * for assignment by the core PostgreSQL project. Beyond that are for PostGIS
+		 * and other projects
+		 */
+		if (slot_kinds[i] == InvalidOid || slot_kinds[i] > PG_STATS_KINDS_MAX)
 			continue;
 
 		for (k = 0; k < STRINGS_PER_OP_OID; ++k)


### PR DESCRIPTION
Extensions like PostGIS introduce custom datatypes for columns. They
also have custom statistics for such custom types. We already state in
our comments that stats for custom types are not supported but it was
never tested. Fix that now.

Fixes #3733