### PR TITLE
Add missing downgrade script files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CheckCCompilerFlag)
 include(GitCommands)
 include(GenerateScripts)
+include(CMakeDependentOption)
 
 # This requires all tests to run. This defaults to OFF but can be enabled to
 # ensure that no tests are skipped because of missing tools.
@@ -131,6 +132,12 @@ option(EXPERIMENTAL "Skip postgres version compatibility check" OFF)
 option(GENERATE_DOWNGRADE_SCRIPT
        "Generate downgrade script. Defaults to not generate a downgrade script."
        OFF)
+cmake_dependent_option(
+  GENERATE_OLD_DOWNGRADE_SCRIPTS
+  "Generate downgrade scripts for old versions. Requires setting GENERATE_DOWNGRADE_SCRIPT to ON. Defaults to OFF."
+  OFF
+  "GENERATE_DOWNGRADE_SCRIPT"
+  ON)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   # CMAKE_BUILD_TYPE is set at CMake configuration type. But usage of

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -31,9 +31,14 @@ set(MOD_FILES
     updates/2.4.0--2.4.1.sql
     updates/2.4.1--2.4.2.sql)
 
-# Files for downgrade scripts. This should only include files for downgrade to
-# previous version since we do not support skipping versions when downgrading
-set(REV_FILES)
+# The downgrade file to generate a downgrade script for the current version, as
+# specified in version.config
+set(CURRENT_REV_FILE reverse-dev.sql)
+# Files for generating old downgrade scripts. This should only include files for
+# downgrade to from one version to its previous version since we do not support
+# skipping versions when downgrading.
+set(OLD_REV_FILES 2.3.1--2.3.0.sql 2.4.0--2.3.1.sql 2.4.1--2.4.0.sql
+                  2.4.2--2.4.1.sql)
 
 set(MODULE_PATHNAME "$libdir/timescaledb-${PROJECT_VERSION_MOD}")
 set(LOADER_PATHNAME "$libdir/timescaledb")
@@ -56,25 +61,27 @@ else()
     INPUT_DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/updates
     FILES
-    reverse-dev.sql)
-  foreach(_downgrade_file ${REV_FILES})
-    if(${_downgrade_file} MATCHES
-       "([0-9]+\\.[0-9]+\\.*[0-9]*)--([0-9]+\\.[0-9]+\\.*[0-9]*).sql")
-      set(_source_version ${CMAKE_MATCH_1})
-      set(_target_version ${CMAKE_MATCH_2})
-      generate_downgrade_script(
-        SOURCE_VERSION
-        ${_source_version}
-        TARGET_VERSION
-        ${_target_version}
-        INPUT_DIRECTORY
-        ${CMAKE_CURRENT_SOURCE_DIR}/updates
-        FILES
-        ${_downgrade_file})
-    else()
-      message(FATAL_ERROR "${_downgrade_file} is not a downgrade file")
-    endif()
-  endforeach()
+    ${CURRENT_REV_FILE})
+  if(GENERATE_OLD_DOWNGRADE_SCRIPTS)
+    foreach(_downgrade_file ${OLD_REV_FILES})
+      if(${_downgrade_file} MATCHES
+         "([0-9]+\\.[0-9]+\\.*[0-9]*)--([0-9]+\\.[0-9]+\\.*[0-9]*).sql")
+        set(_source_version ${CMAKE_MATCH_1})
+        set(_target_version ${CMAKE_MATCH_2})
+        generate_downgrade_script(
+          SOURCE_VERSION
+          ${_source_version}
+          TARGET_VERSION
+          ${_target_version}
+          INPUT_DIRECTORY
+          ${CMAKE_CURRENT_SOURCE_DIR}/updates
+          FILES
+          ${_downgrade_file})
+      else()
+        message(FATAL_ERROR "${_downgrade_file} is not a downgrade file")
+      endif()
+    endforeach()
+  endif()
 endif()
 
 # Function to replace @MODULE_PATHNAME@ in source files, producing an output

--- a/sql/updates/2.4.2--2.4.1.sql
+++ b/sql/updates/2.4.2--2.4.1.sql
@@ -1,0 +1,2 @@
+-- No script modifications necessary for this downgrade
+


### PR DESCRIPTION
Some of the downgrade script files were only added to the release
branch and no downgrade path existed for downgrading from the 2.4.2
release to the 2.4.1 release.

Add the missing downgrade files for 2.4.x releases to the main
development branch.

Also, avoid generating downgrade scripts for old versions, so that
only the downgrade script for the current version is generated by
default. A new CMake option `GENERATE_OLD_DOWNGRADE_SCRIPTS` is added
to control this behavior. Note that `GENERATE_DOWNGRADE_SCRIPT`
needs to be `ON` for the new option to work.

The reason we want to keep the ability to generate old downgrade
scripts is to be able to fix bugs in old downgrade scripts.

