### PR TITLE
Always reset expr context in DecompressChunk

### DIFF
--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -324,8 +324,6 @@ decompress_chunk_exec(CustomScanState *node)
 	if (node->custom_ps == NIL)
 		return NULL;
 
-	ResetExprContext(econtext);
-
 	while (true)
 	{
 		TupleTableSlot *slot = decompress_chunk_create_tuple(state);
@@ -334,6 +332,10 @@ decompress_chunk_exec(CustomScanState *node)
 			return NULL;
 
 		econtext->ecxt_scantuple = slot;
+
+		/* Reset expression memory context to clean out any cruft from
+		 * previous tuple. */
+		ResetExprContext(econtext);
 
 		if (node->ss.ps.qual && !ExecQual(node->ss.ps.qual, econtext))
 		{


### PR DESCRIPTION
When decompressing very large compressed chunks as part of executing a
`DecompressChunk`, the expression memory context was not reset after
each qual evaluation if the qual did not match, meaning that if the
qual did not match often, memory allocations would start to accumulate.

This commit fixes this by resetting the expression memory context for
each tuple when executing a `DecompressChunk` node, even if the qual
did not match.

Fixes #3620