### PR TITLE
Add skeleton release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+# Release pipeline
+#
+# This release pipeline does a release with the contents of the
+# branch that you select when running the workflow. 
+
+name: Release TimescaleDB
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+      publish-artifacts:
+        description: 'Publish all artifacts'
+        required: false
+        default: false
+jobs:
+  # This is just a simple check but does not do anything sensible at
+  # this point except printing some status information about the
+  # branch.
+  check-release:
+    name: Check Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout TimescaleDB
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Print information
+        run: |
+          git describe --dirty --debug
+
+      - name: Fetch list of all commits since last tag
+        shell: bash -x {0}
+        run: |
+          tag=$(git describe --tags --abbrev=0 $GITHUB_REF)
+          git log $tag..


### PR DESCRIPTION
In order to be able to run workflows using `workflow_dispatch`, the
event need to be defined on the default branch. This commit adds a
basic workflow for the release pipeline containing only a workflow that
can be triggered using `workflow_dispatch` with the correct parameters
and will just list the commits in the branch since the last tag.

With this commit, you can run the workflow as:

    gh workflow run release.yaml --ref 2.1.x -f version=2.1.1