### PR TITLE
Refactor function in dist_commands.c

### DIFF
--- a/tsl/src/remote/dist_commands.h
+++ b/tsl/src/remote/dist_commands.h
@@ -12,11 +12,15 @@
 
 typedef struct DistCmdResult DistCmdResult;
 typedef struct List PreparedDistCmd;
+typedef struct DistCmdDescr
+{
+	const char *sql;
+	StmtParams *params;
 
-extern DistCmdResult *ts_dist_multi_cmds_params_invoke_on_data_nodes(const char **sql,
-																	 StmtParams **params,
+} DistCmdDescr;
+
+extern DistCmdResult *ts_dist_multi_cmds_params_invoke_on_data_nodes(List *cmd_descriptors,
 																	 List *data_nodes,
-																	 bool multiple_cmds,
 																	 bool transactional);
 extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes(const char *sql, List *node_names,
 													   bool transactional);


### PR DESCRIPTION
Fix coverity issue for Out-of-bounds access (ARRAY_VS_SINGLETON):
"Passing &sql to function
ts_dist_multi_cmds_params_invoke_on_data_nodes which uses it as an
array"