### PR TITLE
Refactor ts_hypertable_insert_path_create

### DIFF
--- a/src/nodes/chunk_dispatch_state.c
+++ b/src/nodes/chunk_dispatch_state.c
@@ -216,7 +216,7 @@ static CustomExecMethods chunk_dispatch_state_methods = {
  * Check whether the PlanState is a ChunkDispatchState node.
  */
 bool
-ts_chunk_dispatch_is_state(PlanState *state)
+ts_is_chunk_dispatch_state(PlanState *state)
 {
 	CustomScanState *csstate = (CustomScanState *) state;
 

--- a/src/nodes/chunk_dispatch_state.h
+++ b/src/nodes/chunk_dispatch_state.h
@@ -35,7 +35,7 @@ typedef struct ChunkDispatchState
 	ResultRelInfo *rri;
 } ChunkDispatchState;
 
-extern bool ts_chunk_dispatch_is_state(PlanState *state);
+extern bool ts_is_chunk_dispatch_state(PlanState *state);
 extern ChunkDispatchState *ts_chunk_dispatch_state_create(Oid hypertable_oid, Plan *plan);
 extern void ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *parent);
 

--- a/src/nodes/hypertable_insert.h
+++ b/src/nodes/hypertable_insert.h
@@ -30,6 +30,7 @@ typedef struct HypertableInsertState
 } HypertableInsertState;
 
 extern void ts_hypertable_insert_fixup_tlist(Plan *plan);
-extern Path *ts_hypertable_insert_path_create(PlannerInfo *root, ModifyTablePath *mtpath);
+extern Path *ts_hypertable_insert_path_create(PlannerInfo *root, ModifyTablePath *mtpath,
+											  Hypertable *ht);
 
 #endif /* TIMESCALEDB_HYPERTABLE_INSERT_H */

--- a/src/planner.c
+++ b/src/planner.c
@@ -1013,8 +1013,8 @@ replace_hypertable_insert_paths(PlannerInfo *root, List *pathlist)
 			RangeTblEntry *rte = planner_rt_fetch(linitial_int(mt->resultRelations), root);
 			Hypertable *ht = get_hypertable(rte->relid, CACHE_FLAG_CHECK);
 
-			if (NULL != ht)
-				path = ts_hypertable_insert_path_create(root, mt);
+			if (ht)
+				path = ts_hypertable_insert_path_create(root, mt, ht);
 		}
 
 		new_pathlist = lappend(new_pathlist, path);


### PR DESCRIPTION
Change ts_hypertable_insert_path_create and add hypertable as
argument since we always check for that in caller allowing us
to remove an error branch from the function, save an additional
lookup for the hypertable and save a lookup for the range table
entry.