### PR TITLE
Fix segfault in ts_hist_sfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Bugfixes**
+* #3766 Fix segfault in ts_hist_sfunc
+
 **Thanks**
 * @cbisnett for reporting and fixing a typo in an error message
 

--- a/test/expected/histogram_test.out
+++ b/test/expected/histogram_test.out
@@ -92,3 +92,8 @@ SELECT qualify, histogram(score, 0, 10, 5) FROM hitest2 GROUP BY qualify ORDER B
  t       | {0,0,0,0,1,0,1}
 (2 rows)
 
+-- check number of buckets is constant
+\set ON_ERROR_STOP 0
+select histogram(i,10,90,case when i=1 then 1 else 1000000 end) FROM generate_series(1,100) i;
+ERROR:  number of buckets must not change between calls
+\set ON_ERROR_STOP 1

--- a/test/sql/histogram_test.sql
+++ b/test/sql/histogram_test.sql
@@ -46,3 +46,8 @@ SELECT histogram(key, 1, 3, 1) FROM hitest1;
 SELECT qualify, histogram(score, 0, 10, 2) FROM hitest2 GROUP BY qualify ORDER BY qualify;
 -- standard multi-bucket
 SELECT qualify, histogram(score, 0, 10, 5) FROM hitest2 GROUP BY qualify ORDER BY qualify;
+
+-- check number of buckets is constant
+\set ON_ERROR_STOP 0
+select histogram(i,10,90,case when i=1 then 1 else 1000000 end) FROM generate_series(1,100) i;
+\set ON_ERROR_STOP 1


### PR DESCRIPTION
Since the number of buckets of the histogram function is an argument
to the function call it is possible to initialize the histogram
state with a lower number than actually needed in further calls
leading to a segfault. This patch changes the memory access to use
the number the state was initialized with instead of the number
passed to the call. This also changes the function to error when
the passed number differs from the initialized state.

Fixes: https://github.com/timescale/timescaledb-private/issues/935