### PR TITLE
Remove namein calls from scankey initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/CMakeCache.txt
 /sql/tests/unit/testoutputs.tmp
 /sql/timescaledb--*.sql
+/sql/updates/*.gen
 /data/
 /src/*.o
 /src/*.so

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3026,12 +3026,12 @@ init_scan_by_qualified_table_name(ScanIterator *iterator, const char *schema_nam
 								   Anum_chunk_schema_name_idx_schema_name,
 								   BTEqualStrategyNumber,
 								   F_NAMEEQ,
-								   DirectFunctionCall1(namein, CStringGetDatum(schema_name)));
+								   CStringGetDatum(schema_name));
 	ts_scan_iterator_scan_key_init(iterator,
 								   Anum_chunk_schema_name_idx_table_name,
 								   BTEqualStrategyNumber,
 								   F_NAMEEQ,
-								   DirectFunctionCall1(namein, CStringGetDatum(table_name)));
+								   CStringGetDatum(table_name));
 }
 
 static int

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -395,7 +395,7 @@ init_scan_by_chunk_id_constraint_name(ScanIterator *iterator, int32 chunk_id,
 		Anum_chunk_constraint_chunk_id_constraint_name_idx_constraint_name,
 		BTEqualStrategyNumber,
 		F_NAMEEQ,
-		DirectFunctionCall1(namein, CStringGetDatum(constraint_name)));
+		CStringGetDatum(constraint_name));
 }
 
 /*

--- a/src/chunk_data_node.c
+++ b/src/chunk_data_node.c
@@ -159,7 +159,7 @@ ts_chunk_data_node_scan_by_chunk_id_and_node_internal(int32 chunk_id, const char
 					attrnum_node_name,
 					BTEqualStrategyNumber,
 					F_NAMEEQ,
-					DirectFunctionCall1(namein, CStringGetDatum(node_name)));
+					CStringGetDatum(node_name));
 
 	return chunk_data_node_scan_limit_internal(scankey,
 											   nkeys,
@@ -181,7 +181,7 @@ ts_chunk_data_node_scan_by_node_internal(const char *node_name, tuple_found_func
 				Anum_chunk_data_node_node_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(node_name)));
+				CStringGetDatum(node_name));
 
 	return chunk_data_node_scan_limit_internal(scankey,
 											   1,

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -551,7 +551,7 @@ ts_chunk_index_get_mappings(Hypertable *ht, Oid hypertable_indexrelid)
 				Anum_chunk_index_hypertable_id_hypertable_index_name_idx_hypertable_index_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum((indexname))));
+				CStringGetDatum((indexname)));
 
 	chunk_index_scan(CHUNK_INDEX_HYPERTABLE_ID_HYPERTABLE_INDEX_NAME_IDX,
 					 scankey,
@@ -725,7 +725,7 @@ ts_chunk_index_delete(int32 chunk_id, const char *indexname, bool drop_index)
 				Anum_chunk_index_chunk_id_index_name_idx_index_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(indexname)));
+				CStringGetDatum(indexname));
 
 	return chunk_index_scan_update(CHUNK_INDEX_CHUNK_ID_INDEX_NAME_IDX,
 								   scankey,
@@ -801,7 +801,7 @@ ts_chunk_index_get_by_indexrelid(Chunk *chunk, Oid chunk_indexrelid, ChunkIndexM
 				Anum_chunk_index_chunk_id_index_name_idx_index_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(indexname)));
+				CStringGetDatum(indexname));
 
 	tuples_found = chunk_index_scan(CHUNK_INDEX_CHUNK_ID_INDEX_NAME_IDX,
 									scankey,

--- a/src/extension.c
+++ b/src/extension.c
@@ -179,7 +179,7 @@ ts_extension_schema_oid(void)
 				Anum_pg_extension_extname,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(EXTENSION_NAME)));
+				CStringGetDatum(EXTENSION_NAME));
 
 	scandesc = systable_beginscan(rel, ExtensionNameIndexId, true, NULL, 1, entry);
 

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -83,7 +83,7 @@ extension_version(void)
 				Anum_pg_extension_extname,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(EXTENSION_NAME)));
+				CStringGetDatum(EXTENSION_NAME));
 
 	scandesc = systable_beginscan(rel, ExtensionNameIndexId, true, NULL, 1, entry);
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -721,13 +721,13 @@ ts_hypertable_delete_by_name(const char *schema_name, const char *table_name)
 				Anum_hypertable_name_idx_table,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(table_name)));
+				CStringGetDatum(table_name));
 
 	ScanKeyInit(&scankey[1],
 				Anum_hypertable_name_idx_schema,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(schema_name)));
+				CStringGetDatum(schema_name));
 	return hypertable_scan_limit_internal(scankey,
 										  2,
 										  HYPERTABLE_NAME_INDEX,
@@ -807,7 +807,7 @@ ts_hypertable_reset_associated_schema_name(const char *associated_schema)
 				Anum_hypertable_associated_schema_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(associated_schema)));
+				CStringGetDatum(associated_schema));
 
 	return hypertable_scan_limit_internal(scankey,
 										  1,

--- a/src/hypertable_data_node.c
+++ b/src/hypertable_data_node.c
@@ -228,7 +228,7 @@ hypertable_data_node_scan_by_node_name(const char *node_name, tuple_found_func t
 				Anum_hypertable_data_node_node_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(node_name)));
+				CStringGetDatum(node_name));
 
 	return hypertable_data_node_scan_limit_internal(scankey,
 													1,
@@ -257,7 +257,7 @@ hypertable_data_node_scan_by_hypertable_id_and_node_name(int hypertable_id, cons
 				Anum_hypertable_data_node_hypertable_id_node_name_idx_node_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(node_name)));
+				CStringGetDatum(node_name));
 
 	return hypertable_data_node_scan_limit_internal(
 		scankey,

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -168,7 +168,7 @@ extension_owner(void)
 				Anum_pg_extension_extname,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(EXTENSION_NAME)));
+				CStringGetDatum(EXTENSION_NAME));
 
 	scandesc = systable_beginscan(rel, ExtensionNameIndexId, true, NULL, 1, entry);
 

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -9,10 +9,10 @@
 #include <postgres.h>
 #include "export.h"
 
-extern TSDLLEXPORT Datum ts_metadata_get_value(Datum metadata_key, Oid key_type, Oid value_type,
+extern TSDLLEXPORT Datum ts_metadata_get_value(const char *metadata_key, Oid value_type,
 											   bool *isnull);
-extern TSDLLEXPORT Datum ts_metadata_insert(Datum metadata_key, Oid key_type, Datum metadata_value,
+extern TSDLLEXPORT Datum ts_metadata_insert(const char *metadata_key, Datum metadata_value,
 											Oid value_type, bool include_in_telemetry);
-extern TSDLLEXPORT void ts_metadata_drop(Datum metadata_key, Oid key_type);
+extern TSDLLEXPORT void ts_metadata_drop(const char *metadata_key);
 
 #endif /* TIMESCALEDB_METADATA_H */

--- a/src/tablespace.c
+++ b/src/tablespace.c
@@ -154,7 +154,7 @@ tablespace_scan_by_name(const char *tspcname, tuple_found_func tuple_found, void
 					Anum_tablespace_tablespace_name,
 					BTEqualStrategyNumber,
 					F_NAMEEQ,
-					DirectFunctionCall1(namein, CStringGetDatum(tspcname)));
+					CStringGetDatum(tspcname));
 
 	return tablespace_scan_internal(INVALID_INDEXID,
 									scankey,
@@ -384,7 +384,7 @@ ts_tablespace_delete(int32 hypertable_id, const char *tspcname, Oid tspcoid)
 					Anum_tablespace_hypertable_id_tablespace_name_idx_tablespace_name,
 					BTEqualStrategyNumber,
 					F_NAMEEQ,
-					DirectFunctionCall1(namein, CStringGetDatum(tspcname)));
+					CStringGetDatum(tspcname));
 
 	num_deleted = tablespace_scan_internal(TABLESPACE_HYPERTABLE_ID_TABLESPACE_NAME_IDX,
 										   scankey,
@@ -450,7 +450,7 @@ tablespace_delete_from_all(const char *tspcname, Oid userid, List **hypertables)
 				Anum_tablespace_tablespace_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(tspcname)));
+				CStringGetDatum(tspcname));
 
 	num_deleted = tablespace_scan_internal(INVALID_INDEXID,
 										   scankey,

--- a/src/telemetry/telemetry_metadata.c
+++ b/src/telemetry/telemetry_metadata.c
@@ -65,14 +65,10 @@ get_uuid_by_key(const char *key)
 	bool isnull;
 	Datum uuid;
 
-	uuid = ts_metadata_get_value(CStringGetDatum(key), CSTRINGOID, UUIDOID, &isnull);
+	uuid = ts_metadata_get_value(key, UUIDOID, &isnull);
 
 	if (isnull)
-		uuid = ts_metadata_insert(CStringGetDatum(key),
-								  CSTRINGOID,
-								  UUIDPGetDatum(ts_uuid_create()),
-								  UUIDOID,
-								  true);
+		uuid = ts_metadata_insert(key, UUIDPGetDatum(ts_uuid_create()), UUIDOID, true);
 	return uuid;
 }
 
@@ -94,14 +90,10 @@ ts_telemetry_metadata_get_install_timestamp(void)
 	bool isnull;
 	Datum timestamp;
 
-	timestamp = ts_metadata_get_value(CStringGetDatum(METADATA_TIMESTAMP_KEY_NAME),
-									  CSTRINGOID,
-									  TIMESTAMPTZOID,
-									  &isnull);
+	timestamp = ts_metadata_get_value(METADATA_TIMESTAMP_KEY_NAME, TIMESTAMPTZOID, &isnull);
 
 	if (isnull)
-		timestamp = ts_metadata_insert(CStringGetDatum(METADATA_TIMESTAMP_KEY_NAME),
-									   CSTRINGOID,
+		timestamp = ts_metadata_insert(METADATA_TIMESTAMP_KEY_NAME,
 									   TimestampTzGetDatum(GetCurrentTimestamp()),
 									   TIMESTAMPTZOID,
 									   true);

--- a/tsl/src/chunk_copy.c
+++ b/tsl/src/chunk_copy.c
@@ -190,7 +190,7 @@ chunk_copy_operation_scan_update_by_id(const char *operation_id, tuple_found_fun
 				Anum_chunk_copy_operation_idx_operation_id,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(operation_id)));
+				CStringGetDatum(operation_id));
 
 	return ts_scanner_scan(&scanctx);
 }
@@ -247,7 +247,7 @@ chunk_copy_operation_delete_by_id(const char *operation_id)
 				Anum_chunk_copy_operation_idx_operation_id,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(operation_id)));
+				CStringGetDatum(operation_id));
 
 	return ts_scanner_scan(&scanctx);
 }
@@ -856,7 +856,7 @@ chunk_copy_operation_get(const char *operation_id)
 					Anum_chunk_copy_operation_idx_operation_id,
 					BTEqualStrategyNumber,
 					F_NAMEEQ,
-					DirectFunctionCall1(namein, CStringGetDatum(operation_id)));
+					CStringGetDatum(operation_id));
 		indexid = CHUNK_COPY_OPERATION_PKEY_IDX;
 	}
 	else

--- a/tsl/src/dist_util.c
+++ b/tsl/src/dist_util.c
@@ -49,10 +49,7 @@ uuid_matches(Datum a, Datum b)
 static Datum
 local_get_dist_id(bool *isnull)
 {
-	return ts_metadata_get_value(CStringGetDatum(METADATA_DISTRIBUTED_UUID_KEY_NAME),
-								 CSTRINGOID,
-								 UUIDOID,
-								 isnull);
+	return ts_metadata_get_value(METADATA_DISTRIBUTED_UUID_KEY_NAME, UUIDOID, isnull);
 }
 
 DistUtilMembershipStatus
@@ -136,11 +133,7 @@ dist_util_set_id_with_uuid_check(Datum dist_id, bool check_uuid)
 						  "instance or that the 'database' parameter refers to a "
 						  "different database."))));
 
-	ts_metadata_insert(CStringGetDatum(METADATA_DISTRIBUTED_UUID_KEY_NAME),
-					   CSTRINGOID,
-					   dist_id,
-					   UUIDOID,
-					   true);
+	ts_metadata_insert(METADATA_DISTRIBUTED_UUID_KEY_NAME, dist_id, UUIDOID, true);
 	return true;
 }
 
@@ -164,7 +157,7 @@ dist_util_remove_from_db()
 		CatalogSecurityContext sec_ctx;
 
 		ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
-		ts_metadata_drop(CStringGetDatum(METADATA_DISTRIBUTED_UUID_KEY_NAME), CSTRINGOID);
+		ts_metadata_drop(METADATA_DISTRIBUTED_UUID_KEY_NAME);
 		ts_catalog_restore_user(&sec_ctx);
 
 		return true;

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -712,7 +712,7 @@ remote_txn_persistent_record_delete_for_data_node(Oid foreign_server_oid)
 				Anum_remote_txn_data_node_name_idx_data_node_name,
 				BTEqualStrategyNumber,
 				F_NAMEEQ,
-				DirectFunctionCall1(namein, CStringGetDatum(server->servername)));
+				CStringGetDatum(server->servername));
 
 	scanctx = (ScannerCtx){
 		.table = catalog->tables[REMOTE_TXN].id,


### PR DESCRIPTION
A lot of our scankey initialization when scanning indexes for
a name had a superfluous namein call.  This patch remove those
unnecessary calls.

Disable-check: commit-count
