### PR TITLE
Allow ALTER TABLE DROP COLUMN on compressed hypertable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Features**
 * #3768 Allow ALTER TABLE ADD COLUMN with DEFAULT on compressed hypertable
+* #3769 Allow ALTER TABLE DROP COLUMN on compressed hypertable
 
 **Bugfixes**
 * #3766 Fix segfault in ts_hist_sfunc

--- a/src/hypertable_compression.h
+++ b/src/hypertable_compression.h
@@ -12,11 +12,14 @@
 #include <chunk.h>
 
 extern TSDLLEXPORT List *ts_hypertable_compression_get(int32 htid);
+extern TSDLLEXPORT FormData_hypertable_compression *
+ts_hypertable_compression_get_by_pkey(int32 htid, const char *attname);
 extern TSDLLEXPORT void
 ts_hypertable_compression_fill_tuple_values(FormData_hypertable_compression *fd, Datum *values,
 											bool *nulls);
 
 extern TSDLLEXPORT bool ts_hypertable_compression_delete_by_hypertable_id(int32 htid);
+extern TSDLLEXPORT bool ts_hypertable_compression_delete_by_pkey(int32 htid, const char *attname);
 extern TSDLLEXPORT void ts_hypertable_compression_rename_column(int32 htid, char *old_column_name,
 																char *new_column_name);
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -232,6 +232,7 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 			case AT_SetStatistics: /* should this be pushed down in some way? */
 			case AT_AddColumn:	 /* this is passed down */
 			case AT_ColumnDefault: /* this is passed down */
+			case AT_DropColumn:	/* this is passed down */
 #if PG14_GE
 			case AT_ReAddStatistics:
 			case AT_SetCompression:

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -19,6 +19,7 @@
 bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 								WithClauseResult *with_clause_options);
 void tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def);
+void tsl_process_compress_table_drop_column(Hypertable *ht, char *name);
 Chunk *create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk);
 void tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt);
 

--- a/tsl/src/process_utility.c
+++ b/tsl/src/process_utility.c
@@ -35,13 +35,27 @@ tsl_ddl_command_start(ProcessUtilityArgs *args)
 void
 tsl_process_altertable_cmd(Hypertable *ht, const AlterTableCmd *cmd)
 {
-	if (cmd->subtype == AT_AddColumn || cmd->subtype == AT_AddColumnRecurse)
+	switch (cmd->subtype)
 	{
-		if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) || TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
-		{
-			ColumnDef *orig_coldef = castNode(ColumnDef, cmd->def);
-			tsl_process_compress_table_add_column(ht, orig_coldef);
-		}
+		case AT_AddColumn:
+		case AT_AddColumnRecurse:
+			if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) ||
+				TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
+			{
+				ColumnDef *orig_coldef = castNode(ColumnDef, cmd->def);
+				tsl_process_compress_table_add_column(ht, orig_coldef);
+			}
+			break;
+		case AT_DropColumn:
+		case AT_DropColumnRecurse:
+			if (TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht) ||
+				TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
+			{
+				tsl_process_compress_table_drop_column(ht, cmd->name);
+			}
+			break;
+		default:
+			break;
 	}
 }
 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1039,3 +1039,98 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
+-- test dropping columns from compressed
+CREATE TABLE test_drop(f1 text, f2 text, f3 text, time timestamptz, device int, o1 text, o2 text);
+SELECT create_hypertable('test_drop','time');
+psql:include/compression_alter.sql:176: NOTICE:  adding not-null constraint to column "time"
+    create_hypertable    
+-------------------------
+ (14,public,test_drop,t)
+(1 row)
+
+ALTER TABLE test_drop SET (timescaledb.compress,timescaledb.compress_segmentby='device',timescaledb.compress_orderby='o1,o2');
+-- dropping segmentby or orderby columns will fail
+\set ON_ERROR_STOP 0
+ALTER TABLE test_drop DROP COLUMN time;
+psql:include/compression_alter.sql:181: ERROR:  cannot drop column named in partition key
+ALTER TABLE test_drop DROP COLUMN o1;
+psql:include/compression_alter.sql:182: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+ALTER TABLE test_drop DROP COLUMN o2;
+psql:include/compression_alter.sql:183: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+ALTER TABLE test_drop DROP COLUMN device;
+psql:include/compression_alter.sql:184: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+\set ON_ERROR_STOP 1
+-- switch to WARNING only to suppress compress_chunk NOTICEs
+SET client_min_messages TO WARNING;
+-- create some chunks each with different physical layout
+ALTER TABLE test_drop DROP COLUMN f1;
+INSERT INTO test_drop SELECT NULL,NULL,'2000-01-01',1,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     1
+(1 row)
+
+ALTER TABLE test_drop DROP COLUMN f2;
+-- test non-existant column
+\set ON_ERROR_STOP 0
+ALTER TABLE test_drop DROP COLUMN f10;
+psql:include/compression_alter.sql:198: ERROR:  column "f10" of relation "test_drop" does not exist
+\set ON_ERROR_STOP 1
+ALTER TABLE test_drop DROP COLUMN IF EXISTS f10;
+INSERT INTO test_drop SELECT NULL,'2001-01-01',2,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     2
+(1 row)
+
+ALTER TABLE test_drop DROP COLUMN f3;
+INSERT INTO test_drop SELECT '2003-01-01',3,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     3
+(1 row)
+
+ALTER TABLE test_drop ADD COLUMN c1 TEXT;
+ALTER TABLE test_drop ADD COLUMN c2 TEXT;
+INSERT INTO test_drop SELECT '2004-01-01',4,'o1','o2','c1','c2-4';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     4
+(1 row)
+
+ALTER TABLE test_drop DROP COLUMN c1;
+INSERT INTO test_drop SELECT '2005-01-01',5,'o1','o2','c2-5';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     5
+(1 row)
+
+RESET client_min_messages;
+SELECT * FROM test_drop ORDER BY 1;
+             time             | device | o1 | o2 |  c2  
+------------------------------+--------+----+----+------
+ Sat Jan 01 00:00:00 2000 PST |      1 | o1 | o2 | 
+ Mon Jan 01 00:00:00 2001 PST |      2 | o1 | o2 | 
+ Wed Jan 01 00:00:00 2003 PST |      3 | o1 | o2 | 
+ Thu Jan 01 00:00:00 2004 PST |      4 | o1 | o2 | c2-4
+ Sat Jan 01 00:00:00 2005 PST |      5 | o1 | o2 | c2-5
+(5 rows)
+
+-- check dropped columns got removed from catalog
+-- only c2 should be left in metadata
+SELECT attname
+FROM _timescaledb_catalog.hypertable_compression htc
+INNER JOIN _timescaledb_catalog.hypertable ht
+  ON ht.id=htc.hypertable_id AND ht.table_name='test_drop'
+WHERE attname NOT IN ('time','device','o1','o2')
+ORDER BY 1;
+ attname 
+---------
+ c2
+(1 row)
+

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -179,9 +179,10 @@ DETAIL:  Could not identify a less-than operator for the type.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b');
 --ddl on ht with compression
 ALTER TABLE foo DROP COLUMN a;
-ERROR:  operation not supported on hypertables that have compression enabled
-ALTER TABLE foo DROP COLUMN t;
-ERROR:  operation not supported on hypertables that have compression enabled
+ERROR:  cannot drop column named in partition key
+DETAIL:  Cannot drop column that is a hypertable partitioning (space or time) dimension.
+ALTER TABLE foo DROP COLUMN b;
+ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
 ALTER TABLE foo ALTER COLUMN t SET NOT NULL;
 ERROR:  operation not supported on hypertables that have compression enabled
 ALTER TABLE foo RESET (timescaledb.compress);

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -1146,3 +1146,87 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
+-- test dropping columns from compressed
+CREATE TABLE test_drop(f1 text, f2 text, f3 text, time timestamptz, device int, o1 text, o2 text);
+SELECT create_distributed_hypertable('test_drop','time');
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (7,public,test_drop,t)
+(1 row)
+
+ALTER TABLE test_drop SET (timescaledb.compress,timescaledb.compress_segmentby='device',timescaledb.compress_orderby='o1,o2');
+-- switch to WARNING only to suppress compress_chunk NOTICEs
+SET client_min_messages TO WARNING;
+-- create some chunks each with different physical layout
+ALTER TABLE test_drop DROP COLUMN f1;
+INSERT INTO test_drop SELECT NULL,NULL,'2000-01-01',1,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     1
+(1 row)
+
+ALTER TABLE test_drop DROP COLUMN f2;
+-- test non-existant column
+\set ON_ERROR_STOP 0
+ALTER TABLE test_drop DROP COLUMN f10;
+ERROR:  column "f10" of relation "test_drop" does not exist
+\set ON_ERROR_STOP 1
+ALTER TABLE test_drop DROP COLUMN IF EXISTS f10;
+INSERT INTO test_drop SELECT NULL,'2001-01-01',2,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     2
+(1 row)
+
+ALTER TABLE test_drop DROP COLUMN f3;
+INSERT INTO test_drop SELECT '2003-01-01',3,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     3
+(1 row)
+
+ALTER TABLE test_drop ADD COLUMN c1 TEXT;
+ALTER TABLE test_drop ADD COLUMN c2 TEXT;
+INSERT INTO test_drop SELECT '2004-01-01',4,'o1','o2','c1','c2-4';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     4
+(1 row)
+
+ALTER TABLE test_drop DROP COLUMN c1;
+INSERT INTO test_drop SELECT '2005-01-01',5,'o1','o2','c2-5';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ count 
+-------
+     5
+(1 row)
+
+RESET client_min_messages;
+SELECT * FROM test_drop ORDER BY 1;
+             time             | device | o1 | o2 |  c2  
+------------------------------+--------+----+----+------
+ Sat Jan 01 00:00:00 2000 PST |      1 | o1 | o2 | 
+ Mon Jan 01 00:00:00 2001 PST |      2 | o1 | o2 | 
+ Wed Jan 01 00:00:00 2003 PST |      3 | o1 | o2 | 
+ Thu Jan 01 00:00:00 2004 PST |      4 | o1 | o2 | c2-4
+ Sat Jan 01 00:00:00 2005 PST |      5 | o1 | o2 | c2-5
+(5 rows)
+
+-- check dropped columns got removed from catalog
+-- only c2 should be left in metadata
+SELECT attname
+FROM _timescaledb_catalog.hypertable_compression htc
+INNER JOIN _timescaledb_catalog.hypertable ht
+  ON ht.id=htc.hypertable_id AND ht.table_name='test_drop'
+WHERE attname NOT IN ('time','device','o1','o2')
+ORDER BY 1;
+ attname 
+---------
+ c2
+(1 row)
+

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -90,7 +90,7 @@ ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a, b'
 
 --ddl on ht with compression
 ALTER TABLE foo DROP COLUMN a;
-ALTER TABLE foo DROP COLUMN t;
+ALTER TABLE foo DROP COLUMN b;
 ALTER TABLE foo ALTER COLUMN t SET NOT NULL;
 ALTER TABLE foo RESET (timescaledb.compress);
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);

--- a/tsl/test/sql/include/compression_alter.sql
+++ b/tsl/test/sql/include/compression_alter.sql
@@ -171,3 +171,56 @@ SELECT * FROM test_defaults ORDER BY 1,2;
 SELECT recompress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
 SELECT * FROM test_defaults ORDER BY 1,2;
 
+-- test dropping columns from compressed
+CREATE TABLE test_drop(f1 text, f2 text, f3 text, time timestamptz, device int, o1 text, o2 text);
+SELECT create_hypertable('test_drop','time');
+ALTER TABLE test_drop SET (timescaledb.compress,timescaledb.compress_segmentby='device',timescaledb.compress_orderby='o1,o2');
+
+-- dropping segmentby or orderby columns will fail
+\set ON_ERROR_STOP 0
+ALTER TABLE test_drop DROP COLUMN time;
+ALTER TABLE test_drop DROP COLUMN o1;
+ALTER TABLE test_drop DROP COLUMN o2;
+ALTER TABLE test_drop DROP COLUMN device;
+\set ON_ERROR_STOP 1
+
+-- switch to WARNING only to suppress compress_chunk NOTICEs
+SET client_min_messages TO WARNING;
+
+-- create some chunks each with different physical layout
+ALTER TABLE test_drop DROP COLUMN f1;
+INSERT INTO test_drop SELECT NULL,NULL,'2000-01-01',1,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+
+ALTER TABLE test_drop DROP COLUMN f2;
+-- test non-existant column
+\set ON_ERROR_STOP 0
+ALTER TABLE test_drop DROP COLUMN f10;
+\set ON_ERROR_STOP 1
+ALTER TABLE test_drop DROP COLUMN IF EXISTS f10;
+
+INSERT INTO test_drop SELECT NULL,'2001-01-01',2,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ALTER TABLE test_drop DROP COLUMN f3;
+INSERT INTO test_drop SELECT '2003-01-01',3,'o1','o2';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ALTER TABLE test_drop ADD COLUMN c1 TEXT;
+ALTER TABLE test_drop ADD COLUMN c2 TEXT;
+INSERT INTO test_drop SELECT '2004-01-01',4,'o1','o2','c1','c2-4';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+ALTER TABLE test_drop DROP COLUMN c1;
+INSERT INTO test_drop SELECT '2005-01-01',5,'o1','o2','c2-5';
+SELECT count(compress_chunk(chunk,true)) FROM show_chunks('test_drop') chunk;
+
+RESET client_min_messages;
+SELECT * FROM test_drop ORDER BY 1;
+
+-- check dropped columns got removed from catalog
+-- only c2 should be left in metadata
+SELECT attname
+FROM _timescaledb_catalog.hypertable_compression htc
+INNER JOIN _timescaledb_catalog.hypertable ht
+  ON ht.id=htc.hypertable_id AND ht.table_name='test_drop'
+WHERE attname NOT IN ('time','device','o1','o2')
+ORDER BY 1;
+


### PR DESCRIPTION
This patch allows dropping columns from hypertables with compression
enabled when the dropped column is neither an orderby nor a
segmentby column.

Fixes #3683