### PR TITLE
const'ify CaggsInfo structure

### DIFF
--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -251,7 +251,7 @@ continuous_agg_init(ContinuousAgg *cagg, const Form_continuous_agg fd)
 	Assert(OidIsValid(cagg->partition_type));
 }
 
-TSDLLEXPORT CaggsInfo
+TSDLLEXPORT const CaggsInfo
 ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id)
 {
 	CaggsInfo all_caggs_info;
@@ -327,7 +327,7 @@ ts_populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids, ArrayType *buc
 }
 
 TSDLLEXPORT void
-ts_create_arrays_from_caggs_info(CaggsInfo *all_caggs, ArrayType **mat_hypertable_ids,
+ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs, ArrayType **mat_hypertable_ids,
 								 ArrayType **bucket_widths, ArrayType **max_bucket_widths)
 {
 	ListCell *lc1, *lc2, *lc3;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -67,12 +67,12 @@ typedef struct CaggsInfoData
 	List *max_bucket_widths;  /* (int64 *) elements */
 } CaggsInfo;
 
-extern TSDLLEXPORT CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
+extern TSDLLEXPORT const CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
 extern TSDLLEXPORT void ts_populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids,
 														   ArrayType *bucket_widths,
 														   ArrayType *max_bucket_widths,
 														   CaggsInfo *all_caggs);
-TSDLLEXPORT void ts_create_arrays_from_caggs_info(CaggsInfo *all_caggs,
+TSDLLEXPORT void ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs,
 												  ArrayType **mat_hypertable_ids,
 												  ArrayType **bucket_widths,
 												  ArrayType **max_bucket_widths);

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -99,7 +99,7 @@ typedef struct CaggInvalidationState
 	Relation cagg_log_rel;
 	Snapshot snapshot;
 	Tuplestorestate *invalidations;
-	CaggsInfo *all_caggs;
+	const CaggsInfo *all_caggs;
 	int64 bucket_width;
 	int64 max_bucket_width;
 } CaggInvalidationState;
@@ -754,7 +754,7 @@ cut_and_insert_new_cagg_invalidation(const CaggInvalidationState *state, const I
 static void
 move_invalidations_from_hyper_to_cagg_log(const CaggInvalidationState *state)
 {
-	CaggsInfo *all_caggs = state->all_caggs;
+	const CaggsInfo *all_caggs = state->all_caggs;
 	int32 hyper_id = state->raw_hypertable_id;
 	int32 last_cagg_hyper_id;
 	ListCell *lc1, *lc2;
@@ -1003,7 +1003,7 @@ clear_cagg_invalidations_for_refresh(const CaggInvalidationState *state,
 
 static void
 invalidation_state_init(CaggInvalidationState *state, int32 mat_hypertable_id,
-						int32 raw_hypertable_id, Oid dimtype, CaggsInfo *all_caggs)
+						int32 raw_hypertable_id, Oid dimtype, const CaggsInfo *all_caggs)
 {
 	ListCell *lc1, *lc2, *lc3;
 	bool PG_USED_FOR_ASSERTS_ONLY found = false;
@@ -1051,7 +1051,7 @@ invalidation_state_cleanup(const CaggInvalidationState *state)
 
 void
 invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hypertable_id, Oid dimtype,
-									CaggsInfo *all_caggs)
+									const CaggsInfo *all_caggs)
 {
 	CaggInvalidationState state;
 
@@ -1105,7 +1105,7 @@ tsl_invalidation_process_hypertable_log(PG_FUNCTION_ARGS)
 
 void
 remote_invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
-										   Oid dimtype, CaggsInfo *all_caggs)
+										   Oid dimtype, const CaggsInfo *all_caggs)
 {
 	Oid func_oid;
 	ArrayType *mat_hypertable_ids;
@@ -1164,9 +1164,9 @@ remote_invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hy
 
 InvalidationStore *
 invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
-							  const InternalTimeRange *refresh_window, CaggsInfo *all_caggs_info,
-							  const long max_materializations, bool *do_merged_refresh,
-							  InternalTimeRange *ret_merged_refresh_window)
+							  const InternalTimeRange *refresh_window,
+							  const CaggsInfo *all_caggs_info, const long max_materializations,
+							  bool *do_merged_refresh, InternalTimeRange *ret_merged_refresh_window)
 {
 	CaggInvalidationState state;
 	InvalidationStore *store = NULL;
@@ -1302,8 +1302,8 @@ tsl_invalidation_process_cagg_log(PG_FUNCTION_ARGS)
 
 void
 remote_invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
-									 const InternalTimeRange *refresh_window, CaggsInfo *all_caggs,
-									 bool *do_merged_refresh,
+									 const InternalTimeRange *refresh_window,
+									 const CaggsInfo *all_caggs, bool *do_merged_refresh,
 									 InternalTimeRange *ret_merged_refresh_window)
 {
 	Oid func_oid;

--- a/tsl/src/continuous_aggs/invalidation.h
+++ b/tsl/src/continuous_aggs/invalidation.h
@@ -49,21 +49,21 @@ void remote_invalidation_log_add_entry(const Hypertable *raw_ht,
 									   int64 start, int64 end);
 
 extern void invalidation_process_hypertable_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
-												Oid dimtype, CaggsInfo *all_caggs_info);
+												Oid dimtype, const CaggsInfo *all_caggs_info);
 extern void remote_invalidation_process_hypertable_log(int32 mat_hypertable_id,
 													   int32 raw_hypertable_id, Oid dimtype,
-													   CaggsInfo *all_caggs);
+													   const CaggsInfo *all_caggs);
 extern Datum tsl_invalidation_process_hypertable_log(PG_FUNCTION_ARGS);
 
-extern InvalidationStore *
-invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
-							  const InternalTimeRange *refresh_window, CaggsInfo *all_caggs_info,
-							  const long max_materializations, bool *do_merged_refresh,
-							  InternalTimeRange *ret_merged_refresh_window);
+extern InvalidationStore *invalidation_process_cagg_log(
+	int32 mat_hypertable_id, int32 raw_hypertable_id, const InternalTimeRange *refresh_window,
+	const CaggsInfo *all_caggs_info, const long max_materializations, bool *do_merged_refresh,
+	InternalTimeRange *ret_merged_refresh_window);
 extern Datum tsl_invalidation_process_cagg_log(PG_FUNCTION_ARGS);
 extern void remote_invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertable_id,
 												 const InternalTimeRange *refresh_window,
-												 CaggsInfo *all_caggs, bool *do_merged_refresh,
+												 const CaggsInfo *all_caggs,
+												 bool *do_merged_refresh,
 												 InternalTimeRange *ret_merged_refresh_window);
 
 extern void remote_invalidation_log_delete(int32 raw_hypertable_id,

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -605,7 +605,8 @@ process_cagg_invalidations_and_refresh(const ContinuousAgg *cagg,
 	LockRelationOid(hyper_relid, ExclusiveLock);
 	Hypertable *ht = cagg_get_hypertable_or_fail(cagg->data.raw_hypertable_id);
 	bool is_raw_ht_distributed = hypertable_is_distributed(ht);
-	CaggsInfo all_caggs_info = ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
+	const CaggsInfo all_caggs_info =
+		ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
 	max_materializations = materialization_per_refresh_window();
 	if (is_raw_ht_distributed)
 	{
@@ -765,7 +766,8 @@ continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 	}
 
 	/* Process invalidations in the hypertable invalidation log */
-	CaggsInfo all_caggs_info = ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
+	const CaggsInfo all_caggs_info =
+		ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
 	if (is_raw_ht_distributed)
 	{
 		remote_invalidation_process_hypertable_log(cagg->data.mat_hypertable_id,
@@ -841,7 +843,8 @@ continuous_agg_refresh_chunk(PG_FUNCTION_ARGS)
 					AccessExclusiveLock);
 	invalidation_threshold_set_or_get(chunk->fd.hypertable_id, refresh_window.end);
 
-	CaggsInfo all_caggs_info = ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
+	const CaggsInfo all_caggs_info =
+		ts_continuous_agg_get_all_caggs_info(cagg->data.raw_hypertable_id);
 	if (is_raw_ht_distributed)
 	{
 		remote_invalidation_process_hypertable_log(cagg->data.mat_hypertable_id,


### PR DESCRIPTION
CaggsInfo is an immutable structure and a good candidate to be const'ified.
This simplifies the maintenance of the code and probably could save a CPU
cycle or two here and there.