### PR TITLE
Alter constraints on compressed hypertables

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -235,6 +235,10 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 			case AT_AddColumn:	 /* this is passed down */
 			case AT_ColumnDefault: /* this is passed down */
 			case AT_DropColumn:	/* this is passed down */
+
+			case AT_DropConstraint:
+			case AT_AddConstraint:
+			case AT_AlterConstraint:
 #if PG14_GE
 			case AT_ReAddStatistics:
 			case AT_SetCompression:

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -266,8 +266,7 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 					{
 						FormData_hypertable_compression *fd = lfirst(lc);
 						if (fd->segmentby_column_index > 0)
-							allowed = lappend(allowed,
-											  makeString(NameStr(fd->attname)));
+							allowed = lappend(allowed, makeString(NameStr(fd->attname)));
 					}
 
 					/*
@@ -277,19 +276,21 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 					for (i = 0; i < ht->space->num_dimensions; i++)
 					{
 						Dimension *dim = &ht->space->dimensions[i];
-						allowed = lappend(allowed,
-										  makeString(NameStr(dim->fd.column_name)));
+						allowed = lappend(allowed, makeString(NameStr(dim->fd.column_name)));
 					}
 
 					diff = list_difference(constraint->keys, allowed);
-					if(diff != NIL)
+					if (diff != NIL)
 					{
 						StringInfo not_allowed = makeStringInfo();
-						foreach(lc, diff)
+						int i = 0;
+						foreach (lc, diff)
 						{
 							outNode(not_allowed, lfirst(lc));
-							if (foreach_current_index(lc) < list_length(diff) - 1)
+							if (i < list_length(diff) - 1)
 								appendStringInfoString(not_allowed, ", ");
+
+							i++;
 						}
 
 						ereport(ERROR,
@@ -297,10 +298,8 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 								 errmsg("UNIQUE constraints on columns not "
 										"included in compress_segmentby "
 										"are not supported"),
-								 errhint("Not allowed columns: %s",
-									 	 not_allowed->data)));
+								 errhint("Not allowed columns: %s", not_allowed->data)));
 					}
-
 				}
 
 				break;

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -189,7 +189,18 @@ ALTER TABLE foo RESET (timescaledb.compress);
 ERROR:  compression options cannot be reset
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
 ALTER TABLE foo ADD CONSTRAINT chk UNIQUE(b);
-ERROR:  operation not supported on hypertables that have compression enabled
+ERROR:  UNIQUE constraints on columns not included in compress_segmentby are not supported
+HINT:  Not allowed columns: "b"
+-- segment by column b should allow making a unique constraint on it
+ALTER TABLE foo set (timescaledb.compress,
+                     timescaledb.compress_segmentby = 'b',
+                     timescaledb.compress_orderby = 'c');
+ALTER TABLE foo ADD CONSTRAINT unique_chk UNIQUE(b);
+ERROR:  cannot create a unique index without the column "a" (used in partitioning)
+ALTER TABLE foo ADD CONSTRAINT unique_chk UNIQUE(b, c, t);
+ERROR:  UNIQUE constraints on columns not included in compress_segmentby are not supported
+HINT:  Not allowed columns: "c", "t"
+ALTER TABLE foo ADD CONSTRAINT unique_chk UNIQUE(a, b);
 ALTER TABLE foo DROP CONSTRAINT chk_existing;
 --can add index , but not unique index
 CREATE UNIQUE INDEX foo_idx ON foo ( a, c );
@@ -199,9 +210,9 @@ CREATE INDEX foo_idx ON foo ( a, c );
 select hc.* from _timescaledb_catalog.hypertable_compression hc inner join _timescaledb_catalog.hypertable h on (h.id = hc.hypertable_id) where h.table_name = 'foo' order by attname;
  hypertable_id | attname | compression_algorithm_id | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
 ---------------+---------+--------------------------+------------------------+----------------------+-------------+--------------------
-            11 | a       |                        4 |                        |                    1 | t           | f
-            11 | b       |                        4 |                        |                    2 | t           | f
-            11 | c       |                        4 |                        |                      |             | 
+            11 | a       |                        4 |                        |                    2 | f           | t
+            11 | b       |                        0 |                      1 |                      |             | 
+            11 | c       |                        4 |                        |                    1 | t           | f
             11 | p       |                        1 |                        |                      |             | 
             11 | t       |                        2 |                        |                      |             | 
 (5 rows)
@@ -279,7 +290,7 @@ FROM _timescaledb_catalog.hypertable comp_hyper
 INNER JOIN _timescaledb_catalog.hypertable uncomp_hyper ON (comp_hyper.id = uncomp_hyper.compressed_hypertable_id)
 WHERE uncomp_hyper.table_name like 'foo' ORDER BY comp_hyper.id LIMIT 1 \gset
 select add_retention_policy(:'COMPRESSED_HYPER_NAME', INTERVAL '4 months', true);
-ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_14"
+ERROR:  cannot add retention policy to compressed hypertable "_compressed_hypertable_15"
 HINT:  Please add the policy to the corresponding uncompressed hypertable instead.
 --Constraint checking for compression
 create table fortable(col integer primary key);
@@ -350,7 +361,7 @@ CREATE TABLE table_fk (
 SELECT create_hypertable('table_fk', 'time');
    create_hypertable    
 ------------------------
- (17,public,table_fk,t)
+ (18,public,table_fk,t)
 (1 row)
 
 ALTER TABLE table_fk DROP COLUMN id1;
@@ -369,7 +380,7 @@ ORDER BY ch1.id limit 1 \gset
 select compress_chunk(:'CHUNK_NAME');
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_15_7_chunk
+ _timescaledb_internal._hyper_16_7_chunk
 (1 row)
 
 SELECT  total_chunks , number_compressed_chunks
@@ -406,7 +417,7 @@ WHERE ch1.hypertable_id = ht.id and ht.table_name like 'table_constr2' \gset
 SELECT compress_chunk(:'CHUNK_NAME');
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_19_10_chunk
+ _timescaledb_internal._hyper_20_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 set (timescaledb.compress=false);
@@ -416,7 +427,7 @@ DETAIL:  There are compressed chunks that prevent changing the existing compress
 SELECT decompress_chunk(:'CHUNK_NAME');
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_19_10_chunk
+ _timescaledb_internal._hyper_20_10_chunk
 (1 row)
 
 ALTER TABLE table_constr2 SET (timescaledb.compress=false);
@@ -428,7 +439,7 @@ NOTICE:  adding not-null constraint to column "time"
 DETAIL:  Time dimensions cannot have NULL values.
       create_hypertable       
 ------------------------------
- (21,public,test_table_int,t)
+ (22,public,test_table_int,t)
 (1 row)
 
 CREATE OR REPLACE function dummy_now() returns BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 5::BIGINT';
@@ -449,7 +460,7 @@ WHERE id = :compressjob_id;
 SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
         config         
 -----------------------
- {"hypertable_id": 21}
+ {"hypertable_id": 22}
 (1 row)
 
 --should fail
@@ -496,7 +507,7 @@ CREATE TABLE i165 (time timestamptz PRIMARY KEY);
 SELECT create_hypertable('i165','time');
  create_hypertable  
 --------------------
- (23,public,i165,t)
+ (24,public,i165,t)
 (1 row)
 
 ALTER TABLE i165 SET (timescaledb.compress);

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -188,11 +188,9 @@ ERROR:  operation not supported on hypertables that have compression enabled
 ALTER TABLE foo RESET (timescaledb.compress);
 ERROR:  compression options cannot be reset
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
-ERROR:  operation not supported on hypertables that have compression enabled
 ALTER TABLE foo ADD CONSTRAINT chk UNIQUE(b);
-ERROR:  operation not supported on hypertables that have compression enabled
+ERROR:  cannot create a unique index without the column "a" (used in partitioning)
 ALTER TABLE foo DROP CONSTRAINT chk_existing;
-ERROR:  operation not supported on hypertables that have compression enabled
 --can add index , but not unique index
 CREATE UNIQUE INDEX foo_idx ON foo ( a, c );
 ERROR:  operation not supported on hypertables that have compression enabled
@@ -319,7 +317,6 @@ alter table table_constr drop constraint table_constr_exclu ;
 ALTER TABLE table_constr set (timescaledb.compress, timescaledb.compress_orderby = 'timec', timescaledb.compress_segmentby = 'device_id, location, d');
 --can't add fks after compression enabled
 alter table table_constr add constraint table_constr_fk_add_after FOREIGN KEY(d) REFERENCES fortable(col) on delete cascade;
-ERROR:  operation not supported on hypertables that have compression enabled
 -- ddl ADD column variants that are not supported
 ALTER TABLE table_constr ADD COLUMN newcol integer CHECK ( newcol < 10 );
 ERROR:  cannot add column with constraints to a hypertable that has compression enabled

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -189,7 +189,7 @@ ALTER TABLE foo RESET (timescaledb.compress);
 ERROR:  compression options cannot be reset
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
 ALTER TABLE foo ADD CONSTRAINT chk UNIQUE(b);
-ERROR:  cannot create a unique index without the column "a" (used in partitioning)
+ERROR:  operation not supported on hypertables that have compression enabled
 ALTER TABLE foo DROP CONSTRAINT chk_existing;
 --can add index , but not unique index
 CREATE UNIQUE INDEX foo_idx ON foo ( a, c );

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -95,6 +95,13 @@ ALTER TABLE foo ALTER COLUMN t SET NOT NULL;
 ALTER TABLE foo RESET (timescaledb.compress);
 ALTER TABLE foo ADD CONSTRAINT chk CHECK(b > 0);
 ALTER TABLE foo ADD CONSTRAINT chk UNIQUE(b);
+-- segment by column b should allow making a unique constraint on it
+ALTER TABLE foo set (timescaledb.compress,
+                     timescaledb.compress_segmentby = 'b',
+                     timescaledb.compress_orderby = 'c');
+ALTER TABLE foo ADD CONSTRAINT unique_chk UNIQUE(b);
+ALTER TABLE foo ADD CONSTRAINT unique_chk UNIQUE(b, c, t);
+ALTER TABLE foo ADD CONSTRAINT unique_chk UNIQUE(a, b);
 ALTER TABLE foo DROP CONSTRAINT chk_existing;
 --can add index , but not unique index
 CREATE UNIQUE INDEX foo_idx ON foo ( a, c );


### PR DESCRIPTION
Hi,

From what I see currently it's not possible e.g. to drop a foreign key on a
compressed hypertable (among other DDL limitations). I haven't found any
detailed description on why is it like that in the original commit a399a57, and
few simple experiments show that at least dropping or adding a foreign key
actually works without any extra changes (except allowing those). Are there any
particular reasons to forbid such constraint related AlterTableCmd?