### PR TITLE
add shellcheck to CI

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,22 @@
+name: Shellcheck
+on:
+  pull_request:
+  push:
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install shellcheck
+
+    - name: Checkout TimescaleDB
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Run shellcheck
+      run: scripts/shellcheck-ci.sh

--- a/bootstrap
+++ b/bootstrap
@@ -22,7 +22,7 @@ if [ ${BUILD_FORCE_REMOVE} == "true" ]; then
 elif [ -d ${BUILD_DIR} ]; then
     echo "Build system already initialized in ${BUILD_DIR}"
 
-    read  -n 1 -p "Do you want to remove it (this is IMMEDIATE and PERMANENT), y/n? " choice
+    read -r -n 1 -p "Do you want to remove it (this is IMMEDIATE and PERMANENT), y/n? " choice
     echo ""
     if [ $choice == "y" ]; then
         rm -fr ${BUILD_DIR}

--- a/scripts/check_file_license.sh
+++ b/scripts/check_file_license.sh
@@ -11,8 +11,8 @@ get_sql_license() {
 check_file() {
     FLAG=${1}
     FILE=${2}
-    SCRIPTPATH="$( cd "$(dirname "${0}")" ; pwd -P )"
-    TIMESCALE_LOCATION=`dirname ${SCRIPTPATH}`
+    SCRIPTPATH="$( cd "$(dirname "${0}")" || exit ; pwd -P )"
+    TIMESCALE_LOCATION=$(dirname ${SCRIPTPATH})
 
     LICENSE_FILE=
     LICENSE_STRING=
@@ -21,38 +21,38 @@ check_file() {
     case ${FLAG} in
         ('-c')
             LICENSE_FILE="${SCRIPTPATH}/c_license_header-apache.h"
-            LICENSE_STRING=`get_c_license ${LICENSE_FILE}`
-            FIRST_COMMENT=`get_c_license ${FILE}`
+            LICENSE_STRING=$(get_c_license ${LICENSE_FILE})
+            FIRST_COMMENT=$(get_c_license ${FILE})
             ;;
         ('-e')
             LICENSE_FILE="${SCRIPTPATH}/c_license_header-timescale.h"
-            LICENSE_STRING=`get_c_license ${LICENSE_FILE}`
-            FIRST_COMMENT=`get_c_license ${FILE}`
+            LICENSE_STRING=$(get_c_license ${LICENSE_FILE})
+            FIRST_COMMENT=$(get_c_license ${FILE})
             ;;
         ('-i')
             LICENSE_FILE="${SCRIPTPATH}/license_apache.spec"
-            LICENSE_STRING=`get_sql_license ${LICENSE_FILE}`
-            FIRST_COMMENT=`get_sql_license ${FILE}`
+            LICENSE_STRING=$(get_sql_license ${LICENSE_FILE})
+            FIRST_COMMENT=$(get_sql_license ${FILE})
             ;;
         ('-j')
             LICENSE_FILE="${SCRIPTPATH}/license_tsl.spec"
-            LICENSE_STRING=`get_sql_license ${LICENSE_FILE}`
-            FIRST_COMMENT=`get_sql_license ${FILE}`
+            LICENSE_STRING=$(get_sql_license ${LICENSE_FILE})
+            FIRST_COMMENT=$(get_sql_license ${FILE})
             ;;
         ('-s')
             LICENSE_FILE="${SCRIPTPATH}/sql_license_apache.sql"
-            LICENSE_STRING=`get_sql_license ${LICENSE_FILE}`
-            FIRST_COMMENT=`get_sql_license ${FILE}`
+            LICENSE_STRING=$(get_sql_license ${LICENSE_FILE})
+            FIRST_COMMENT=$(get_sql_license ${FILE})
             ;;
         ('-t')
             LICENSE_FILE="${SCRIPTPATH}/sql_license_tsl.sql"
-            LICENSE_STRING=`get_sql_license ${LICENSE_FILE}`
-            FIRST_COMMENT=`get_sql_license ${FILE}`
+            LICENSE_STRING=$(get_sql_license ${LICENSE_FILE})
+            FIRST_COMMENT=$(get_sql_license ${FILE})
             ;;
         ('-p')
             LICENSE_FILE="${SCRIPTPATH}/license_tsl.spec"
-            LICENSE_STRING=`get_sql_license ${LICENSE_FILE}`
-            FIRST_COMMENT=`get_sql_license ${FILE}`
+            LICENSE_STRING=$(get_sql_license ${LICENSE_FILE})
+            FIRST_COMMENT=$(get_sql_license ${FILE})
             ;;
         ("--")
             return 0;
@@ -72,7 +72,7 @@ check_file() {
     fi
 }
 
-args=`getopt "c:e:i:j:p:s:t:" $*`; errcode=$?; set -- $args
+args=$(getopt "c:e:i:j:p:s:t:" "$@"); errcode=$?; set -- $args
 
 if [[ ${errcode} != 0 ]]; then
         echo 'Usage: check_file_license ((-c|-e|-i|-j|-s|-t) <filename> ...)'
@@ -88,7 +88,7 @@ while [[ ${1} ]]; do
     fi
     check_file ${1} ${2}
     FILE_ERR=${?}
-    ERRORCODE=$((${FILE_ERR} | ${ERRORCODE}));
+    ERRORCODE=$((FILE_ERR | ERRORCODE));
     shift; shift;
 done
 

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -27,10 +27,10 @@ check_file() {
         SUFFIX1='*.sql.in'
     fi
 
-    find $2 -type f \( -name "${SUFFIX0}" -or -name "${SUFFIX1}" \) -and -not -path "${SRC_DIR}/sql/updates/*.sql" -and -not -path "${SRC_DIR}/test/sql/dump/*.sql" -and -not -path "${SRC_DIR}/src/chunk_adaptive.*" -print0 | xargs -0 -n1 $(dirname ${0})/check_file_license.sh ${1}
+    find $2 -type f \( -name "${SUFFIX0}" -or -name "${SUFFIX1}" \) -and -not -path "${SRC_DIR}/sql/updates/*.sql" -and -not -path "${SRC_DIR}/test/sql/dump/*.sql" -and -not -path "${SRC_DIR}/src/chunk_adaptive.*" -print0 | xargs -0 -n1 "$(dirname ${0})/check_file_license.sh" ${1}
 }
 
-args=`getopt "c:e:i:j:p:s:t:" $*`; errcode=$?; set -- $args
+args=$(getopt "c:e:i:j:p:s:t:" "$@"); set -- $args
 
 ERRORCODE=0
 
@@ -40,7 +40,7 @@ while [[ ${1} ]]; do
     fi
     check_file ${1} ${2}
     FILE_ERR=${?}
-    ERRORCODE=$((${FILE_ERR} | ${ERRORCODE}));
+    ERRORCODE=$((FILE_ERR | ERRORCODE));
     shift; shift;
 done
 

--- a/scripts/check_unreferenced_files.sh
+++ b/scripts/check_unreferenced_files.sh
@@ -6,11 +6,11 @@ BASE_DIR=$(pwd)/$SCRIPT_DIR/..
 unreferenced=0
 
 function get_filenames {
-  echo *.$2 *.$2.in | xargs git ls-files | xargs -IFILE basename FILE
+  echo ./*.$2 ./*.$2.in | xargs git ls-files | xargs -IFILE basename FILE
 }
 
 function check_directory {
-  cd $BASE_DIR/$1
+  cd $BASE_DIR/$1 || exit
   test_files=$(get_filenames $1 $2)
 
   for file in $test_files; do

--- a/scripts/clang_format_all.sh
+++ b/scripts/clang_format_all.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # we need to convert script dir to an absolute path
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
+SCRIPT_DIR=$(cd "$(dirname $0)" || exit; pwd)
 BASE_DIR=$(dirname $SCRIPT_DIR)
 
 find ${BASE_DIR} \( -path "${BASE_DIR}/src/*" -or -path "${BASE_DIR}/test/*" -or -path "${BASE_DIR}/tsl/*" \) \
     -and -not \( -path "*/.*" -or -path "*CMake*" \) \
-    -and \( -name '*.c' -or -name '*.h' \) -print | xargs ${SCRIPT_DIR}/clang_format_wrapper.sh -style=file -i
+    -and \( -name '*.c' -or -name '*.h' \) -print0 | xargs -0 ${SCRIPT_DIR}/clang_format_wrapper.sh -style=file -i

--- a/scripts/clang_format_wrapper.sh
+++ b/scripts/clang_format_wrapper.sh
@@ -6,11 +6,11 @@
 # This script replaces PG_FUNCTION_ARGS with "PG_FUNCTION_ARGS fake_var_for_clang" to
 # make it look like a proper function for clang and then converts it back after clang runs.
 
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
+SCRIPT_DIR=$(cd "$(dirname $0)"; pwd)
 BASE_DIR=$(dirname $SCRIPT_DIR)
 TEMP_DIR="/tmp/timescaledb_format"
 
-OPTIONS="${@}"
+OPTIONS=("${@}")
 
 if [ -e ${TEMP_DIR} ]
 then
@@ -26,8 +26,7 @@ cleanup() {
 
 trap cleanup EXIT SIGINT SIGTERM
 
-mkdir ${TEMP_DIR}
-if [[ $? != 0 ]]
+if ! mkdir ${TEMP_DIR}
 then
     echo "error: could not create temporary directory ${TEMP_DIR}"
     exit 1
@@ -39,7 +38,7 @@ set -e
 CLANG_FORMAT_FLAGS=""
 FILE_NAMES=""
 
-for opt in ${OPTIONS}
+for opt in "${OPTIONS[@]}"
 do
     if [[ "${opt:0:1}" != "-" ]]
     then
@@ -55,7 +54,7 @@ echo "copying to ${TEMP_DIR}"
 for name in ${FILE_NAMES}
 do
     # sed -i have different semantics on mac and linux, don't use
-    mkdir -p $(dirname ${TEMP_DIR}/${name})
+    mkdir -p "$(dirname "${TEMP_DIR}/${name}")"
     sed -e 's/(PG_FUNCTION_ARGS)/(PG_FUNCTION_ARGS fake_var_for_clang)/' ${BASE_DIR}/${name} > ${TEMP_DIR}/${name}
 done
 

--- a/scripts/cmake_format_all.sh
+++ b/scripts/cmake_format_all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPTDIR=$(cd $(dirname $0); pwd)
+SCRIPTDIR=$(cd "$(dirname $0)" || exit; pwd)
 BASEDIR=$(dirname $SCRIPTDIR)
 
 find $BASEDIR -name CMakeLists.txt  -exec cmake-format -i {} +

--- a/scripts/docker-run-abi-test.sh
+++ b/scripts/docker-run-abi-test.sh
@@ -20,8 +20,8 @@ CONTAINER_NAME_RUN=${CONTAINER_NAME_RUN:-pgtest_run}
 COMPILE_VOLUME=${COMPILE_VOLUME:-pgtest_compile}
 
 set +e
-docker rm -f $(docker ps -a -q -f name=${CONTAINER_NAME_COMPILE} 2>/dev/null) 2>/dev/null
-docker rm -f $(docker ps -a -q -f name=${CONTAINER_NAME_RUN} 2>/dev/null) 2>/dev/null
+docker rm -f "$(docker ps -a -q -f name=${CONTAINER_NAME_COMPILE} 2>/dev/null)" 2>/dev/null
+docker rm -f "$(docker ps -a -q -f name=${CONTAINER_NAME_RUN} 2>/dev/null)" 2>/dev/null
 docker volume rm $COMPILE_VOLUME
 set -e
 

--- a/scripts/docker-run-restore-points-test.sh
+++ b/scripts/docker-run-restore-points-test.sh
@@ -15,6 +15,10 @@ do
             echo "!!Debug mode: Containers and temporary directory will be left on disk"
             echo
             ;;
+    	*)
+    		echo "Unknown flag '$opt'"
+    		exit 1
+    		;;
     esac
 done
 

--- a/scripts/export_prefix_check.sh.in
+++ b/scripts/export_prefix_check.sh.in
@@ -69,7 +69,7 @@ exports=$(find @CMAKE_BINARY_DIR@ -not -path '*/\.*' -name '*.so' -print0 \
         -e '^_\?backtrace_uncompress_zdebug$' \
 )
 
-num_exports=$(echo "${exports}" | grep -v '^$' | wc -l)
+num_exports=$(echo "${exports}" | grep -v '^$' -c)
 echo "${exports}"
 
 if [ ${num_exports} -gt 0 ];

--- a/scripts/run_sql.sh
+++ b/scripts/run_sql.sh
@@ -4,8 +4,8 @@
 set -u
 set -e
 
-PWD=`pwd`
-DIR=`dirname $0`
+PWD=$(pwd)
+DIR=$(dirname $0)
 
 export PGUSER=${PGUSER:-postgres}
 export PGHOST=${PGHOST:-localhost}

--- a/scripts/shellcheck-ci.sh
+++ b/scripts/shellcheck-ci.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+find ./* .github -type f -executable \
+  -exec bash -c '[ "$(file --brief --mime-type "$1")" == "text/x-shellscript" ]' sh {} \; \
+  -not -exec shellcheck -x --exclude=SC2086 {} \; \
+  -print \
+  | grep . \
+  && exit 1 \
+  || exit 0

--- a/scripts/test_restore_points.sh
+++ b/scripts/test_restore_points.sh
@@ -24,7 +24,7 @@ DN1_PORT=${DN1_PORT:-5443}
 DN2_PORT=${DN2_PORT:-5444}
 DN3_PORT=${DN3_PORT:-5445}
 
-TEST_DIR=${TEST_DIR:-`pwd`}
+TEST_DIR=${TEST_DIR:-$(pwd)}
 WAL_DIR=${TEST_DIR}/wal
 BASEBACKUP_DIR=${TEST_DIR}/basebackup
 STORAGE_DIR=${TEST_DIR}/storage
@@ -34,8 +34,8 @@ TEST_RESTORE_POINT_1=${TEST_RESTORE_POINT_1:-rp1}
 TEST_RESTORE_POINT_2=${TEST_RESTORE_POINT_2:-rp2}
 TEST_RESTORE_POINT_3=${TEST_RESTORE_POINT_3:-rp3}
 
-PG_BINDIR=${PG_BINDIR:-`pg_config --bindir`}
-PG_VERSION_MAJOR=`${PG_BINDIR}/postgres -V | awk '{print $3}' | sed 's/\./ /g' | awk '{print $1}'`
+PG_BINDIR=${PG_BINDIR:-$(pg_config --bindir)}
+PG_VERSION_MAJOR=$(${PG_BINDIR}/postgres -V | awk '{print $3}' | sed 's/\./ /g' | awk '{print $1}')
 PG_USER=${PG_USER:-postgres}
 
 function instance_configure()
@@ -63,10 +63,10 @@ function instance_start()
 	HOST=$2
 	PORT=$3
 	${PG_BINDIR}/pg_ctl start -U ${PG_USER} -D "${STORAGE_DIR}/${NAME}"
-	for i in {1..20}; do
+	for _ in {1..20}; do
 		sleep 0.5
-		${PG_BINDIR}/pg_isready -q -U ${PG_USER} -h ${HOST} -p ${PORT} -d postgres
-		if [[ $? == 0 ]] ; then
+		if ${PG_BINDIR}/pg_isready -q -U ${PG_USER} -h ${HOST} -p ${PORT} -d postgres
+		then
 			sleep 0.2
 			return 0
 		fi
@@ -122,15 +122,15 @@ function instance_basebackup()
 function instance_cleanup_storage()
 {
 	NAME=$1
-	rm -rf "${STORAGE_DIR}/${NAME}"
+	rm -rf "${STORAGE_DIR:?}/${NAME}"
 }
 
 function instance_cleanup()
 {
 	NAME=$1
-	rm -rf "${STORAGE_DIR}/${NAME}"
-	rm -rf "${WAL_DIR}/${NAME}"
-	rm -rf "${BASEBACKUP_DIR}/${NAME}"
+	rm -rf "${STORAGE_DIR:?}/${NAME}"
+	rm -rf "${WAL_DIR:?}/${NAME}"
+	rm -rf "${BASEBACKUP_DIR:?}/${NAME}"
 }
 
 function instance_cleanup_dirs()

--- a/scripts/test_sanitizers.sh
+++ b/scripts/test_sanitizers.sh
@@ -24,6 +24,10 @@ do
             echo "!!Debug mode: Containers and temporary directory will be left on disk"
             echo
             ;;
+    	*)
+    		echo "Unknown flag '$opt'"
+    		exit 1
+    		;;
     esac
 done
 

--- a/scripts/test_updates.sh
+++ b/scripts/test_updates.sh
@@ -37,6 +37,10 @@ do
             KEEP_TEMP_DIRS=true
             TEST_UPDATE_FROM_TAGS_EXTRA_ARGS="-d"
             ;;
+    	*)
+    		echo "Unknown flag '$opt'"
+    		exit 1
+    		;;
     esac
 done
 
@@ -44,7 +48,7 @@ kill_all_tests() {
     local exit_code="$?"
     set +e # do not exit immediately on failure
     echo "Killing all tests"
-    kill ${!tests[@]} 2>/dev/null
+    kill "${!tests[@]}" 2>/dev/null
     return $exit_code
 }
 
@@ -67,7 +71,7 @@ IMAGE_NAME=${UPDATE_TO_IMAGE} TAG_NAME=${UPDATE_TO_TAG} PG_VERSION=${PG_VERSION}
 # Run update tests in parallel
 for tag in ${TAGS};
 do
-    UPDATE_FROM_TAG=${tag} TEST_VERSION=${TEST_VERSION} $(dirname $0)/test_update_from_tag.sh ${TEST_UPDATE_FROM_TAGS_EXTRA_ARGS} > ${TEST_TMPDIR}/${tag}.log 2>&1 &
+    UPDATE_FROM_TAG=${tag} TEST_VERSION=${TEST_VERSION} "$(dirname $0)/test_update_from_tag.sh" ${TEST_UPDATE_FROM_TAGS_EXTRA_ARGS} > ${TEST_TMPDIR}/${tag}.log 2>&1 &
 
     tests[$!]=${tag}
     echo "Launched test ${tag} with pid $!"
@@ -77,7 +81,7 @@ done
 
 # Since we are iterating a hash table, the tests are not going to be
 # in order started. But it doesn't matter.
-for pid in ${!tests[@]};
+for pid in "${!tests[@]}"
 do
     echo "Waiting for test pid $pid"
     wait $pid

--- a/scripts/test_updates_pg12.sh
+++ b/scripts/test_updates_pg12.sh
@@ -4,6 +4,7 @@ set -e
 
 SCRIPT_DIR=$(dirname $0)
 
+# shellcheck source=scripts/test_functions.inc
 source ${SCRIPT_DIR}/test_functions.inc
 
 # There are repair steps between:

--- a/scripts/test_updates_pg13.sh
+++ b/scripts/test_updates_pg13.sh
@@ -4,6 +4,7 @@ set -e
 
 SCRIPT_DIR=$(dirname $0)
 
+# shellcheck source=scripts/test_functions.inc
 source ${SCRIPT_DIR}/test_functions.inc
 
 run_tests -v7 \

--- a/scripts/test_updates_pg14.sh
+++ b/scripts/test_updates_pg14.sh
@@ -4,6 +4,7 @@ set -e
 
 SCRIPT_DIR=$(dirname $0)
 
+# shellcheck source=scripts/test_functions.inc
 source ${SCRIPT_DIR}/test_functions.inc
 
 run_tests -v7 \

--- a/scripts/ts_dump.sh
+++ b/scripts/ts_dump.sh
@@ -30,14 +30,14 @@ PREFIX=$2
 shift 2
 set -e
 echo "Backing up schema as $PREFIX-schema.sql..."
-pg_dump $@ --schema-only -t $HYPERTABLE -f $PREFIX-schema.sql
-echo "--" >> $PREFIX-schema.sql
-echo "-- Restore to hypertable" >> $PREFIX-schema.sql
-echo "--" >> $PREFIX-schema.sql
-psql $@ -qAtX -c "SELECT _timescaledb_internal.get_create_command('$HYPERTABLE');" >> $PREFIX-schema.sql
+pg_dump "$@" --schema-only -t $HYPERTABLE -f $PREFIX-schema.sql
+echo >> $PREFIX-schema.sql "--
+-- Restore to hypertable
+--"
+psql "$@" -qAtX -c "SELECT _timescaledb_internal.get_create_command('$HYPERTABLE');" >> $PREFIX-schema.sql
 
 echo "Backing up data as $PREFIX-data.csv..."
-psql $@ -c "\COPY (SELECT * FROM $HYPERTABLE) TO $PREFIX-data.csv DELIMITER ',' CSV"
+psql "$@" -c "\COPY (SELECT * FROM $HYPERTABLE) TO $PREFIX-data.csv DELIMITER ',' CSV"
 
 echo "Archiving and removing previous files..."
 tar -czvf $PREFIX.tar.gz $PREFIX-data.csv $PREFIX-schema.sql

--- a/scripts/ts_restore.sh
+++ b/scripts/ts_restore.sh
@@ -28,8 +28,8 @@ echo "Unarchiving tarball..."
 tar xvzf $TARFILE
 
 echo "Restoring hypertable's schema..."
-psql -q -v "ON_ERROR_STOP=1" $@ < $PREFIX-schema.sql
-if [ $? -ne 0 ]; then
+if ! psql -q -v "ON_ERROR_STOP=1" "$@" < $PREFIX-schema.sql
+then
     echo "Restoring schema failed, exiting."
     rm $PREFIX-data.csv
     rm $PREFIX-schema.sql
@@ -37,8 +37,8 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Restoring hypertable's data..."
-psql $@ -v "ON_ERROR_STOP=1" -c "\COPY $HYPERTABLE FROM $PREFIX-data.csv DELIMITER ',' CSV"
-if [ $? -ne 0 ]; then
+if ! psql "$@" -v "ON_ERROR_STOP=1" -c "\COPY $HYPERTABLE FROM $PREFIX-data.csv DELIMITER ',' CSV"
+then
     echo "Restoring data failed, exiting."
 fi
 

--- a/test/pg_prove.sh
+++ b/test/pg_prove.sh
@@ -21,7 +21,7 @@ PROVE=${PROVE:-prove}
 if [ -z "$PROVE_TESTS" ]
 then
     # Exit early if we are running with TESTS=expr
-    if [ ! -z "$TESTS" ]
+    if [ -n "$TESTS" ]
     then
         exit 0
     fi

--- a/test/pg_regress.sh
+++ b/test/pg_regress.sh
@@ -80,6 +80,8 @@ else
   for t in ${TESTS}; do
     if ! contains "${SKIPS}" "${t}"; then
       for t2 in ${ALL_TESTS}; do
+        # shellcheck disable=SC2053
+        # We do want to match globs in $t here.
         if [[ $t2 == $t ]]; then
           current_tests="${current_tests} ${t2}"
         fi
@@ -151,4 +153,4 @@ mkdir -p ${EXE_DIR}/sql/dump
 export PG_REGRESS_DIFF_OPTS
 
 PG_REGRESS_OPTS="${PG_REGRESS_OPTS}  --schedule=${SCHEDULE}"
-${PG_REGRESS} $@ ${PG_REGRESS_OPTS}
+${PG_REGRESS} "$@" ${PG_REGRESS_OPTS}

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -26,7 +26,7 @@ if [[ ${TEST_BASE_NAME} == *-1[0-9] ]]; then
 fi
 
 #docker doesn't set user
-USER=${USER:-`whoami`}
+USER=${USER:-$(whoami)}
 
 TEST_ROLE_SUPERUSER=${TEST_ROLE_SUPERUSER:-super_user}
 TEST_ROLE_DEFAULT_PERM_USER=${TEST_ROLE_DEFAULT_PERM_USER:-default_perm_user}
@@ -38,7 +38,7 @@ shift
 # we use mkdir here because it is an atomic operation unlike existance of a lockfile
 # where creating and checking are 2 separate operations
 if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
-  ${PSQL} $@ -U ${USER} -d postgres -v ECHO=none -c "ALTER USER ${TEST_ROLE_SUPERUSER} WITH SUPERUSER;" >/dev/null
+  ${PSQL} "$@" -U ${USER} -d postgres -v ECHO=none -c "ALTER USER ${TEST_ROLE_SUPERUSER} WITH SUPERUSER;" >/dev/null
   ${PSQL} -U ${USER} \
      -v TEST_BASE_NAME=${TEST_BASE_NAME} \
      -v TEST_INPUT_DIR=${TEST_INPUT_DIR} \
@@ -48,7 +48,7 @@ if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
      -v ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
-     $@ -d ${TEST_DBNAME} < ${TEST_INPUT_DIR}/shared/sql/include/shared_setup.sql >/dev/null
+     "$@" -d ${TEST_DBNAME} < ${TEST_INPUT_DIR}/shared/sql/include/shared_setup.sql >/dev/null
   touch ${TEST_OUTPUT_DIR}/.pg_init/done
 fi
 
@@ -73,4 +73,4 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
-     $@ -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d'  -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' -e 's! Memory: [0-9]\{1,\}kB!!' -e 's! Memory Usage: [0-9]\{1,\}kB!!' -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!'
+     "$@" -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d'  -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' -e 's! Memory: [0-9]\{1,\}kB!!' -e 's! Memory Usage: [0-9]\{1,\}kB!!' -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!'


### PR DESCRIPTION
In my experience, writing a shell script correctly is hard even for a skilled programmer.  [shellcheck](https://github.com/koalaman/shellcheck) is a static analysis tool that helps catch common errors in shell scripts. I found it to be very useful when working with shell scripts.

We now have 36 executable scripts in our repository, for which shellcheck reports 126 errors (calculated like `find . -type f -executable -exec bash -c '[ "$(file --brief --mime-type "$1")" == "text/x-shellscript" ]' sh {} \; -exec shellcheck -f gcc --exclude=SC2086 {} \; | cut -d: -f1 | sort | uniq | wc -l`) I think it might make sense to run shellcheck on changed scripts in pull requests. This PR adds a GitHub actions workflow that does this.

This check only runs on the changed files, so this PR doesn't fix all the existing shellcheck warnings. To test the check, I first fixing a single warning in `test/pg_regress.sh` and confirmed that the check complains about the remaining warnings. I fixed them as well and confirmed that the check passes.

The warning [SC2086: Double quote to prevent globbing and word splitting](https://github.com/koalaman/shellcheck/wiki/SC2086) is disabled globally, because it has little practical consequences, sometimes leads to false positives, and is general is too widespread because people forget to quote.