### PR TITLE
Fix possible uninitialized value in test_utils.c

### DIFF
--- a/test/src/test_utils.c
+++ b/test/src/test_utils.c
@@ -87,8 +87,8 @@ ts_bgw_wait(PG_FUNCTION_ARGS)
 
 	/* This function contains a timeout of 5 seconds, so we iterate a few
 	 * times to make sure that it really has terminated. */
-	int notherbackends;
-	int npreparedxacts;
+	int notherbackends = 0;
+	int npreparedxacts = 0;
 	while (iterations-- > 0)
 	{
 		if (!CountOtherDBBackends(dboid, &notherbackends, &npreparedxacts))


### PR DESCRIPTION
Supress the following CLang warning:

```
warning: 2nd function call argument is an uninitialized value
[clang-analyzer-core.CallAndMessage]
```