### PR TITLE
Silence 3 clang warnings for simple8b_rle.h/dictionary.c

### DIFF
--- a/tsl/src/compression/dictionary.c
+++ b/tsl/src/compression/dictionary.c
@@ -326,6 +326,8 @@ dictionary_compressor_finish(DictionaryCompressor *compressor)
 	if (sizes.is_all_null)
 		return NULL;
 
+	Assert(0 != sizes.num_distinct);
+
 	/* calculate what the expected size would have be if we recompressed this as
 	 * an array, if this is smaller than the current size, recompress as an array.
 	 */

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -230,6 +230,7 @@ simple8brle_serialized_recv(StringInfo buffer)
 static void
 simple8brle_serialized_send(StringInfo buffer, const Simple8bRleSerialized *data)
 {
+	Assert(NULL != data);
 	uint32 num_selector_slots = simple8brle_num_selector_slots_for_num_blocks(data->num_blocks);
 	uint32 i;
 	pq_sendint32(buffer, data->num_elements);
@@ -601,6 +602,8 @@ simple8brle_decompression_iterator_init_reverse(Simple8bRleDecompressionIterator
 	bit_array_iterator_init_rev(&iter->selectors, &iter->selector_data);
 	skipped_in_last = simple8brle_decompression_iterator_max_elements(iter, compressed) -
 					  compressed->num_elements;
+
+	Assert(NULL != iter->compressed_data);
 
 	iter->current_block =
 		simple8brle_block_create(bit_array_iter_next_rev(&iter->selectors,


### PR DESCRIPTION
CLang 11 generates several warnings regarding possible null pointer
dereferences and division by zero. The warnings seem to be false-positive.
However, they may hide new valuable warnings. Thus this patch double-checks
that there is nothing to be concerned about and also silences these warnings.