### PR TITLE
Tweak chunk creation error message

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1464,7 +1464,7 @@ ts_chunk_create_from_point(const Hypertable *ht, const Point *p, const char *sch
 			ereport(ERROR,
 					(errcode(ERRCODE_TS_INTERNAL_ERROR),
 					 errmsg("distributed hypertable member cannot create chunk on its own"),
-					 errhint("chunk creation should only happen through an access node")));
+					 errhint("Chunk creation should only happen through an access node.")));
 
 		chunk = chunk_create_from_point_after_lock(ht, p, schema, NULL, prefix);
 	}


### PR DESCRIPTION
When a data node tries to create a chunk itself, and not via the
access node, an error is raised. The hint in this error was not
conforming to the error style guide, so fix it.