### PR TITLE
Fail size utility functions when data nodes do not respond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ accidentally triggering the load of a previous DB version.**
 * #3739 Fix compression policy on tables using INTEGER
 * #3766 Fix segfault in ts_hist_sfunc
 * #3789 Fix time_bucket comparison transformation
+* #3801 Fail size utility functions when data nodes do not respond
 
 **Thanks**
 * @cbisnett for reporting and fixing a typo in an error message

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -122,8 +122,7 @@ $BODY$
         srv.node_name
     FROM (
         SELECT
-            s.node_name,
-            _timescaledb_internal.ping_data_node (s.node_name) AS node_up
+            s.node_name
         FROM
             _timescaledb_catalog.hypertable AS ht,
             _timescaledb_catalog.hypertable_data_node AS s
@@ -133,11 +132,7 @@ $BODY$
             AND s.hypertable_id = ht.id
          ) AS srv
     LEFT OUTER JOIN LATERAL _timescaledb_internal.data_node_hypertable_info(
-    CASE WHEN srv.node_up THEN
-        srv.node_name
-    ELSE
-        NULL
-    END, schema_name_in, table_name_in) entry ON TRUE
+        srv.node_name, schema_name_in, table_name_in) entry ON TRUE
     GROUP BY srv.node_name;
 $BODY$;
 
@@ -258,8 +253,7 @@ $BODY$
         srv.node_name
     FROM (
         SELECT
-            s.node_name,
-            _timescaledb_internal.ping_data_node (s.node_name) AS node_up
+            s.node_name
         FROM
             _timescaledb_catalog.hypertable AS ht,
             _timescaledb_catalog.hypertable_data_node AS s
@@ -269,11 +263,7 @@ $BODY$
             AND s.hypertable_id = ht.id
          ) AS srv
     LEFT OUTER JOIN LATERAL _timescaledb_internal.data_node_chunk_info(
-    CASE WHEN srv.node_up THEN
-        srv.node_name
-    ELSE
-        NULL
-    END , schema_name_in, table_name_in) entry ON TRUE
+        srv.node_name, schema_name_in, table_name_in) entry ON TRUE
 	WHERE
 	    entry.chunk_name IS NOT NULL;
 $BODY$;
@@ -488,8 +478,7 @@ $BODY$
         srv.node_name
     FROM (
         SELECT
-            s.node_name,
-            _timescaledb_internal.ping_data_node (s.node_name) AS node_up
+            s.node_name
         FROM
             _timescaledb_catalog.hypertable AS ht,
             _timescaledb_catalog.hypertable_data_node AS s
@@ -498,11 +487,7 @@ $BODY$
             AND ht.table_name = table_name_in
             AND s.hypertable_id = ht.id) AS srv
     LEFT OUTER JOIN LATERAL _timescaledb_internal.data_node_compressed_chunk_stats (
-    CASE WHEN srv.node_up THEN
-        srv.node_name
-    ELSE
-        NULL
-    END, schema_name_in, table_name_in) ch ON TRUE
+        srv.node_name, schema_name_in, table_name_in) ch ON TRUE
 	WHERE ch.chunk_name IS NOT NULL;
 $BODY$;
 
@@ -662,8 +647,7 @@ $BODY$
         sum(entry.total_bytes)::bigint AS total_bytes
     FROM (
         SELECT
-            s.node_name,
-            _timescaledb_internal.ping_data_node (s.node_name) AS node_up
+            s.node_name
         FROM
             _timescaledb_catalog.hypertable AS ht,
             _timescaledb_catalog.hypertable_data_node AS s
@@ -673,11 +657,7 @@ $BODY$
             AND s.hypertable_id = ht.id
          ) AS srv
     JOIN LATERAL _timescaledb_internal.data_node_index_size(
-    CASE WHEN srv.node_up THEN
-        srv.node_name
-    ELSE
-        NULL
-    END, schema_name_in, index_name_in) entry ON TRUE;
+        srv.node_name, schema_name_in, index_name_in) entry ON TRUE;
 $BODY$;
 
 -- Get sizes of indexes on a hypertable


### PR DESCRIPTION
Size utility functions, such as `hypertable_size()`, excluded
non-responding data nodes from size calculations, which led to the
functions succeeding but returning the wrong size information. To
avoid reporting confusing numbers, it is better to fail.

This change updates the SQL queries for the relevant functions to no
longer exclude non-responding data nodes and also adds a TAP test to
illustrate the error when data nodes are not responding.

Fixes #3713