### PR TITLE
Fix INSERT..SELECT involving dist hypertables

### DIFF
--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -5018,6 +5018,73 @@ SELECT count(*) FROM disttable;
     16
 (1 row)
 
+-- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
+-- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
+-- different distributed hypertable as source
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(10 rows)
+
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable LIMIT 1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Subquery Scan on "*SELECT*"
+                           ->  Limit
+                                 ->  Custom Scan (AsyncAppend)
+                                       ->  Append
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(13 rows)
+
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable RETURNING *;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(10 rows)
+
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+INSERT INTO disttable (time, device, temp_c)
+SELECT * FROM hyper_estimate LIMIT 2;
+SELECT count(*) FROM disttable;
+ count 
+-------
+    34
+(1 row)
+
 -- REMOVE a column on data nodes to check how errors are handled:
 CALL distributed_exec($$ ALTER TABLE disttable DROP COLUMN minmaxes $$);
 \set ON_ERROR_STOP 0

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -5017,6 +5017,73 @@ SELECT count(*) FROM disttable;
     16
 (1 row)
 
+-- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
+-- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
+-- different distributed hypertable as source
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(10 rows)
+
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable LIMIT 1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Subquery Scan on "*SELECT*"
+                           ->  Limit
+                                 ->  Custom Scan (AsyncAppend)
+                                       ->  Append
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(13 rows)
+
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable RETURNING *;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(10 rows)
+
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+INSERT INTO disttable (time, device, temp_c)
+SELECT * FROM hyper_estimate LIMIT 2;
+SELECT count(*) FROM disttable;
+ count 
+-------
+    34
+(1 row)
+
 -- REMOVE a column on data nodes to check how errors are handled:
 CALL distributed_exec($$ ALTER TABLE disttable DROP COLUMN minmaxes $$);
 \set ON_ERROR_STOP 0

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -5020,6 +5020,73 @@ SELECT count(*) FROM disttable;
     16
 (1 row)
 
+-- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
+-- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
+-- different distributed hypertable as source
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(10 rows)
+
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable LIMIT 1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Subquery Scan on "*SELECT*"
+                           ->  Limit
+                                 ->  Custom Scan (AsyncAppend)
+                                       ->  Append
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                                             ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(13 rows)
+
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable RETURNING *;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Custom Scan (HypertableInsert)
+ Insert on distributed hypertable disttable
+   ->  Insert on disttable
+         ->  Custom Scan (DataNodeDispatch)
+               Batch size: 1000
+               ->  Custom Scan (ChunkDispatch)
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_2
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_3
+                           ->  Custom Scan (DataNodeScan) on disttable disttable_4
+(10 rows)
+
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+INSERT INTO disttable (time, device, temp_c)
+SELECT * FROM hyper_estimate LIMIT 2;
+SELECT count(*) FROM disttable;
+ count 
+-------
+    34
+(1 row)
+
 -- REMOVE a column on data nodes to check how errors are handled:
 CALL distributed_exec($$ ALTER TABLE disttable DROP COLUMN minmaxes $$);
 \set ON_ERROR_STOP 0

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -1673,6 +1673,24 @@ SET timescaledb.enable_connection_binary_data=false;
 SELECT * FROM disttable ORDER BY 1;
 SELECT count(*) FROM disttable;
 
+-- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
+-- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
+-- different distributed hypertable as source
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable LIMIT 1;
+EXPLAIN (COSTS OFF)
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable RETURNING *;
+INSERT INTO disttable (time, device, temp_c)
+SELECT time, device, temp_c FROM disttable;
+INSERT INTO disttable (time, device, temp_c)
+SELECT * FROM hyper_estimate LIMIT 2;
+SELECT count(*) FROM disttable;
+
 -- REMOVE a column on data nodes to check how errors are handled:
 CALL distributed_exec($$ ALTER TABLE disttable DROP COLUMN minmaxes $$);
 


### PR DESCRIPTION
If the relation being inserted into and the relation in the SELECT are
both distributed hypertables then do not use COPY. This is because we
will need two connections to the same set of datanodes (one to ingest
data into src table using COPY and one to SELECT from dst table) which
is not supported currently in a single transaction. This restriction
will be lifted in the future.

Fixes #3447