### PR TITLE
Add krb5-dev dependency to alpine build

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -53,7 +53,7 @@ create_postgres_build_image() {
     docker run -d --name ${BUILD_CONTAINER_NAME} --env POSTGRES_HOST_AUTH_METHOD=trust -v ${BASE_DIR}:/src postgres:${PG_IMAGE_TAG}
 
     # Install build dependencies
-    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps postgresql-dev gdb coreutils dpkg-dev gcc git libc-dev make cmake util-linux-dev diffutils openssl-dev && mkdir -p /build/debug"
+    docker exec -u root ${BUILD_CONTAINER_NAME} /bin/bash -c "apk add --no-cache --virtual .build-deps postgresql-dev gdb coreutils dpkg-dev gcc git libc-dev make cmake util-linux-dev diffutils openssl-dev krb5-dev && mkdir -p /build/debug"
     docker commit -a $USER -m "TimescaleDB build base image version $PG_IMAGE_TAG" ${BUILD_CONTAINER_NAME} ${image}
     remove_build_container ${BUILD_CONTAINER_NAME}
 


### PR DESCRIPTION
The header file `gssapi/gssapi.h` is present in Alpine package
`krb5-dev` but for some reason it was not installed prior to building,
causing upgrade and downgrade test failures.