### PR TITLE
Backport PG13 typalign macros for PG12

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -449,4 +449,15 @@ get_reindex_options(ReindexStmt *stmt)
 #define find_em_expr_for_rel ts_find_em_expr_for_rel
 #endif
 
+/* PG13 added macros for typalign and typstorage constants
+ *
+ * https://github.com/postgres/postgres/commit/3ed2005ff59
+ */
+#if PG12
+#define TYPALIGN_CHAR 'c'   /* char alignment (i.e. unaligned) */
+#define TYPALIGN_SHORT 's'  /* short alignment (typically 2 bytes) */
+#define TYPALIGN_INT 'i'	/* int alignment (typically 4 bytes) */
+#define TYPALIGN_DOUBLE 'd' /* double alignment (often 8 bytes) */
+#endif
+
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -362,21 +362,21 @@ ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs, ArrayType **mat_hyp
 										  INT4OID,
 										  4,
 										  true,
-										  'i');
+										  TYPALIGN_INT);
 
 	*bucket_widths = construct_array(widthdatums,
 									 list_length(all_caggs->bucket_widths),
 									 INT8OID,
 									 8,
 									 FLOAT8PASSBYVAL,
-									 'd');
+									 TYPALIGN_DOUBLE);
 
 	*max_bucket_widths = construct_array(maxwidthdatums,
 										 list_length(all_caggs->max_bucket_widths),
 										 INT8OID,
 										 8,
 										 FLOAT8PASSBYVAL,
-										 'd');
+										 TYPALIGN_DOUBLE);
 }
 
 TSDLLEXPORT ContinuousAggHypertableStatus

--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -93,7 +93,7 @@ extract_addrnames(ArrayType *arr)
 	List *list = NIL;
 	int i;
 
-	deconstruct_array(arr, TEXTOID, -1, false, 'i', &elems, &nulls, &nelems);
+	deconstruct_array(arr, TEXTOID, -1, false, TYPALIGN_INT, &elems, &nulls, &nelems);
 
 	for (i = 0; i < nelems; i++)
 	{

--- a/tsl/test/src/remote/remote_exec.c
+++ b/tsl/test/src/remote/remote_exec.c
@@ -281,7 +281,7 @@ ts_remote_exec_get_result_strings(PG_FUNCTION_ARGS)
 									CSTRINGOID,
 									-2, /* pg_type.typlen */
 									false,
-									'c');
+									TYPALIGN_CHAR);
 		pfree(fields);
 		SRF_RETURN_NEXT(funcctx, PointerGetDatum(array));
 	}


### PR DESCRIPTION
Postgres 13 introduced macros for typalign and typstorage constants in
commit postgres/postgres@3ed2005ff59.

For better code readability let's port `TYPALIGN_CHAR` macro for the
compatibility layer.

Closes #3817