### PR TITLE
Fix reading garbage value from TSConnectionError

### DIFF
--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -1846,6 +1846,8 @@ remote_connection_cancel_query(TSConnection *conn)
 	if (!conn)
 		return true;
 
+	memset(&err, 0, sizeof(TSConnectionError));
+
 	/*
 	 * Catch exceptions so that we can ensure the status is IDLE after the
 	 * cancel operation even in case of errors being thrown. Note that we


### PR DESCRIPTION
clang-tidy reports that after eed2810d under certain conditions
remote_connection_error_elog() macro can read from the memory that was not
initialized. Make sure this can't happen.