### PR TITLE
Treat clang-tidy warnings as errors

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DREQUIRE_ALL_TESTS=ON
+        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DREQUIRE_ALL_TESTS=ON -DLINTER_STRICT=ON
         make -j $MAKE_JOBS -C build
         make -C build install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,9 @@ endif()
 option(LINTER "Enable linter support using clang-tidy (ON when using clang)"
        ${LINTER_DEFAULT})
 
+set(LINTER_STRICT_DEFAULT OFF)
+option(LINTER_STRICT "Treat linter warnings as errors" ${LINTER_STRICT_DEFAULT})
+
 if(LINTER)
   find_program(
     CLANG_TIDY clang-tidy
@@ -516,7 +519,13 @@ if(LINTER)
 
   if(CLANG_TIDY)
     message(STATUS "Linter support (clang-tidy) enabled")
-    set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")
+    if(LINTER_STRICT)
+      set(CMAKE_C_CLANG_TIDY
+          "${CLANG_TIDY};--warnings-as-errors=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*"
+      )
+    else()
+      set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")
+    endif(LINTER_STRICT)
   else()
     message(STATUS "Install clang-tidy to enable code linting")
   endif(CLANG_TIDY)


### PR DESCRIPTION
This change makes the build fail on macos-* if clang-tidy detects any bugs.
This improves our process in two ways.

Firstly, currently we execute clang-tidy on macos-* but ignore the warnings.
As a result we waste CPU resources. Also, somebody who uses MacOS has to fix
the warnings manually while this could be done by the person who introduced
corresponding changes.

Secondly, running clang-tidy on a laptop is relatively expensive. This change
allows to disable clang-tidy locally and speed up the development process.