### PR TITLE
Remove pointers from CAGG lists for 64-bit archs

### DIFF
--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -62,9 +62,9 @@ typedef struct ContinuousAggMatOptions
 
 typedef struct CaggsInfoData
 {
-	List *mat_hypertable_ids; /* (int32) elements */
-	List *bucket_widths;	  /* (int64 *) elements */
-	List *max_bucket_widths;  /* (int64 *) elements */
+	List *mat_hypertable_ids; /* (int32) element */
+	List *bucket_widths;	  /* (int64) Datum */
+	List *max_bucket_widths;  /* (int64) Datum */
 } CaggsInfo;
 
 extern TSDLLEXPORT const CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -775,7 +775,7 @@ move_invalidations_from_hyper_to_cagg_log(const CaggInvalidationState *state)
 	forboth (lc1, all_caggs->mat_hypertable_ids, lc2, all_caggs->bucket_widths)
 	{
 		int32 cagg_hyper_id = lfirst_int(lc1);
-		int64 bucket_width = *(int64 *) lfirst(lc2);
+		int64 bucket_width = DatumGetInt64(PointerGetDatum(lfirst(lc2)));
 		Invalidation mergedentry;
 		ScanIterator iterator;
 
@@ -1029,8 +1029,8 @@ invalidation_state_init(CaggInvalidationState *state, int32 mat_hypertable_id,
 
 		if (cagg_hyper_id == mat_hypertable_id)
 		{
-			int64 bucket_width = *(int64 *) lfirst(lc2);
-			int64 max_bucket_width = *(int64 *) lfirst(lc3);
+			int64 bucket_width = DatumGetInt64(PointerGetDatum(lfirst(lc2)));
+			int64 max_bucket_width = DatumGetInt64(PointerGetDatum(lfirst(lc3)));
 
 			state->bucket_width = bucket_width;
 			state->max_bucket_width = max_bucket_width;


### PR DESCRIPTION
Currently, the int64 elements are always passed by reference, which is
not necessary on 64-bit architectures where it can be passed by value.
Make it so they are only passed by reference for 32-bit architectures
and by value for 64-bit architectures, since the element fits in a
64-bit architecture pointer.

Fixes #3816