### PR TITLE
Fix snapshot pg regresscheck

### DIFF
--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -33,7 +33,7 @@ jobs:
         brew install timescaledb ${{ matrix.install_options }}
         timescaledb-tune --quiet --yes
         timescaledb_move.sh
-        brew services restart postgresql
+        brew services start postgresql
 
     # checkout code to get version information
     - uses: actions/checkout@v2

--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -24,7 +24,8 @@ set(PG_IGNORE_TESTS
     rolenames
     rules
     sanity_check
-    security_label)
+    security_label
+    type_sanity)
 
 # Modify the test schedule to ignore some tests
 foreach(IGNORE_TEST ${PG_IGNORE_TESTS})


### PR DESCRIPTION
Upstream added a new regression test for binary compatibility check.
Since we define our own types the test will fail with timescaledb
installed as the test does not expect to see those additional types.
This patch changes our CI to ignore result of type_sanity test.
Currently those are only in REL_XX_STABLE but with release of next minor
version those will enter normal tests as well.

https://github.com/postgres/postgres/commit/cf3d79aa31f

Disable-check: commit-count

