### PR TITLE
Add missing gitignore entry

### DIFF
--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -7,6 +7,7 @@
 /compression_insert-*.sql
 /compression_permissions-*.sql
 /hypertable_distributed-*.sql
+/dist_grant-*.sql
 /dist_hypertable-*.sql
 /dist_partial_agg-*.sql
 /plan_skip_scan-*.sql


### PR DESCRIPTION
Pull request #3779 introduced a new template SQL test file but missed
to add the properly gitgnore entry to ignore generated test files.