### PR TITLE
Eliminate deadlock for recompress_chunk

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -21,6 +21,10 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.calculate_chunk_interval(
         chunk_target_size BIGINT
 ) RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_calculate_chunk_interval' LANGUAGE C;
 
+-- Get the status of the chunk
+CREATE OR REPLACE FUNCTION _timescaledb_internal.chunk_status(REGCLASS) RETURNS INT
+AS '@MODULE_PATHNAME@', 'ts_chunk_status' LANGUAGE C;
+
 -- Function for explicit chunk exclusion. Supply a record and an array
 -- of chunk ids as input.
 -- Intended to be used in WHERE clause.

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -29,7 +29,42 @@ CREATE OR REPLACE FUNCTION decompress_chunk(
     if_compressed BOOLEAN = false
 ) RETURNS REGCLASS AS '@MODULE_PATHNAME@', 'ts_decompress_chunk' LANGUAGE C STRICT VOLATILE;
 
-CREATE OR REPLACE FUNCTION recompress_chunk(
-    chunk REGCLASS,
-    if_not_compressed BOOLEAN = false
-) RETURNS REGCLASS AS '@MODULE_PATHNAME@', 'ts_recompress_chunk' LANGUAGE C STRICT VOLATILE;
+-- Recompress a chunk
+--
+-- Will give an error if the chunk was not already compressed. In this
+-- case, the user should use compress_chunk instead. Note that this
+-- function cannot be executed in an explicit transaction since it
+-- contains transaction control commands.
+--
+-- Parameters:
+--   chunk: Chunk to recompress.
+--   if_not_compressed: Print notice instead of error if chunk is already compressed.
+CREATE OR REPLACE PROCEDURE recompress_chunk(chunk REGCLASS,
+                                             if_not_compressed BOOLEAN = false)
+AS $$
+DECLARE
+  status INT;
+  chunk_name TEXT[];
+BEGIN
+    status := _timescaledb_internal.chunk_status(chunk);
+
+    -- Chunk names are in the internal catalog, but we only care about
+    -- the chunk name here.
+    chunk_name := parse_ident(chunk::text);
+    CASE status
+    WHEN 0 THEN
+        RAISE EXCEPTION 'call compress_chunk instead of recompress_chunk';
+    WHEN 1 THEN
+        IF if_not_compressed THEN
+            RAISE NOTICE 'nothing to recompress in chunk "%"', chunk_name[array_upper(chunk_name,1)];
+            RETURN;
+        ELSE
+            RAISE EXCEPTION 'nothing to recompress in chunk "%"', chunk_name[array_upper(chunk_name,1)];
+        END IF;
+    WHEN 3 THEN
+        PERFORM decompress_chunk(chunk);
+        COMMIT;
+    END CASE;
+    PERFORM compress_chunk(chunk, if_not_compressed);
+END
+$$ LANGUAGE plpgsql;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS recompress_chunk;
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,0 +1,2 @@
+DROP PROCEDURE IF EXISTS recompress_chunk;
+DROP FUNCTION IF EXISTS _timescaledb_internal.chunk_status;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -71,6 +71,7 @@ TS_FUNCTION_INFO_V1(ts_chunks_in);
 TS_FUNCTION_INFO_V1(ts_chunk_id_from_relid);
 TS_FUNCTION_INFO_V1(ts_chunk_show);
 TS_FUNCTION_INFO_V1(ts_chunk_create);
+TS_FUNCTION_INFO_V1(ts_chunk_status);
 
 static const char *
 DatumGetNameString(Datum datum)
@@ -4220,4 +4221,21 @@ Datum
 ts_chunk_create(PG_FUNCTION_ARGS)
 {
 	return ts_cm_functions->create_chunk(fcinfo);
+}
+
+/**
+ * Get the chunk status.
+ *
+ * Values returned are documented above and is a bitwise or of the values.
+ *
+ * @see CHUNK_STATUS_DEFAULT
+ * @see CHUNK_STATUS_COMPRESSED
+ * @see CHUNK_STATUS_COMPRESSED_UNORDERED
+ */
+Datum
+ts_chunk_status(PG_FUNCTION_ARGS)
+{
+	Oid chunk_relid = PG_GETARG_OID(0);
+	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, /* fail_if_not_found */ true);
+	PG_RETURN_INT32(chunk->fd.status);
 }

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -13,6 +13,7 @@
 
 #include "hypertable_data_node.h"
 
+extern Datum chunk_status(PG_FUNCTION_ARGS);
 extern Datum chunk_show(PG_FUNCTION_ARGS);
 extern Datum chunk_create(PG_FUNCTION_ARGS);
 extern void chunk_api_create_on_data_nodes(const Chunk *chunk, const Hypertable *ht,

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -413,11 +413,24 @@ SELECT count(*) from test2;
     29
 (1 row)
 
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
-             recompress_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_14_62_chunk
-(1 row)
+-- call recompress_chunk inside a transaction. This should fails since
+-- it contains transaction-terminating commands.
+\set ON_ERROR_STOP 0
+START TRANSACTION;
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:62: ERROR:  invalid transaction termination
+ROLLBACK;
+\set ON_ERROR_STOP 1
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+-- Demonstrate that no locks are held on the hypertable, chunk, or the
+-- compressed chunk after recompress_chunk has executed.
+SELECT pid, locktype, relation, relation::regclass, mode, granted
+FROM pg_locks
+WHERE relation::regclass::text IN (:'CHUNK_NAME', :'COMP_CHUNK_NAME', 'test2')
+ORDER BY pid;
+ pid | locktype | relation | relation | mode | granted 
+-----+----------+----------+----------+------+---------
+(0 rows)
 
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
@@ -473,15 +486,11 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 \set ON_ERROR_STOP 0
 -- call recompress_chunk when status is not unordered
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, true);
-psql:include/recompress_basic.sql:95: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk" 
- recompress_chunk 
-------------------
- 
-(1 row)
-
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, false);
-psql:include/recompress_basic.sql:96: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk" 
+CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
+psql:include/recompress_basic.sql:110: NOTICE:  nothing to recompress in chunk "_hyper_14_62_chunk"
+-- This will succeed and compress the chunk for the test below.
+CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
+psql:include/recompress_basic.sql:113: ERROR:  nothing to recompress in chunk "_hyper_14_62_chunk"
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
              decompress_chunk             
@@ -489,8 +498,8 @@ SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
  _timescaledb_internal._hyper_14_62_chunk
 (1 row)
 
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
-psql:include/recompress_basic.sql:100: ERROR:  call compress_chunk instead of recompress_chunk
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+psql:include/recompress_basic.sql:117: ERROR:  call compress_chunk instead of recompress_chunk
 \set ON_ERROR_STOP 1
 -- test recompress policy
 CREATE TABLE metrics(time timestamptz NOT NULL);
@@ -595,7 +604,7 @@ SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'met
 
 ---- nothing to do yet
 CALL run_job(:JOB_RECOMPRESS);
-psql:include/recompress_basic.sql:172: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
+psql:include/recompress_basic.sql:189: NOTICE:  no chunks for hypertable "public.metrics" that satisfy recompress chunk policy
 ---- status should be 1
 SELECT chunk_status FROM compressed_chunk_info_view WHERE hypertable_name = 'metrics';
  chunk_status 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -725,9 +725,14 @@ ALTER TABLE i2844 SET (timescaledb.compress = FALSE);
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\ir compression_utils.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
 CREATE TABLE test1 ("Time" timestamptz, intcol integer, bntcol bigint, txtcol text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
-psql:include/compression_alter.sql:6: NOTICE:  adding not-null constraint to column "Time"
+psql:include/compression_alter.sql:8: NOTICE:  adding not-null constraint to column "Time"
  table_name 
 ------------
  test1
@@ -951,7 +956,7 @@ FROM ( SELECT attrelid::regclass, attname FROM pg_attribute
 -- check if the name change is reflected for settings
 ALTER TABLE test1 RENAME  bigintcol TO 
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc;
-psql:include/compression_alter.sql:133: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
+psql:include/compression_alter.sql:135: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
 SELECT * from timescaledb_information.compression_settings 
 WHERE hypertable_name = 'test1' and attname like 'ccc%';
  hypertable_schema | hypertable_name |                             attname                             | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
@@ -972,7 +977,7 @@ FROM ( SELECT attrelid::regclass, attname FROM pg_attribute
 ALTER TABLE test1 RENAME 
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc
 TO bigintcol;
-psql:include/compression_alter.sql:146: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
+psql:include/compression_alter.sql:148: NOTICE:  identifier "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccabdeeeeeeccccccccccccc" will be truncated to "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccca"
 SELECT * from timescaledb_information.compression_settings 
 WHERE hypertable_name = 'test1' and attname = 'bigintcol' ;
  hypertable_schema | hypertable_name |  attname  | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
@@ -1025,12 +1030,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
-SELECT recompress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
-             compressed_chunk             
-------------------------------------------
- _timescaledb_internal._hyper_12_89_chunk
-(1 row)
-
+CALL recompress_all_chunks('test_defaults', 1, false);
 SELECT * FROM test_defaults ORDER BY 1,2;
              time             | device_id | c1 | c2 
 ------------------------------+-----------+----+----
@@ -1042,7 +1042,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
 -- test dropping columns from compressed
 CREATE TABLE test_drop(f1 text, f2 text, f3 text, time timestamptz, device int, o1 text, o2 text);
 SELECT create_hypertable('test_drop','time');
-psql:include/compression_alter.sql:176: NOTICE:  adding not-null constraint to column "time"
+psql:include/compression_alter.sql:178: NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
  (14,public,test_drop,t)
@@ -1052,13 +1052,13 @@ ALTER TABLE test_drop SET (timescaledb.compress,timescaledb.compress_segmentby='
 -- dropping segmentby or orderby columns will fail
 \set ON_ERROR_STOP 0
 ALTER TABLE test_drop DROP COLUMN time;
-psql:include/compression_alter.sql:181: ERROR:  cannot drop column named in partition key
+psql:include/compression_alter.sql:183: ERROR:  cannot drop column named in partition key
 ALTER TABLE test_drop DROP COLUMN o1;
-psql:include/compression_alter.sql:182: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
-ALTER TABLE test_drop DROP COLUMN o2;
-psql:include/compression_alter.sql:183: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
-ALTER TABLE test_drop DROP COLUMN device;
 psql:include/compression_alter.sql:184: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+ALTER TABLE test_drop DROP COLUMN o2;
+psql:include/compression_alter.sql:185: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
+ALTER TABLE test_drop DROP COLUMN device;
+psql:include/compression_alter.sql:186: ERROR:  cannot drop orderby or segmentby column from a hypertable with compression enabled
 \set ON_ERROR_STOP 1
 -- switch to WARNING only to suppress compress_chunk NOTICEs
 SET client_min_messages TO WARNING;
@@ -1075,7 +1075,7 @@ ALTER TABLE test_drop DROP COLUMN f2;
 -- test non-existant column
 \set ON_ERROR_STOP 0
 ALTER TABLE test_drop DROP COLUMN f10;
-psql:include/compression_alter.sql:198: ERROR:  column "f10" of relation "test_drop" does not exist
+psql:include/compression_alter.sql:200: ERROR:  column "f10" of relation "test_drop" does not exist
 \set ON_ERROR_STOP 1
 ALTER TABLE test_drop DROP COLUMN IF EXISTS f10;
 INSERT INTO test_drop SELECT NULL,'2001-01-01',2,'o1','o2';

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -23,6 +23,11 @@ CREATE OR REPLACE FUNCTION test.remote_exec_get_result_strings(srv_name name[], 
 RETURNS TABLE("table_record" CSTRING[])
 AS :TSL_MODULE_PATHNAME, 'ts_remote_exec_get_result_strings'
 LANGUAGE C;
+\ir include/compression_utils.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
 SELECT (add_data_node (name, host => 'localhost', DATABASE => name)).*
 FROM (VALUES (:'DATA_NODE_1'), (:'DATA_NODE_2'), (:'DATA_NODE_3')) v (name);
        node_name       |   host    | port  |       database        | node_created | database_created | extension_created 
@@ -929,12 +934,7 @@ c.schema_name || '.' || c.table_name as "CHUNK_NAME"
 FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
 WHERE h.id = c.hypertable_id and h.table_name = 'test_recomp_int' \gset
 --call recompress_chunk directly on distributed chunk
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
-               recompress_chunk               
-----------------------------------------------
- _timescaledb_internal._dist_hyper_6_24_chunk
-(1 row)
-
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
 --check chunk status now, should be compressed
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
@@ -1058,14 +1058,7 @@ GROUP BY time_bucket(20, time) ORDER BY 1;
 
 RESET timescaledb.enable_per_data_node_queries;
 --check compression_status afterwards--
-SELECT recompress_chunk(chunk, true) FROM
-( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 2)q;
-               recompress_chunk               
-----------------------------------------------
- _timescaledb_internal._dist_hyper_6_24_chunk
- _timescaledb_internal._dist_hyper_6_25_chunk
-(2 rows)
-
+CALL recompress_all_chunks('test_recomp_int', 2, true);
 SELECT * from test_recomp_int_chunk_status ORDER BY 1;
        chunk_name       | chunk_status 
 ------------------------+--------------
@@ -1086,18 +1079,10 @@ SELECT * from test_recomp_int_chunk_status ORDER BY 1;
 --verify that there are no errors if the policy/recompress_chunk is executed again
 --on previously compressed chunks
 CALL run_job(:compressjob_id);
-SELECT recompress_chunk(chunk, true) FROM
-( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk )q;
-NOTICE:  nothing to recompress in chunk "_dist_hyper_6_24_chunk" 
-NOTICE:  nothing to recompress in chunk "_dist_hyper_6_25_chunk" 
-NOTICE:  nothing to recompress in chunk "_dist_hyper_6_26_chunk" 
- recompress_chunk 
-------------------
- 
- 
- 
-(3 rows)
-
+CALL recompress_all_chunks('test_recomp_int', true);
+NOTICE:  nothing to recompress in chunk "_dist_hyper_6_24_chunk"
+NOTICE:  nothing to recompress in chunk "_dist_hyper_6_25_chunk"
+NOTICE:  nothing to recompress in chunk "_dist_hyper_6_26_chunk"
 --decompress and recompress chunk
 \set ON_ERROR_STOP 0
 SELECT decompress_chunk(chunk, true) FROM
@@ -1107,8 +1092,7 @@ SELECT decompress_chunk(chunk, true) FROM
  _timescaledb_internal._dist_hyper_6_24_chunk
 (1 row)
 
-SELECT recompress_chunk(chunk)  FROM
-( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 1 )q;
+CALL recompress_all_chunks('test_recomp_int', 1, false);
 ERROR:  call compress_chunk instead of recompress_chunk
 \set ON_ERROR_STOP 1
 -- test alter column type with distributed hypertable
@@ -1221,12 +1205,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
  Mon Jan 01 00:00:00 2001 PST |         1 |    | 42
 (3 rows)
 
-SELECT recompress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
-               compressed_chunk               
-----------------------------------------------
- _timescaledb_internal._dist_hyper_8_28_chunk
-(1 row)
-
+CALL recompress_all_chunks('test_defaults', 1, false);
 SELECT * FROM test_defaults ORDER BY 1,2;
              time             | device_id | c1 | c2 
 ------------------------------+-----------+----+----

--- a/tsl/test/isolation/expected/compression_ddl.out
+++ b/tsl/test/isolation/expected/compression_ddl.out
@@ -332,7 +332,7 @@ status
 (1 row)
 
 
-starting permutation: CA1 CAc I1 Ic SChunkStat LockChunk1 RC1 IN1 UnlockChunk RCc INc SH
+starting permutation: CA1 CAc I1 Ic SChunkStat LockChunk1 RC1 IN1 UnlockChunk INc SH
 step CA1: 
   BEGIN;
   SELECT
@@ -372,25 +372,28 @@ lock_chunktable
 (1 row)
 
 step RC1: 
-  BEGIN;
-  SELECT
-    recompress_chunk(ch.schema_name || '.' || ch.table_name)
-  FROM _timescaledb_catalog.hypertable ht, _timescaledb_catalog.chunk ch
-  WHERE ch.hypertable_id = ht.id AND ht.table_name like 'ts_device_table'
-  ORDER BY ch.id LIMIT 1;
-
+  DO $$
+  DECLARE
+    chunk_name text;
+  BEGIN
+  FOR chunk_name IN
+      SELECT ch.schema_name || '.' || ch.table_name
+        FROM _timescaledb_catalog.hypertable ht,
+             _timescaledb_catalog.chunk ch
+       WHERE ch.hypertable_id = ht.id
+         AND ht.table_name like 'ts_device_table'
+       ORDER BY ch.id LIMIT 1
+     LOOP
+         CALL recompress_chunk(chunk_name);
+     END LOOP;
+  END;
+  $$;
  <waiting ...>
 step IN1: BEGIN; INSERT INTO ts_device_table VALUES (1, 1, 200, 100); <waiting ...>
 step UnlockChunk: ROLLBACK;
-step RC1: <... completed>
-recompress_chunk                        
-----------------------------------------
-_timescaledb_internal._hyper_17_32_chunk
-(1 row)
-
-step RCc: COMMIT;
 step IN1: <... completed>
 step INc: COMMIT;
+step RC1: <... completed>
 step SH: SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table');
 total_chunks|number_compressed_chunks
 ------------+------------------------

--- a/tsl/test/isolation/expected/deadlock_recompress_chunk.out
+++ b/tsl/test/isolation/expected/deadlock_recompress_chunk.out
@@ -11,11 +11,22 @@ step recompress_insert_rows:
     SELECT to_timestamp(ser), ser, ser+100 FROM generate_series(0,100) ser;
 
 step lock_after_decompress: 
-    SELECT debug_waitpoint_enable('recompress_after_decompress');
+    SELECT count(*) FROM show_chunks('hyper');
+    DO $$
+    DECLARE
+      chunk regclass;
+    BEGIN
+      SELECT format('%I.%I', c.schema_name, c.table_name)::regclass INTO chunk
+      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c
+      WHERE p.compressed_chunk_id = c.id
+      AND format('%I.%I', p.schema_name, p.table_name)::regclass = show_chunks;
+      EXECUTE format('LOCK TABLE %s IN EXCLUSIVE MODE', chunk);
+    END;
+    $$;
 
-debug_waitpoint_enable
-----------------------
-                      
+count
+-----
+    1
 (1 row)
 
 step recompress_chunks_start: 
@@ -24,7 +35,7 @@ step recompress_chunks_start:
       chunk regclass;
     BEGIN
       SELECT show_chunks('hyper') INTO chunk;
-      CALL recompress_chunk_procedure(chunk);
+      CALL recompress_chunk(chunk);
     END;
     $$;
  <waiting ...>
@@ -32,12 +43,7 @@ step query_start:
     SELECT count(*) FROM hyper;
  <waiting ...>
 step unlock_after_decompress: 
-    SELECT debug_waitpoint_release('recompress_after_decompress');
-
-debug_waitpoint_release
------------------------
-                       
-(1 row)
+    ROLLBACK;
 
 step recompress_chunks_start: <... completed>
 step query_start: <... completed>

--- a/tsl/test/isolation/specs/deadlock_recompress_chunk.spec.in
+++ b/tsl/test/isolation/specs/deadlock_recompress_chunk.spec.in
@@ -15,30 +15,7 @@
 # re-implement it here to be able to test that it works as
 # expected. Please check policy_internal.sql to see the code it is
 # based on.
-setup {
-    CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT)
-    RETURNS VOID LANGUAGE C VOLATILE STRICT
-    AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_enable';
-
-    CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT)
-    RETURNS VOID LANGUAGE C VOLATILE STRICT
-    AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_release';
-
-    CREATE OR REPLACE FUNCTION debug_waitpoint_id(TEXT)
-    RETURNS BIGINT LANGUAGE C VOLATILE STRICT
-    AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_id';
-
-    CREATE OR REPLACE PROCEDURE recompress_chunk_procedure(regclass) AS $$
-    BEGIN
-      PERFORM decompress_chunk($1, if_compressed => true);
-      PERFORM pg_advisory_lock(debug_waitpoint_id('recompress_after_decompress'));
-      PERFORM pg_advisory_unlock(debug_waitpoint_id('recompress_after_decompress'));
-      COMMIT;
-      PERFORM compress_chunk($1);
-    END $$
-    LANGUAGE plpgsql;
-}
-
+#
 setup {
     CREATE TABLE hyper (time TIMESTAMP NOT NULL, a DOUBLE PRECISION NULL, b DOUBLE PRECISION NULL);
 
@@ -58,12 +35,31 @@ teardown {
     DROP TABLE hyper;
 }
 
+# We are not using a debug point when locking inside recompress_chunk
+# after decompress since it is an PL/SQL procedure. Instead we lock
+# the compressed chunk, which will block the actual drop in the
+# recompress procedure at the right point (before the commit), and we
+# can then start the query, which will queue after the others.
 session "locks"
-step "lock_after_decompress"     {
-    SELECT debug_waitpoint_enable('recompress_after_decompress');
+setup {
+  BEGIN;
+}
+step "lock_after_decompress" {
+    SELECT count(*) FROM show_chunks('hyper');
+    DO $$
+    DECLARE
+      chunk regclass;
+    BEGIN
+      SELECT format('%I.%I', c.schema_name, c.table_name)::regclass INTO chunk
+      FROM show_chunks('hyper'), _timescaledb_catalog.chunk p, _timescaledb_catalog.chunk c
+      WHERE p.compressed_chunk_id = c.id
+      AND format('%I.%I', p.schema_name, p.table_name)::regclass = show_chunks;
+      EXECUTE format('LOCK TABLE %s IN EXCLUSIVE MODE', chunk);
+    END;
+    $$;
 }
 step "unlock_after_decompress" {
-    SELECT debug_waitpoint_release('recompress_after_decompress');
+    ROLLBACK;
 }
 
 # When building a simple relation for the query (using
@@ -88,7 +84,7 @@ step "recompress_chunks_start" {
       chunk regclass;
     BEGIN
       SELECT show_chunks('hyper') INTO chunk;
-      CALL recompress_chunk_procedure(chunk);
+      CALL recompress_chunk(chunk);
     END;
     $$;
 }

--- a/tsl/test/sql/include/compression_alter.sql
+++ b/tsl/test/sql/include/compression_alter.sql
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+\ir compression_utils.sql
+
 CREATE TABLE test1 ("Time" timestamptz, intcol integer, bntcol bigint, txtcol text);
 SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 day');
 
@@ -168,7 +170,7 @@ SELECT * FROM test_defaults ORDER BY 1,2;
 -- try insert into compressed and recompress
 INSERT INTO test_defaults SELECT '2000-01-01', 2;
 SELECT * FROM test_defaults ORDER BY 1,2;
-SELECT recompress_chunk(show_chunks) AS compressed_chunk FROM show_chunks('test_defaults') ORDER BY show_chunks::text LIMIT 1;
+CALL recompress_all_chunks('test_defaults', 1, false);
 SELECT * FROM test_defaults ORDER BY 1,2;
 
 -- test dropping columns from compressed

--- a/tsl/test/sql/include/recompress_basic.sql
+++ b/tsl/test/sql/include/recompress_basic.sql
@@ -55,7 +55,22 @@ WHERE hypertable_name = 'test2' \gset
 
 SELECT count(*) from test2;
 
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
+-- call recompress_chunk inside a transaction. This should fails since
+-- it contains transaction-terminating commands.
+\set ON_ERROR_STOP 0
+START TRANSACTION;
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+ROLLBACK;
+\set ON_ERROR_STOP 1
+
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
+
+-- Demonstrate that no locks are held on the hypertable, chunk, or the
+-- compressed chunk after recompress_chunk has executed.
+SELECT pid, locktype, relation, relation::regclass, mode, granted
+FROM pg_locks
+WHERE relation::regclass::text IN (:'CHUNK_NAME', :'COMP_CHUNK_NAME', 'test2')
+ORDER BY pid;
 
 SELECT chunk_status,
        chunk_name as "CHUNK_NAME"
@@ -92,12 +107,14 @@ WHERE hypertable_name = 'test2' ORDER BY chunk_name;
 
 \set ON_ERROR_STOP 0
 -- call recompress_chunk when status is not unordered
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, true);
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass, false);
+CALL recompress_chunk(:'CHUNK_NAME'::regclass, true);
+
+-- This will succeed and compress the chunk for the test below.
+CALL recompress_chunk(:'CHUNK_NAME'::regclass, false);
 
 --now decompress it , then try and recompress
 SELECT decompress_chunk(:'CHUNK_NAME'::regclass);
-SELECT recompress_chunk(:'CHUNK_NAME'::regclass);
+CALL recompress_chunk(:'CHUNK_NAME'::regclass);
 \set ON_ERROR_STOP 1
 
 -- test recompress policy


### PR DESCRIPTION
When executing `recompress_chunk` and a query at the same time, a
deadlock can be generated because the chunk relation and the chunk
index and the compressed and uncompressd chunks are locked in different
orders. In particular, when `recompress_chunk` is executing, it will
first decompress the chunk and as part of that lock the uncompressed
chunk index in AccessExclusive mode and when trying to compress the
chunk again it will try to lock the uncompressed chunk in
AccessExclusive as part of truncating it.

Note that `decompress_chunk` and `compress_chunk` lock the relations in
the same order and the issue arises because the procedures are combined
inth a single transaction.

To avoid the deadlock, this commit rewrites the `recompress_chunk` to
be a procedure and adds a commit between the decompression and
compression. Committing the transaction after the decompress will allow
reads and inserts to proceed by working on the uncompressed chunk, and
the compression part of the procedure will take the necessary locks in
strict order, thereby avoiding a deadlock.

In addition, the isolation test is rewritten so that instead of adding
a waitpoint in the PL/SQL function, we implement the isolation test by
taking a lock on the compressed table after the decompression.

Fixes #3846