### PR TITLE
use row-by-row fetcher for some queries to enable parallel plans on data nodes

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -37,6 +37,7 @@ static const struct config_enum_entry telemetry_level_options[] = {
 static const struct config_enum_entry remote_data_fetchers[] = {
 	{ "rowbyrow", RowByRowFetcherType, false },
 	{ "cursor", CursorFetcherType, false },
+	{ "auto", AutoFetcherType, false },
 	{ NULL, 0, false }
 };
 
@@ -69,7 +70,7 @@ TSDLLEXPORT bool ts_guc_enable_client_ddl_on_data_nodes = false;
 TSDLLEXPORT char *ts_guc_ssl_dir = NULL;
 TSDLLEXPORT char *ts_guc_passfile = NULL;
 TSDLLEXPORT bool ts_guc_enable_remote_explain = false;
-TSDLLEXPORT DataFetcherType ts_guc_remote_data_fetcher = RowByRowFetcherType;
+TSDLLEXPORT DataFetcherType ts_guc_remote_data_fetcher = AutoFetcherType;
 
 #ifdef TS_DEBUG
 bool ts_shutdown_bgw = false;
@@ -310,7 +311,7 @@ _guc_init(void)
 							 "Pick data fetcher type based on type of queries you plan to run "
 							 "(rowbyrow or cursor)",
 							 (int *) &ts_guc_remote_data_fetcher,
-							 CursorFetcherType,
+							 AutoFetcherType,
 							 remote_data_fetchers,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -43,7 +43,8 @@ extern TSDLLEXPORT bool ts_guc_enable_remote_explain;
 typedef enum DataFetcherType
 {
 	CursorFetcherType,
-	RowByRowFetcherType
+	RowByRowFetcherType,
+	AutoFetcherType,
 } DataFetcherType;
 
 extern TSDLLEXPORT DataFetcherType ts_guc_remote_data_fetcher;

--- a/src/planner.h
+++ b/src/planner.h
@@ -12,6 +12,7 @@
 #include <nodes/pathnodes.h>
 
 #include "export.h"
+#include "guc.h"
 
 typedef struct TsFdwRelationInfo TsFdwRelationInfo;
 typedef struct TimescaleDBPrivate
@@ -29,6 +30,8 @@ typedef struct TimescaleDBPrivate
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte, bool *isdistributed);
 extern TSDLLEXPORT bool ts_rte_is_marked_for_expansion(const RangeTblEntry *rte);
+
+extern TSDLLEXPORT DataFetcherType ts_data_node_fetcher_scan_type;
 
 static inline TimescaleDBPrivate *
 ts_create_private_reloptinfo(RelOptInfo *rel)

--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -595,7 +595,12 @@ data_node_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *best_
 		bms_free(attrs_used);
 	}
 
-	cscan->custom_private = list_make2(scaninfo.fdw_private, list_make1_int(scaninfo.systemcol));
+	/* Should have determined the fetcher type by now. */
+	Assert(ts_data_node_fetcher_scan_type != AutoFetcherType);
+
+	cscan->custom_private = list_make3(scaninfo.fdw_private,
+									   list_make1_int(scaninfo.systemcol),
+									   makeInteger(ts_data_node_fetcher_scan_type));
 
 	return &cscan->scan.plan;
 }

--- a/tsl/src/fdw/data_node_scan_plan.h
+++ b/tsl/src/fdw/data_node_scan_plan.h
@@ -17,4 +17,12 @@ extern void data_node_scan_create_upper_paths(PlannerInfo *root, UpperRelationKi
 											  RelOptInfo *input_rel, RelOptInfo *output_rel,
 											  void *extra);
 
+/* Indexes of fields in ForeignScan->custom_private */
+typedef enum
+{
+	DataNodeScanFdwPrivate,
+	DataNodeScanSystemcol,
+	DataNodeScanFetcherType,
+} DataNodeScanPrivateIndex;
+
 #endif /* TIMESCALEDB_TSL_FDW_DATA_NODE_SCAN_H */

--- a/tsl/src/fdw/scan_exec.h
+++ b/tsl/src/fdw/scan_exec.h
@@ -14,6 +14,7 @@
 #include <commands/explain.h>
 
 #include "remote/data_fetcher.h"
+#include "guc.h"
 
 /*
  * Execution state of a foreign scan using timescaledb_fdw.
@@ -30,13 +31,14 @@ typedef struct TsFdwScanState
 	List *retrieved_attrs; /* list of retrieved attribute numbers */
 
 	/* for remote query execution */
-	struct TSConnection *conn;   /* connection for the scan */
-	struct DataFetcher *fetcher; /* fetches tuples from data node */
-	int num_params;				 /* number of parameters passed to query */
-	FmgrInfo *param_flinfo;		 /* output conversion functions for them */
-	List *param_exprs;			 /* executable expressions for param values */
-	const char **param_values;   /* textual values of query parameters */
-	int fetch_size;				 /* number of tuples per fetch */
+	struct TSConnection *conn;	/* connection for the scan */
+	struct DataFetcher *fetcher;  /* fetches tuples from data node */
+	int num_params;				  /* number of parameters passed to query */
+	FmgrInfo *param_flinfo;		  /* output conversion functions for them */
+	List *param_exprs;			  /* executable expressions for param values */
+	const char **param_values;	/* textual values of query parameters */
+	int fetch_size;				  /* number of tuples per fetch */
+	DataFetcherType fetcher_type; /* the type of data fetcher to use  */
 	int row_counter;
 } TsFdwScanState;
 

--- a/tsl/src/remote/data_fetcher.c
+++ b/tsl/src/remote/data_fetcher.c
@@ -11,26 +11,6 @@
 #include "guc.h"
 #include "errors.h"
 
-DataFetcher *
-data_fetcher_create_for_rel(TSConnection *conn, Relation rel, List *retrieved_attrs,
-							const char *stmt, StmtParams *params)
-{
-	if (ts_guc_remote_data_fetcher == CursorFetcherType)
-		return cursor_fetcher_create_for_rel(conn, rel, retrieved_attrs, stmt, params);
-	else
-		return row_by_row_fetcher_create_for_rel(conn, rel, retrieved_attrs, stmt, params);
-}
-
-DataFetcher *
-data_fetcher_create_for_scan(TSConnection *conn, ScanState *ss, List *retrieved_attrs,
-							 const char *stmt, StmtParams *params)
-{
-	if (ts_guc_remote_data_fetcher == CursorFetcherType)
-		return cursor_fetcher_create_for_scan(conn, ss, retrieved_attrs, stmt, params);
-	else
-		return row_by_row_fetcher_create_for_scan(conn, ss, retrieved_attrs, stmt, params);
-}
-
 #define DEFAULT_FETCH_SIZE 100
 
 void

--- a/tsl/src/remote/data_fetcher.h
+++ b/tsl/src/remote/data_fetcher.h
@@ -61,12 +61,6 @@ typedef struct DataFetcher
 	AsyncRequest *data_req; /* a request to fetch data */
 } DataFetcher;
 
-extern DataFetcher *data_fetcher_create_for_rel(TSConnection *conn, Relation rel,
-												List *retrieved_attrs, const char *stmt,
-												StmtParams *params);
-extern DataFetcher *data_fetcher_create_for_scan(TSConnection *conn, ScanState *ss,
-												 List *retrieved_attrs, const char *stmt,
-												 StmtParams *params);
 void data_fetcher_free(DataFetcher *df);
 
 extern void data_fetcher_init(DataFetcher *df, TSConnection *conn, const char *stmt,

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -439,19 +439,22 @@ SELECT * FROM disttable;
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                Output: disttable_1."time", disttable_1.device, disttable_1.temp
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                Output: disttable_2."time", disttable_2.device, disttable_2.temp
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                Output: disttable_3."time", disttable_3.device, disttable_3.temp
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(18 rows)
+(21 rows)
 
 SELECT * FROM disttable;
              time             | device | temp 
@@ -493,19 +496,22 @@ ORDER BY 1;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: time_bucket('@ 3 hours'::interval, disttable_1."time"), disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: time_bucket('@ 3 hours'::interval, disttable_2."time"), disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: time_bucket('@ 3 hours'::interval, disttable_3."time"), disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 -- Execute some queries on the frontend and return the results
 SELECT * FROM disttable;
@@ -593,19 +599,22 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(24 rows)
+(27 rows)
 
 SELECT max(temp)
 FROM disttable;
@@ -631,19 +640,22 @@ FROM disttable;
                  ->  Custom Scan (DataNodeScan) on public.disttable
                        Output: disttable.temp
                        Data node: db_dist_hypertable_1
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                        Output: disttable_1.temp
                        Data node: db_dist_hypertable_2
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                        Output: disttable_2.temp
                        Data node: db_dist_hypertable_3
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(22 rows)
+(25 rows)
 
 SET timescaledb.enable_async_append = ON;
 EXPLAIN (VERBOSE, COSTS FALSE)
@@ -659,19 +671,22 @@ FROM disttable;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(20 rows)
+(23 rows)
 
 SELECT min(temp), max(temp)
 FROM disttable;
@@ -699,19 +714,22 @@ ORDER BY device, temp;
                      ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                            Output: disttable_1.device, disttable_1.temp
                            Data node: db_dist_hypertable_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                            Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                            Output: disttable_2.device, disttable_2.temp
                            Data node: db_dist_hypertable_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                            Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                            Output: disttable_3.device, disttable_3.temp
                            Data node: db_dist_hypertable_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                            Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 SELECT device, temp, avg(temp) OVER (PARTITION BY device)
 FROM disttable
@@ -766,6 +784,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1."time"
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_4_chunk, _dist_hyper_1_1_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -786,6 +805,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2."time"
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_3_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -806,6 +826,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3."time"
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_6_chunk, _dist_hyper_1_2_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -823,7 +844,7 @@ FROM disttable;
                                              Output: _dist_hyper_1_2_chunk."time"
                                              Index Cond: (_dist_hyper_1_2_chunk."time" IS NOT NULL)
  
-(69 rows)
+(72 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 SELECT max(temp)
@@ -842,6 +863,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -861,6 +883,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -880,6 +903,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -896,7 +920,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(66 rows)
+(69 rows)
 
 -- Don't remote explain if there is no VERBOSE flag
 EXPLAIN (COSTS FALSE)
@@ -933,6 +957,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1 (actual rows=1 loops=1)
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -953,6 +978,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2 (actual rows=1 loops=1)
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -973,6 +999,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3 (actual rows=1 loops=1)
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -990,7 +1017,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(69 rows)
+(72 rows)
 
 -- The constraints, indexes, and triggers on foreign chunks. Only
 -- check constraints should recurse to foreign chunks (although they
@@ -2296,19 +2323,22 @@ SELECT * FROM disttable_replicated;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=4 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=2 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
-(18 rows)
+(21 rows)
 
 --guc disables the optimization
 SET timescaledb.enable_per_data_node_queries = FALSE;
@@ -2320,28 +2350,34 @@ SELECT * FROM disttable_replicated;
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk (actual rows=2 loops=1)
          Output: _dist_hyper_6_12_chunk."time", _dist_hyper_6_12_chunk.device, _dist_hyper_6_12_chunk.temp, _dist_hyper_6_12_chunk."Color"
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_12_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_13_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_13_chunk."time", _dist_hyper_6_13_chunk.device, _dist_hyper_6_13_chunk.temp, _dist_hyper_6_13_chunk."Color"
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_13_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_14_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_14_chunk."time", _dist_hyper_6_14_chunk.device, _dist_hyper_6_14_chunk.temp, _dist_hyper_6_14_chunk."Color"
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_14_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_15_chunk (actual rows=2 loops=1)
          Output: _dist_hyper_6_15_chunk."time", _dist_hyper_6_15_chunk.device, _dist_hyper_6_15_chunk.temp, _dist_hyper_6_15_chunk."Color"
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_15_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_16_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_16_chunk."time", _dist_hyper_6_16_chunk.device, _dist_hyper_6_16_chunk.temp, _dist_hyper_6_16_chunk."Color"
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_16_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_17_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_17_chunk."time", _dist_hyper_6_17_chunk.device, _dist_hyper_6_17_chunk.temp, _dist_hyper_6_17_chunk."Color"
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_17_chunk
-(25 rows)
+(31 rows)
 
 SET timescaledb.enable_per_data_node_queries = TRUE;
 --test WHERE clause
@@ -2355,19 +2391,22 @@ SELECT * FROM disttable_replicated WHERE temp > 2.0;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=0 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
-(18 rows)
+(21 rows)
 
 --test OR
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE, TIMING FALSE, SUMMARY FALSE)
@@ -2380,19 +2419,22 @@ SELECT * FROM disttable_replicated WHERE temp > 2.0 or "Color" = 11;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=1 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
-(18 rows)
+(21 rows)
 
 --test some chunks excluded
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2405,14 +2447,16 @@ SELECT * FROM disttable_replicated WHERE time < '2018-01-01 09:11';
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=2 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6]) AND (("time" < '2018-01-01 09:11:00-08'::timestamp with time zone))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6]) AND (("time" < '2018-01-01 09:11:00-08'::timestamp with time zone))
-(13 rows)
+(15 rows)
 
 --test all chunks excluded
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2438,19 +2482,22 @@ SELECT * FROM cte;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=4 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=2 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
-(18 rows)
+(21 rows)
 
 --queries that involve updates/inserts are not optimized
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2486,16 +2533,19 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=1 loops=1)
                                    Output: disttable_replicated_2.device
                                    Data node: db_dist_hypertable_1
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=1 loops=1)
                                    Output: disttable_replicated_3.device
                                    Data node: db_dist_hypertable_2
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_4 (actual rows=1 loops=1)
                                    Output: disttable_replicated_4.device
                                    Data node: db_dist_hypertable_3
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
    ->  Seq Scan on public.disttable_replicated (actual rows=0 loops=1)
@@ -2504,28 +2554,34 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk (actual rows=2 loops=1)
          Output: _dist_hyper_6_12_chunk."time", 2, _dist_hyper_6_12_chunk.temp, _dist_hyper_6_12_chunk."Color", _dist_hyper_6_12_chunk.ctid
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_12_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_13_chunk (actual rows=0 loops=1)
          Output: _dist_hyper_6_13_chunk."time", 2, _dist_hyper_6_13_chunk.temp, _dist_hyper_6_13_chunk."Color", _dist_hyper_6_13_chunk.ctid
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_13_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_14_chunk (actual rows=0 loops=1)
          Output: _dist_hyper_6_14_chunk."time", 2, _dist_hyper_6_14_chunk.temp, _dist_hyper_6_14_chunk."Color", _dist_hyper_6_14_chunk.ctid
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_14_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_15_chunk (actual rows=0 loops=1)
          Output: _dist_hyper_6_15_chunk."time", 2, _dist_hyper_6_15_chunk.temp, _dist_hyper_6_15_chunk."Color", _dist_hyper_6_15_chunk.ctid
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_15_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_16_chunk (actual rows=0 loops=1)
          Output: _dist_hyper_6_16_chunk."time", 2, _dist_hyper_6_16_chunk.temp, _dist_hyper_6_16_chunk."Color", _dist_hyper_6_16_chunk.ctid
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_16_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_17_chunk (actual rows=0 loops=1)
          Output: _dist_hyper_6_17_chunk."time", 2, _dist_hyper_6_17_chunk.temp, _dist_hyper_6_17_chunk."Color", _dist_hyper_6_17_chunk.ctid
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_17_chunk WHERE ((device = $1::integer)) FOR UPDATE
-(65 rows)
+(74 rows)
 
 -- Test inserts with smaller batch size and more tuples to reach full
 -- batch
@@ -2688,6 +2744,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_1
                Output: twodim_1."time", twodim_1."Color", twodim_1.temp
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_18_chunk, _dist_hyper_7_22_chunk, _dist_hyper_7_25_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12, 14]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2706,6 +2763,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_2
                Output: twodim_2."time", twodim_2."Color", twodim_2.temp
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_19_chunk, _dist_hyper_7_21_chunk, _dist_hyper_7_24_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 11, 13]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2724,6 +2782,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_3
                Output: twodim_3."time", twodim_3."Color", twodim_3.temp
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_20_chunk, _dist_hyper_7_23_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2737,7 +2796,7 @@ ORDER BY time;
                    ->  Index Scan Backward using _dist_hyper_7_23_chunk_twodim_time_idx on _timescaledb_internal._dist_hyper_7_23_chunk
                          Output: _dist_hyper_7_23_chunk."time", _dist_hyper_7_23_chunk."Color", _dist_hyper_7_23_chunk.temp
  
-(56 rows)
+(59 rows)
 
 SET timescaledb.enable_remote_explain = OFF;
 -- Check results
@@ -3477,9 +3536,10 @@ SELECT * FROM dist_device;
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
-(5 rows)
+(6 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
 -- "Remote SQL" when only time partitioning is being used.
@@ -3491,6 +3551,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
@@ -3502,7 +3563,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
        ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
              Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(14 rows)
+(15 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 
@@ -5351,6 +5412,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5361,6 +5423,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5372,7 +5435,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- Also test different code paths used with aggregation pushdown.
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
@@ -5391,6 +5454,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5401,6 +5465,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5412,7 +5477,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- TODO: test HAVING here and in the later now() tests as well.
 -- Change the timezone and check that the conversion is applied correctly.
@@ -5441,6 +5506,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5451,6 +5517,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5465,7 +5532,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(30 rows)
+(32 rows)
 
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
  count 
@@ -5483,6 +5550,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5493,6 +5561,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5506,7 +5575,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(29 rows)
+(31 rows)
 
 -- Conversion to timestamptz cannot be evaluated at the access node, because the
 -- argument is a column reference.
@@ -5539,6 +5608,7 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5549,6 +5619,7 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5560,7 +5631,7 @@ WHERE time > x
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- Reference value for the above test.
 WITH dummy AS (SELECT '2018-01-02 12:00:00 +00'::timestamptz::timestamp x)
@@ -5584,6 +5655,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5594,6 +5666,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5608,7 +5681,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Filter: (((_dist_hyper_31_98_chunk."time")::time without time zone > '01:00:00'::time without time zone) AND (date_trunc('month'::text, _dist_hyper_31_98_chunk."time") > '2021-01-01'::date))
  
-(30 rows)
+(32 rows)
 
 -- Check that the test function for partly overriding now() works. It's very
 -- hacky and only has effect when we estimate some costs or evaluate sTABLE

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -439,19 +439,22 @@ SELECT * FROM disttable;
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                Output: disttable_1."time", disttable_1.device, disttable_1.temp
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                Output: disttable_2."time", disttable_2.device, disttable_2.temp
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                Output: disttable_3."time", disttable_3.device, disttable_3.temp
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(18 rows)
+(21 rows)
 
 SELECT * FROM disttable;
              time             | device | temp 
@@ -493,19 +496,22 @@ ORDER BY 1;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: time_bucket('@ 3 hours'::interval, disttable_1."time"), disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: time_bucket('@ 3 hours'::interval, disttable_2."time"), disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: time_bucket('@ 3 hours'::interval, disttable_3."time"), disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 -- Execute some queries on the frontend and return the results
 SELECT * FROM disttable;
@@ -593,19 +599,22 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(24 rows)
+(27 rows)
 
 SELECT max(temp)
 FROM disttable;
@@ -631,19 +640,22 @@ FROM disttable;
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                        Output: disttable_1.temp
                        Data node: db_dist_hypertable_1
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                        Output: disttable_2.temp
                        Data node: db_dist_hypertable_2
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                        Output: disttable_3.temp
                        Data node: db_dist_hypertable_3
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(22 rows)
+(25 rows)
 
 SET timescaledb.enable_async_append = ON;
 EXPLAIN (VERBOSE, COSTS FALSE)
@@ -659,19 +671,22 @@ FROM disttable;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(20 rows)
+(23 rows)
 
 SELECT min(temp), max(temp)
 FROM disttable;
@@ -698,19 +713,22 @@ ORDER BY device, temp;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 SELECT device, temp, avg(temp) OVER (PARTITION BY device)
 FROM disttable
@@ -765,6 +783,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1."time"
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_4_chunk, _dist_hyper_1_1_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -785,6 +804,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2."time"
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_3_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -805,6 +825,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3."time"
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_6_chunk, _dist_hyper_1_2_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -822,7 +843,7 @@ FROM disttable;
                                              Output: _dist_hyper_1_2_chunk."time"
                                              Index Cond: (_dist_hyper_1_2_chunk."time" IS NOT NULL)
  
-(69 rows)
+(72 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 SELECT max(temp)
@@ -841,6 +862,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -860,6 +882,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -879,6 +902,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -895,7 +919,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(66 rows)
+(69 rows)
 
 -- Don't remote explain if there is no VERBOSE flag
 EXPLAIN (COSTS FALSE)
@@ -932,6 +956,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1 (actual rows=1 loops=1)
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -952,6 +977,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2 (actual rows=1 loops=1)
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -972,6 +998,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3 (actual rows=1 loops=1)
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -989,7 +1016,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(69 rows)
+(72 rows)
 
 -- The constraints, indexes, and triggers on foreign chunks. Only
 -- check constraints should recurse to foreign chunks (although they
@@ -2295,19 +2322,22 @@ SELECT * FROM disttable_replicated;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=4 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=2 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
-(18 rows)
+(21 rows)
 
 --guc disables the optimization
 SET timescaledb.enable_per_data_node_queries = FALSE;
@@ -2319,28 +2349,34 @@ SELECT * FROM disttable_replicated;
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk (actual rows=2 loops=1)
          Output: _dist_hyper_6_12_chunk."time", _dist_hyper_6_12_chunk.device, _dist_hyper_6_12_chunk.temp, _dist_hyper_6_12_chunk."Color"
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_12_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_13_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_13_chunk."time", _dist_hyper_6_13_chunk.device, _dist_hyper_6_13_chunk.temp, _dist_hyper_6_13_chunk."Color"
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_13_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_14_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_14_chunk."time", _dist_hyper_6_14_chunk.device, _dist_hyper_6_14_chunk.temp, _dist_hyper_6_14_chunk."Color"
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_14_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_15_chunk (actual rows=2 loops=1)
          Output: _dist_hyper_6_15_chunk."time", _dist_hyper_6_15_chunk.device, _dist_hyper_6_15_chunk.temp, _dist_hyper_6_15_chunk."Color"
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_15_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_16_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_16_chunk."time", _dist_hyper_6_16_chunk.device, _dist_hyper_6_16_chunk.temp, _dist_hyper_6_16_chunk."Color"
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_16_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_17_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_17_chunk."time", _dist_hyper_6_17_chunk.device, _dist_hyper_6_17_chunk.temp, _dist_hyper_6_17_chunk."Color"
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_17_chunk
-(25 rows)
+(31 rows)
 
 SET timescaledb.enable_per_data_node_queries = TRUE;
 --test WHERE clause
@@ -2354,19 +2390,22 @@ SELECT * FROM disttable_replicated WHERE temp > 2.0;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=0 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
-(18 rows)
+(21 rows)
 
 --test OR
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE, TIMING FALSE, SUMMARY FALSE)
@@ -2379,19 +2418,22 @@ SELECT * FROM disttable_replicated WHERE temp > 2.0 or "Color" = 11;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=1 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
-(18 rows)
+(21 rows)
 
 --test some chunks excluded
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2404,14 +2446,16 @@ SELECT * FROM disttable_replicated WHERE time < '2018-01-01 09:11';
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=2 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6]) AND (("time" < '2018-01-01 09:11:00-08'::timestamp with time zone))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6]) AND (("time" < '2018-01-01 09:11:00-08'::timestamp with time zone))
-(13 rows)
+(15 rows)
 
 --test all chunks excluded
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2437,19 +2481,22 @@ SELECT * FROM cte;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=4 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=2 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
-(18 rows)
+(21 rows)
 
 --queries that involve updates/inserts are not optimized
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2485,16 +2532,19 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_8 (actual rows=1 loops=1)
                                    Output: disttable_replicated_8.device
                                    Data node: db_dist_hypertable_1
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_9 (actual rows=1 loops=1)
                                    Output: disttable_replicated_9.device
                                    Data node: db_dist_hypertable_2
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_10 (actual rows=1 loops=1)
                                    Output: disttable_replicated_10.device
                                    Data node: db_dist_hypertable_3
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
    ->  Seq Scan on public.disttable_replicated (actual rows=0 loops=1)
@@ -2503,28 +2553,34 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk disttable_replicated_1 (actual rows=2 loops=1)
          Output: disttable_replicated_1."time", 2, disttable_replicated_1.temp, disttable_replicated_1."Color", disttable_replicated_1.ctid
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_12_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_13_chunk disttable_replicated_2 (actual rows=0 loops=1)
          Output: disttable_replicated_2."time", 2, disttable_replicated_2.temp, disttable_replicated_2."Color", disttable_replicated_2.ctid
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_13_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_14_chunk disttable_replicated_3 (actual rows=0 loops=1)
          Output: disttable_replicated_3."time", 2, disttable_replicated_3.temp, disttable_replicated_3."Color", disttable_replicated_3.ctid
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_14_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_15_chunk disttable_replicated_4 (actual rows=0 loops=1)
          Output: disttable_replicated_4."time", 2, disttable_replicated_4.temp, disttable_replicated_4."Color", disttable_replicated_4.ctid
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_15_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_16_chunk disttable_replicated_5 (actual rows=0 loops=1)
          Output: disttable_replicated_5."time", 2, disttable_replicated_5.temp, disttable_replicated_5."Color", disttable_replicated_5.ctid
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_16_chunk WHERE ((device = $1::integer)) FOR UPDATE
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_17_chunk disttable_replicated_6 (actual rows=0 loops=1)
          Output: disttable_replicated_6."time", 2, disttable_replicated_6.temp, disttable_replicated_6."Color", disttable_replicated_6.ctid
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_17_chunk WHERE ((device = $1::integer)) FOR UPDATE
-(65 rows)
+(74 rows)
 
 -- Test inserts with smaller batch size and more tuples to reach full
 -- batch
@@ -2687,6 +2743,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_1
                Output: twodim_1."time", twodim_1."Color", twodim_1.temp
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_18_chunk, _dist_hyper_7_22_chunk, _dist_hyper_7_25_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12, 14]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2705,6 +2762,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_2
                Output: twodim_2."time", twodim_2."Color", twodim_2.temp
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_19_chunk, _dist_hyper_7_21_chunk, _dist_hyper_7_24_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 11, 13]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2723,6 +2781,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_3
                Output: twodim_3."time", twodim_3."Color", twodim_3.temp
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_20_chunk, _dist_hyper_7_23_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2736,7 +2795,7 @@ ORDER BY time;
                    ->  Index Scan Backward using _dist_hyper_7_23_chunk_twodim_time_idx on _timescaledb_internal._dist_hyper_7_23_chunk
                          Output: _dist_hyper_7_23_chunk."time", _dist_hyper_7_23_chunk."Color", _dist_hyper_7_23_chunk.temp
  
-(56 rows)
+(59 rows)
 
 SET timescaledb.enable_remote_explain = OFF;
 -- Check results
@@ -3476,9 +3535,10 @@ SELECT * FROM dist_device;
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
-(5 rows)
+(6 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
 -- "Remote SQL" when only time partitioning is being used.
@@ -3490,6 +3550,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
@@ -3501,7 +3562,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
        ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
              Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(14 rows)
+(15 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 
@@ -5350,6 +5411,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5360,6 +5422,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5371,7 +5434,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- Also test different code paths used with aggregation pushdown.
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
@@ -5390,6 +5453,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5400,6 +5464,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5411,7 +5476,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- TODO: test HAVING here and in the later now() tests as well.
 -- Change the timezone and check that the conversion is applied correctly.
@@ -5440,6 +5505,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5450,6 +5516,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5464,7 +5531,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(30 rows)
+(32 rows)
 
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
  count 
@@ -5482,6 +5549,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5492,6 +5560,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5505,7 +5574,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(29 rows)
+(31 rows)
 
 -- Conversion to timestamptz cannot be evaluated at the access node, because the
 -- argument is a column reference.
@@ -5538,6 +5607,7 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5548,6 +5618,7 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5559,7 +5630,7 @@ WHERE time > x
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- Reference value for the above test.
 WITH dummy AS (SELECT '2018-01-02 12:00:00 +00'::timestamptz::timestamp x)
@@ -5583,6 +5654,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5593,6 +5665,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5607,7 +5680,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Filter: (((_dist_hyper_31_98_chunk."time")::time without time zone > '01:00:00'::time without time zone) AND (date_trunc('month'::text, _dist_hyper_31_98_chunk."time") > '2021-01-01'::date))
  
-(30 rows)
+(32 rows)
 
 -- Check that the test function for partly overriding now() works. It's very
 -- hacky and only has effect when we estimate some costs or evaluate sTABLE

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -439,19 +439,22 @@ SELECT * FROM disttable;
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                Output: disttable_1."time", disttable_1.device, disttable_1.temp
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                Output: disttable_2."time", disttable_2.device, disttable_2.temp
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                Output: disttable_3."time", disttable_3.device, disttable_3.temp
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(18 rows)
+(21 rows)
 
 SELECT * FROM disttable;
              time             | device | temp 
@@ -493,19 +496,22 @@ ORDER BY 1;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: time_bucket('@ 3 hours'::interval, disttable_1."time"), disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: time_bucket('@ 3 hours'::interval, disttable_2."time"), disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: time_bucket('@ 3 hours'::interval, disttable_3."time"), disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 -- Execute some queries on the frontend and return the results
 SELECT * FROM disttable;
@@ -593,19 +599,22 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(24 rows)
+(27 rows)
 
 SELECT max(temp)
 FROM disttable;
@@ -631,19 +640,22 @@ FROM disttable;
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                        Output: disttable_1.temp
                        Data node: db_dist_hypertable_1
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                        Output: disttable_2.temp
                        Data node: db_dist_hypertable_2
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                        Output: disttable_3.temp
                        Data node: db_dist_hypertable_3
+                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(22 rows)
+(25 rows)
 
 SET timescaledb.enable_async_append = ON;
 EXPLAIN (VERBOSE, COSTS FALSE)
@@ -659,19 +671,22 @@ FROM disttable;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(20 rows)
+(23 rows)
 
 SELECT min(temp), max(temp)
 FROM disttable;
@@ -698,19 +713,22 @@ ORDER BY device, temp;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 SELECT device, temp, avg(temp) OVER (PARTITION BY device)
 FROM disttable
@@ -765,6 +783,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1."time"
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_4_chunk, _dist_hyper_1_1_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -785,6 +804,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2."time"
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_3_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -805,6 +825,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3."time"
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_6_chunk, _dist_hyper_1_2_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -822,7 +843,7 @@ FROM disttable;
                                              Output: _dist_hyper_1_2_chunk."time"
                                              Index Cond: (_dist_hyper_1_2_chunk."time" IS NOT NULL)
  
-(69 rows)
+(72 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 SELECT max(temp)
@@ -841,6 +862,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -860,6 +882,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -879,6 +902,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -895,7 +919,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(66 rows)
+(69 rows)
 
 -- Don't remote explain if there is no VERBOSE flag
 EXPLAIN (COSTS FALSE)
@@ -932,6 +956,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1 (actual rows=1 loops=1)
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -952,6 +977,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2 (actual rows=1 loops=1)
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -972,6 +998,7 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3 (actual rows=1 loops=1)
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
+                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -989,7 +1016,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(69 rows)
+(72 rows)
 
 -- The constraints, indexes, and triggers on foreign chunks. Only
 -- check constraints should recurse to foreign chunks (although they
@@ -2295,19 +2322,22 @@ SELECT * FROM disttable_replicated;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=4 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=2 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
-(18 rows)
+(21 rows)
 
 --guc disables the optimization
 SET timescaledb.enable_per_data_node_queries = FALSE;
@@ -2319,28 +2349,34 @@ SELECT * FROM disttable_replicated;
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk (actual rows=2 loops=1)
          Output: _dist_hyper_6_12_chunk."time", _dist_hyper_6_12_chunk.device, _dist_hyper_6_12_chunk.temp, _dist_hyper_6_12_chunk."Color"
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_12_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_13_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_13_chunk."time", _dist_hyper_6_13_chunk.device, _dist_hyper_6_13_chunk.temp, _dist_hyper_6_13_chunk."Color"
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_13_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_14_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_14_chunk."time", _dist_hyper_6_14_chunk.device, _dist_hyper_6_14_chunk.temp, _dist_hyper_6_14_chunk."Color"
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_14_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_15_chunk (actual rows=2 loops=1)
          Output: _dist_hyper_6_15_chunk."time", _dist_hyper_6_15_chunk.device, _dist_hyper_6_15_chunk.temp, _dist_hyper_6_15_chunk."Color"
          Data node: db_dist_hypertable_1
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_15_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_16_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_16_chunk."time", _dist_hyper_6_16_chunk.device, _dist_hyper_6_16_chunk.temp, _dist_hyper_6_16_chunk."Color"
          Data node: db_dist_hypertable_2
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_16_chunk
    ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_17_chunk (actual rows=1 loops=1)
          Output: _dist_hyper_6_17_chunk."time", _dist_hyper_6_17_chunk.device, _dist_hyper_6_17_chunk.temp, _dist_hyper_6_17_chunk."Color"
          Data node: db_dist_hypertable_3
+         Fetcher Type: Cursor
          Remote SQL: SELECT "time", device, temp, "Color" FROM _timescaledb_internal._dist_hyper_6_17_chunk
-(25 rows)
+(31 rows)
 
 SET timescaledb.enable_per_data_node_queries = TRUE;
 --test WHERE clause
@@ -2354,19 +2390,22 @@ SELECT * FROM disttable_replicated WHERE temp > 2.0;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=0 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND ((temp > 2::double precision))
-(18 rows)
+(21 rows)
 
 --test OR
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE, TIMING FALSE, SUMMARY FALSE)
@@ -2379,19 +2418,22 @@ SELECT * FROM disttable_replicated WHERE temp > 2.0 or "Color" = 11;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=1 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) AND (((temp > 2::double precision) OR ("Color" = 11)))
-(18 rows)
+(21 rows)
 
 --test some chunks excluded
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2404,14 +2446,16 @@ SELECT * FROM disttable_replicated WHERE time < '2018-01-01 09:11';
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=2 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6]) AND (("time" < '2018-01-01 09:11:00-08'::timestamp with time zone))
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=0 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6]) AND (("time" < '2018-01-01 09:11:00-08'::timestamp with time zone))
-(13 rows)
+(15 rows)
 
 --test all chunks excluded
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2437,19 +2481,22 @@ SELECT * FROM cte;
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_1 (actual rows=4 loops=1)
                Output: disttable_replicated_1."time", disttable_replicated_1.device, disttable_replicated_1.temp, disttable_replicated_1."Color"
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_2 (actual rows=2 loops=1)
                Output: disttable_replicated_2."time", disttable_replicated_2.device, disttable_replicated_2.temp, disttable_replicated_2."Color"
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
          ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_3 (actual rows=2 loops=1)
                Output: disttable_replicated_3."time", disttable_replicated_3.device, disttable_replicated_3.temp, disttable_replicated_3."Color"
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                Remote SQL: SELECT "time", device, temp, "Color" FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8])
-(18 rows)
+(21 rows)
 
 --queries that involve updates/inserts are not optimized
 EXPLAIN (VERBOSE, ANALYZE, COSTS FALSE,  TIMING FALSE, SUMMARY FALSE)
@@ -2485,16 +2532,19 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_9 (actual rows=1 loops=1)
                                    Output: disttable_replicated_9.device
                                    Data node: db_dist_hypertable_1
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_12_chunk, _dist_hyper_6_15_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_10 (actual rows=1 loops=1)
                                    Output: disttable_replicated_10.device
                                    Data node: db_dist_hypertable_2
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_13_chunk, _dist_hyper_6_16_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
                              ->  Custom Scan (DataNodeScan) on public.disttable_replicated disttable_replicated_11 (actual rows=1 loops=1)
                                    Output: disttable_replicated_11.device
                                    Data node: db_dist_hypertable_3
+                                   Fetcher Type: Cursor
                                    Chunks: _dist_hyper_6_14_chunk, _dist_hyper_6_17_chunk
                                    Remote SQL: SELECT DISTINCT device FROM public.disttable_replicated WHERE _timescaledb_internal.chunks_in(public.disttable_replicated.*, ARRAY[6, 8]) ORDER BY device ASC NULLS LAST
    ->  Result (actual rows=2 loops=1)
@@ -2506,28 +2556,34 @@ UPDATE disttable_replicated SET device = 2 WHERE device = (SELECT device FROM de
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_12_chunk disttable_replicated_2 (actual rows=2 loops=1)
                      Output: disttable_replicated_2.tableoid, disttable_replicated_2.ctid, disttable_replicated_2.*
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT "time", device, temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_12_chunk WHERE ((device = $1::integer))
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_13_chunk disttable_replicated_3 (actual rows=0 loops=1)
                      Output: disttable_replicated_3.tableoid, disttable_replicated_3.ctid, disttable_replicated_3.*
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT "time", device, temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_13_chunk WHERE ((device = $1::integer))
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_14_chunk disttable_replicated_4 (actual rows=0 loops=1)
                      Output: disttable_replicated_4.tableoid, disttable_replicated_4.ctid, disttable_replicated_4.*
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT "time", device, temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_14_chunk WHERE ((device = $1::integer))
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_15_chunk disttable_replicated_5 (actual rows=0 loops=1)
                      Output: disttable_replicated_5.tableoid, disttable_replicated_5.ctid, disttable_replicated_5.*
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT "time", device, temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_15_chunk WHERE ((device = $1::integer))
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_16_chunk disttable_replicated_6 (actual rows=0 loops=1)
                      Output: disttable_replicated_6.tableoid, disttable_replicated_6.ctid, disttable_replicated_6.*
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT "time", device, temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_16_chunk WHERE ((device = $1::integer))
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_6_17_chunk disttable_replicated_7 (actual rows=0 loops=1)
                      Output: disttable_replicated_7.tableoid, disttable_replicated_7.ctid, disttable_replicated_7.*
                      Data node: db_dist_hypertable_3
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT "time", device, temp, "Color", ctid FROM _timescaledb_internal._dist_hyper_6_17_chunk WHERE ((device = $1::integer))
-(68 rows)
+(77 rows)
 
 -- Test inserts with smaller batch size and more tuples to reach full
 -- batch
@@ -2690,6 +2746,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_1
                Output: twodim_1."time", twodim_1."Color", twodim_1.temp
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_18_chunk, _dist_hyper_7_22_chunk, _dist_hyper_7_25_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12, 14]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2708,6 +2765,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_2
                Output: twodim_2."time", twodim_2."Color", twodim_2.temp
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_19_chunk, _dist_hyper_7_21_chunk, _dist_hyper_7_24_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 11, 13]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2726,6 +2784,7 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_3
                Output: twodim_3."time", twodim_3."Color", twodim_3.temp
                Data node: db_dist_hypertable_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_20_chunk, _dist_hyper_7_23_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2739,7 +2798,7 @@ ORDER BY time;
                    ->  Index Scan Backward using _dist_hyper_7_23_chunk_twodim_time_idx on _timescaledb_internal._dist_hyper_7_23_chunk
                          Output: _dist_hyper_7_23_chunk."time", _dist_hyper_7_23_chunk."Color", _dist_hyper_7_23_chunk.temp
  
-(56 rows)
+(59 rows)
 
 SET timescaledb.enable_remote_explain = OFF;
 -- Check results
@@ -3479,9 +3538,10 @@ SELECT * FROM dist_device;
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
-(5 rows)
+(6 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
 -- "Remote SQL" when only time partitioning is being used.
@@ -3493,6 +3553,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
@@ -3504,7 +3565,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
        ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
              Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(14 rows)
+(15 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 
@@ -5353,6 +5414,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5363,6 +5425,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5374,7 +5437,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- Also test different code paths used with aggregation pushdown.
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
@@ -5393,6 +5456,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5403,6 +5467,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5414,7 +5479,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- TODO: test HAVING here and in the later now() tests as well.
 -- Change the timezone and check that the conversion is applied correctly.
@@ -5443,6 +5508,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5453,6 +5519,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5467,7 +5534,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(30 rows)
+(32 rows)
 
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
  count 
@@ -5485,6 +5552,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5495,6 +5563,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5508,7 +5577,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(29 rows)
+(31 rows)
 
 -- Conversion to timestamptz cannot be evaluated at the access node, because the
 -- argument is a column reference.
@@ -5541,6 +5610,7 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5551,6 +5621,7 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5562,7 +5633,7 @@ WHERE time > x
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(27 rows)
+(29 rows)
 
 -- Reference value for the above test.
 WITH dummy AS (SELECT '2018-01-02 12:00:00 +00'::timestamptz::timestamp x)
@@ -5586,6 +5657,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5596,6 +5668,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5610,7 +5683,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Filter: (((_dist_hyper_31_98_chunk."time")::time without time zone > '01:00:00'::time without time zone) AND (date_trunc('month'::text, _dist_hyper_31_98_chunk."time") > '2021-01-01'::date))
  
-(30 rows)
+(32 rows)
 
 -- Check that the test function for partly overriding now() works. It's very
 -- hacky and only has effect when we estimate some costs or evaluate sTABLE

--- a/tsl/test/expected/dist_partial_agg.out
+++ b/tsl/test/expected/dist_partial_agg.out
@@ -123,6 +123,7 @@ SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-04 08:00'::timest
 INSERT INTO :TEST_TABLE
 SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-04 08:00'::timestamp, '5 minute'), 'AUS', 'south', generate_series(61, 85, 0.025), 55, NULL, 28, NULL, NULL, 8, true;
 SET enable_partitionwise_aggregate = ON;
+SET timescaledb.remote_data_fetcher = 'cursor';
 -- Run an explain on the aggregate queries to make sure expected aggregates are being pushed down.
 -- Grouping by the paritioning column should result in full aggregate pushdown where possible,
 -- while using a non-partitioning column should result in a partial pushdown
@@ -181,21 +182,24 @@ SET enable_partitionwise_aggregate = ON;
                Output: conditions.location, (min(conditions.allnull)), (max(conditions.temperature)), ((sum(conditions.temperature) + sum(conditions.humidity))), (avg(conditions.humidity)), (round(stddev((conditions.humidity)::integer), 5)), (bit_and(conditions.bit_int)), (bit_or(conditions.bit_int)), (bool_and(conditions.good_life)), (every((conditions.temperature > '0'::double precision))), (bool_or(conditions.good_life)), (count(*)), (count(conditions.temperature)), (count(conditions.allnull)), (round((corr(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((covar_pop(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((covar_samp(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_count(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_intercept(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_r2(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_slope(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_syy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round(stddev((conditions.temperature)::integer), 5)), (round(stddev_pop((conditions.temperature)::integer), 5)), (round(stddev_samp((conditions.temperature)::integer), 5)), (round(variance((conditions.temperature)::integer), 5)), (round(var_pop((conditions.temperature)::integer), 5)), (round(var_samp((conditions.temperature)::integer), 5)), (last(conditions.temperature, conditions.timec)), (histogram(conditions.temperature, '0'::double precision, '100'::double precision, 1)), conditions.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_1
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT location, min(allnull), max(temperature), (sum(temperature) + sum(humidity)), avg(humidity), round(stddev(humidity::integer), 5), bit_and(bit_int), bit_or(bit_int), bool_and(good_life), every((temperature > 0::double precision)), bool_or(good_life), count(*), count(temperature), count(allnull), round(corr(temperature::integer, humidity::integer)::numeric, 5), round(covar_pop(temperature::integer, humidity::integer)::numeric, 5), round(covar_samp(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgx(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgy(temperature::integer, humidity::integer)::numeric, 5), round(regr_count(temperature::integer, humidity::integer)::numeric, 5), round(regr_intercept(temperature::integer, humidity::integer)::numeric, 5), round(regr_r2(temperature::integer, humidity::integer)::numeric, 5), round(regr_slope(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxx(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxy(temperature::integer, humidity::integer)::numeric, 5), round(regr_syy(temperature::integer, humidity::integer)::numeric, 5), round(stddev(temperature::integer), 5), round(stddev_pop(temperature::integer), 5), round(stddev_samp(temperature::integer), 5), round(variance(temperature::integer), 5), round(var_pop(temperature::integer), 5), round(var_samp(temperature::integer), 5), public.last(temperature, timec), public.histogram(temperature, 0::double precision, 100::double precision, 1), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 35 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_1.location, (min(conditions_1.allnull)), (max(conditions_1.temperature)), ((sum(conditions_1.temperature) + sum(conditions_1.humidity))), (avg(conditions_1.humidity)), (round(stddev((conditions_1.humidity)::integer), 5)), (bit_and(conditions_1.bit_int)), (bit_or(conditions_1.bit_int)), (bool_and(conditions_1.good_life)), (every((conditions_1.temperature > '0'::double precision))), (bool_or(conditions_1.good_life)), (count(*)), (count(conditions_1.temperature)), (count(conditions_1.allnull)), (round((corr(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((covar_pop(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((covar_samp(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_count(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_intercept(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_r2(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_slope(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_syy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round(stddev((conditions_1.temperature)::integer), 5)), (round(stddev_pop((conditions_1.temperature)::integer), 5)), (round(stddev_samp((conditions_1.temperature)::integer), 5)), (round(variance((conditions_1.temperature)::integer), 5)), (round(var_pop((conditions_1.temperature)::integer), 5)), (round(var_samp((conditions_1.temperature)::integer), 5)), (last(conditions_1.temperature, conditions_1.timec)), (histogram(conditions_1.temperature, '0'::double precision, '100'::double precision, 1)), conditions_1.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_2
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT location, min(allnull), max(temperature), (sum(temperature) + sum(humidity)), avg(humidity), round(stddev(humidity::integer), 5), bit_and(bit_int), bit_or(bit_int), bool_and(good_life), every((temperature > 0::double precision)), bool_or(good_life), count(*), count(temperature), count(allnull), round(corr(temperature::integer, humidity::integer)::numeric, 5), round(covar_pop(temperature::integer, humidity::integer)::numeric, 5), round(covar_samp(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgx(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgy(temperature::integer, humidity::integer)::numeric, 5), round(regr_count(temperature::integer, humidity::integer)::numeric, 5), round(regr_intercept(temperature::integer, humidity::integer)::numeric, 5), round(regr_r2(temperature::integer, humidity::integer)::numeric, 5), round(regr_slope(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxx(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxy(temperature::integer, humidity::integer)::numeric, 5), round(regr_syy(temperature::integer, humidity::integer)::numeric, 5), round(stddev(temperature::integer), 5), round(stddev_pop(temperature::integer), 5), round(stddev_samp(temperature::integer), 5), round(variance(temperature::integer), 5), round(var_pop(temperature::integer), 5), round(var_samp(temperature::integer), 5), public.last(temperature, timec), public.histogram(temperature, 0::double precision, 100::double precision, 1), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 35 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_2.location, (min(conditions_2.allnull)), (max(conditions_2.temperature)), ((sum(conditions_2.temperature) + sum(conditions_2.humidity))), (avg(conditions_2.humidity)), (round(stddev((conditions_2.humidity)::integer), 5)), (bit_and(conditions_2.bit_int)), (bit_or(conditions_2.bit_int)), (bool_and(conditions_2.good_life)), (every((conditions_2.temperature > '0'::double precision))), (bool_or(conditions_2.good_life)), (count(*)), (count(conditions_2.temperature)), (count(conditions_2.allnull)), (round((corr(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((covar_pop(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((covar_samp(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_count(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_intercept(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_r2(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_slope(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_syy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round(stddev((conditions_2.temperature)::integer), 5)), (round(stddev_pop((conditions_2.temperature)::integer), 5)), (round(stddev_samp((conditions_2.temperature)::integer), 5)), (round(variance((conditions_2.temperature)::integer), 5)), (round(var_pop((conditions_2.temperature)::integer), 5)), (round(var_samp((conditions_2.temperature)::integer), 5)), (last(conditions_2.temperature, conditions_2.timec)), (histogram(conditions_2.temperature, '0'::double precision, '100'::double precision, 1)), conditions_2.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_3
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT location, min(allnull), max(temperature), (sum(temperature) + sum(humidity)), avg(humidity), round(stddev(humidity::integer), 5), bit_and(bit_int), bit_or(bit_int), bool_and(good_life), every((temperature > 0::double precision)), bool_or(good_life), count(*), count(temperature), count(allnull), round(corr(temperature::integer, humidity::integer)::numeric, 5), round(covar_pop(temperature::integer, humidity::integer)::numeric, 5), round(covar_samp(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgx(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgy(temperature::integer, humidity::integer)::numeric, 5), round(regr_count(temperature::integer, humidity::integer)::numeric, 5), round(regr_intercept(temperature::integer, humidity::integer)::numeric, 5), round(regr_r2(temperature::integer, humidity::integer)::numeric, 5), round(regr_slope(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxx(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxy(temperature::integer, humidity::integer)::numeric, 5), round(regr_syy(temperature::integer, humidity::integer)::numeric, 5), round(stddev(temperature::integer), 5), round(stddev_pop(temperature::integer), 5), round(stddev_samp(temperature::integer), 5), round(variance(temperature::integer), 5), round(var_pop(temperature::integer), 5), round(var_samp(temperature::integer), 5), public.last(temperature, timec), public.histogram(temperature, 0::double precision, 100::double precision, 1), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 35 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 -- Aggregates on custom types are not yet pushed down
 :PREFIX SELECT :GROUPING,
@@ -214,6 +218,7 @@ SET enable_partitionwise_aggregate = ON;
          ->  Custom Scan (DataNodeScan) on public.conditions
                Output: conditions.location, conditions.timec, conditions.highlow
                Data node: data_node_1
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT timec, location, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -222,6 +227,7 @@ SET enable_partitionwise_aggregate = ON;
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                Output: conditions_1.location, conditions_1.timec, conditions_1.highlow
                Data node: data_node_2
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT timec, location, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -230,9 +236,10 @@ SET enable_partitionwise_aggregate = ON;
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                Output: conditions_2.location, conditions_2.timec, conditions_2.highlow
                Data node: data_node_3
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT timec, location, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 -- Mix of aggregates that push down and those that don't
 :PREFIX SELECT :GROUPING,
@@ -260,6 +267,7 @@ SET enable_partitionwise_aggregate = ON;
          ->  Custom Scan (DataNodeScan) on public.conditions
                Output: conditions.location, conditions.timec, conditions.allnull, conditions.temperature, conditions.humidity, conditions.bit_int, conditions.good_life, conditions.highlow
                Data node: data_node_1
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT timec, location, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -268,6 +276,7 @@ SET enable_partitionwise_aggregate = ON;
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                Output: conditions_1.location, conditions_1.timec, conditions_1.allnull, conditions_1.temperature, conditions_1.humidity, conditions_1.bit_int, conditions_1.good_life, conditions_1.highlow
                Data node: data_node_2
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT timec, location, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -276,9 +285,10 @@ SET enable_partitionwise_aggregate = ON;
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                Output: conditions_2.location, conditions_2.timec, conditions_2.allnull, conditions_2.temperature, conditions_2.humidity, conditions_2.bit_int, conditions_2.good_life, conditions_2.highlow
                Data node: data_node_3
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT timec, location, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 -- Aggregates nested in expressions and no top-level aggregate #3672
 :PREFIX SELECT :GROUPING,
@@ -296,21 +306,24 @@ SET enable_partitionwise_aggregate = ON;
                Output: conditions.location, ((sum(conditions.temperature) + sum(conditions.humidity))), conditions.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_1
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT location, (sum(temperature) + sum(humidity)), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 3 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_1.location, ((sum(conditions_1.temperature) + sum(conditions_1.humidity))), conditions_1.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_2
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT location, (sum(temperature) + sum(humidity)), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 3 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_2.location, ((sum(conditions_2.temperature) + sum(conditions_2.humidity))), conditions_2.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_3
+               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT location, (sum(temperature) + sum(humidity)), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 3 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 -- Aggregates with no aggregate reference in targetlist #3664
 :PREFIX SELECT :GROUPING
@@ -330,21 +343,24 @@ SET enable_partitionwise_aggregate = ON;
                      Output: conditions.location, conditions.timec
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT location, timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2 HAVING ((avg(temperature) > 20::double precision))
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.location, conditions_1.timec
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT location, timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2 HAVING ((avg(temperature) > 20::double precision))
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.location, conditions_2.timec
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT location, timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2 HAVING ((avg(temperature) > 20::double precision))
-(24 rows)
+(27 rows)
 
 \set GROUPING 'region, temperature'
 \ir 'include/aggregate_queries.sql'
@@ -403,21 +419,24 @@ SET enable_partitionwise_aggregate = ON;
                      Output: conditions.region, conditions.temperature, conditions.timec, (PARTIAL min(conditions.allnull)), (PARTIAL max(conditions.temperature)), (PARTIAL sum(conditions.temperature)), (PARTIAL sum(conditions.humidity)), (PARTIAL avg(conditions.humidity)), (PARTIAL stddev((conditions.humidity)::integer)), (PARTIAL bit_and(conditions.bit_int)), (PARTIAL bit_or(conditions.bit_int)), (PARTIAL bool_and(conditions.good_life)), (PARTIAL every((conditions.temperature > '0'::double precision))), (PARTIAL bool_or(conditions.good_life)), (PARTIAL count(*)), (PARTIAL count(conditions.temperature)), (PARTIAL count(conditions.allnull)), (PARTIAL corr(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL covar_pop(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL covar_samp(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_avgx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_avgy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_count(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_intercept(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_r2(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_slope(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_sxx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_sxy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_syy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL stddev((conditions.temperature)::integer)), (PARTIAL stddev_pop((conditions.temperature)::integer)), (PARTIAL stddev_samp((conditions.temperature)::integer)), (PARTIAL variance((conditions.temperature)::integer)), (PARTIAL var_pop((conditions.temperature)::integer)), (PARTIAL var_samp((conditions.temperature)::integer)), (PARTIAL last(conditions.temperature, conditions.timec)), (PARTIAL histogram(conditions.temperature, '0'::double precision, '100'::double precision, 1))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(min(allnull)), _timescaledb_internal.partialize_agg(max(temperature)), _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)), _timescaledb_internal.partialize_agg(avg(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity::integer)), _timescaledb_internal.partialize_agg(bit_and(bit_int)), _timescaledb_internal.partialize_agg(bit_or(bit_int)), _timescaledb_internal.partialize_agg(bool_and(good_life)), _timescaledb_internal.partialize_agg(every((temperature > 0::double precision))), _timescaledb_internal.partialize_agg(bool_or(good_life)), _timescaledb_internal.partialize_agg(count(*)), _timescaledb_internal.partialize_agg(count(temperature)), _timescaledb_internal.partialize_agg(count(allnull)), _timescaledb_internal.partialize_agg(corr(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_pop(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_samp(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_count(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_intercept(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_r2(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_slope(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_syy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(stddev(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_pop(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_samp(temperature::integer)), _timescaledb_internal.partialize_agg(variance(temperature::integer)), _timescaledb_internal.partialize_agg(var_pop(temperature::integer)), _timescaledb_internal.partialize_agg(var_samp(temperature::integer)), _timescaledb_internal.partialize_agg(public.last(temperature, timec)), _timescaledb_internal.partialize_agg(public.histogram(temperature, 0::double precision, 100::double precision, 1)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, (PARTIAL min(conditions_1.allnull)), (PARTIAL max(conditions_1.temperature)), (PARTIAL sum(conditions_1.temperature)), (PARTIAL sum(conditions_1.humidity)), (PARTIAL avg(conditions_1.humidity)), (PARTIAL stddev((conditions_1.humidity)::integer)), (PARTIAL bit_and(conditions_1.bit_int)), (PARTIAL bit_or(conditions_1.bit_int)), (PARTIAL bool_and(conditions_1.good_life)), (PARTIAL every((conditions_1.temperature > '0'::double precision))), (PARTIAL bool_or(conditions_1.good_life)), (PARTIAL count(*)), (PARTIAL count(conditions_1.temperature)), (PARTIAL count(conditions_1.allnull)), (PARTIAL corr(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL covar_pop(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL covar_samp(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_avgx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_avgy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_count(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_intercept(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_r2(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_slope(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_sxx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_sxy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_syy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL stddev((conditions_1.temperature)::integer)), (PARTIAL stddev_pop((conditions_1.temperature)::integer)), (PARTIAL stddev_samp((conditions_1.temperature)::integer)), (PARTIAL variance((conditions_1.temperature)::integer)), (PARTIAL var_pop((conditions_1.temperature)::integer)), (PARTIAL var_samp((conditions_1.temperature)::integer)), (PARTIAL last(conditions_1.temperature, conditions_1.timec)), (PARTIAL histogram(conditions_1.temperature, '0'::double precision, '100'::double precision, 1))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(min(allnull)), _timescaledb_internal.partialize_agg(max(temperature)), _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)), _timescaledb_internal.partialize_agg(avg(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity::integer)), _timescaledb_internal.partialize_agg(bit_and(bit_int)), _timescaledb_internal.partialize_agg(bit_or(bit_int)), _timescaledb_internal.partialize_agg(bool_and(good_life)), _timescaledb_internal.partialize_agg(every((temperature > 0::double precision))), _timescaledb_internal.partialize_agg(bool_or(good_life)), _timescaledb_internal.partialize_agg(count(*)), _timescaledb_internal.partialize_agg(count(temperature)), _timescaledb_internal.partialize_agg(count(allnull)), _timescaledb_internal.partialize_agg(corr(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_pop(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_samp(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_count(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_intercept(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_r2(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_slope(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_syy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(stddev(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_pop(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_samp(temperature::integer)), _timescaledb_internal.partialize_agg(variance(temperature::integer)), _timescaledb_internal.partialize_agg(var_pop(temperature::integer)), _timescaledb_internal.partialize_agg(var_samp(temperature::integer)), _timescaledb_internal.partialize_agg(public.last(temperature, timec)), _timescaledb_internal.partialize_agg(public.histogram(temperature, 0::double precision, 100::double precision, 1)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, (PARTIAL min(conditions_2.allnull)), (PARTIAL max(conditions_2.temperature)), (PARTIAL sum(conditions_2.temperature)), (PARTIAL sum(conditions_2.humidity)), (PARTIAL avg(conditions_2.humidity)), (PARTIAL stddev((conditions_2.humidity)::integer)), (PARTIAL bit_and(conditions_2.bit_int)), (PARTIAL bit_or(conditions_2.bit_int)), (PARTIAL bool_and(conditions_2.good_life)), (PARTIAL every((conditions_2.temperature > '0'::double precision))), (PARTIAL bool_or(conditions_2.good_life)), (PARTIAL count(*)), (PARTIAL count(conditions_2.temperature)), (PARTIAL count(conditions_2.allnull)), (PARTIAL corr(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL covar_pop(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL covar_samp(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_avgx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_avgy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_count(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_intercept(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_r2(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_slope(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_sxx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_sxy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_syy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL stddev((conditions_2.temperature)::integer)), (PARTIAL stddev_pop((conditions_2.temperature)::integer)), (PARTIAL stddev_samp((conditions_2.temperature)::integer)), (PARTIAL variance((conditions_2.temperature)::integer)), (PARTIAL var_pop((conditions_2.temperature)::integer)), (PARTIAL var_samp((conditions_2.temperature)::integer)), (PARTIAL last(conditions_2.temperature, conditions_2.timec)), (PARTIAL histogram(conditions_2.temperature, '0'::double precision, '100'::double precision, 1))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(min(allnull)), _timescaledb_internal.partialize_agg(max(temperature)), _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)), _timescaledb_internal.partialize_agg(avg(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity::integer)), _timescaledb_internal.partialize_agg(bit_and(bit_int)), _timescaledb_internal.partialize_agg(bit_or(bit_int)), _timescaledb_internal.partialize_agg(bool_and(good_life)), _timescaledb_internal.partialize_agg(every((temperature > 0::double precision))), _timescaledb_internal.partialize_agg(bool_or(good_life)), _timescaledb_internal.partialize_agg(count(*)), _timescaledb_internal.partialize_agg(count(temperature)), _timescaledb_internal.partialize_agg(count(allnull)), _timescaledb_internal.partialize_agg(corr(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_pop(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_samp(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_count(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_intercept(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_r2(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_slope(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_syy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(stddev(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_pop(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_samp(temperature::integer)), _timescaledb_internal.partialize_agg(variance(temperature::integer)), _timescaledb_internal.partialize_agg(var_pop(temperature::integer)), _timescaledb_internal.partialize_agg(var_samp(temperature::integer)), _timescaledb_internal.partialize_agg(public.last(temperature, timec)), _timescaledb_internal.partialize_agg(public.histogram(temperature, 0::double precision, 100::double precision, 1)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 -- Aggregates on custom types are not yet pushed down
 :PREFIX SELECT :GROUPING,
@@ -439,6 +458,7 @@ SET enable_partitionwise_aggregate = ON;
                ->  Custom Scan (DataNodeScan) on public.conditions
                      Output: conditions.region, conditions.temperature, conditions.timec, conditions.highlow
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT timec, region, temperature, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -447,6 +467,7 @@ SET enable_partitionwise_aggregate = ON;
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, conditions_1.highlow
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT timec, region, temperature, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -455,9 +476,10 @@ SET enable_partitionwise_aggregate = ON;
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, conditions_2.highlow
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT timec, region, temperature, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(29 rows)
+(32 rows)
 
 -- Mix of aggregates that push down and those that don't
 :PREFIX SELECT :GROUPING,
@@ -488,6 +510,7 @@ SET enable_partitionwise_aggregate = ON;
                ->  Custom Scan (DataNodeScan) on public.conditions
                      Output: conditions.region, conditions.temperature, conditions.timec, conditions.allnull, conditions.humidity, conditions.bit_int, conditions.good_life, conditions.highlow
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT timec, region, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -496,6 +519,7 @@ SET enable_partitionwise_aggregate = ON;
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, conditions_1.allnull, conditions_1.humidity, conditions_1.bit_int, conditions_1.good_life, conditions_1.highlow
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT timec, region, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -504,9 +528,10 @@ SET enable_partitionwise_aggregate = ON;
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, conditions_2.allnull, conditions_2.humidity, conditions_2.bit_int, conditions_2.good_life, conditions_2.highlow
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT timec, region, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(29 rows)
+(32 rows)
 
 -- Aggregates nested in expressions and no top-level aggregate #3672
 :PREFIX SELECT :GROUPING,
@@ -527,21 +552,24 @@ SET enable_partitionwise_aggregate = ON;
                      Output: conditions.region, conditions.temperature, conditions.timec, (PARTIAL sum(conditions.temperature)), (PARTIAL sum(conditions.humidity))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, (PARTIAL sum(conditions_1.temperature)), (PARTIAL sum(conditions_1.humidity))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, (PARTIAL sum(conditions_2.temperature)), (PARTIAL sum(conditions_2.humidity))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 -- Aggregates with no aggregate reference in targetlist #3664
 :PREFIX SELECT :GROUPING
@@ -563,21 +591,24 @@ SET enable_partitionwise_aggregate = ON;
                      Output: conditions.region, conditions.temperature, conditions.timec, (PARTIAL avg(conditions.temperature))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(avg(temperature)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, (PARTIAL avg(conditions_1.temperature))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(avg(temperature)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, (PARTIAL avg(conditions_2.temperature))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(avg(temperature)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 -- Full aggregate pushdown correctness check, compare location grouped query results with partionwise aggregates on and off
 \set GROUPING 'location'

--- a/tsl/test/expected/dist_query.out
+++ b/tsl/test/expected/dist_query.out
@@ -212,12 +212,14 @@ GROUP BY 1
                      Output: hyper."time", (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1."time", (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Partial GroupAggregate
@@ -226,9 +228,10 @@ GROUP BY 1
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -252,12 +255,14 @@ GROUP BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Partial GroupAggregate
@@ -266,9 +271,10 @@ GROUP BY 1
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -289,12 +295,14 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -303,9 +311,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -326,12 +335,14 @@ GROUP BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -340,9 +351,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -363,12 +375,14 @@ GROUP BY 1,2
                Output: (date_trunc('month'::text, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: (date_trunc('month'::text, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -377,9 +391,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: date_trunc('month'::text, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -401,12 +416,14 @@ HAVING device > 4
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -415,9 +432,10 @@ HAVING device > 4
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -436,21 +454,24 @@ HAVING avg(temp) > 40 AND max(temp) < 70
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision))
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision))
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision))
-(21 rows)
+(24 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -471,12 +492,14 @@ GROUP BY 1
                Output: hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
          ->  GroupAggregate
@@ -485,9 +508,10 @@ GROUP BY 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### No push down on some functions
@@ -512,21 +536,24 @@ GROUP BY 1
                      Output: hyper_1.location, hyper_1.temp
                      Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2.location, hyper_2.temp
                      Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3.location, hyper_3.temp
                      Filter: ((hyper_3.temp * random()) >= '0'::double precision)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### No push down on some functions
@@ -549,19 +576,22 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(21 rows)
+(24 rows)
 
 
 ######### No push down on some functions
@@ -586,19 +616,22 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device, hyper_3.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -621,19 +654,22 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device, hyper_3.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(21 rows)
+(24 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -652,12 +688,14 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -666,9 +704,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
                                                                                                                                                                   QUERY PLAN                                                                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -679,12 +718,14 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -693,9 +734,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -711,12 +753,14 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -725,9 +769,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -747,19 +792,22 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 10
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -780,19 +828,22 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 10
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -812,19 +863,22 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 1
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -844,19 +898,22 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 2000
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -876,19 +933,22 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -911,19 +971,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time", hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time", hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time", hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -946,19 +1009,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -981,19 +1047,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -1011,23 +1080,26 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(27 rows)
+(30 rows)
 
 
 ######### CTEs/Sub-queries
@@ -1064,16 +1136,19 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -1092,12 +1167,14 @@ ORDER BY 1,2
                                                          Output: hyper_4.device, (avg(hyper_4.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_1
+                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_1_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  Custom Scan (DataNodeScan)
                                                          Output: hyper_5.device, (avg(hyper_5.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_2
+                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_2_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  GroupAggregate
@@ -1106,9 +1183,10 @@ ORDER BY 1,2
                                                          ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
                                                                Output: hyper_6.device, hyper_6.temp
                                                                Data node: data_node_3
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_3_chunk
                                                                Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(60 rows)
+(66 rows)
 
 
 ######### CTEs/Sub-queries
@@ -1135,16 +1213,19 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -1152,9 +1233,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(36 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -1192,21 +1274,24 @@ ORDER BY 1
                      Output: hyper."time", (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1."time", (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2."time", (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -1231,21 +1316,24 @@ ORDER BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1267,12 +1355,14 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1281,9 +1371,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1305,12 +1396,14 @@ ORDER BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1319,9 +1412,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1343,12 +1437,14 @@ ORDER BY 1,2
                Output: (date_trunc('month'::text, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (date_trunc('month'::text, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1357,9 +1453,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: date_trunc('month'::text, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1382,21 +1479,24 @@ ORDER BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -1416,21 +1516,24 @@ ORDER BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -1452,21 +1555,24 @@ ORDER BY 1
                Output: hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -1491,21 +1597,24 @@ ORDER BY 1
                      Output: hyper_1.location, hyper_1.temp
                      Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2.location, hyper_2.temp
                      Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3.location, hyper_3.temp
                      Filter: ((hyper_3.temp * random()) >= '0'::double precision)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### No push down on some functions
@@ -1529,19 +1638,22 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -1569,19 +1681,22 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### No push down on some functions
@@ -1605,19 +1720,22 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device, hyper_3.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -1637,12 +1755,14 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1651,9 +1771,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
                                                                                                                                                                          QUERY PLAN                                                                                                                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1665,12 +1786,14 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1679,9 +1802,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -1698,12 +1822,14 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1712,9 +1838,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### LIMIT push down cases
@@ -1735,19 +1862,22 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -1769,19 +1899,22 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -1802,19 +1935,22 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -1835,19 +1971,22 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -1868,19 +2007,22 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -1906,19 +2048,22 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 
 ######### LIMIT push down cases
@@ -1941,19 +2086,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -1976,19 +2124,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -2006,23 +2157,26 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(27 rows)
+(30 rows)
 
 
 ######### CTEs/Sub-queries
@@ -2059,16 +2213,19 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -2087,12 +2244,14 @@ ORDER BY 1,2
                                                          Output: hyper_4.device, (avg(hyper_4.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_1
+                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_1_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  Custom Scan (DataNodeScan)
                                                          Output: hyper_5.device, (avg(hyper_5.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_2
+                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_2_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  GroupAggregate
@@ -2101,9 +2260,10 @@ ORDER BY 1,2
                                                          ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
                                                                Output: hyper_6.device, hyper_6.temp
                                                                Data node: data_node_3
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_3_chunk
                                                                Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(60 rows)
+(66 rows)
 
 
 ######### CTEs/Sub-queries
@@ -2130,16 +2290,19 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -2147,9 +2310,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(36 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -2180,9 +2344,10 @@ ORDER BY 1
    Output: hyper."time", (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -2200,9 +2365,10 @@ ORDER BY 1
    Output: (time_bucket('@ 2 days'::interval, hyper."time")), (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2220,9 +2386,10 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2240,9 +2407,10 @@ ORDER BY 1,2
    Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2260,9 +2428,10 @@ ORDER BY 1,2
    Output: (date_trunc('month'::text, hyper."time")), hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2281,9 +2450,10 @@ ORDER BY 1,2
    Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -2299,9 +2469,10 @@ ORDER BY 1,2
    Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -2319,9 +2490,10 @@ ORDER BY 1
    Output: hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1
-(6 rows)
+(7 rows)
 
 
 ######### No push down on some functions
@@ -2342,9 +2514,10 @@ ORDER BY 1
          Output: hyper.location, hyper.temp
          Filter: ((hyper.temp * random()) >= '0'::double precision)
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY location ASC NULLS LAST
-(9 rows)
+(10 rows)
 
 
 ######### No push down on some functions
@@ -2364,9 +2537,10 @@ ORDER BY 1,2
    ->  Custom Scan (DataNodeScan) on public.hyper
          Output: time_bucket('@ 2 days'::interval, hyper."time"), hyper.device, hyper.temp
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(8 rows)
+(9 rows)
 
 
 ######### No push down on some functions
@@ -2388,9 +2562,10 @@ ORDER BY 1,2
    ->  Custom Scan (DataNodeScan) on public.hyper
          Output: hyper."time", hyper.device, hyper.temp
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY "time" ASC NULLS LAST
-(9 rows)
+(10 rows)
 
 
 ######### No push down on some functions
@@ -2410,9 +2585,10 @@ ORDER BY 1,2
    ->  Custom Scan (DataNodeScan) on public.hyper
          Output: hyper."time", hyper.device, hyper.temp
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY "time" ASC NULLS LAST
-(8 rows)
+(9 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -2428,9 +2604,10 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(6 rows)
+(7 rows)
 
                                                                                                                                                                  QUERY PLAN                                                                                                                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -2438,9 +2615,10 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(6 rows)
+(7 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -2453,9 +2631,10 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
+   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(6 rows)
+(7 rows)
 
 
 ######### LIMIT push down cases
@@ -2476,19 +2655,22 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -2510,19 +2692,22 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -2543,19 +2728,22 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -2576,19 +2764,22 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -2609,19 +2800,22 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -2647,19 +2841,22 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 
 ######### LIMIT push down cases
@@ -2682,19 +2879,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -2717,19 +2917,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -2747,23 +2950,26 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(27 rows)
+(30 rows)
 
 
 ######### CTEs/Sub-queries
@@ -2792,6 +2998,7 @@ ORDER BY 1,2
          ->  Custom Scan (DataNodeScan) on public.hyper
                Output: hyper."time", hyper.device, hyper.temp, time_bucket('@ 1 min'::interval, hyper."time")
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST
          ->  Materialize
@@ -2805,9 +3012,10 @@ ORDER BY 1,2
                                  Output: hyper_1.device, (avg(hyper_1.temp))
                                  Relations: Aggregate on (public.hyper)
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY avg(temp) DESC NULLS FIRST
-(23 rows)
+(25 rows)
 
 
 ######### CTEs/Sub-queries
@@ -2834,16 +3042,19 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -2851,9 +3062,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(36 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -2892,19 +3104,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -2930,19 +3145,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2968,19 +3186,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3006,19 +3227,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3044,19 +3268,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: date_trunc('month'::text, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: date_trunc('month'::text, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: date_trunc('month'::text, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3083,19 +3310,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -3117,21 +3347,24 @@ LIMIT 10
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -3157,19 +3390,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### No push down on some functions
@@ -3196,21 +3432,24 @@ LIMIT 10
                            Output: hyper_1.location, hyper_1.temp
                            Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.location, hyper_2.temp
                            Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.location, hyper_3.temp
                            Filter: ((hyper_3.temp * random()) >= '0'::double precision)
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(27 rows)
+(30 rows)
 
 
 ######### No push down on some functions
@@ -3236,19 +3475,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### No push down on some functions
@@ -3276,19 +3518,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### No push down on some functions
@@ -3314,19 +3559,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -3350,19 +3598,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
                                                                                                                                                                      QUERY PLAN                                                                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -3378,19 +3629,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -3411,19 +3665,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 
 ######### LIMIT push down cases
@@ -3444,19 +3701,22 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -3478,19 +3738,22 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -3511,19 +3774,22 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -3544,19 +3810,22 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -3577,19 +3846,22 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -3615,19 +3887,22 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 
 ######### LIMIT push down cases
@@ -3650,19 +3925,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -3685,19 +3963,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -3715,23 +3996,26 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(27 rows)
+(30 rows)
 
 
 ######### CTEs/Sub-queries
@@ -3768,16 +4052,19 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -3796,12 +4083,14 @@ ORDER BY 1,2
                                                          Output: hyper_4.device, (avg(hyper_4.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_1
+                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_1_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  Custom Scan (DataNodeScan)
                                                          Output: hyper_5.device, (avg(hyper_5.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_2
+                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_2_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  GroupAggregate
@@ -3810,9 +4099,10 @@ ORDER BY 1,2
                                                          ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
                                                                Output: hyper_6.device, hyper_6.temp
                                                                Data node: data_node_3
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_3_chunk
                                                                Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(60 rows)
+(66 rows)
 
 
 ######### CTEs/Sub-queries
@@ -3839,16 +4129,19 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -3856,9 +4149,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(36 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -3895,21 +4189,24 @@ GROUP BY 1
                      Output: hyper."time", (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1."time", (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2."time", (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -3933,21 +4230,24 @@ GROUP BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3969,21 +4269,24 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4008,21 +4311,24 @@ ORDER BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4047,21 +4353,24 @@ ORDER BY 1,2
                      Output: (date_trunc('month'::text, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4087,21 +4396,24 @@ ORDER BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -4125,21 +4437,24 @@ ORDER BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp)), (PARTIAL max(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp)), (PARTIAL max(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp)), (PARTIAL max(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -4163,21 +4478,24 @@ GROUP BY 1
                      Output: hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
-(24 rows)
+(27 rows)
 
 
 ######### No push down on some functions
@@ -4205,6 +4523,7 @@ GROUP BY 1
                            Output: hyper.location, hyper.temp
                            Filter: ((hyper.temp * random()) >= '0'::double precision)
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -4214,6 +4533,7 @@ GROUP BY 1
                            Output: hyper_1.location, hyper_1.temp
                            Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -4223,9 +4543,10 @@ GROUP BY 1
                            Output: hyper_2.location, hyper_2.temp
                            Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(34 rows)
+(37 rows)
 
 
 ######### No push down on some functions
@@ -4250,6 +4571,7 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper
                      Output: time_bucket('@ 2 days'::interval, hyper."time"), hyper.device, hyper.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -4258,6 +4580,7 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -4266,9 +4589,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(29 rows)
+(32 rows)
 
 
 ######### No push down on some functions
@@ -4294,6 +4618,7 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper
                      Output: hyper."time", hyper.device, hyper.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4303,6 +4628,7 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4312,9 +4638,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(31 rows)
+(34 rows)
 
 
 ######### No push down on some functions
@@ -4338,6 +4665,7 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper
                      Output: hyper."time", hyper.device, hyper.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4346,6 +4674,7 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4354,9 +4683,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(28 rows)
+(31 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -4376,21 +4706,24 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
                                                                                                                                                QUERY PLAN                                                                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4402,21 +4735,24 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -4433,21 +4769,24 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### LIMIT push down cases
@@ -4468,19 +4807,22 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -4502,19 +4844,22 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -4535,19 +4880,22 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -4568,19 +4916,22 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -4601,19 +4952,22 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -4639,19 +4993,22 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(29 rows)
 
 
 ######### LIMIT push down cases
@@ -4674,19 +5031,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -4709,19 +5069,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -4739,23 +5102,26 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(27 rows)
+(30 rows)
 
 
 ######### CTEs/Sub-queries
@@ -4792,16 +5158,19 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -4824,21 +5193,24 @@ ORDER BY 1,2
                                                                Output: hyper_4.device, (PARTIAL avg(hyper_4.temp))
                                                                Relations: Aggregate on (public.hyper)
                                                                Data node: data_node_1
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper_5.device, (PARTIAL avg(hyper_5.temp))
                                                                Relations: Aggregate on (public.hyper)
                                                                Data node: data_node_2
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper_6.device, (PARTIAL avg(hyper_6.temp))
                                                                Relations: Aggregate on (public.hyper)
                                                                Data node: data_node_3
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(62 rows)
+(68 rows)
 
 
 ######### CTEs/Sub-queries
@@ -4865,16 +5237,19 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -4882,9 +5257,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(36 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper1d
@@ -4919,21 +5295,24 @@ ORDER BY 1
                Output: hyper1d."time", (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
-(22 rows)
+(25 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -4958,21 +5337,24 @@ ORDER BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4993,21 +5375,24 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(21 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -5031,21 +5416,24 @@ GROUP BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -5069,21 +5457,24 @@ GROUP BY 1,2
                      Output: (date_trunc('month'::text, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(24 rows)
+(27 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -5108,21 +5499,24 @@ HAVING device > 4
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
-(24 rows)
+(27 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -5148,21 +5542,24 @@ HAVING avg(temp) > 40 AND max(temp) < 70
                            Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp)), (PARTIAL max(hyper1d.temp))
                            Relations: Aggregate on (public.hyper1d)
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                      ->  Custom Scan (DataNodeScan)
                            Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp)), (PARTIAL max(hyper1d_1.temp))
                            Relations: Aggregate on (public.hyper1d)
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                      ->  Custom Scan (DataNodeScan)
                            Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp)), (PARTIAL max(hyper1d_2.temp))
                            Relations: Aggregate on (public.hyper1d)
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(28 rows)
+(31 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -5187,21 +5584,24 @@ ORDER BY 1
                      Output: hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_17_chunk, _dist_hyper_1_1_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_13_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 7, 1, 6, 2, 5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_14_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_18_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_7_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[6, 5, 7, 1, 2, 4, 3]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_3_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[3, 4, 2, 1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(25 rows)
+(28 rows)
 
 
 ######### No push down on some functions
@@ -5229,6 +5629,7 @@ ORDER BY 1
                            Output: hyper1d.location, hyper1d.temp
                            Filter: ((hyper1d.temp * random()) >= '0'::double precision)
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -5238,6 +5639,7 @@ ORDER BY 1
                            Output: hyper1d_1.location, hyper1d_1.temp
                            Filter: ((hyper1d_1.temp * random()) >= '0'::double precision)
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -5247,9 +5649,10 @@ ORDER BY 1
                            Output: hyper1d_2.location, hyper1d_2.temp
                            Filter: ((hyper1d_2.temp * random()) >= '0'::double precision)
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(34 rows)
+(37 rows)
 
 
 ######### No push down on some functions
@@ -5274,6 +5677,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: time_bucket('@ 2 days'::interval, hyper1d."time"), hyper1d.device, hyper1d.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -5282,6 +5686,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: time_bucket('@ 2 days'::interval, hyper1d_1."time"), hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -5290,9 +5695,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: time_bucket('@ 2 days'::interval, hyper1d_2."time"), hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(29 rows)
+(32 rows)
 
 
 ######### No push down on some functions
@@ -5317,6 +5723,7 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: hyper1d."time", hyper1d.device, hyper1d.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5326,6 +5733,7 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5335,9 +5743,10 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(30 rows)
+(33 rows)
 
 
 ######### No push down on some functions
@@ -5360,6 +5769,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: hyper1d."time", hyper1d.device, hyper1d.temp
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5368,6 +5778,7 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5376,9 +5787,10 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(30 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -5397,21 +5809,24 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(21 rows)
+(24 rows)
 
                                                                                                              QUERY PLAN                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -5422,21 +5837,24 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(21 rows)
+(24 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -5452,21 +5870,24 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(21 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -5486,19 +5907,22 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 10
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -5519,19 +5943,22 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 10
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -5551,19 +5978,22 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 1
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -5583,19 +6013,22 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 2000
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -5615,19 +6048,22 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5])
-(20 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -5650,19 +6086,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time", hyper1d_1.temp
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time", hyper1d_2.temp
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time", hyper1d_3.temp
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -5685,19 +6124,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -5720,19 +6162,22 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -5750,23 +6195,26 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(27 rows)
+(30 rows)
 
 
 ######### CTEs/Sub-queries
@@ -5803,16 +6251,19 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                                  Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_2_20_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                                  Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_2_21_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                                  Output: hyper1d_3."time", hyper1d_3.device, hyper1d_3.temp
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_2_19_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -5834,21 +6285,24 @@ ORDER BY 1,2
                                                                Output: hyper1d_4.device, (PARTIAL avg(hyper1d_4.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_1
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_2_20_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper1d_5.device, (PARTIAL avg(hyper1d_5.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_2
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_2_21_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper1d_6.device, (PARTIAL avg(hyper1d_6.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_3
+                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_2_19_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(61 rows)
+(67 rows)
 
 
 ######### CTEs/Sub-queries
@@ -5875,16 +6329,19 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -5892,9 +6349,10 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(36 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: reference

--- a/tsl/test/shared/expected/dist_distinct.out
+++ b/tsl/test/shared/expected/dist_distinct.out
@@ -39,19 +39,22 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 RESET enable_hashagg;
 SET timescaledb.enable_per_data_node_queries = true;
@@ -74,19 +77,22 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: (metrics_dist_1.device_id * metrics_dist_1.v1)
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: (metrics_dist_2.device_id * metrics_dist_2.v1)
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: (metrics_dist_3.device_id * metrics_dist_3.v1)
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 SET timescaledb.enable_remote_explain = ON;
 SELECT DISTINCT on column with index uses SkipScan
@@ -108,6 +114,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -134,6 +141,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -160,6 +168,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -183,7 +192,7 @@ LIMIT 10;
                                                  Output: _dist_hyper_X_X_chunk.device_id
                                                  Index Cond: (_dist_hyper_X_X_chunk.device_id > NULL::integer)
  
-(86 rows)
+(89 rows)
 
 SELECT DISTINCT with constants and NULLs in targetlist uses SkipScan
 EXPLAIN (verbose, costs off)
@@ -204,6 +213,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, NULL::text, 'const1'::text
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -230,6 +240,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, NULL::text, 'const1'::text
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -256,6 +267,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, NULL::text, 'const1'::text
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -279,7 +291,7 @@ LIMIT 10;
                                                  Output: _dist_hyper_X_X_chunk.device_id
                                                  Index Cond: (_dist_hyper_X_X_chunk.device_id > NULL::integer)
  
-(86 rows)
+(89 rows)
 
 SELECT DISTINCT only sends columns to the data nodes
 EXPLAIN (verbose, costs off)
@@ -300,6 +312,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1."time", NULL::text, 'const1'::text
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -319,6 +332,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2."time", NULL::text, 'const1'::text
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -339,6 +353,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3."time", NULL::text, 'const1'::text
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -355,7 +370,7 @@ LIMIT 10;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(66 rows)
+(69 rows)
 
 SELECT DISTINCE is pushed down in attribute attno order
 EXPLAIN (verbose, costs off)
@@ -376,6 +391,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -395,6 +411,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -415,6 +432,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -431,7 +449,7 @@ LIMIT 10;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(66 rows)
+(69 rows)
 
 SELECT DISTINCT ON multiple columns is pushed to data nodes
 EXPLAIN (verbose, costs off)
@@ -452,6 +470,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1."time"
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -471,6 +490,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2."time"
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -490,6 +510,7 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3."time"
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -506,7 +527,7 @@ LIMIT 10;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(65 rows)
+(68 rows)
 
 SELECT DISTINCT within a sub-select
 EXPLAIN (verbose, costs off)
@@ -529,6 +550,7 @@ LIMIT 10) a;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                                  Output: metrics_dist_1.device_id, metrics_dist_1."time"
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                                  Remote EXPLAIN: 
@@ -548,6 +570,7 @@ LIMIT 10) a;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                                  Output: metrics_dist_2.device_id, metrics_dist_2."time"
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                                  Remote EXPLAIN: 
@@ -567,6 +590,7 @@ LIMIT 10) a;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                                  Output: metrics_dist_3.device_id, metrics_dist_3."time"
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                                  Remote EXPLAIN: 
@@ -583,7 +607,7 @@ LIMIT 10) a;
                                                  ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                        Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(67 rows)
+(70 rows)
 
 SET timescaledb.enable_per_data_node_queries = false;
 SELECT DISTINCT works with enable_per_data_node_queries disabled
@@ -603,6 +627,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -616,6 +641,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -629,6 +655,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -642,6 +669,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -655,6 +683,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -668,6 +697,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -681,6 +711,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_1
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -694,6 +725,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_2
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -707,6 +739,7 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_3
+                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -717,7 +750,7 @@ LIMIT 10;
                                      Output: device_id
                                      Index Cond: (_dist_hyper_X_X_chunk.device_id > NULL::integer)
  
-(123 rows)
+(132 rows)
 
 SET timescaledb.enable_per_data_node_queries = true;
 SET timescaledb.enable_remote_explain = OFF;
@@ -740,19 +773,22 @@ ORDER BY 1;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1.device_id
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2.device_id
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3.device_id
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
-(24 rows)
+(27 rows)
 
 SELECT DISTINCT handles whole row correctly
 EXPLAIN (verbose, costs off)
@@ -773,19 +809,22 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1."time", metrics_dist_1.device_id, metrics_dist_1.v0, metrics_dist_1.v1, metrics_dist_1.v2, metrics_dist_1.v3
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2."time", metrics_dist_2.device_id, metrics_dist_2.v0, metrics_dist_2.v1, metrics_dist_2.v2, metrics_dist_2.v3
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3."time", metrics_dist_3.device_id, metrics_dist_3.v0, metrics_dist_3.v1, metrics_dist_3.v2, metrics_dist_3.v3
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 SELECT DISTINCT ON (expr) handles whole row correctly
 EXPLAIN (verbose, costs off)
@@ -806,19 +845,22 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1."time", metrics_dist_1.device_id, metrics_dist_1.v0, metrics_dist_1.v1, metrics_dist_1.v2, metrics_dist_1.v3
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2."time", metrics_dist_2.device_id, metrics_dist_2.v0, metrics_dist_2.v1, metrics_dist_2.v2, metrics_dist_2.v3
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3."time", metrics_dist_3.device_id, metrics_dist_3.v0, metrics_dist_3.v1, metrics_dist_3.v2, metrics_dist_3.v3
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 SELECT DISTINCT RECORD works correctly
 SET enable_hashagg TO false;
@@ -842,19 +884,22 @@ LIMIT 10;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                                  Output: metrics_dist_1.*
                                  Data node: data_node_1
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                                  Output: metrics_dist_2.*
                                  Data node: data_node_2
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                                  Output: metrics_dist_3.*
                                  Data node: data_node_3
+                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
-(25 rows)
+(28 rows)
 
 RESET enable_hashagg;
 SELECT DISTINCT FUNCTION_EXPR not pushed down currently
@@ -876,19 +921,22 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: time_bucket('@ 1 hour'::interval, metrics_dist_1."time")
                            Data node: data_node_1
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: time_bucket('@ 1 hour'::interval, metrics_dist_2."time")
                            Data node: data_node_2
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: time_bucket('@ 1 hour'::interval, metrics_dist_3."time")
                            Data node: data_node_3
+                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
-(23 rows)
+(26 rows)
 
 SELECT DISTINCT without any var references is handled correctly
 EXPLAIN (verbose, costs off)
@@ -904,19 +952,22 @@ FROM metrics_dist;
                ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                      Output: 1, 'constx'::text
                      Data node: data_node_1
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                      Remote SQL: SELECT NULL FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                      Output: 1, 'constx'::text
                      Data node: data_node_2
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                      Remote SQL: SELECT NULL FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                      Output: 1, 'constx'::text
                      Data node: data_node_3
+                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                      Remote SQL: SELECT NULL FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
-(20 rows)
+(23 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: metrics

--- a/tsl/test/shared/expected/dist_distinct_pushdown.out
+++ b/tsl/test/shared/expected/dist_distinct_pushdown.out
@@ -43,9 +43,10 @@ select distinct on (id) ts, id from distinct_on_distributed order by id, ts desc
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(7 rows)
+(8 rows)
 
 -- A case where we have a filter on the DISTINCT ON column.
 select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1') order by id, ts desc;
@@ -64,9 +65,10 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = ANY ('{0,1}'::integer[]))) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(7 rows)
+(8 rows)
 
 -- A somewhat dumb case where the DISTINCT ON column is deduced to be constant
 -- and not added to pathkeys.
@@ -88,9 +90,10 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0') or
          ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
                Output: distinct_on_distributed.ts, distinct_on_distributed.id
                Data node: data_node_1
+               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = 0))
-(10 rows)
+(11 rows)
 
 -- All above but with disabled local sort, to try to force more interesting plans where the sort
 -- is pushed down.
@@ -110,9 +113,10 @@ select ts, id from distinct_on_distributed order by id, ts desc limit 1;
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST LIMIT 1
-(7 rows)
+(8 rows)
 
 select distinct on (id) ts, id from distinct_on_distributed order by id, ts desc;
             ts            | id 
@@ -132,9 +136,10 @@ select distinct on (id) ts, id from distinct_on_distributed order by id, ts desc
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(7 rows)
+(8 rows)
 
 select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1') order by id, ts desc;
             ts            | id 
@@ -152,9 +157,10 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = ANY ('{0,1}'::integer[]))) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(7 rows)
+(8 rows)
 
 select distinct on (id) ts, id from distinct_on_distributed where id in ('0') order by id, ts desc;
             ts            | id 
@@ -171,8 +177,9 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0') or
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
+         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = 0)) ORDER BY ts DESC NULLS FIRST
-(7 rows)
+(8 rows)
 
 reset enable_sort;

--- a/tsl/test/shared/expected/dist_fetcher_type.out
+++ b/tsl/test/shared/expected/dist_fetcher_type.out
@@ -1,0 +1,93 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ON_ERROR_STOP off
+-- Test that we use the correct type of remote data fetcher.
+set timescaledb.remote_data_fetcher = 'auto';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+ x 
+---
+ 1
+(1 row)
+
+set timescaledb.remote_data_fetcher = 'cursor';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+ x 
+---
+ 1
+(1 row)
+
+explain (verbose, costs off)
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: 1
+   ->  Nested Loop
+         Output: 1
+         Join Filter: (t1.id = (t2.id + 1))
+         ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1
+               Output: t1.id
+               Data node: data_node_1
+               Fetcher Type: Cursor
+               Chunks: _dist_hyper_X_X_chunk
+               Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+         ->  Materialize
+               Output: t2.id
+               ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t2
+                     Output: t2.id
+                     Data node: data_node_1
+                     Fetcher Type: Cursor
+                     Chunks: _dist_hyper_X_X_chunk
+                     Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+(19 rows)
+
+set timescaledb.remote_data_fetcher = 'rowbyrow';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+ERROR:  could not set single-row mode on connection to "data_node_1"
+explain (verbose, costs off)
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+                                                                            QUERY PLAN                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: 1
+   ->  Nested Loop
+         Output: 1
+         Join Filter: (t1.id = (t2.id + 1))
+         ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1
+               Output: t1.id
+               Data node: data_node_1
+               Fetcher Type: Row by row
+               Chunks: _dist_hyper_X_X_chunk
+               Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+         ->  Materialize
+               Output: t2.id
+               ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t2
+                     Output: t2.id
+                     Data node: data_node_1
+                     Fetcher Type: Row by row
+                     Chunks: _dist_hyper_X_X_chunk
+                     Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+(19 rows)
+
+-- Check once again that 'auto' is used after 'rowbyrow'.
+set timescaledb.remote_data_fetcher = 'auto';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+ x 
+---
+ 1
+(1 row)
+
+reset timescaledb.remote_data_fetcher;

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -3,10 +3,11 @@ set(TEST_FILES_SHARED
     constraint_exclusion_prepared.sql
     decompress_placeholdervar.sql
     dist_chunk.sql
-    dist_gapfill.sql
-    dist_insert.sql
     dist_distinct.sql
-    dist_distinct_pushdown.sql)
+    dist_distinct_pushdown.sql
+    dist_fetcher_type.sql
+    dist_gapfill.sql
+    dist_insert.sql)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   list(APPEND TEST_FILES_SHARED memoize.sql)

--- a/tsl/test/shared/sql/dist_fetcher_type.sql
+++ b/tsl/test/shared/sql/dist_fetcher_type.sql
@@ -1,0 +1,39 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set ON_ERROR_STOP off
+
+-- Test that we use the correct type of remote data fetcher.
+set timescaledb.remote_data_fetcher = 'auto';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+
+set timescaledb.remote_data_fetcher = 'cursor';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+
+explain (verbose, costs off)
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+
+set timescaledb.remote_data_fetcher = 'rowbyrow';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+
+explain (verbose, costs off)
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+
+-- Check once again that 'auto' is used after 'rowbyrow'.
+set timescaledb.remote_data_fetcher = 'auto';
+select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
+where t1.id = t2.id + 1
+limit 1;
+
+reset timescaledb.remote_data_fetcher;

--- a/tsl/test/sql/dist_partial_agg.sql
+++ b/tsl/test/sql/dist_partial_agg.sql
@@ -33,6 +33,7 @@ SELECT table_name FROM create_distributed_hypertable( 'conditions', 'timec', 'lo
 \ir 'include/aggregate_table_populate.sql'
 
 SET enable_partitionwise_aggregate = ON;
+SET timescaledb.remote_data_fetcher = 'cursor';
 
 -- Run an explain on the aggregate queries to make sure expected aggregates are being pushed down.
 -- Grouping by the paritioning column should result in full aggregate pushdown where possible,


### PR DESCRIPTION
Fixes https://github.com/timescale/timescaledb/issues/2807

The row-by-row fetcher is more efficient, so we want to use it when we can -- that is, when the have to read only one table from the data node, without interleaving it with anything else. This patch adds an option of choosing the fetcher type automatically. It detects the simplest case of only one distributed table in the entire query, and enables row-by-row fetcher. For other cases, the cursor fetcher is used. 