### PR TITLE
Handle default privileges on distributed databases

### DIFF
--- a/tsl/src/deparse.c
+++ b/tsl/src/deparse.c
@@ -924,9 +924,8 @@ deparse_oid_function_call_coll(Oid funcid, Oid collation, unsigned int num_args,
 }
 
 const char *
-deparse_grant_revoke_on_database(Node *node, const char *dbname)
+deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname)
 {
-	GrantStmt *stmt = castNode(GrantStmt, node);
 	ListCell *lc;
 
 	/*

--- a/tsl/src/deparse.h
+++ b/tsl/src/deparse.h
@@ -8,6 +8,7 @@
 
 #include <postgres.h>
 #include <nodes/pg_list.h>
+#include <nodes/parsenodes.h>
 
 typedef struct TableInfo
 {
@@ -49,7 +50,7 @@ DeparsedHypertableCommands *deparse_get_distributed_hypertable_create_command(Hy
 
 const char *deparse_func_call(FunctionCallInfo finfo);
 const char *deparse_oid_function_call_coll(Oid funcid, Oid collation, unsigned int num_args, ...);
-const char *deparse_grant_revoke_on_database(Node *node, const char *dbname);
+const char *deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname);
 const char *deparse_create_trigger(CreateTrigStmt *stmt);
 
 #endif

--- a/tsl/test/expected/dist_grant-12.out
+++ b/tsl/test/expected/dist_grant-12.out
@@ -1159,6 +1159,67 @@ SELECT * FROM disttable_role_3;
 
 DROP USER MAPPING FOR :ROLE_3 SERVER data1;
 DROP USER MAPPING FOR :ROLE_3 SERVER data2;
+-- Test altering default privileges
+RESET ROLE;
+-- Should be superuser
+SELECT current_user;
+    current_user    
+--------------------
+ cluster_super_user
+(1 row)
+
+CALL distributed_exec($$ CREATE TABLE nodefprivs (time timestamptz, value int) $$);
+SET ROLE :ROLE_1;
+\set ON_ERROR_STOP 0
+-- Should fail due to lack of privileges (only insert on one data node
+-- to make error reporting deterministic)
+CALL distributed_exec($$ INSERT INTO nodefprivs VALUES ('2019-01-01 00:00:00', 1) $$, '{ "data1" }');
+ERROR:  [data1]: permission denied for table nodefprivs
+\set ON_ERROR_STOP 1
+-- Reset to super user
+RESET ROLE;
+-- Now alter default privileges and create table
+ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO :ROLE_1;
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+NOTICE:  [data1]: 
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+
+NOTICE:  [data1]:
+defaclrole        |defaclobjtype|defaclacl                                                                       
+------------------+-------------+--------------------------------------------------------------------------------
+cluster_super_user|r            |{cluster_super_user=arwdDxt/cluster_super_user,test_role_1=a/cluster_super_user}
+(1 row)
+
+
+--
+(1 row)
+
+CALL distributed_exec($$ CREATE TABLE defprivs (time timestamptz, value int) $$);
+-- Switch to the role that was granted default privileges
+SET ROLE :ROLE_1;
+-- Should succeed since user will have insert privileges by default
+CALL distributed_exec($$ INSERT INTO defprivs VALUES ('2019-01-01 00:00:00', 1) $$);
+RESET ROLE;
+ALTER DEFAULT PRIVILEGES REVOKE INSERT ON TABLES FROM :ROLE_1;
+-- No default privileges remain
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+NOTICE:  [data1]: 
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+
+NOTICE:  [data1]:
+defaclrole|defaclobjtype|defaclacl
+----------+-------------+---------
+(0 rows)
+
+
+--
+(1 row)
+
+CALL distributed_exec($$ DROP TABLE defprivs $$);
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;

--- a/tsl/test/expected/dist_grant-13.out
+++ b/tsl/test/expected/dist_grant-13.out
@@ -1159,6 +1159,67 @@ SELECT * FROM disttable_role_3;
 
 DROP USER MAPPING FOR :ROLE_3 SERVER data1;
 DROP USER MAPPING FOR :ROLE_3 SERVER data2;
+-- Test altering default privileges
+RESET ROLE;
+-- Should be superuser
+SELECT current_user;
+    current_user    
+--------------------
+ cluster_super_user
+(1 row)
+
+CALL distributed_exec($$ CREATE TABLE nodefprivs (time timestamptz, value int) $$);
+SET ROLE :ROLE_1;
+\set ON_ERROR_STOP 0
+-- Should fail due to lack of privileges (only insert on one data node
+-- to make error reporting deterministic)
+CALL distributed_exec($$ INSERT INTO nodefprivs VALUES ('2019-01-01 00:00:00', 1) $$, '{ "data1" }');
+ERROR:  [data1]: permission denied for table nodefprivs
+\set ON_ERROR_STOP 1
+-- Reset to super user
+RESET ROLE;
+-- Now alter default privileges and create table
+ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO :ROLE_1;
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+NOTICE:  [data1]: 
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+
+NOTICE:  [data1]:
+defaclrole        |defaclobjtype|defaclacl                                                                       
+------------------+-------------+--------------------------------------------------------------------------------
+cluster_super_user|r            |{cluster_super_user=arwdDxt/cluster_super_user,test_role_1=a/cluster_super_user}
+(1 row)
+
+
+--
+(1 row)
+
+CALL distributed_exec($$ CREATE TABLE defprivs (time timestamptz, value int) $$);
+-- Switch to the role that was granted default privileges
+SET ROLE :ROLE_1;
+-- Should succeed since user will have insert privileges by default
+CALL distributed_exec($$ INSERT INTO defprivs VALUES ('2019-01-01 00:00:00', 1) $$);
+RESET ROLE;
+ALTER DEFAULT PRIVILEGES REVOKE INSERT ON TABLES FROM :ROLE_1;
+-- No default privileges remain
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+NOTICE:  [data1]: 
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+
+NOTICE:  [data1]:
+defaclrole|defaclobjtype|defaclacl
+----------+-------------+---------
+(0 rows)
+
+
+--
+(1 row)
+
+CALL distributed_exec($$ DROP TABLE defprivs $$);
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;

--- a/tsl/test/expected/dist_grant-14.out
+++ b/tsl/test/expected/dist_grant-14.out
@@ -1159,6 +1159,67 @@ SELECT * FROM disttable_role_3;
 
 DROP USER MAPPING FOR :ROLE_3 SERVER data1;
 DROP USER MAPPING FOR :ROLE_3 SERVER data2;
+-- Test altering default privileges
+RESET ROLE;
+-- Should be superuser
+SELECT current_user;
+    current_user    
+--------------------
+ cluster_super_user
+(1 row)
+
+CALL distributed_exec($$ CREATE TABLE nodefprivs (time timestamptz, value int) $$);
+SET ROLE :ROLE_1;
+\set ON_ERROR_STOP 0
+-- Should fail due to lack of privileges (only insert on one data node
+-- to make error reporting deterministic)
+CALL distributed_exec($$ INSERT INTO nodefprivs VALUES ('2019-01-01 00:00:00', 1) $$, '{ "data1" }');
+ERROR:  [data1]: permission denied for table nodefprivs
+\set ON_ERROR_STOP 1
+-- Reset to super user
+RESET ROLE;
+-- Now alter default privileges and create table
+ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO :ROLE_1;
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+NOTICE:  [data1]: 
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+
+NOTICE:  [data1]:
+defaclrole        |defaclobjtype|defaclacl                                                                       
+------------------+-------------+--------------------------------------------------------------------------------
+cluster_super_user|r            |{cluster_super_user=arwdDxt/cluster_super_user,test_role_1=a/cluster_super_user}
+(1 row)
+
+
+--
+(1 row)
+
+CALL distributed_exec($$ CREATE TABLE defprivs (time timestamptz, value int) $$);
+-- Switch to the role that was granted default privileges
+SET ROLE :ROLE_1;
+-- Should succeed since user will have insert privileges by default
+CALL distributed_exec($$ INSERT INTO defprivs VALUES ('2019-01-01 00:00:00', 1) $$);
+RESET ROLE;
+ALTER DEFAULT PRIVILEGES REVOKE INSERT ON TABLES FROM :ROLE_1;
+-- No default privileges remain
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+NOTICE:  [data1]: 
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+
+NOTICE:  [data1]:
+defaclrole|defaclobjtype|defaclacl
+----------+-------------+---------
+(0 rows)
+
+
+--
+(1 row)
+
+CALL distributed_exec($$ DROP TABLE defprivs $$);
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;

--- a/tsl/test/sql/dist_grant.sql.in
+++ b/tsl/test/sql/dist_grant.sql.in
@@ -383,6 +383,42 @@ SELECT * FROM disttable_role_3;
 DROP USER MAPPING FOR :ROLE_3 SERVER data1;
 DROP USER MAPPING FOR :ROLE_3 SERVER data2;
 
+-- Test altering default privileges
+RESET ROLE;
+-- Should be superuser
+SELECT current_user;
+
+CALL distributed_exec($$ CREATE TABLE nodefprivs (time timestamptz, value int) $$);
+SET ROLE :ROLE_1;
+
+\set ON_ERROR_STOP 0
+-- Should fail due to lack of privileges (only insert on one data node
+-- to make error reporting deterministic)
+CALL distributed_exec($$ INSERT INTO nodefprivs VALUES ('2019-01-01 00:00:00', 1) $$, '{ "data1" }');
+\set ON_ERROR_STOP 1
+
+-- Reset to super user
+RESET ROLE;
+-- Now alter default privileges and create table
+ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO :ROLE_1;
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+CALL distributed_exec($$ CREATE TABLE defprivs (time timestamptz, value int) $$);
+
+-- Switch to the role that was granted default privileges
+SET ROLE :ROLE_1;
+-- Should succeed since user will have insert privileges by default
+CALL distributed_exec($$ INSERT INTO defprivs VALUES ('2019-01-01 00:00:00', 1) $$);
+
+RESET ROLE;
+ALTER DEFAULT PRIVILEGES REVOKE INSERT ON TABLES FROM :ROLE_1;
+-- No default privileges remain
+SELECT FROM test.remote_exec('{ "data1" }', $$
+	   SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl
+$$);
+CALL distributed_exec($$ DROP TABLE defprivs $$);
+
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;


### PR DESCRIPTION
Statements that alter default privileges are now by default forwarded
to all data nodes. For instance:

```sql
ALTER DEFAULT PRIVILEGES IN SCHEMA myschema GRANT INSERT ON TABLES TO myrole;
```

is applied across the entire cluster of data nodes.

Fixes #3851