### PR TITLE
Fix remote txn heal logic

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -1369,7 +1369,7 @@ data_node_delete(PG_FUNCTION_ARGS)
 										   OP_DELETE);
 
 	/* clean up persistent transaction records */
-	remote_txn_persistent_record_delete_for_data_node(server->serverid);
+	remote_txn_persistent_record_delete_for_data_node(server->serverid, NULL);
 
 	stmt = (DropStmt){
 		.type = T_DropStmt,

--- a/tsl/src/remote/txn.h
+++ b/tsl/src/remote/txn.h
@@ -36,7 +36,7 @@ extern void remote_txn_set_will_prep_statement(RemoteTxn *entry,
 											   RemoteTxnPrepStmtOption prep_stmt_option);
 extern TSConnection *remote_txn_get_connection(RemoteTxn *txn);
 extern TSConnectionId remote_txn_get_connection_id(RemoteTxn *txn);
-extern bool remote_txn_is_still_in_progress(TransactionId access_node_xid);
+extern bool remote_txn_is_still_in_progress_on_access_node(TransactionId access_node_xid);
 extern size_t remote_txn_size(void);
 extern bool remote_txn_is_at_sub_txn_level(RemoteTxn *entry, int curlevel);
 extern bool remote_txn_is_ongoing(RemoteTxn *entry);
@@ -50,7 +50,8 @@ extern void remote_txn_report_prepare_transaction_result(RemoteTxn *txn, bool su
 /* Persitent record */
 extern RemoteTxnId *remote_txn_persistent_record_write(TSConnectionId id);
 extern bool remote_txn_persistent_record_exists(const RemoteTxnId *gid);
-extern int remote_txn_persistent_record_delete_for_data_node(Oid foreign_server_oid);
+extern int remote_txn_persistent_record_delete_for_data_node(Oid foreign_server_oid,
+															 const char *gid);
 
 #ifdef DEBUG
 /* Debugging functions used in testing */

--- a/tsl/src/remote/txn_id.c
+++ b/tsl/src/remote/txn_id.c
@@ -17,14 +17,15 @@
 
 #define GID_SEP "-"
 
-#define GID_PREFIX "ts"
+/* The separator is part of the GID prefix */
+#define GID_PREFIX "ts-"
 /* This is the maximum size of the literal accepted by PREPARE TRANSACTION, etc. */
 #define GID_MAX_SIZE 200
 
 #define REMOTE_TXN_ID_VERSION ((uint8) 1)
 
 /* current_pattern: ts-version-xid-server_id-user_id */
-#define FMT_PATTERN GID_PREFIX GID_SEP "%hhu" GID_SEP "%u" GID_SEP "%u" GID_SEP "%u"
+#define FMT_PATTERN GID_PREFIX "%hhu" GID_SEP "%u" GID_SEP "%u" GID_SEP "%u"
 
 static char *
 remote_txn_id_get_sql(const char *command, RemoteTxnId *id)

--- a/tsl/src/remote/txn_resolve.h
+++ b/tsl/src/remote/txn_resolve.h
@@ -39,7 +39,8 @@
  * on the access node:
  *
  * Case 1 - The transaction is ongoing:
- *   In this case the state of the remote transaction is unknown (REMOTE_TXN_RESOLVE_UNKNOWN)
+ *   In this case the state of the remote transaction is in progress
+ *(REMOTE_TXN_RESOLVE_IN_PROGRESS)
  *
  * Case 2 - The transaction is committed:
  *  The remote transaction MUST BE be committed (REMOTE_TXN_RESOLVE_COMMT)
@@ -74,9 +75,9 @@
 
 typedef enum RemoteTxnResolution
 {
-	REMOTE_TXN_RESOLUTION_UNKNOWN = 0,
+	REMOTE_TXN_RESOLUTION_IN_PROGRESS = 0,
 	REMOTE_TXN_RESOLUTION_ABORT,
-	REMOTE_TXN_RESOLUTION_COMMT
+	REMOTE_TXN_RESOLUTION_COMMIT
 } RemoteTxnResolution;
 
 extern RemoteTxnResolution remote_txn_resolution(Oid foreign_server,

--- a/tsl/test/expected/remote_txn_resolve.out
+++ b/tsl/test/expected/remote_txn_resolve.out
@@ -6,6 +6,10 @@ CREATE OR REPLACE FUNCTION create_records()
 RETURNS VOID
 AS :TSL_MODULE_PATHNAME, 'ts_test_remote_txn_resolve_create_records'
 LANGUAGE C;
+CREATE OR REPLACE FUNCTION create_prepared_record()
+RETURNS VOID
+AS :TSL_MODULE_PATHNAME, 'ts_test_remote_txn_resolve_create_prepared_record'
+LANGUAGE C;
 CREATE OR REPLACE FUNCTION create_records_with_concurrent_heal()
 RETURNS VOID
 AS :TSL_MODULE_PATHNAME, 'ts_test_remote_txn_resolve_create_records_with_concurrent_heal'
@@ -137,6 +141,187 @@ SELECT count(*) FROM _timescaledb_catalog.remote_txn;
      1
 (1 row)
 
+SELECT create_records();
+ create_records 
+----------------
+ 
+(1 row)
+
+-- create an additional prepared entry. This will allow us to test heal behavior when one
+-- attempt errors out and when the other should succeed. The debug_inject_gid_error logic
+-- only induces one error for now. This can be modified later as desired via another
+-- session variable.
+SELECT create_prepared_record();
+ create_prepared_record 
+------------------------
+ 
+(1 row)
+
+--inject errors in the GID and test "commit" resolution for it
+SET timescaledb.debug_inject_gid_error TO 'commit';
+--heal should error out and the prepared transaction should still be visible
+SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback2'));
+WARNING:  could not commit prepared transaction on data node "loopback2"
+ remote_txn_heal_data_node 
+---------------------------
+                         1
+(1 row)
+
+SELECT * FROM table_modified_by_txns;
+           describes            
+--------------------------------
+ committed
+ prepared not comitted
+ committed with concurrent heal
+ committed
+ prepared not comitted
+(5 rows)
+
+SELECT count(*) FROM pg_prepared_xacts;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.remote_txn;
+ count 
+-------
+     4
+(1 row)
+
+-- Again process 2 records where one errors out and other succeeds
+SELECT create_prepared_record();
+ create_prepared_record 
+------------------------
+ 
+(1 row)
+
+--inject errors in the GID and test "abort" resolution for it
+SET timescaledb.debug_inject_gid_error TO 'abort';
+--heal should error out and the prepared transaction should still be visible
+SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback2'));
+WARNING:  could not roll back prepared transaction on data node "loopback2"
+ remote_txn_heal_data_node 
+---------------------------
+                         1
+(1 row)
+
+SELECT * FROM table_modified_by_txns;
+           describes            
+--------------------------------
+ committed
+ prepared not comitted
+ committed with concurrent heal
+ committed
+ prepared not comitted
+ prepared not comitted
+(6 rows)
+
+SELECT count(*) FROM pg_prepared_xacts;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.remote_txn;
+ count 
+-------
+     4
+(1 row)
+
+-- Again process 2 records where one errors out and other succeeds
+SELECT create_prepared_record();
+ create_prepared_record 
+------------------------
+ 
+(1 row)
+
+--test "inprogress" resolution for the prepared 2PC
+SET timescaledb.debug_inject_gid_error TO 'inprogress';
+--heal will not error out but the prepared transaction should still be visible
+SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback2'));
+ remote_txn_heal_data_node 
+---------------------------
+                         1
+(1 row)
+
+SELECT * FROM table_modified_by_txns;
+           describes            
+--------------------------------
+ committed
+ prepared not comitted
+ committed with concurrent heal
+ committed
+ prepared not comitted
+ prepared not comitted
+ prepared not comitted
+(7 rows)
+
+SELECT count(*) FROM pg_prepared_xacts;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.remote_txn;
+ count 
+-------
+     4
+(1 row)
+
+-- Again process 2 records where one errors out and other succeeds
+SELECT create_prepared_record();
+ create_prepared_record 
+------------------------
+ 
+(1 row)
+
+--set to any random value so that it does not have any effect and allows healing
+SET timescaledb.debug_inject_gid_error TO 'ignored';
+SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback'));
+ remote_txn_heal_data_node 
+---------------------------
+                         2
+(1 row)
+
+SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback2'));
+ remote_txn_heal_data_node 
+---------------------------
+                         0
+(1 row)
+
+SELECT _timescaledb_internal.remote_txn_heal_data_node((SELECT OID FROM pg_foreign_server WHERE srvname = 'loopback3'));
+ remote_txn_heal_data_node 
+---------------------------
+                         0
+(1 row)
+
+SELECT * FROM table_modified_by_txns;
+           describes            
+--------------------------------
+ committed
+ prepared not comitted
+ committed with concurrent heal
+ committed
+ prepared not comitted
+ prepared not comitted
+ prepared not comitted
+ prepared not comitted
+ prepared not comitted
+(9 rows)
+
+SELECT count(*) FROM pg_prepared_xacts;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM _timescaledb_catalog.remote_txn;
+ count 
+-------
+     0
+(1 row)
+
 --test that it is safe to have non-ts prepared-txns with heal
 BEGIN;
     INSERT INTO public.table_modified_by_txns VALUES ('non-ts-txn');
@@ -169,8 +354,14 @@ SELECT * FROM table_modified_by_txns;
  committed
  prepared not comitted
  committed with concurrent heal
+ committed
+ prepared not comitted
+ prepared not comitted
+ prepared not comitted
+ prepared not comitted
+ prepared not comitted
  non-ts-txn
-(4 rows)
+(10 rows)
 
 SELECT count(*) FROM pg_prepared_xacts;
  count 

--- a/tsl/test/src/remote/txn_persistent_record.c
+++ b/tsl/test/src/remote/txn_persistent_record.c
@@ -23,10 +23,17 @@ test_basic_persistent_record(TSConnectionId cid)
 	RemoteTxnId *id = remote_txn_id_create(GetTopTransactionId(), cid);
 
 	TestAssertTrue(!remote_txn_persistent_record_exists(id));
+
 	remote_txn_persistent_record_write(cid);
 	TestAssertTrue(remote_txn_persistent_record_exists(id));
+	/* delete by just specifying the data node */
+	remote_txn_persistent_record_delete_for_data_node(cid.server_id, NULL);
+	TestAssertTrue(!remote_txn_persistent_record_exists(id));
 
-	remote_txn_persistent_record_delete_for_data_node(cid.server_id);
+	remote_txn_persistent_record_write(cid);
+	TestAssertTrue(remote_txn_persistent_record_exists(id));
+	/* delete by specifying the exact GID */
+	remote_txn_persistent_record_delete_for_data_node(cid.server_id, remote_txn_id_out(id));
 	TestAssertTrue(!remote_txn_persistent_record_exists(id));
 }
 

--- a/tsl/test/src/remote/txn_resolve.c
+++ b/tsl/test/src/remote/txn_resolve.c
@@ -13,6 +13,7 @@
 #include "test_utils.h"
 
 TS_FUNCTION_INFO_V1(ts_test_remote_txn_resolve_create_records);
+TS_FUNCTION_INFO_V1(ts_test_remote_txn_resolve_create_prepared_record);
 TS_FUNCTION_INFO_V1(ts_test_remote_txn_resolve_create_records_with_concurrent_heal);
 
 static RemoteTxn *
@@ -64,6 +65,18 @@ ts_test_remote_txn_resolve_create_records(PG_FUNCTION_ARGS)
 
 	id.server_id = GetForeignServerByName("loopback3", false)->serverid;
 	create_rollback_prepared_txn(&id);
+
+	PG_RETURN_VOID();
+}
+
+/* create an additional prepared gid in a separate transaction */
+Datum
+ts_test_remote_txn_resolve_create_prepared_record(PG_FUNCTION_ARGS)
+{
+	TSConnectionId id;
+
+	id.server_id = GetForeignServerByName("loopback", false)->serverid;
+	create_prepared_txn(&id);
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
* A few tweaks to the remote txn resolution logic
* Add logic to delete a specific record in remote_txn table by GID
* Allow heal logic to move on to other cleanup if one specific GID
fails
* Do not rely on ongoing txns while cleaning up entries from remote_txn
table

Includes test case changes to try out various failure scenarios in the
healing function.

Fixes #3219