### PR TITLE
Fix ALTER SET/DROP NULL contstraint on dist hypertable

### DIFF
--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -746,6 +746,8 @@ dist_ddl_process_alter_table(const ProcessUtilityArgs *args)
 			case AT_AddConstraintRecurse:
 			case AT_DropConstraint:
 			case AT_DropConstraintRecurse:
+			case AT_SetNotNull:
+			case AT_DropNotNull:
 			case AT_AddIndex:
 			case AT_AlterColumnType:
 				exec_type = set_alter_table_exec_type(exec_type, DIST_DDL_EXEC_ON_END);

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -5756,6 +5756,30 @@ SELECT compress_chunk(show_chunks) FROM show_chunks('test');
 (1 row)
 
 DROP TABLE test;
+-- Fix ALTER SET/DROP NULL contstraint on distributed hypertable
+--
+-- #3860
+--
+CREATE TABLE test (time timestamp NOT NULL, my_column int NOT NULL);
+SELECT create_distributed_hypertable('test','time');
+ create_distributed_hypertable 
+-------------------------------
+ (35,public,test,t)
+(1 row)
+
+\set ON_ERROR_STOP 0
+INSERT INTO test VALUES (now(), NULL);
+ERROR:  [db_dist_hypertable_3]: null value in column "my_column" violates not-null constraint
+\set ON_ERROR_STOP 1
+ALTER TABLE test ALTER COLUMN my_column DROP NOT NULL;
+INSERT INTO test VALUES (now(), NULL);
+\set ON_ERROR_STOP 0
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+ERROR:  [db_dist_hypertable_3]: column "my_column" contains null values
+\set ON_ERROR_STOP 1
+DELETE FROM test;
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+DROP TABLE test;
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -5755,6 +5755,30 @@ SELECT compress_chunk(show_chunks) FROM show_chunks('test');
 (1 row)
 
 DROP TABLE test;
+-- Fix ALTER SET/DROP NULL contstraint on distributed hypertable
+--
+-- #3860
+--
+CREATE TABLE test (time timestamp NOT NULL, my_column int NOT NULL);
+SELECT create_distributed_hypertable('test','time');
+ create_distributed_hypertable 
+-------------------------------
+ (35,public,test,t)
+(1 row)
+
+\set ON_ERROR_STOP 0
+INSERT INTO test VALUES (now(), NULL);
+ERROR:  [db_dist_hypertable_3]: null value in column "my_column" of relation "_dist_hyper_35_105_chunk" violates not-null constraint
+\set ON_ERROR_STOP 1
+ALTER TABLE test ALTER COLUMN my_column DROP NOT NULL;
+INSERT INTO test VALUES (now(), NULL);
+\set ON_ERROR_STOP 0
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+ERROR:  [db_dist_hypertable_3]: column "my_column" of relation "_dist_hyper_35_106_chunk" contains null values
+\set ON_ERROR_STOP 1
+DELETE FROM test;
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+DROP TABLE test;
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -5758,6 +5758,30 @@ SELECT compress_chunk(show_chunks) FROM show_chunks('test');
 (1 row)
 
 DROP TABLE test;
+-- Fix ALTER SET/DROP NULL contstraint on distributed hypertable
+--
+-- #3860
+--
+CREATE TABLE test (time timestamp NOT NULL, my_column int NOT NULL);
+SELECT create_distributed_hypertable('test','time');
+ create_distributed_hypertable 
+-------------------------------
+ (35,public,test,t)
+(1 row)
+
+\set ON_ERROR_STOP 0
+INSERT INTO test VALUES (now(), NULL);
+ERROR:  [db_dist_hypertable_3]: null value in column "my_column" of relation "_dist_hyper_35_105_chunk" violates not-null constraint
+\set ON_ERROR_STOP 1
+ALTER TABLE test ALTER COLUMN my_column DROP NOT NULL;
+INSERT INTO test VALUES (now(), NULL);
+\set ON_ERROR_STOP 0
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+ERROR:  [db_dist_hypertable_3]: column "my_column" of relation "_dist_hyper_35_106_chunk" contains null values
+\set ON_ERROR_STOP 1
+DELETE FROM test;
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+DROP TABLE test;
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -1940,6 +1940,29 @@ INSERT INTO test VALUES (now(), 0);
 SELECT compress_chunk(show_chunks) FROM show_chunks('test');
 DROP TABLE test;
 
+-- Fix ALTER SET/DROP NULL contstraint on distributed hypertable
+--
+-- #3860
+--
+CREATE TABLE test (time timestamp NOT NULL, my_column int NOT NULL);
+SELECT create_distributed_hypertable('test','time');
+
+\set ON_ERROR_STOP 0
+INSERT INTO test VALUES (now(), NULL);
+\set ON_ERROR_STOP 1
+
+ALTER TABLE test ALTER COLUMN my_column DROP NOT NULL;
+INSERT INTO test VALUES (now(), NULL);
+
+\set ON_ERROR_STOP 0
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+\set ON_ERROR_STOP 1
+
+DELETE FROM test;
+ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
+
+DROP TABLE test;
+
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;


### PR DESCRIPTION
This change adds support for `ALTER TABLE SET/DROP NULL` commands
to the list of supported commands that can be run with
distributed hypertable.

Fix #3860