### PR TITLE
Fix race condition in deadlock_recompress_chunk

### DIFF
--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -3,9 +3,18 @@ set(TEST_TEMPLATES_MODULE reorder_deadlock.spec.in
                           reorder_vs_insert_other_chunk.spec.in)
 
 set(TEST_TEMPLATES_MODULE_DEBUG
-    deadlock_recompress_chunk.spec.in reorder_vs_insert.spec.in
-    reorder_vs_select.spec.in remote_create_chunk.spec.in
-    dist_restore_point.spec.in continuous_aggs_drop_chunks.spec.in)
+    reorder_vs_insert.spec.in reorder_vs_select.spec.in
+    remote_create_chunk.spec.in dist_restore_point.spec.in
+    continuous_aggs_drop_chunks.spec.in)
+
+# These tests are using markers for the isolation tests (to avoid race
+# conditions causing differing output), which were added after 12.7, 13.3, and
+# 14.0.
+if(PG_VERSION VERSION_GREATER "12.7"
+   OR PG_VERSION VERSION_GREATER "13.3"
+   OR PG_VERSION VERSION_GREATER_EQUAL "14.0")
+  list(APPEND TEST_TEMPLATES_MODULE_DEBUG deadlock_recompress_chunk.spec.in)
+endif()
 
 list(
   APPEND

--- a/tsl/test/isolation/specs/deadlock_recompress_chunk.spec.in
+++ b/tsl/test/isolation/specs/deadlock_recompress_chunk.spec.in
@@ -95,5 +95,5 @@ step "recompress_chunks_start" {
 		      
 # Since the locking order is different, we locking before reindex we should one one lock on the index and
 # one lock on the chunk from different processes.
-permutation "recompress_insert_rows" "lock_after_decompress" "recompress_chunks_start" "query_start" "unlock_after_decompress"
+permutation recompress_insert_rows lock_after_decompress recompress_chunks_start query_start(recompress_chunks_start) unlock_after_decompress
 


### PR DESCRIPTION
After the synchronizing lock is released and the transaction is
committed, both sessions are free to execute independently. This means
that the query can actually start running before the recompress step
has completed, which means that the order for completion is
non-deterministic.

We fix this by adding a marker so that the query is not reported as
completed until the recompress has finished execution. Since markers in
isolation tests is a recent thing, we only run the test for PostgreSQL
versions with markers added.

Part-Of: #3846