### PR TITLE
Use generic URL in windows package test

### DIFF
--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install TimescaleDB
       run: |
-        wget --quiet -O timescaledb.zip 'https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-${{ matrix.pg }}_${{ steps.version.outputs.version }}-windows-amd64.zip'
+        wget --quiet -O timescaledb.zip 'https://timescalereleases.blob.core.windows.net/windows/timescaledb-postgresql-${{ matrix.pg }}_latest-windows-amd64.zip'
         tar -xf timescaledb.zip
         cd timescaledb
         ./setup.exe -yes-tune -pgconfig "$HOME/PostgreSQL/${{ matrix.pg }}/bin/pg_config"


### PR DESCRIPTION
Change the windows package test to use an URL with latest instead
of explicit package version since this is what we use in docs.