### PR TITLE
Support compression policy on continuous aggregates

### DIFF
--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -9,7 +9,6 @@
 #include <miscadmin.h>
 #include <utils/builtins.h>
 
-#include "bgw/job.h"
 #include "compression_api.h"
 #include "errors.h"
 #include "hypertable.h"
@@ -17,7 +16,9 @@
 #include "policy_utils.h"
 #include "utils.h"
 #include "jsonb_utils.h"
+#include "bgw/job.h"
 #include "bgw_policy/job.h"
+#include "bgw_policy/continuous_aggregate_api.h"
 
 /*
  * Default scheduled interval for compress jobs = default chunk length.
@@ -43,6 +44,9 @@
 #define CONFIG_KEY_RECOMPRESS_AFTER "recompress_after"
 #define CONFIG_KEY_RECOMPRESS "recompress"
 #define CONFIG_KEY_MAXCHUNKS_TO_COMPRESS "maxchunks_to_compress"
+
+static Hypertable *validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid,
+													   bool *is_cagg);
 
 bool
 policy_compression_get_recompress(const Jsonb *config)
@@ -151,13 +155,35 @@ policy_recompression_proc(PG_FUNCTION_ARGS)
 	PG_RETURN_VOID();
 }
 
+static void
+validate_compress_after_type(Oid partitioning_type, Oid compress_after_type)
+{
+	Oid expected_type = InvalidOid;
+	if (IS_INTEGER_TYPE(partitioning_type))
+	{
+       if ( !IS_INTEGER_TYPE(compress_after_type))
+		  expected_type = partitioning_type;
+	}
+	else if (compress_after_type != INTERVALOID)
+	{
+		expected_type = INTERVALOID;
+	}
+	if (expected_type != InvalidOid)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("unsupported compress_after argument type, expected type : %s",
+						format_type_be(expected_type))));
+	}
+}
+
 Datum
 policy_compression_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
 	NameData proc_name, proc_schema, owner;
 	int32 job_id;
-	Oid ht_oid = PG_GETARG_OID(0);
+	Oid user_oid = PG_GETARG_OID(0);
 	Datum compress_after_datum = PG_GETARG_DATUM(1);
 	Oid compress_after_type = PG_ARGISNULL(1) ? InvalidOid : get_fn_expr_argtype(fcinfo->flinfo, 1);
 	bool if_not_exists = PG_GETARG_BOOL(2);
@@ -166,22 +192,14 @@ policy_compression_add(PG_FUNCTION_ARGS)
 	Cache *hcache;
 	const Dimension *dim;
 	Oid owner_id;
+	bool is_cagg = false;
 
 	TS_PREVENT_FUNC_IF_READ_ONLY();
 
-	/* check if this is a table with compression enabled */
-	hypertable = ts_hypertable_cache_get_cache_and_entry(ht_oid, CACHE_FLAG_NONE, &hcache);
+	hcache = ts_hypertable_cache_pin();
+	hypertable = validate_compress_chunks_hypertable(hcache, user_oid, &is_cagg);
 
-	if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(hypertable))
-	{
-		ts_cache_release(hcache);
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("compression not enabled on hypertable \"%s\"", get_rel_name(ht_oid)),
-				 errhint("Enable compression before adding a compression policy.")));
-	}
-
-	owner_id = ts_hypertable_permissions_check(ht_oid, GetUserId());
+	owner_id = ts_hypertable_permissions_check(user_oid, GetUserId());
 	ts_bgw_job_validate_job_owner(owner_id);
 
 	/* Make sure that an existing policy doesn't exist on this hypertable */
@@ -199,8 +217,9 @@ policy_compression_add(PG_FUNCTION_ARGS)
 			ts_cache_release(hcache);
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_OBJECT),
-					 errmsg("compression policy already exists for hypertable \"%s\"",
-							get_rel_name(ht_oid)),
+					 errmsg("compression policy already exists for hypertable or continuous "
+							"aggregate \"%s\"",
+							get_rel_name(user_oid)),
 					 errhint("Set option \"if_not_exists\" to true to avoid error.")));
 		}
 		Assert(list_length(jobs) == 1);
@@ -215,7 +234,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 			ts_cache_release(hcache);
 			ereport(NOTICE,
 					(errmsg("compression policy already exists for hypertable \"%s\", skipping",
-							get_rel_name(ht_oid))));
+							get_rel_name(user_oid))));
 			PG_RETURN_INT32(-1);
 		}
 		else
@@ -223,7 +242,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 			ts_cache_release(hcache);
 			ereport(WARNING,
 					(errmsg("compression policy already exists for hypertable \"%s\"",
-							get_rel_name(ht_oid)),
+							get_rel_name(user_oid)),
 					 errdetail("A policy already exists with different arguments."),
 					 errhint("Remove the existing policy before adding a new one.")));
 			PG_RETURN_INT32(-1);
@@ -246,7 +265,7 @@ policy_compression_add(PG_FUNCTION_ARGS)
 
 	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
 	ts_jsonb_add_int32(parse_state, CONFIG_KEY_HYPERTABLE_ID, hypertable->fd.id);
-
+	validate_compress_after_type(partitioning_type, compress_after_type);
 	switch (compress_after_type)
 	{
 		case INTERVALOID:
@@ -275,6 +294,20 @@ policy_compression_add(PG_FUNCTION_ARGS)
 					 errmsg("unsupported datatype for %s: %s",
 							CONFIG_KEY_COMPRESS_AFTER,
 							format_type_be(compress_after_type))));
+	}
+	/* If this is a compression policy for a cagg, verify that
+	 * compress_after > refresh_start of cagg policy. We do not want
+	 * to compress regions that can eb refreshed by the cagg policy.
+	 */
+	if (is_cagg && !policy_refresh_cagg_refresh_start_lt(hypertable->fd.id,
+														 compress_after_type,
+														 compress_after_datum))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("compress_after value for compression policy should be greater than the "
+						"start of the refresh window of continuous aggregate policy for %s",
+						get_rel_name(user_oid))));
 	}
 
 	JsonbValue *result = pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);
@@ -339,4 +372,76 @@ policy_compression_remove(PG_FUNCTION_ARGS)
 	ts_bgw_job_delete_by_id(job->fd.id);
 
 	PG_RETURN_BOOL(true);
+}
+
+/* compare cagg job config  with compression job config. If there is an overlap, then
+ * throw an error. We do this since we cannot refresh compressed
+ * regions. We do not want cont. aggregate jobs to fail
+ */
+
+/* If this is a cagg, then mark it as a cagg */
+static Hypertable *
+validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg)
+{
+	ContinuousAggHypertableStatus status;
+	Hypertable *ht = ts_hypertable_cache_get_entry(hcache, user_htoid, true /* missing_ok */);
+	*is_cagg = false;
+
+	if (ht != NULL)
+	{
+		if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
+		{
+			ts_cache_release(hcache);
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("compression not enabled on hypertable \"%s\"",
+							get_rel_name(user_htoid)),
+					 errhint("Enable compression before adding a compression policy.")));
+		}
+		status = ts_continuous_agg_hypertable_status(ht->fd.id);
+		if ((status == HypertableIsMaterialization || status == HypertableIsMaterializationAndRaw))
+		{
+			ts_cache_release(hcache);
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("cannot add compression policy to materialized hypertable \"%s\" ",
+							get_rel_name(user_htoid)),
+					 errhint("Please add the policy to the corresponding continuous aggregate "
+							 "instead.")));
+		}
+	}
+	else
+	{
+		/*check if this is a cont aggregate view */
+		int32 mat_id;
+		bool found;
+
+		ContinuousAgg *cagg = ts_continuous_agg_find_by_relid(user_htoid);
+
+		if (cagg == NULL)
+		{
+			ts_cache_release(hcache);
+			ereport(ERROR,
+					(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
+					 errmsg("\"%s\" is not a hypertable or a continuous aggregate",
+							get_rel_name(user_htoid))));
+		}
+		*is_cagg = true;
+		mat_id = cagg->data.mat_hypertable_id;
+		ht = ts_hypertable_get_by_id(mat_id);
+
+		found = policy_refresh_cagg_exists(mat_id);
+		if (!found)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("continuous aggregate policy does not exist for \"%s\"",
+							get_rel_name(user_htoid)),
+					 errmsg("setup a refresh policy for \"%s\" before setting up a compression "
+							"policy",
+							get_rel_name(user_htoid))));
+		}
+	}
+	Assert(ht != NULL);
+	return ht;
 }

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -15,6 +15,7 @@
 #include <utils/builtins.h>
 #include "bgw_policy/continuous_aggregate_api.h"
 #include "bgw_policy/job.h"
+#include "bgw_policy/policy_utils.h"
 #include "bgw/job.h"
 #include "continuous_agg.h"
 #include "continuous_aggs/materialize.h"
@@ -130,6 +131,84 @@ policy_refresh_cagg_get_refresh_end(const Dimension *dim, const Jsonb *config)
 	if (end_isnull)
 		return ts_time_get_end_or_max(ts_dimension_get_partition_type(dim));
 	return res;
+}
+
+/* returns false if a policy could not be found */
+bool
+policy_refresh_cagg_exists(int32 materialization_id)
+{
+	Hypertable *mat_ht = ts_hypertable_get_by_id(materialization_id);
+
+	if (!mat_ht)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("configuration materialization hypertable id %d not found",
+						materialization_id)));
+
+	List *jobs = ts_bgw_job_find_by_proc_and_hypertable_id(POLICY_REFRESH_CAGG_PROC_NAME,
+														   INTERNAL_SCHEMA_NAME,
+														   materialization_id);
+	if (jobs == NIL)
+		return false;
+
+	/* only 1 cont. aggregate policy job allowed */
+	Assert(list_length(jobs) == 1);
+	return true;
+}
+
+/* Compare passed in interval value with refresh_start parameter
+ * of cagg policy.
+ */
+bool
+policy_refresh_cagg_refresh_start_lt(int32 materialization_id, Oid cmp_type, Datum cmp_interval)
+{
+	Hypertable *mat_ht = ts_hypertable_get_by_id(materialization_id);
+	bool ret = false;
+
+	if (!mat_ht)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("configuration materialization hypertable id %d not found",
+						materialization_id)));
+
+	List *jobs = ts_bgw_job_find_by_proc_and_hypertable_id(POLICY_REFRESH_CAGG_PROC_NAME,
+														   INTERNAL_SCHEMA_NAME,
+														   materialization_id);
+	if (jobs == NIL)
+		return false;
+
+	/* only 1 cont. aggregate policy job allowed */
+	BgwJob *cagg_job = linitial(jobs);
+	Jsonb *cagg_config = cagg_job->fd.config;
+
+	const Dimension *open_dim = get_open_dimension_for_hypertable(mat_ht);
+	Oid dim_type = ts_dimension_get_partition_type(open_dim);
+	if (IS_INTEGER_TYPE(dim_type))
+	{
+		bool found;
+		Assert(IS_INTEGER_TYPE(cmp_type));
+		int64 cmpval = ts_interval_value_to_internal(cmp_interval, cmp_type);
+		int64 refresh_start =
+			ts_jsonb_get_int64_field(cagg_config, CONFIG_KEY_START_OFFSET, &found);
+		if (!found) /*this is a null value. NULL compares to false */
+			return false;
+		Datum res =
+			DirectFunctionCall2(int8lt, Int64GetDatum(refresh_start), Int64GetDatum(cmpval));
+		ret = DatumGetBool(res);
+	}
+	else if
+		IS_TIMESTAMP_TYPE(dim_type)
+		{
+			Assert(cmp_type == INTERVALOID);
+			Interval *refresh_start =
+				ts_jsonb_get_interval_field(cagg_config, CONFIG_KEY_START_OFFSET);
+			if (refresh_start == NULL) /* NULL compares to false */
+				return false;
+			Datum res =
+				DirectFunctionCall2(interval_lt, IntervalPGetDatum(refresh_start), cmp_interval);
+			ret = DatumGetBool(res);
+		}
+	return ret;
 }
 
 Datum

--- a/tsl/src/bgw_policy/continuous_aggregate_api.h
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.h
@@ -10,6 +10,7 @@
 #include <postgres.h>
 #include <utils/jsonb.h>
 #include "dimension.h"
+#include <continuous_aggs/materialize.h>
 
 extern Datum policy_refresh_cagg_add(PG_FUNCTION_ARGS);
 extern Datum policy_refresh_cagg_proc(PG_FUNCTION_ARGS);
@@ -18,4 +19,8 @@ extern Datum policy_refresh_cagg_remove(PG_FUNCTION_ARGS);
 int32 policy_continuous_aggregate_get_mat_hypertable_id(const Jsonb *config);
 int64 policy_refresh_cagg_get_refresh_start(const Dimension *dim, const Jsonb *config);
 int64 policy_refresh_cagg_get_refresh_end(const Dimension *dim, const Jsonb *config);
+bool policy_refresh_cagg_refresh_start_lt(int32 materialization_id, Oid cmp_type,
+										  Datum cmp_interval);
+bool policy_refresh_cagg_exists(int32 materialization_id);
+
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_CAGG_API_H */

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -246,30 +246,6 @@ policy_reorder_read_and_validate_config(Jsonb *config, PolicyReorderData *policy
 	}
 }
 
-static const Dimension *
-get_open_dimension_for_hypertable(const Hypertable *ht)
-{
-	int32 mat_id = ht->fd.id;
-	const Dimension *open_dim = hyperspace_get_open_dimension(ht->space, 0);
-	Oid partitioning_type = ts_dimension_get_partition_type(open_dim);
-	if (IS_INTEGER_TYPE(partitioning_type))
-	{
-		/* if this a materialization hypertable related to cont agg
-		 * then need to get the right dimension which has
-		 * integer_now function
-		 */
-
-		open_dim = ts_continuous_agg_find_integer_now_func_by_materialization_id(mat_id);
-		if (open_dim == NULL)
-		{
-			elog(ERROR,
-				 "missing integer_now function for hypertable \"%s\" ",
-				 get_rel_name(ht->main_table_relid));
-		}
-	}
-	return open_dim;
-}
-
 bool
 policy_retention_execute(int32 job_id, Jsonb *config)
 {

--- a/tsl/src/bgw_policy/policy_utils.h
+++ b/tsl/src/bgw_policy/policy_utils.h
@@ -13,4 +13,5 @@ bool policy_config_check_hypertable_lag_equality(Jsonb *config, const char *json
 int64 subtract_integer_from_now_internal(int64 interval, Oid time_dim_type, Oid now_func,
 										 bool *overflow);
 Datum subtract_interval_from_now(Interval *interval, Oid time_dim_type);
+const Dimension *get_open_dimension_for_hypertable(const Hypertable *ht);
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_UTILS_H */

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -90,7 +90,7 @@ NOTICE:  compression policy already exists for hypertable "conditions", skipping
 (1 row)
 
 select add_compression_policy('conditions', '60d'::interval);
-ERROR:  compression policy already exists for hypertable "conditions"
+ERROR:  compression policy already exists for hypertable or continuous aggregate "conditions"
 select add_compression_policy('conditions', '30d'::interval, if_not_exists=>true);
 WARNING:  compression policy already exists for hypertable "conditions"
  add_compression_policy 

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -618,8 +618,40 @@ select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \g
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
 ERROR:  configuration materialization hypertable id 1000 not found
-\set ON_ERROR_STOP 1
 --test creating continuous aggregate with compression enabled --
 CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.compress)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
 ERROR:  cannot enable compression while creating a continuous aggregate
+--this one succeeds
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous)
+AS SELECT time_bucket('1h',time) as bucket, avg(7) FROM i2980 GROUP BY 1;
+NOTICE:  continuous aggregate "i2980_cagg2" is already up-to-date
+--now enable compression with invalid parameters
+ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, 
+timescaledb.compress_segmentby = 'bucket');
+ERROR:  unrecognized parameter "timescaledb.compress_segmentby"
+ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, 
+timescaledb.compress_orderby = 'bucket');
+ERROR:  unrecognized parameter "timescaledb.compress_orderby"
+--enable compression and trigger compression policy errors
+ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress);
+--Errors with compression policy on caggs--
+select add_continuous_aggregate_policy('i2980_cagg2', interval '10 day', interval '2 day' ,'4h') AS job_id ;
+ job_id 
+--------
+   1002
+(1 row)
+
+--this one fails as i2980_cagg refresh policy is (NULL, NULL)
+SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
+ERROR:  compress_after value for compression policy should be greater than the start of the refresh window of continuous aggregate policy for i2980_cagg
+SELECT add_continuous_aggregate_policy('i2980_cagg2', '10 day'::interval, '6 day'::interval);
+ERROR:  function add_continuous_aggregate_policy(unknown, interval, interval) does not exist at character 8
+SELECT add_compression_policy('i2980_cagg2', '3 day'::interval);
+ERROR:  compress_after value for compression policy should be greater than the start of the refresh window of continuous aggregate policy for i2980_cagg2
+SELECT add_compression_policy('i2980_cagg2', '1 day'::interval);
+ERROR:  compress_after value for compression policy should be greater than the start of the refresh window of continuous aggregate policy for i2980_cagg2
+SELECT add_compression_policy('i2980_cagg2', '3'::integer);
+ERROR:  unsupported compress_after argument type, expected type : interval
+SELECT add_compression_policy('i2980_cagg2', 13::integer);
+ERROR:  unsupported compress_after argument type, expected type : interval

--- a/tsl/test/expected/continuous_aggs_policy.out
+++ b/tsl/test/expected/continuous_aggs_policy.out
@@ -508,3 +508,99 @@ SELECT * FROM mat_bigint WHERE a>100 ORDER BY 1;
 (1 row)
 
 -- end of coverage tests
+--TEST continuous aggregate + compression policy on caggs
+CREATE TABLE metrics (
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 int,
+    v2 float,
+    v3 float
+);
+SELECT create_hypertable('metrics', 'time');
+   create_hypertable   
+-----------------------
+ (11,public,metrics,t)
+(1 row)
+
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-02 23:55:00+0', '20m') gtime (time), 
+    generate_series(1, 2, 1) gdevice (device_id);
+ALTER TABLE metrics SET ( timescaledb.compress );
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_11_19_chunk
+(1 row)
+
+CREATE MATERIALIZED VIEW metrics_cagg WITH (timescaledb.continuous,
+  timescaledb.materialized_only = true)
+AS
+SELECT time_bucket('1 day', time) as dayb, device_id,
+       sum(v0), avg(v3)
+FROM metrics
+GROUP BY 1, 2
+WITH NO DATA;
+ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
+--can set compression policy only after setting up refresh policy --
+\set ON_ERROR_STOP 0
+SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
+ERROR:  setup a refresh policy for "metrics_cagg" before setting up a compression policy
+\set ON_ERROR_STOP 1
+SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
+SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" \gset 
+--verify that jobs were added for the policies ---
+SELECT materialization_hypertable_schema AS "MAT_SCHEMA_NAME",
+       materialization_hypertable_name AS "MAT_TABLE_NAME",
+       materialization_hypertable_schema || '.' || materialization_hypertable_name AS "MAT_NAME"
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name = 'metrics_cagg' \gset
+SELECT count(*) FROM timescaledb_information.jobs
+WHERE hypertable_name = :'MAT_TABLE_NAME';
+ count 
+-------
+     2
+(1 row)
+
+--exec the cagg compression job --
+CALL refresh_continuous_aggregate('metrics_cagg', NULL, '2001-02-01 00:00:00+0');
+CALL run_job(:COMP_JOB);
+SELECT count(*), count(*) FILTER ( WHERE is_compressed is TRUE  )
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'MAT_TABLE_NAME' ORDER BY 1;
+ count | count 
+-------+-------
+     1 |     1
+(1 row)
+
+--add some new data into metrics_cagg so that cagg policy job has something to do
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT now() - '5 day'::interval, 102, 0, 10, 10, 10, 10;
+CALL run_job(:REFRESH_JOB);
+--now we have a new chunk and it is not compressed
+SELECT count(*), count(*) FILTER ( WHERE is_compressed is TRUE  )
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'MAT_TABLE_NAME' ORDER BY 1;
+ count | count 
+-------+-------
+     2 |     1
+(1 row)
+
+--verify that both jobs are dropped when view is dropped
+DROP MATERIALIZED VIEW metrics_cagg;
+NOTICE:  drop cascades to 2 other objects
+SELECT count(*) FROM timescaledb_information.jobs
+WHERE hypertable_name = :'MAT_TABLE_NAME';
+ count 
+-------
+     0
+(1 row)
+

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -707,7 +707,7 @@ NOTICE:  compression policy already exists for hypertable "conditions", skipping
 (1 row)
 
 select add_compression_policy('conditions', '60d'::interval);
-ERROR:  compression policy already exists for hypertable "conditions"
+ERROR:  compression policy already exists for hypertable or continuous aggregate "conditions"
 select add_compression_policy('conditions', '30d'::interval, if_not_exists=>true);
 WARNING:  compression policy already exists for hypertable "conditions"
  add_compression_policy 

--- a/tsl/test/sql/continuous_aggs_errors.sql
+++ b/tsl/test/sql/continuous_aggs_errors.sql
@@ -540,8 +540,32 @@ create materialized view i2980_cagg with (timescaledb.continuous) AS SELECT time
 select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \gset
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
-\set ON_ERROR_STOP 1
 
 --test creating continuous aggregate with compression enabled --
 CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.compress)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
+
+--this one succeeds
+CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous)
+AS SELECT time_bucket('1h',time) as bucket, avg(7) FROM i2980 GROUP BY 1;
+
+--now enable compression with invalid parameters
+ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, 
+timescaledb.compress_segmentby = 'bucket');
+
+ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, 
+timescaledb.compress_orderby = 'bucket');
+
+--enable compression and trigger compression policy errors
+ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress);
+
+--Errors with compression policy on caggs--
+select add_continuous_aggregate_policy('i2980_cagg2', interval '10 day', interval '2 day' ,'4h') AS job_id ;
+--this one fails as i2980_cagg refresh policy is (NULL, NULL)
+SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
+
+SELECT add_continuous_aggregate_policy('i2980_cagg2', '10 day'::interval, '6 day'::interval);
+SELECT add_compression_policy('i2980_cagg2', '3 day'::interval);
+SELECT add_compression_policy('i2980_cagg2', '1 day'::interval);
+SELECT add_compression_policy('i2980_cagg2', '3'::integer);
+SELECT add_compression_policy('i2980_cagg2', 13::integer);

--- a/tsl/test/sql/continuous_aggs_policy.sql
+++ b/tsl/test/sql/continuous_aggs_policy.sql
@@ -291,3 +291,82 @@ CALL run_job(:job_id);
 SELECT * FROM mat_bigint WHERE a>100 ORDER BY 1;
 
 -- end of coverage tests
+
+--TEST continuous aggregate + compression policy on caggs
+CREATE TABLE metrics (
+    time timestamptz NOT NULL,
+    device_id int,
+    device_id_peer int,
+    v0 int,
+    v1 int,
+    v2 float,
+    v3 float
+);
+
+SELECT create_hypertable('metrics', 'time');
+
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-02 23:55:00+0', '20m') gtime (time), 
+    generate_series(1, 2, 1) gdevice (device_id);
+
+ALTER TABLE metrics SET ( timescaledb.compress );
+SELECT compress_chunk(ch) FROM show_chunks('metrics') ch;
+
+CREATE MATERIALIZED VIEW metrics_cagg WITH (timescaledb.continuous,
+  timescaledb.materialized_only = true)
+AS
+SELECT time_bucket('1 day', time) as dayb, device_id,
+       sum(v0), avg(v3)
+FROM metrics
+GROUP BY 1, 2
+WITH NO DATA;
+
+ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
+
+--can set compression policy only after setting up refresh policy --
+\set ON_ERROR_STOP 0
+SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
+\set ON_ERROR_STOP 1
+
+SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
+SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" \gset 
+
+--verify that jobs were added for the policies ---
+SELECT materialization_hypertable_schema AS "MAT_SCHEMA_NAME",
+       materialization_hypertable_name AS "MAT_TABLE_NAME",
+       materialization_hypertable_schema || '.' || materialization_hypertable_name AS "MAT_NAME"
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name = 'metrics_cagg' \gset
+
+SELECT count(*) FROM timescaledb_information.jobs
+WHERE hypertable_name = :'MAT_TABLE_NAME';
+
+--exec the cagg compression job --
+CALL refresh_continuous_aggregate('metrics_cagg', NULL, '2001-02-01 00:00:00+0');
+CALL run_job(:COMP_JOB);
+SELECT count(*), count(*) FILTER ( WHERE is_compressed is TRUE  )
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'MAT_TABLE_NAME' ORDER BY 1;
+
+--add some new data into metrics_cagg so that cagg policy job has something to do
+INSERT INTO metrics (time, device_id, device_id_peer, v0, v1, v2, v3)
+SELECT now() - '5 day'::interval, 102, 0, 10, 10, 10, 10;
+CALL run_job(:REFRESH_JOB);
+--now we have a new chunk and it is not compressed
+SELECT count(*), count(*) FILTER ( WHERE is_compressed is TRUE  )
+FROM timescaledb_information.chunks
+WHERE hypertable_name = :'MAT_TABLE_NAME' ORDER BY 1;
+
+--verify that both jobs are dropped when view is dropped
+DROP MATERIALIZED VIEW metrics_cagg;
+
+SELECT count(*) FROM timescaledb_information.jobs
+WHERE hypertable_name = :'MAT_TABLE_NAME';
+


### PR DESCRIPTION
Move code from job.c to policy_utils.c
Add support functions to check compression
policy validity for continuous aggregates.
Add compression policy tests for caggs