### PR TITLE
Add shm_mq_send_compat() macro for compatibility with PG15

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -24,19 +24,28 @@
 #define is_supported_pg_version_12(version) ((version >= 120000) && (version < 130000))
 #define is_supported_pg_version_13(version) ((version >= 130002) && (version < 140000))
 #define is_supported_pg_version_14(version) ((version >= 140000) && (version < 150000))
+#define is_supported_pg_version_15(version) ((version >= 150000) && (version < 160000))
 
+/*
+ * PG15 is in fact not yet supported, but we are working on this. The user will
+ * be unable to compile aginst this version unless he/she explicitly uses
+ * -DEXPERIMENTAL=ON. This is checked by our CMakeLists.txt.
+ */
 #define is_supported_pg_version(version)                                                           \
 	(is_supported_pg_version_12(version) || is_supported_pg_version_13(version) ||                 \
-	 is_supported_pg_version_14(version))
+	 is_supported_pg_version_14(version) || is_supported_pg_version_15(version))
 
 #define PG12 is_supported_pg_version_12(PG_VERSION_NUM)
 #define PG13 is_supported_pg_version_13(PG_VERSION_NUM)
 #define PG14 is_supported_pg_version_14(PG_VERSION_NUM)
+#define PG15 is_supported_pg_version_15(PG_VERSION_NUM)
 
 #define PG13_LT (PG_VERSION_NUM < 130000)
 #define PG13_GE (PG_VERSION_NUM >= 130000)
 #define PG14_LT (PG_VERSION_NUM < 140000)
 #define PG14_GE (PG_VERSION_NUM >= 140000)
+#define PG15_LT (PG_VERSION_NUM < 150000)
+#define PG15_GE (PG_VERSION_NUM >= 150000)
 
 #if !(is_supported_pg_version(PG_VERSION_NUM))
 #error "Unsupported PostgreSQL version"
@@ -458,6 +467,22 @@ get_reindex_options(ReindexStmt *stmt)
 #define TYPALIGN_SHORT 's'  /* short alignment (typically 2 bytes) */
 #define TYPALIGN_INT 'i'	/* int alignment (typically 4 bytes) */
 #define TYPALIGN_DOUBLE 'd' /* double alignment (often 8 bytes) */
+#endif
+
+/*
+ * PG15 added additional `force_flush` argument to shm_mq_send().
+ *
+ * Our _compat() version currently uses force_flush = true on PG15 to preseve
+ * the same behaviour on all supported PostgreSQL versions.
+ *
+ * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=46846433
+ */
+#if PG15
+#define shm_mq_send_compat(shm_mq_handle, nbytes, data, nowait)                                    \
+	shm_mq_send(shm_mq_handle, nbytes, data, nowait, true)
+#else
+#define shm_mq_send_compat(shm_mq_handle, nbytes, data, nowait)                                    \
+	shm_mq_send(shm_mq_handle, nbytes, data, nowait)
 #endif
 
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/src/loader/bgw_message_queue.c
+++ b/src/loader/bgw_message_queue.c
@@ -376,7 +376,7 @@ send_ack(dsm_segment *seg, bool success)
 	/* Send the message off, non blocking, with retries */
 	for (n = 1; n <= BGW_ACK_RETRIES; n++)
 	{
-		ack_res = shm_mq_send(ack_queue_handle, sizeof(bool), &success, true);
+		ack_res = shm_mq_send_compat(ack_queue_handle, sizeof(bool), &success, true);
 		if (ack_res != SHM_MQ_WOULD_BLOCK)
 			break;
 		ereport(DEBUG1, (errmsg("TimescaleDB ack message send failure, retrying")));


### PR DESCRIPTION
There was an additional argument added to shm_mq_send() in the upstream. This
patch adds a corresponding _compat() macro to be able to compile against
future versions of PostgreSQL. Better handle this now than solve a bunch of
problems one year later.

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=46846433