### PR TITLE
Use compat.h version of FirstBootstrapObjectId

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -485,4 +485,15 @@ get_reindex_options(ReindexStmt *stmt)
 	shm_mq_send(shm_mq_handle, nbytes, data, nowait)
 #endif
 
+/*
+ * The macro FirstBootstrapObjectId was renamed in PG15.
+ *
+ * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=a49d0812
+ */
+#if PG15
+#define FirstBootstrapObjectIdCompat FirstUnpinnedObjectId
+#else
+#define FirstBootstrapObjectIdCompat FirstBootstrapObjectId
+#endif
+
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/tsl/src/deparse.c
+++ b/tsl/src/deparse.c
@@ -179,7 +179,7 @@ deparse_columns(StringInfo stmt, Relation rel)
 		 * if it's not a builtin type then schema qualify the same. There's a function
 		 * deparse_type_name in fdw, but we don't want cross linking unnecessarily
 		 */
-		if (attr->atttypid >= FirstBootstrapObjectId)
+		if (attr->atttypid >= FirstBootstrapObjectIdCompat)
 			flags |= FORMAT_TYPE_FORCE_QUALIFY;
 
 		appendStringInfo(stmt,

--- a/tsl/src/fdw/shippable.c
+++ b/tsl/src/fdw/shippable.c
@@ -160,7 +160,7 @@ lookup_shippable(Oid objectId, Oid classId, TsFdwRelInfo *fpinfo)
 bool
 is_builtin(Oid objectId)
 {
-	return (objectId < FirstBootstrapObjectId);
+	return (objectId < FirstBootstrapObjectIdCompat);
 }
 
 /*


### PR DESCRIPTION
The macro FirstBootstrapObjectId was renamed in the upstream. This patch adds
a corresponding FirstBootstrapObjectIdCompat macro to compat.h and uses it
instead of FirstBootstrapObjectId. This will allow us to compile agains PG15.

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=a49d0812