### PR TITLE
Remove C language recompress_chunk 

### DIFF
--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -67,7 +67,6 @@ CROSSMODULE_WRAPPER(array_compressor_append);
 CROSSMODULE_WRAPPER(array_compressor_finish);
 CROSSMODULE_WRAPPER(compress_chunk);
 CROSSMODULE_WRAPPER(decompress_chunk);
-CROSSMODULE_WRAPPER(recompress_chunk);
 
 /* continous aggregate */
 CROSSMODULE_WRAPPER(continuous_agg_invalidation_trigger);
@@ -390,7 +389,6 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.process_compress_table = process_compress_table_default,
 	.compress_chunk = error_no_default_fn_pg_community,
 	.decompress_chunk = error_no_default_fn_pg_community,
-	.recompress_chunk = error_no_default_fn_pg_community,
 	.compressed_data_decompress_forward = error_no_default_fn_pg_community,
 	.compressed_data_decompress_reverse = error_no_default_fn_pg_community,
 	.deltadelta_compressor_append = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -124,7 +124,6 @@ typedef struct CrossModuleFunctions
 	void (*process_rename_cmd)(Oid relid, Cache *hcache, const RenameStmt *stmt);
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
-	PGFunction recompress_chunk;
 	/* The compression functions below are not installed in SQL as part of create extension;
 	 *  They are installed and tested during testing scripts. They are exposed in cross-module
 	 *  functions because they may be very useful for debugging customer problems if the sql

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -162,7 +162,6 @@ CrossModuleFunctions tsl_cm_functions = {
 	.process_rename_cmd = tsl_process_rename_cmd,
 	.compress_chunk = tsl_compress_chunk,
 	.decompress_chunk = tsl_decompress_chunk,
-	.recompress_chunk = tsl_recompress_chunk,
 	.compress_row_init = compress_row_init,
 	.compress_row_exec = compress_row_exec,
 	.compress_row_end = compress_row_end,


### PR DESCRIPTION
Since we are re-implementing `recompress_chunk` as a PL/SQL function,
there is no need to keep the C language version around any more, so we
remove it from the code.