### PR TITLE
Add make_new_heap_compat() macro

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -477,7 +477,7 @@ get_reindex_options(ReindexStmt *stmt)
  *
  * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=46846433
  */
-#if PG15
+#if PG15_GE
 #define shm_mq_send_compat(shm_mq_handle, nbytes, data, nowait)                                    \
 	shm_mq_send(shm_mq_handle, nbytes, data, nowait, true)
 #else
@@ -490,10 +490,25 @@ get_reindex_options(ReindexStmt *stmt)
  *
  * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=a49d0812
  */
-#if PG15
+#if PG15_GE
 #define FirstBootstrapObjectIdCompat FirstUnpinnedObjectId
 #else
 #define FirstBootstrapObjectIdCompat FirstBootstrapObjectId
+#endif
+
+/*
+ * The number of arguments of make_new_heap() has changed in PG15. Note that
+ * on PostgreSQL <= 14 our _compat() version ignores the NewAccessMethod
+ * argument and uses the default access method.
+ *
+ * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b0483263
+ */
+#if PG15_GE
+#define make_new_heap_compat(tableOid, tableSpace, NewAccessMethod, relpersistence, ExclusiveLock) \
+	make_new_heap(tableOid, tableSpace, NewAccessMethod, relpersistence, ExclusiveLock)
+#else
+#define make_new_heap_compat(tableOid, tableSpace, _ignored, relpersistence, ExclusiveLock)        \
+	make_new_heap(tableOid, tableSpace, relpersistence, ExclusiveLock)
 #endif
 
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -569,7 +569,11 @@ timescale_rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose, Oid wai
 	table_close(OldHeap, NoLock);
 
 	/* Create the transient table that will receive the re-ordered data */
-	OIDNewHeap = make_new_heap(tableOid, tableSpace, relpersistence, ExclusiveLock);
+	OIDNewHeap = make_new_heap_compat(tableOid,
+									  tableSpace,
+									  OldHeap->rd_rel->relam,
+									  relpersistence,
+									  ExclusiveLock);
 
 	/* Copy the heap data into the new table in the desired order */
 	copy_heap_data(OIDNewHeap,


### PR DESCRIPTION
The number of arguments of make_new_heap() has changed in PG15. In order to be
able to compile against PostgreSQL 15 use a _compat() macro instead of the
direct function call.

 Also, it should have been #if PG15_GE, not #if PG15 - fix this too!

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b0483263