### PR TITLE
Fix segfault in Continuous Aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #4225 Fix TRUNCATE error as non-owner on hypertable
+* #3899 Fix segfault in Continuous Aggregates
 
 ## 2.6.1 (2022-04-11)
 This release is patch release. We recommend that you upgrade at the next available opportunity.

--- a/scripts/test_repairs.sh
+++ b/scripts/test_repairs.sh
@@ -3,6 +3,7 @@
 set -o pipefail
 
 SCRIPT_DIR=$(dirname $0)
+BASE_DIR=${PWD}/${SCRIPT_DIR}/..
 GIT_ID=$(git -C ${BASE_DIR} describe --dirty --always | sed -e "s|/|_|g")
 TEST_TMPDIR=${TEST_TMPDIR:-$(mktemp -d 2>/dev/null || mktemp -d -t 'timescaledb_repair_test' || mkdir -p /tmp/${RANDOM})}
 UPDATE_TO_IMAGE=${UPDATE_TO_IMAGE:-repair_test}
@@ -22,7 +23,7 @@ for tag in ${TAGS}; do
 done
 
 # Need to wait on each pid in a loop to return the exit status of each
-for pid in ${!tests[@]}; do
+for pid in "${!tests[@]}"; do
     echo "Waiting for test pid $pid"
     wait $pid
     exit_code=$?
@@ -32,10 +33,12 @@ for pid in ${!tests[@]}; do
         FAIL_COUNT=$((FAIL_COUNT + 1))
         FAILED_TEST=${tests[$pid]}
         if [ -f ${TEST_TMPDIR}/${FAILED_TEST}.log ]; then
-            echo "###### Failed test log below #####"
+            echo "###### Failed $UPDATE_TO_TAG test log below #####"
             cat ${TEST_TMPDIR}/${FAILED_TEST}.log
         fi
     fi
+    echo "###### test log $UPDATE_TO_TAG below #####"
+    cat ${TEST_TMPDIR}/${tests[$pid]}.log
 done
 
 if [ "$KEEP_TEMP_DIRS" = "false" ]; then

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -80,6 +80,7 @@ CROSSMODULE_WRAPPER(invalidation_hyper_log_add_entry);
 CROSSMODULE_WRAPPER(drop_dist_ht_invalidation_trigger);
 CROSSMODULE_WRAPPER(invalidation_process_hypertable_log);
 CROSSMODULE_WRAPPER(invalidation_process_cagg_log);
+CROSSMODULE_WRAPPER(cagg_try_repair);
 
 CROSSMODULE_WRAPPER(data_node_ping);
 CROSSMODULE_WRAPPER(data_node_block_new_chunks);
@@ -394,6 +395,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.remote_drop_dist_ht_invalidation_trigger = NULL,
 	.invalidation_process_hypertable_log = error_no_default_fn_pg_community,
 	.invalidation_process_cagg_log = error_no_default_fn_pg_community,
+	.cagg_try_repair = error_no_default_fn_pg_community,
 
 	/* compression */
 	.compressed_data_send = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -114,6 +114,7 @@ typedef struct CrossModuleFunctions
 	void (*remote_drop_dist_ht_invalidation_trigger)(int32 raw_hypertable_id);
 	PGFunction invalidation_process_hypertable_log;
 	PGFunction invalidation_process_cagg_log;
+	PGFunction cagg_try_repair;
 
 	PGFunction compressed_data_send;
 	PGFunction compressed_data_recv;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1092,3 +1092,24 @@ ts_get_node_name(Node *node)
 			return psprintf("Node (%d)", nodeTag(node));
 	}
 }
+
+/*
+ * Implementation marked unused in PostgreSQL lsyscache.c
+ */
+int
+ts_get_relnatts(Oid relid)
+{
+	HeapTuple tp;
+	Form_pg_class reltup;
+	int result;
+
+	tp = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+	if (!HeapTupleIsValid(tp))
+		return InvalidAttrNumber;
+
+	reltup = (Form_pg_class) GETSTRUCT(tp);
+	result = reltup->relnatts;
+
+	ReleaseSysCache(tp);
+	return result;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -195,5 +195,6 @@ typedef struct RelationSize
 extern TSDLLEXPORT RelationSize ts_relation_size_impl(Oid relid);
 
 extern TSDLLEXPORT const char *ts_get_node_name(Node *node);
+extern TSDLLEXPORT int ts_get_relnatts(Oid relid);
 
 #endif /* TIMESCALEDB_UTILS_H */

--- a/test/sql/updates/setup.repair.cagg.sql
+++ b/test/sql/updates/setup.repair.cagg.sql
@@ -1,0 +1,45 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- We want to check for inconsistent view generation for code coverage but we do not want to check
+-- for differences between clean and upgraded installation because we only issue warnings instead
+-- of actually repairing. As a result, if we run update tests instead of repair tests there would
+-- be differences and the update tests would fail.
+DO $$
+DECLARE
+ ts_version TEXT;
+BEGIN
+  SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
+  IF ts_version >= '2.0.0' AND ts_version < '2.7.0' THEN
+
+    CREATE TABLE conditions_v3 (
+          timec       TIMESTAMPTZ       NOT NULL,
+          temperature DOUBLE PRECISION  NULL,
+          humidity    DOUBLE PRECISION  NULL
+    );
+    PERFORM create_hypertable('conditions_v3', 'timec');
+
+    INSERT INTO conditions_v3
+    SELECT generate_series('2018-12-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 55, 75;
+    INSERT INTO conditions_v3
+    SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-31 00:00'::timestamp, '1 day'), 35, 45;
+    INSERT INTO conditions_v3
+    SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 73, 55;
+
+    -- Targets that contain Aggref nodes and Var nodes don't generate correct views before version 2.7.0
+    CREATE MATERIALIZED VIEW inconsistent_target
+    WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+      SELECT time_bucket('1 week', timec) AS bucket,
+      temperature,
+      CASE
+          WHEN temperature < 0 THEN (avg(humidity) + 10)
+          ELSE avg(humidity)
+      END AS problematic_target
+    FROM conditions_v3
+    GROUP BY bucket, temperature
+    WITH NO DATA;
+
+   END IF;
+END
+$$;

--- a/test/sql/updates/setup.repair.sql
+++ b/test/sql/updates/setup.repair.sql
@@ -177,3 +177,5 @@ SELECT DISTINCT
   WHERE dimension_slice_id NOT IN (SELECT id FROM _timescaledb_catalog.dimension_slice);
 
 DROP VIEW slices;
+
+\ir setup.repair.cagg.sql

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -33,6 +33,7 @@
 #include "error_utils.h"
 #include "hypercube.h"
 #include "hypertable_cache.h"
+#include "utils.h"
 
 #include "remote/async.h"
 #include "remote/dist_txn.h"
@@ -1389,27 +1390,6 @@ fetch_remote_chunk_stats(Hypertable *ht, FunctionCallInfo fcinfo, bool col_stats
 	ts_dist_cmd_close_response(cmdres);
 }
 
-/*
- * Implementation marked unused in PostgresQL lsyscache.c
- */
-static int
-get_relnatts(Oid relid)
-{
-	HeapTuple tp;
-	Form_pg_class reltup;
-	int result;
-
-	tp = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
-	if (!HeapTupleIsValid(tp))
-		return InvalidAttrNumber;
-
-	reltup = (Form_pg_class) GETSTRUCT(tp);
-	result = reltup->relnatts;
-
-	ReleaseSysCache(tp);
-	return result;
-}
-
 static void *
 chunk_api_generate_relstats_context(List *oids)
 {
@@ -1457,7 +1437,7 @@ chunk_api_generate_colstats_context(List *oids, Oid ht_relid)
 
 	ctx->chunk_oids = list_copy(oids);
 	ctx->col_id = 1;
-	ctx->nattrs = get_relnatts(ht_relid);
+	ctx->nattrs = ts_get_relnatts(ht_relid);
 
 	return ctx;
 }

--- a/tsl/src/continuous_aggs/create.h
+++ b/tsl/src/continuous_aggs/create.h
@@ -16,6 +16,9 @@
 DDLResult tsl_process_continuous_agg_viewstmt(Node *stmt, const char *query_string, void *pstmt,
 											  WithClauseResult *with_clause_options);
 
-void cagg_update_view_definition(ContinuousAgg *agg, Hypertable *mat_ht);
+extern void cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht);
+extern void cagg_rename_view_columns(ContinuousAgg *agg);
+
+extern Datum tsl_cagg_try_repair(PG_FUNCTION_ARGS);
 
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_CAGG_CREATE_H */

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -148,6 +148,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.remote_drop_dist_ht_invalidation_trigger = remote_drop_dist_ht_invalidation_trigger,
 	.invalidation_process_hypertable_log = tsl_invalidation_process_hypertable_log,
 	.invalidation_process_cagg_log = tsl_invalidation_process_cagg_log,
+	.cagg_try_repair = tsl_cagg_try_repair,
 
 	.compressed_data_decompress_forward = tsl_compressed_data_decompress_forward,
 	.compressed_data_decompress_reverse = tsl_compressed_data_decompress_reverse,

--- a/tsl/src/process_utility.c
+++ b/tsl/src/process_utility.c
@@ -72,7 +72,7 @@ tsl_process_rename_cmd(Oid relid, Cache *hcache, const RenameStmt *stmt)
 			{
 				ht = ts_hypertable_cache_get_entry_by_id(hcache, cagg->data.mat_hypertable_id);
 				Assert(ht);
-				cagg_update_view_definition(cagg, ht);
+				cagg_rename_view_columns(cagg);
 			}
 		}
 

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -1791,3 +1791,155 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 (1 row)
 
 -- END TEST with multiple settings
+-- Test View Target Entries that contain both aggrefs and Vars in the same expression
+CREATE TABLE transactions
+(
+    "time" timestamp with time zone NOT NULL,
+    dummy1 integer,
+    dummy2 integer,
+    dummy3 integer,
+    dummy4 integer,
+    dummy5 integer,
+    amount integer,
+    fiat_value integer
+);
+\if :IS_DISTRIBUTED
+SELECT create_distributed_hypertable('transactions', 'time', replication_factor => 2);
+\else
+SELECT create_hypertable('transactions', 'time');
+     create_hypertable      
+----------------------------
+ (46,public,transactions,t)
+(1 row)
+
+\endif
+INSERT INTO transactions VALUES ( '2018-01-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:30:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:20:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 10:40:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 11:50:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 12:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 13:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-02 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-02 10:30:00-08', 0, 0, 0, 0, 0, -1, 10);
+CREATE materialized view cashflows(
+    bucket,
+  	amount,
+    cashflow,
+    cashflow2
+) WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only = true
+) AS
+SELECT time_bucket ('1 day', time) AS bucket,
+	amount,
+  CASE
+      WHEN amount < 0 THEN (0 - sum(fiat_value))
+      ELSE sum(fiat_value)
+  END AS cashflow,
+  amount + sum(fiat_value)
+FROM transactions
+GROUP BY bucket, amount;
+psql:include/cagg_ddl_common.sql:1257: NOTICE:  refreshing continuous aggregate "cashflows"
+SELECT h.table_name AS "MAT_TABLE_NAME",
+       partial_view_name AS "PART_VIEW_NAME",
+       direct_view_name AS "DIRECT_VIEW_NAME"
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'cashflows'
+\gset
+-- Show both the columns and the view definitions to see that
+-- references are correct in the view as well.
+\d+ "_timescaledb_internal".:"DIRECT_VIEW_NAME"
+                         View "_timescaledb_internal._direct_view_47"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
+    transactions.amount,
+        CASE
+            WHEN transactions.amount < 0 THEN 0 - sum(transactions.fiat_value)
+            ELSE sum(transactions.fiat_value)
+        END AS cashflow,
+    transactions.amount + sum(transactions.fiat_value) AS cashflow2
+   FROM transactions
+  GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
+
+\d+ "_timescaledb_internal".:"PART_VIEW_NAME"
+                         View "_timescaledb_internal._partial_view_47"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ amount   | integer                  |           |          |         | plain    | 
+ agg_3_3  | bytea                    |           |          |         | extended | 
+ agg_3_4  | bytea                    |           |          |         | extended | 
+ var_3_5  | integer                  |           |          |         | plain    | 
+ agg_4_6  | bytea                    |           |          |         | extended | 
+ chunk_id | integer                  |           |          |         | plain    | 
+View definition:
+ SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
+    transactions.amount,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_3,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_4,
+    transactions.amount AS var_3_5,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_4_6,
+    _timescaledb_internal.chunk_id_from_relid(transactions.tableoid) AS chunk_id
+   FROM transactions
+  GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount, (_timescaledb_internal.chunk_id_from_relid(transactions.tableoid));
+
+\d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
+                          Table "_timescaledb_internal._materialized_hypertable_47"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Stats target | Description 
+----------+--------------------------+-----------+----------+---------+----------+--------------+-------------
+ bucket   | timestamp with time zone |           | not null |         | plain    |              | 
+ amount   | integer                  |           |          |         | plain    |              | 
+ agg_3_3  | bytea                    |           |          |         | extended |              | 
+ agg_3_4  | bytea                    |           |          |         | extended |              | 
+ var_3_5  | integer                  |           |          |         | plain    |              | 
+ agg_4_6  | bytea                    |           |          |         | extended |              | 
+ chunk_id | integer                  |           |          |         | plain    |              | 
+Indexes:
+    "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
+    "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
+    "_materialized_hypertable_47_var_3_5_bucket_idx" btree (var_3_5, bucket DESC)
+Triggers:
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
+Child tables: _timescaledb_internal._hyper_47_52_chunk,
+              _timescaledb_internal._hyper_47_53_chunk
+
+\d+ 'cashflows'
+                                    View "public.cashflows"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_47.bucket,
+    _materialized_hypertable_47.amount,
+        CASE
+            WHEN _materialized_hypertable_47.var_3_5 < 0 THEN 0 - _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_3, NULL::bigint)
+            ELSE _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_4, NULL::bigint)
+        END AS cashflow,
+    _materialized_hypertable_47.var_3_5 + _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_4_6, NULL::bigint) AS cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_47
+  GROUP BY _materialized_hypertable_47.bucket, _materialized_hypertable_47.amount;
+
+SELECT * FROM cashflows;
+            bucket            | amount | cashflow | cashflow2 
+------------------------------+--------+----------+-----------
+ Sun Dec 31 16:00:00 2017 PST |      1 |       10 |        11
+ Mon Jan 01 16:00:00 2018 PST |     -1 |      -30 |        29
+ Wed Oct 31 17:00:00 2018 PDT |     -1 |      -20 |        19
+ Wed Oct 31 17:00:00 2018 PDT |      1 |       30 |        31
+ Thu Nov 01 17:00:00 2018 PDT |     -1 |      -10 |         9
+ Thu Nov 01 17:00:00 2018 PDT |      1 |       10 |        11
+(6 rows)
+

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -1829,6 +1829,158 @@ SELECT count(*) from test_setting_cagg ORDER BY 1;
 (1 row)
 
 -- END TEST with multiple settings
+-- Test View Target Entries that contain both aggrefs and Vars in the same expression
+CREATE TABLE transactions
+(
+    "time" timestamp with time zone NOT NULL,
+    dummy1 integer,
+    dummy2 integer,
+    dummy3 integer,
+    dummy4 integer,
+    dummy5 integer,
+    amount integer,
+    fiat_value integer
+);
+\if :IS_DISTRIBUTED
+SELECT create_distributed_hypertable('transactions', 'time', replication_factor => 2);
+ create_distributed_hypertable 
+-------------------------------
+ (46,public,transactions,t)
+(1 row)
+
+\else
+SELECT create_hypertable('transactions', 'time');
+\endif
+INSERT INTO transactions VALUES ( '2018-01-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:30:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:20:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 10:40:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 11:50:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 12:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 13:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-02 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-02 10:30:00-08', 0, 0, 0, 0, 0, -1, 10);
+CREATE materialized view cashflows(
+    bucket,
+  	amount,
+    cashflow,
+    cashflow2
+) WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only = true
+) AS
+SELECT time_bucket ('1 day', time) AS bucket,
+	amount,
+  CASE
+      WHEN amount < 0 THEN (0 - sum(fiat_value))
+      ELSE sum(fiat_value)
+  END AS cashflow,
+  amount + sum(fiat_value)
+FROM transactions
+GROUP BY bucket, amount;
+psql:include/cagg_ddl_common.sql:1257: NOTICE:  refreshing continuous aggregate "cashflows"
+SELECT h.table_name AS "MAT_TABLE_NAME",
+       partial_view_name AS "PART_VIEW_NAME",
+       direct_view_name AS "DIRECT_VIEW_NAME"
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'cashflows'
+\gset
+-- Show both the columns and the view definitions to see that
+-- references are correct in the view as well.
+\d+ "_timescaledb_internal".:"DIRECT_VIEW_NAME"
+                         View "_timescaledb_internal._direct_view_47"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
+    transactions.amount,
+        CASE
+            WHEN transactions.amount < 0 THEN 0 - sum(transactions.fiat_value)
+            ELSE sum(transactions.fiat_value)
+        END AS cashflow,
+    transactions.amount + sum(transactions.fiat_value) AS cashflow2
+   FROM transactions
+  GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
+
+\d+ "_timescaledb_internal".:"PART_VIEW_NAME"
+                         View "_timescaledb_internal._partial_view_47"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ amount   | integer                  |           |          |         | plain    | 
+ agg_3_3  | bytea                    |           |          |         | extended | 
+ agg_3_4  | bytea                    |           |          |         | extended | 
+ var_3_5  | integer                  |           |          |         | plain    | 
+ agg_4_6  | bytea                    |           |          |         | extended | 
+ chunk_id | integer                  |           |          |         | plain    | 
+View definition:
+ SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
+    transactions.amount,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_3,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_4,
+    transactions.amount AS var_3_5,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_4_6,
+    _timescaledb_internal.chunk_id_from_relid(transactions.tableoid) AS chunk_id
+   FROM transactions
+  GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount, (_timescaledb_internal.chunk_id_from_relid(transactions.tableoid));
+
+\d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
+                          Table "_timescaledb_internal._materialized_hypertable_47"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Stats target | Description 
+----------+--------------------------+-----------+----------+---------+----------+--------------+-------------
+ bucket   | timestamp with time zone |           | not null |         | plain    |              | 
+ amount   | integer                  |           |          |         | plain    |              | 
+ agg_3_3  | bytea                    |           |          |         | extended |              | 
+ agg_3_4  | bytea                    |           |          |         | extended |              | 
+ var_3_5  | integer                  |           |          |         | plain    |              | 
+ agg_4_6  | bytea                    |           |          |         | extended |              | 
+ chunk_id | integer                  |           |          |         | plain    |              | 
+Indexes:
+    "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
+    "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
+    "_materialized_hypertable_47_var_3_5_bucket_idx" btree (var_3_5, bucket DESC)
+Triggers:
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
+Child tables: _timescaledb_internal._hyper_47_52_chunk,
+              _timescaledb_internal._hyper_47_53_chunk
+
+\d+ 'cashflows'
+                                    View "public.cashflows"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_47.bucket,
+    _materialized_hypertable_47.amount,
+        CASE
+            WHEN _materialized_hypertable_47.var_3_5 < 0 THEN 0 - _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_3, NULL::bigint)
+            ELSE _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_4, NULL::bigint)
+        END AS cashflow,
+    _materialized_hypertable_47.var_3_5 + _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_4_6, NULL::bigint) AS cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_47
+  GROUP BY _materialized_hypertable_47.bucket, _materialized_hypertable_47.amount;
+
+SELECT * FROM cashflows;
+            bucket            | amount | cashflow | cashflow2 
+------------------------------+--------+----------+-----------
+ Sun Dec 31 16:00:00 2017 PST |      1 |       10 |        11
+ Mon Jan 01 16:00:00 2018 PST |     -1 |      -30 |        29
+ Wed Oct 31 17:00:00 2018 PDT |     -1 |      -20 |        19
+ Wed Oct 31 17:00:00 2018 PDT |      1 |       30 |        31
+ Thu Nov 01 17:00:00 2018 PDT |     -1 |      -10 |         9
+ Thu Nov 01 17:00:00 2018 PDT |      1 |       10 |        11
+(6 rows)
+
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;


### PR DESCRIPTION
Add the missing variables to the finalization view of Continuous Aggregates and the corresponding columns to the materialization table. Cover the case of targets that contain Aggref nodes and Var nodes that are outside of the Aggref nodes at the same time.
    
Stop rebuilding the Continuous Aggregate view with ALTER MATERIALIZED VIEW. Attempt to repair the view at post-update time instead, and fail gracefully if it is not possible to do so without raw hypertable schema or data modifications.
    
Stop rebuilding the Continuous Aggregate view when switching realtime aggregation on and off. Instead, manipulate the User View by either:
  1. removing the `UNION ALL` right-hand side and the `WHERE` clause when disabling realtime aggregation
  2. adding the Direct View to the right of a `UNION ALL` operator and defining `WHERE` clauses with the relevant watermark checks when enabling realtime aggregation
    
Fixes #3898