### PR TITLE
Check custom scan node registration

### DIFF
--- a/src/nodes/chunk_append/planner.c
+++ b/src/nodes/chunk_append/planner.c
@@ -40,7 +40,7 @@ static CustomScanMethods chunk_append_plan_methods = {
 void
 _chunk_append_init(void)
 {
-	RegisterCustomScanMethods(&chunk_append_plan_methods);
+	TryRegisterCustomScanMethods(&chunk_append_plan_methods);
 }
 
 static Plan *

--- a/src/nodes/constraint_aware_append/constraint_aware_append.c
+++ b/src/nodes/constraint_aware_append/constraint_aware_append.c
@@ -573,5 +573,5 @@ ts_is_constraint_aware_append_path(Path *path)
 void
 _constraint_aware_append_init(void)
 {
-	RegisterCustomScanMethods(&constraint_aware_append_plan_methods);
+	TryRegisterCustomScanMethods(&constraint_aware_append_plan_methods);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,7 @@
 #include <catalog/pg_proc.h>
 #include <common/int.h>
 #include <nodes/pathnodes.h>
+#include <nodes/extensible.h>
 #include <utils/datetime.h>
 
 #include "compat/compat.h"
@@ -165,6 +166,21 @@ static inline uint32
 ts_clear_flags_32(uint32 bitmap, uint32 flags)
 {
 	return bitmap & ~flags;
+}
+
+/**
+ * Try to register a custom scan method.
+ *
+ * When registering a custom scan node, it might be called multiple times when
+ * different databases have different versions of the extension installed, so
+ * this function can be used to try to register a custom scan method but not
+ * fail if it has already been registered.
+ */
+static inline void
+TryRegisterCustomScanMethods(const CustomScanMethods *methods)
+{
+	if (!GetCustomScanMethods(methods->CustomName, true))
+		RegisterCustomScanMethods(methods);
 }
 
 #endif /* TIMESCALEDB_UTILS_H */

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -37,16 +37,7 @@ static CustomScanMethods decompress_chunk_plan_methods = {
 void
 _decompress_chunk_init(void)
 {
-	/*
-	 * Because we reinitialize the tsl stuff when the license
-	 * changes the init function may be called multiple times
-	 * per session so we check if DecompressChunk node has been
-	 * registered already here to prevent registering it twice.
-	 */
-	if (GetCustomScanMethods(decompress_chunk_plan_methods.CustomName, true) == NULL)
-	{
-		RegisterCustomScanMethods(&decompress_chunk_plan_methods);
-	}
+	TryRegisterCustomScanMethods(&decompress_chunk_plan_methods);
 }
 
 static TargetEntry *

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -73,14 +73,7 @@ static CustomScanMethods skip_scan_plan_methods = {
 void
 _skip_scan_init(void)
 {
-	/*
-	 * Because we reinitialize the tsl stuff when the license
-	 * changes the init function may be called multiple times
-	 * per session so we check if the SkipScan node has been
-	 * registered already here to prevent registering it twice.
-	 */
-	if (GetCustomScanMethods(skip_scan_plan_methods.CustomName, true) == NULL)
-		RegisterCustomScanMethods(&skip_scan_plan_methods);
+	TryRegisterCustomScanMethods(&skip_scan_plan_methods);
 }
 
 static Plan *


### PR DESCRIPTION
When loading several different versions of shared libraries after a
restart, it might attempt to register the custom scan nodes several
times.  This is fixed by adding a function that checks if the custom
scan method was already registered and skips registering it if it was.

Fixes #3901