### PR TITLE
Remove the rest of Value* type usage

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -1658,8 +1658,7 @@ finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
 	foreach (lc, matcollist)
 	{
 		ColumnDef *cdef = (ColumnDef *) lfirst(lc);
-		Value *attrname = makeString(cdef->colname);
-		rte->eref->colnames = lappend(rte->eref->colnames, attrname);
+		rte->eref->colnames = lappend(rte->eref->colnames, makeString(cdef->colname));
 		rte->selectedCols =
 			bms_add_member(rte->selectedCols,
 						   list_length(rte->eref->colnames) - FirstLowInvalidHeapAttributeNumber);

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -1089,15 +1089,9 @@ decompress_chunk_make_rte(Oid compressed_relid, LOCKMODE lockmode)
 	for (varattno = 0; varattno < r->rd_att->natts; varattno++)
 	{
 		Form_pg_attribute attr = TupleDescAttr(r->rd_att, varattno);
-		Value *attrname;
-
-		if (attr->attisdropped)
-			/* Always insert an empty string for a dropped column */
-			attrname = makeString(pstrdup(""));
-		else
-			attrname = makeString(pstrdup(NameStr(attr->attname)));
-
-		rte->eref->colnames = lappend(rte->eref->colnames, attrname);
+		/* Always insert an empty string for a dropped column */
+		const char *attrname = attr->attisdropped ? "" : NameStr(attr->attname);
+		rte->eref->colnames = lappend(rte->eref->colnames, makeString(pstrdup(attrname)));
 	}
 
 	/*

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -179,13 +179,13 @@ build_scan_tlist(DecompressChunkPath *path)
 
 		foreach (lc, path->info->ht_rte->eref->colnames)
 		{
-			Value *chunk_col = (Value *) lfirst(lc);
+			const char *chunk_col = strVal(lfirst(lc));
 			ht_attno++;
 
 			/*
 			 * dropped columns have empty string
 			 */
-			if (IsA(lfirst(lc), String) && strlen(chunk_col->val.str) > 0)
+			if (IsA(lfirst(lc), String) && strlen(chunk_col) > 0)
 			{
 				tle = make_compressed_scan_targetentry(path, ht_attno, list_length(scan_tlist) + 1);
 				scan_tlist = lappend(scan_tlist, tle);

--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -489,9 +489,7 @@ dist_ddl_process_grant_on_database(const GrantStmt *stmt)
 	dbmatch = false;
 	foreach (i, stmt->objects)
 	{
-		Value *value = lfirst(i);
-
-		if (!strcmp(dbname, strVal(value)))
+		if (!strcmp(dbname, strVal(lfirst(i))))
 		{
 			dbmatch = true;
 			break;


### PR DESCRIPTION
This is a follow-up to 8afac602. In this commit we refactored the code that
used Value* type because the type was removed in the upstream. However, we
missed a few places. This patch fixes it.