### PR TITLE
Support UPPERREL_PARTIAL_DISTINCT stage in fdw_create_upper_paths()

### DIFF
--- a/tsl/src/fdw/scan_plan.c
+++ b/tsl/src/fdw/scan_plan.c
@@ -967,6 +967,9 @@ fdw_create_upper_paths(TsFdwRelInfo *input_fpinfo, PlannerInfo *root, UpperRelat
 		case UPPERREL_SETOP:
 		case UPPERREL_WINDOW:
 		case UPPERREL_FINAL:
+#if PG15_GE
+		case UPPERREL_PARTIAL_DISTINCT:
+#endif
 			break;
 	}
 }


### PR DESCRIPTION
UpperRelationKind enum was extended in the upstream and now can be
UPPERREL_PARTIAL_DISTINCT as well. This patch rewrites the switch-case
expression in the fdw_create_upper_paths() procedure accordingly.

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=22c4e88e