### PR TITLE
Stop early when checking if the chunk is historical

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2640,10 +2640,12 @@ ts_chunk_get_by_id(int32 id, bool fail_if_not_found)
 
 /*
  * Number of chunks created after given chunk.
- * If chunk2.id > chunk1.id then chunk2 is created after chunk1
+ * If chunk2.id > chunk1.id then chunk2 is created after chunk1.
+ * Can accept a limit for cases where we only need to check that there is more
+ * than a certain number of chunks after the given one.
  */
 int
-ts_chunk_num_of_chunks_created_after(const Chunk *chunk)
+ts_chunk_num_of_chunks_created_after(const Chunk *chunk, int limit)
 {
 	ScanKeyData scankey[1];
 
@@ -2662,7 +2664,7 @@ ts_chunk_num_of_chunks_created_after(const Chunk *chunk)
 							   NULL,
 							   NULL,
 							   NULL,
-							   0,
+							   limit,
 							   ForwardScanDirection,
 							   AccessShareLock,
 							   CurrentMemoryContext);

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -154,7 +154,7 @@ extern Oid ts_chunk_get_schema_id(int32 chunk_id, bool missing_ok);
 extern bool ts_chunk_get_id(const char *schema, const char *table, int32 *chunk_id,
 							bool missing_ok);
 extern bool ts_chunk_exists_relid(Oid relid);
-extern TSDLLEXPORT int ts_chunk_num_of_chunks_created_after(const Chunk *chunk);
+extern TSDLLEXPORT int ts_chunk_num_of_chunks_created_after(const Chunk *chunk, int limit);
 extern TSDLLEXPORT bool ts_chunk_exists_with_compression(int32 hypertable_id);
 extern void ts_chunk_recreate_all_constraints_for_dimension(Hyperspace *hs, int32 dimension_id);
 extern TSDLLEXPORT void ts_chunk_drop_fks(const Chunk *const chunk);

--- a/tsl/src/fdw/relinfo.c
+++ b/tsl/src/fdw/relinfo.c
@@ -184,8 +184,6 @@ estimate_chunk_fillfactor(Chunk *chunk, Hyperspace *space)
 	const Dimension *time_dim = hyperspace_get_open_dimension(space, 0);
 	const DimensionSlice *time_slice = get_chunk_time_slice(chunk, space);
 	Oid time_dim_type = ts_dimension_get_partition_type(time_dim);
-	int num_created_after = ts_chunk_num_of_chunks_created_after(chunk);
-	int total_slices = get_total_number_of_slices(space);
 
 	if (IS_TIMESTAMP_TYPE(time_dim_type))
 	{
@@ -203,6 +201,9 @@ estimate_chunk_fillfactor(Chunk *chunk, Hyperspace *space)
 		/* if we are beyond end range then chunk can possibly be totally filled */
 		if (time_slice->fd.range_end <= now_internal_time)
 		{
+			int total_slices = get_total_number_of_slices(space);
+			int num_created_after = ts_chunk_num_of_chunks_created_after(chunk, total_slices);
+
 			/* If there are less newly created chunks then the number of slices then this is current
 			 * chunk. This also works better when writing historical data */
 			return num_created_after < total_slices ? FILL_FACTOR_CURRENT_CHUNK :
@@ -223,6 +224,9 @@ estimate_chunk_fillfactor(Chunk *chunk, Hyperspace *space)
 	}
 	else
 	{
+		int total_slices = get_total_number_of_slices(space);
+		int num_created_after = ts_chunk_num_of_chunks_created_after(chunk, total_slices);
+
 		/* if current chunk is the last created we assume it has 0.5 fill factor */
 		return num_created_after < total_slices ? FILL_FACTOR_CURRENT_CHUNK :
 												  FILL_FACTOR_HISTORICAL_CHUNK;


### PR DESCRIPTION
We don't have to enumerate all the subsequent chunks to find out that
the given chunk is not historical. Stop doing this useless work to
improve performance.

Part of https://github.com/timescale/timescaledb/pull/3890