### PR TITLE
Don't excessively look up the extension oid

### DIFF
--- a/src/extension.h
+++ b/src/extension.h
@@ -19,4 +19,6 @@ extern const char *ts_experimental_schema_name(void);
 extern const char *ts_extension_get_so_name(void);
 extern TSDLLEXPORT const char *ts_extension_get_version(void);
 
+extern TSDLLEXPORT Oid ts_extension_oid;
+
 #endif /* TIMESCALEDB_EXTENSION_H */

--- a/src/planner.c
+++ b/src/planner.c
@@ -7,6 +7,7 @@
 #include <access/tsmapi.h>
 #include <access/xact.h>
 #include <catalog/namespace.h>
+#include <commands/extension.h>
 #include <executor/nodeAgg.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
@@ -348,6 +349,14 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 		context.rootquery = parse;
 		if (ts_extension_is_loaded())
 		{
+			/*
+			 * Some debug checks.
+			 */
+			Assert(ts_extension_oid == get_extension_oid(EXTENSION_NAME, /* missing_ok = */ false));
+
+			/*
+			 * Preprocess the hypertables in the query and warm up the caches.
+			 */
 			preprocess_query((Node *) parse, &context);
 
 			/*

--- a/tsl/src/fdw/relinfo.c
+++ b/tsl/src/fdw/relinfo.c
@@ -18,19 +18,20 @@
 #include <extension_constants.h>
 #include <planner.h>
 
-#include "remote/connection.h"
-#include "option.h"
-#include "deparse.h"
-#include "relinfo.h"
-#include "estimate.h"
-#include "chunk_adaptive.h"
 #include "cache.h"
+#include "chunk.h"
+#include "chunk_adaptive.h"
+#include "deparse.h"
+#include "dimension.h"
+#include "errors.h"
+#include "estimate.h"
+#include "extension.h"
+#include "hypercube.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
-#include "dimension.h"
-#include "chunk.h"
-#include "hypercube.h"
-#include "errors.h"
+#include "option.h"
+#include "relinfo.h"
+#include "remote/connection.h"
 #include "scan_exec.h"
 
 /* Default CPU cost to start up a foreign query. */
@@ -427,7 +428,8 @@ fdw_relinfo_create(PlannerInfo *root, RelOptInfo *rel, Oid server_oid, Oid local
 	 */
 	fpinfo->fdw_startup_cost = DEFAULT_FDW_STARTUP_COST;
 	fpinfo->fdw_tuple_cost = DEFAULT_FDW_TUPLE_COST;
-	fpinfo->shippable_extensions = list_make1_oid(get_extension_oid(EXTENSION_NAME, true));
+	Assert(ts_extension_oid != InvalidOid);
+	fpinfo->shippable_extensions = list_make1_oid(ts_extension_oid);
 	fpinfo->fetch_size = DEFAULT_FDW_FETCH_SIZE;
 
 	apply_fdw_and_server_options(fpinfo);


### PR DESCRIPTION
Use the one from the static variable. This improves performance by
avoiding excessive catalog lookups.

Part of https://github.com/timescale/timescaledb/pull/3890