### PR TITLE
Fix DataNodeScan plans with One-Time Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #3808 Properly handle `max_retries` option
+* #3918 Fix DataNodeScan plans with one-time filter
 
 ## 2.5.1 (2021-12-02)
 

--- a/tsl/src/nodes/async_append.c
+++ b/tsl/src/nodes/async_append.c
@@ -157,8 +157,9 @@ find_data_node_scan_state_child(PlanState *state)
 		{
 			case T_CustomScanState:
 				return state;
-			case T_SortState:
 			case T_AggState:
+			case T_ResultState:
+			case T_SortState:
 				/* Data scan state can be buried under AggState or SortState  */
 				return find_data_node_scan_state_child(state->lefttree);
 			default:

--- a/tsl/test/shared/expected/dist_queries.out
+++ b/tsl/test/shared/expected/dist_queries.out
@@ -1,0 +1,20 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test DataNodeScan with subquery with one-time filter
+SELECT
+  id
+FROM
+  insert_test
+WHERE
+  NULL::int2 >= NULL::int2 OR
+  EXISTS (SELECT 1 from dist_chunk_copy WHERE insert_test.id IS NOT NULL)
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+  4
+(4 rows)
+

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -7,7 +7,8 @@ set(TEST_FILES_SHARED
     dist_distinct_pushdown.sql
     dist_fetcher_type.sql
     dist_gapfill.sql
-    dist_insert.sql)
+    dist_insert.sql
+    dist_queries.sql)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   list(APPEND TEST_FILES_SHARED memoize.sql)

--- a/tsl/test/shared/sql/dist_queries.sql
+++ b/tsl/test/shared/sql/dist_queries.sql
@@ -1,0 +1,14 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test DataNodeScan with subquery with one-time filter
+SELECT
+  id
+FROM
+  insert_test
+WHERE
+  NULL::int2 >= NULL::int2 OR
+  EXISTS (SELECT 1 from dist_chunk_copy WHERE insert_test.id IS NOT NULL)
+ORDER BY id;
+


### PR DESCRIPTION
When a query has a filter that only needs to be evaluated once per
query it will be represented as a Result node with the filter
condition on the Result node and the actual query as child of the
result node. find_data_node_scan_state_child did not consider
Result node as valid node to contain a DataNodeScan node leading
to a `unexpected child node of Append or MergeAppend: 62` for
queries that had one-time filter with a subquery.

Fixes #3658