### PR TITLE
Enable downgrade test for PG14 packages

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -79,7 +79,6 @@ jobs:
         fi
 
     - name: Test Downgrade
-      if: matrix.pg != 14 && matrix.image != 'ubuntu:impish'
       run: |
         # since this runs nightly on master we have to get the previous version from the last released version and not current branch
         prev_version=$(wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -83,7 +83,6 @@ jobs:
         fi
 
     - name: Test Downgrade
-      if: matrix.pg != 14
       run: |
         # since this runs nightly on master we have to get the previous version from the last released version and not current branch
         prev_version=$(wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')


### PR DESCRIPTION
When initially adding the package tests for PG14 Debian, Ubuntu and
RPM packages we couldn't test downgrade with the packages because
there was no previous version with PG14 support. Since we now have
released a 2nd version with PG14 support we can enable the downgrade
test for Debian, Ubuntu and RPM packages.