### PR TITLE
Allow changing a data node via alter server

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -474,10 +474,13 @@ process_alter_foreign_server(ProcessUtilityArgs *args)
 {
 	AlterForeignServerStmt *stmt = (AlterForeignServerStmt *) args->parsetree;
 
-	if (block_on_foreign_server(stmt->servername))
+	if (stmt->has_version)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("alter server not supported on a TimescaleDB data node")));
+				 errmsg("operation not supported"),
+				 errdetail("It is not possible to set a version on the data node configuration.")));
+
+	/* Other options are validated by the FDW */
 
 	return DDL_CONTINUE;
 }
@@ -2091,13 +2094,6 @@ process_rename(ProcessUtilityArgs *args)
 		 * stmt->relation never be NULL unless we are renaming a schema or
 		 * other objects, like foreign server
 		 */
-		if ((stmt->renameType == OBJECT_FOREIGN_SERVER) &&
-			block_on_foreign_server(strVal(stmt->object)))
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("rename not supported on a TimescaleDB data node")));
-		}
 		if (stmt->renameType != OBJECT_SCHEMA)
 			return DDL_CONTINUE;
 	}

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -74,14 +74,29 @@ SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => :'DN
  data_node_3 | localhost | 55432 | db_data_node_3 | t            | t                | t
 (1 row)
 
--- Test altering server command is blocked
+-- Altering the host, dbname, and port should work via ALTER SERVER
+BEGIN;
+ALTER SERVER data_node_3 OPTIONS (SET host 'data_node_3', SET dbname 'new_db_name', SET port '9999');
+SELECT srvname, srvoptions FROM pg_foreign_server WHERE srvname = 'data_node_3';
+   srvname   |                   srvoptions                    
+-------------+-------------------------------------------------
+ data_node_3 | {host=data_node_3,port=9999,dbname=new_db_name}
+(1 row)
+
+-- Altering the name should work
+ALTER SERVER data_node_3 RENAME TO data_node_4;
+SELECT srvname FROM pg_foreign_server WHERE srvname = 'data_node_4';
+   srvname   
+-------------
+ data_node_4
+(1 row)
+
+-- Revert name and options
+ROLLBACK;
 \set ON_ERROR_STOP 0
-ALTER SERVER data_node_1 OPTIONS (SET fdw_startup_cost '110.0');
-ERROR:  alter server not supported on a TimescaleDB data node
-ALTER SERVER data_node_1 OPTIONS (DROP sslmode);
-ERROR:  alter server not supported on a TimescaleDB data node
-ALTER SERVER data_node_1 RENAME TO data_node_k;
-ERROR:  rename not supported on a TimescaleDB data node
+-- Should not be possible to set a version:
+ALTER SERVER data_node_3 VERSION '2';
+ERROR:  operation not supported
 \set ON_ERROR_STOP 1
 -- Make sure changing server owner is allowed
 ALTER SERVER data_node_1 OWNER TO CURRENT_USER;
@@ -1321,7 +1336,7 @@ SET ROLE :ROLE_3;
 \set ON_ERROR_STOP 0
 SELECT * FROM add_data_node('data_node_6', host => 'localhost', database => :'DN_DBNAME_6');
 ERROR:  permission denied for foreign-data wrapper timescaledb_fdw
-\set ON_ERROR_STOP 0
+\set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON FOREIGN DATA WRAPPER timescaledb_fdw TO :ROLE_3;
 SET ROLE :ROLE_3;
@@ -1330,7 +1345,7 @@ SET ROLE :ROLE_3;
 -- authenticate so adding a data node will still fail.
 SELECT * FROM add_data_node('data_node_6', host => 'localhost', database => :'DN_DBNAME_6');
 ERROR:  could not connect to "data_node_6"
-\set ON_ERROR_STOP 0
+\set ON_ERROR_STOP 1
 -- Providing the password on the command line should work
 SELECT * FROM add_data_node('data_node_6', host => 'localhost', database => :'DN_DBNAME_6', password => :'ROLE_3_PASS');
 NOTICE:  database "db_data_node_6" already exists on data node, skipping


### PR DESCRIPTION
Allow changing the name and configuration of a data node via `ALTER
SERVER` since there is no `alter_data_node` command.

The functions `add_data_node` and `delete_data_node` are wrappers
around `CREATE SERVER` and `DROP SERVER`, respectively. They block the
PostgreSQL commmands since they do additional things, like data node
bootstrapping.

However, there's currently no way to change a data node's
configuration, and no additional functionality is required over
standard `ALTER SERVER`, so we might as well allow it until a
`alter_data_node` is implemented.

Fixes #3915