### PR TITLE
Use moving average to estimate chunk size

### DIFF
--- a/tsl/src/fdw/relinfo.h
+++ b/tsl/src/fdw/relinfo.h
@@ -130,6 +130,16 @@ typedef struct TsFdwRelInfo
 							   to be only used for printing cost debug
 							   output */
 #endif
+
+	/*
+	 * Moving averages of chunk size. We use them to compute the size for remote
+	 * chunks that don't have local statistics, e.g. because ANALYZE haven't
+	 * been run. Note that these values are adjusted for fill factor, i.e. they
+	 * correspond to a fill factor of 1.0. The fill factor for a particular
+	 * chunk is estimated separately.
+	 */
+	double average_chunk_pages;
+	double average_chunk_tuples;
 } TsFdwRelInfo;
 
 extern TsFdwRelInfo *fdw_relinfo_create(PlannerInfo *root, RelOptInfo *rel, Oid server_oid,

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -3649,14 +3649,14 @@ SELECT *
 FROM hyper_estimate;
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
- Append  (cost=100.00..707.74 rows=17 width=20)
+ Append  (cost=100.00..707.79 rows=17 width=20)
    ->  Foreign Scan on _dist_hyper_16_38_chunk  (cost=100.00..101.40 rows=4 width=20)
    ->  Foreign Scan on _dist_hyper_16_39_chunk  (cost=100.00..101.20 rows=2 width=20)
    ->  Foreign Scan on _dist_hyper_16_40_chunk  (cost=100.00..101.30 rows=3 width=20)
    ->  Foreign Scan on _dist_hyper_16_41_chunk  (cost=100.00..101.20 rows=2 width=20)
    ->  Foreign Scan on _dist_hyper_16_42_chunk  (cost=100.00..101.30 rows=3 width=20)
    ->  Foreign Scan on _dist_hyper_16_43_chunk  (cost=100.00..101.10 rows=1 width=20)
-   ->  Foreign Scan on _dist_hyper_16_44_chunk  (cost=100.00..100.15 rows=2 width=20)
+   ->  Foreign Scan on _dist_hyper_16_44_chunk  (cost=100.00..100.20 rows=2 width=20)
 (8 rows)
 
 CREATE TABLE devices (

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -3648,14 +3648,14 @@ SELECT *
 FROM hyper_estimate;
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
- Append  (cost=100.00..707.74 rows=17 width=20)
+ Append  (cost=100.00..707.79 rows=17 width=20)
    ->  Foreign Scan on _dist_hyper_16_38_chunk  (cost=100.00..101.40 rows=4 width=20)
    ->  Foreign Scan on _dist_hyper_16_39_chunk  (cost=100.00..101.20 rows=2 width=20)
    ->  Foreign Scan on _dist_hyper_16_40_chunk  (cost=100.00..101.30 rows=3 width=20)
    ->  Foreign Scan on _dist_hyper_16_41_chunk  (cost=100.00..101.20 rows=2 width=20)
    ->  Foreign Scan on _dist_hyper_16_42_chunk  (cost=100.00..101.30 rows=3 width=20)
    ->  Foreign Scan on _dist_hyper_16_43_chunk  (cost=100.00..101.10 rows=1 width=20)
-   ->  Foreign Scan on _dist_hyper_16_44_chunk  (cost=100.00..100.15 rows=2 width=20)
+   ->  Foreign Scan on _dist_hyper_16_44_chunk  (cost=100.00..100.20 rows=2 width=20)
 (8 rows)
 
 CREATE TABLE devices (

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -3651,14 +3651,14 @@ SELECT *
 FROM hyper_estimate;
                                       QUERY PLAN                                      
 --------------------------------------------------------------------------------------
- Append  (cost=100.00..707.74 rows=17 width=20)
+ Append  (cost=100.00..707.79 rows=17 width=20)
    ->  Foreign Scan on _dist_hyper_16_38_chunk  (cost=100.00..101.40 rows=4 width=20)
    ->  Foreign Scan on _dist_hyper_16_39_chunk  (cost=100.00..101.20 rows=2 width=20)
    ->  Foreign Scan on _dist_hyper_16_40_chunk  (cost=100.00..101.30 rows=3 width=20)
    ->  Foreign Scan on _dist_hyper_16_41_chunk  (cost=100.00..101.20 rows=2 width=20)
    ->  Foreign Scan on _dist_hyper_16_42_chunk  (cost=100.00..101.30 rows=3 width=20)
    ->  Foreign Scan on _dist_hyper_16_43_chunk  (cost=100.00..101.10 rows=1 width=20)
-   ->  Foreign Scan on _dist_hyper_16_44_chunk  (cost=100.00..100.15 rows=2 width=20)
+   ->  Foreign Scan on _dist_hyper_16_44_chunk  (cost=100.00..100.20 rows=2 width=20)
 (8 rows)
 
 CREATE TABLE devices (


### PR DESCRIPTION
When no size statistics is available for a chunk because it haven't
been ANALYZEd, we have to resort to some estimates. A good way to
estimate the size of the chunk is to look at the sizes of the nearby
chunk.  Before this commit, we would look up the ten nearby chunk for
each chunk w/o statistics, which was slow. This commit adds the code
to maintain exponential moving average of the recent chunk sizes in
the parent RelOptInfo as we go through them, avoiding the additional
lookups.

Part of #3890