### PR TITLE
Add -Wundef to compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU|AppleClang|Clang")
     -Wempty-body
     -Wvla
     -Wall
+    -Wundef
     -Wmissing-prototypes
     -Wpointer-arith
     -Werror=vla

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -139,7 +139,7 @@ ts_bgw_start_worker(const char *function, const char *name, const char *extra)
 	return handle;
 }
 
-#if USE_ASSERT_CHECKING
+#ifdef USE_ASSERT_CHECKING
 static void
 assert_that_worker_has_stopped(ScheduledBgwJob *sjob)
 {
@@ -177,7 +177,7 @@ worker_state_cleanup(ScheduledBgwJob *sjob)
 	 */
 	if (sjob->handle != NULL)
 	{
-#if USE_ASSERT_CHECKING
+#ifdef USE_ASSERT_CHECKING
 		/* Sanity check: worker has stopped (if it was started) */
 		assert_that_worker_has_stopped(sjob);
 #endif
@@ -239,7 +239,7 @@ worker_state_cleanup(ScheduledBgwJob *sjob)
 static void
 scheduled_bgw_job_transition_state_to(ScheduledBgwJob *sjob, JobState new_state)
 {
-#if USE_ASSERT_CHECKING
+#ifdef USE_ASSERT_CHECKING
 	JobState prev_state = sjob->state;
 #endif
 

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -27,7 +27,7 @@
 #include <miscadmin.h>
 #include <fmgr.h>
 
-#if USE_ASSERT_CHECKING
+#ifdef USE_ASSERT_CHECKING
 #include <funcapi.h>
 #endif
 

--- a/tsl/src/chunk_copy.c
+++ b/tsl/src/chunk_copy.c
@@ -27,7 +27,7 @@
 #include <fmgr.h>
 #include <executor/spi.h>
 
-#if USE_ASSERT_CHECKING
+#ifdef USE_ASSERT_CHECKING
 #include <funcapi.h>
 #endif
 


### PR DESCRIPTION
Today was another time I used `#if PG14_LT` but forgot to include
compat.h, spent a good deal of time debugging this. This flag will
catch references to undefined macros.