### PR TITLE
Refactoring: get rid of max_bucket_width

### DIFF
--- a/sql/cagg_utils.sql
+++ b/sql/cagg_utils.sql
@@ -51,8 +51,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_dist_ht_invalidation_trigg
 --                      Access Node that belong to 'raw_hypertable_id'
 -- bucket_widths - The array of time bucket widths for all the CAGGs that belong to
 --                 'raw_hypertable_id'
--- max_bucket_widths - The array of the maximum time bucket widths for all the CAGGs that belong
---                     to 'raw_hypertable_id'
+-- max_bucket_widths - (Deprecated) This argument is ignored and is present only
+--                     for backward compatibility.
 -- bucket_functions - (Optional) The array of serialized information about bucket functions
 CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_process_hypertable_log(
     mat_hypertable_id INTEGER,
@@ -87,8 +87,8 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.invalidation_process_hypertable
 --                      Access Node that belong to 'raw_hypertable_id'
 -- bucket_widths - The array of time bucket widths for all the CAGGs that belong to
 --                 'raw_hypertable_id'
--- max_bucket_widths - The array of the maximum time bucket widths for all the CAGGs that belong
---                     to 'raw_hypertable_id'
+-- max_bucket_widths - (Deprecated) This argument is ignored and is present only
+--                     for backward compatibility.
 -- bucket_functions - (Optional) The array of serialized information about bucket functions
 --
 -- Returns a tuple of:

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -884,7 +884,6 @@ typedef struct FormData_continuous_agg
 	 * procedures instead, such as:
 	 * - ts_continuous_agg_bucket_width_variable
 	 * - ts_continuous_agg_bucket_width
-	 * - ts_continuous_agg_max_bucket_width
 	 * - ts_bucket_function_to_bucket_width_in_months
 	 */
 	int64 bucket_width;

--- a/src/continuous_agg.c
+++ b/src/continuous_agg.c
@@ -361,7 +361,6 @@ ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id)
 	Datum bucket_width;
 
 	all_caggs_info.bucket_widths = NIL;
-	all_caggs_info.max_bucket_widths = NIL;
 	all_caggs_info.mat_hypertable_ids = NIL;
 	all_caggs_info.bucket_functions = NIL;
 
@@ -376,12 +375,6 @@ ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id)
 										 ts_continuous_agg_bucket_width(cagg));
 		all_caggs_info.bucket_widths =
 			lappend(all_caggs_info.bucket_widths, DatumGetPointer(bucket_width));
-
-		bucket_width = Int64GetDatum(ts_continuous_agg_bucket_width_variable(cagg) ?
-										 BUCKET_WIDTH_VARIABLE :
-										 ts_continuous_agg_max_bucket_width(cagg));
-		all_caggs_info.max_bucket_widths =
-			lappend(all_caggs_info.max_bucket_widths, DatumGetPointer(bucket_width));
 
 		all_caggs_info.bucket_functions =
 			lappend(all_caggs_info.bucket_functions, cagg->bucket_function);
@@ -492,34 +485,29 @@ bucket_function_deserialize(const char *str)
  */
 TSDLLEXPORT void
 ts_populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids, ArrayType *bucket_widths,
-								   ArrayType *max_bucket_widths, ArrayType *bucket_functions,
-								   CaggsInfo *all_caggs)
+								   ArrayType *bucket_functions, CaggsInfo *all_caggs)
 {
 	all_caggs->mat_hypertable_ids = NIL;
 	all_caggs->bucket_widths = NIL;
-	all_caggs->max_bucket_widths = NIL;
 	all_caggs->bucket_functions = NIL;
 
 	Assert(ARR_NDIM(mat_hypertable_ids) > 0 && ARR_NDIM(bucket_widths) > 0 &&
-		   ARR_NDIM(max_bucket_widths) > 0 && ARR_NDIM(bucket_functions) > 0);
+		   ARR_NDIM(bucket_functions) > 0);
 	Assert(ARR_NDIM(mat_hypertable_ids) == ARR_NDIM(bucket_widths) &&
-		   ARR_NDIM(max_bucket_widths) == ARR_NDIM(bucket_widths) &&
 		   ARR_NDIM(bucket_functions) == ARR_NDIM(bucket_widths));
 
-	ArrayIterator it_htids, it_widths, it_maxes, it_bfs;
-	Datum array_datum1, array_datum2, array_datum3, array_datum4;
-	bool isnull1, isnull2, isnull3, isnull4;
+	ArrayIterator it_htids, it_widths, it_bfs;
+	Datum array_datum1, array_datum2, array_datum3;
+	bool isnull1, isnull2, isnull3;
 
 	it_htids = array_create_iterator(mat_hypertable_ids, 0, NULL);
 	it_widths = array_create_iterator(bucket_widths, 0, NULL);
-	it_maxes = array_create_iterator(max_bucket_widths, 0, NULL);
 	it_bfs = array_create_iterator(bucket_functions, 0, NULL);
 	while (array_iterate(it_htids, &array_datum1, &isnull1) &&
 		   array_iterate(it_widths, &array_datum2, &isnull2) &&
-		   array_iterate(it_maxes, &array_datum3, &isnull3) &&
-		   array_iterate(it_bfs, &array_datum4, &isnull4))
+		   array_iterate(it_bfs, &array_datum3, &isnull3))
 	{
-		Assert(!isnull1 && !isnull2 && !isnull3 && !isnull4);
+		Assert(!isnull1 && !isnull2 && !isnull3);
 		int32 mat_hypertable_id = DatumGetInt32(array_datum1);
 		all_caggs->mat_hypertable_ids =
 			lappend_int(all_caggs->mat_hypertable_ids, mat_hypertable_id);
@@ -528,19 +516,15 @@ ts_populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids, ArrayType *buc
 		bucket_width = array_datum2;
 		all_caggs->bucket_widths = lappend(all_caggs->bucket_widths, DatumGetPointer(bucket_width));
 
-		bucket_width = array_datum3;
-		all_caggs->max_bucket_widths =
-			lappend(all_caggs->max_bucket_widths, DatumGetPointer(bucket_width));
-
 		const ContinuousAggsBucketFunction *bucket_function =
-			bucket_function_deserialize(TextDatumGetCString(array_datum4));
+			bucket_function_deserialize(TextDatumGetCString(array_datum3));
 		/* bucket_function is cast to non-const type to make Visual Studio happy */
 		all_caggs->bucket_functions =
 			lappend(all_caggs->bucket_functions, (ContinuousAggsBucketFunction *) bucket_function);
 	}
 	array_free_iterator(it_htids);
 	array_free_iterator(it_widths);
-	array_free_iterator(it_maxes);
+	array_free_iterator(it_bfs);
 }
 
 /*
@@ -549,34 +533,29 @@ ts_populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids, ArrayType *buc
  */
 TSDLLEXPORT void
 ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs, ArrayType **mat_hypertable_ids,
-								 ArrayType **bucket_widths, ArrayType **max_bucket_widths,
-								 ArrayType **bucket_functions)
+								 ArrayType **bucket_widths, ArrayType **bucket_functions)
 {
-	ListCell *lc1, *lc2, *lc3, *lc4;
+	ListCell *lc1, *lc2, *lc3;
 	unsigned i;
 
 	Datum *matiddatums = palloc(sizeof(Datum) * list_length(all_caggs->mat_hypertable_ids));
 	Datum *widthdatums = palloc(sizeof(Datum) * list_length(all_caggs->bucket_widths));
-	Datum *maxwidthdatums = palloc(sizeof(Datum) * list_length(all_caggs->max_bucket_widths));
 	Datum *bucketfunctions = palloc(sizeof(Datum) * list_length(all_caggs->bucket_functions));
 
 	i = 0;
-	forfour(lc1,
-			all_caggs->mat_hypertable_ids,
-			lc2,
-			all_caggs->bucket_widths,
-			lc3,
-			all_caggs->max_bucket_widths,
-			lc4,
-			all_caggs->bucket_functions)
+	forthree (lc1,
+			  all_caggs->mat_hypertable_ids,
+			  lc2,
+			  all_caggs->bucket_widths,
+			  lc3,
+			  all_caggs->bucket_functions)
 	{
 		int32 cagg_hyper_id = lfirst_int(lc1);
 		matiddatums[i] = Int32GetDatum(cagg_hyper_id);
 
 		widthdatums[i] = PointerGetDatum(lfirst(lc2));
-		maxwidthdatums[i] = PointerGetDatum(lfirst(lc3));
 
-		const ContinuousAggsBucketFunction *bucket_function = lfirst(lc4);
+		const ContinuousAggsBucketFunction *bucket_function = lfirst(lc3);
 		bucketfunctions[i] = CStringGetTextDatum(bucket_function_serialize(bucket_function));
 
 		++i;
@@ -595,13 +574,6 @@ ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs, ArrayType **mat_hyp
 									 8,
 									 FLOAT8PASSBYVAL,
 									 TYPALIGN_DOUBLE);
-
-	*max_bucket_widths = construct_array(maxwidthdatums,
-										 list_length(all_caggs->max_bucket_widths),
-										 INT8OID,
-										 8,
-										 FLOAT8PASSBYVAL,
-										 TYPALIGN_DOUBLE);
 
 	*bucket_functions = construct_array(bucketfunctions,
 										list_length(all_caggs->bucket_functions),
@@ -1505,21 +1477,6 @@ ts_continuous_agg_bucket_width(const ContinuousAgg *agg)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("bucket width is not defined for a variable bucket")));
-	}
-
-	return agg->data.bucket_width;
-}
-
-/* Determines maximum possible bucket width for given continuous aggregate. */
-int64
-ts_continuous_agg_max_bucket_width(const ContinuousAgg *agg)
-{
-	if (ts_continuous_agg_bucket_width_variable(agg))
-	{
-		/* should never happen, this code is useful mostly for debugging purposes */
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("maximum bucket width is not defined for a variable bucket")));
 	}
 
 	return agg->data.bucket_width;

--- a/src/continuous_agg.h
+++ b/src/continuous_agg.h
@@ -110,8 +110,6 @@ typedef struct CaggsInfoData
 	List *mat_hypertable_ids;
 	/* (int64) Datum elements; stores BUCKET_WIDTH_VARIABLE for variable buckets */
 	List *bucket_widths;
-	/* (int64) Datum elements; stores BUCKET_WIDTH_VARIABLE for variable buckets */
-	List *max_bucket_widths;
 	/* (const ContinuousAggsBucketFunction *) elements; stores NULL for fixed buckets */
 	List *bucket_functions;
 } CaggsInfo;
@@ -119,13 +117,11 @@ typedef struct CaggsInfoData
 extern TSDLLEXPORT const CaggsInfo ts_continuous_agg_get_all_caggs_info(int32 raw_hypertable_id);
 extern TSDLLEXPORT void ts_populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids,
 														   ArrayType *bucket_widths,
-														   ArrayType *max_bucket_widths,
 														   ArrayType *bucket_functions,
 														   CaggsInfo *all_caggs);
 TSDLLEXPORT void ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs,
 												  ArrayType **mat_hypertable_ids,
 												  ArrayType **bucket_widths,
-												  ArrayType **max_bucket_widths,
 												  ArrayType **bucket_functions);
 
 extern TSDLLEXPORT ContinuousAgg *
@@ -161,7 +157,6 @@ extern ContinuousAgg *ts_continuous_agg_find_userview_name(const char *schema, c
 
 extern TSDLLEXPORT bool ts_continuous_agg_bucket_width_variable(const ContinuousAgg *agg);
 extern TSDLLEXPORT int64 ts_continuous_agg_bucket_width(const ContinuousAgg *agg);
-extern TSDLLEXPORT int64 ts_continuous_agg_max_bucket_width(const ContinuousAgg *agg);
 extern TSDLLEXPORT int32
 ts_bucket_function_to_bucket_width_in_months(const ContinuousAggsBucketFunction *agg);
 

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -358,7 +358,7 @@ validate_window_size(const ContinuousAgg *cagg, const CaggPolicyConfig *config)
 {
 	int64 start_offset;
 	int64 end_offset;
-	int64 max_bucket_width;
+	int64 bucket_width;
 
 	if (config->offset_start.isnull)
 		start_offset = ts_time_get_max(cagg->partition_type);
@@ -370,8 +370,8 @@ validate_window_size(const ContinuousAgg *cagg, const CaggPolicyConfig *config)
 	else
 		end_offset = interval_to_int64(config->offset_end.value, config->offset_end.type);
 
-	max_bucket_width = ts_continuous_agg_max_bucket_width(cagg);
-	if (ts_time_saturating_add(end_offset, max_bucket_width * 2, INT8OID) > start_offset)
+	bucket_width = ts_continuous_agg_bucket_width(cagg);
+	if (ts_time_saturating_add(end_offset, bucket_width * 2, INT8OID) > start_offset)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("policy refresh window too small"),

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -89,9 +89,6 @@
 #define INTERNAL_TO_TSTZ_FUNCTION "to_timestamp"
 #define INTERNAL_TO_TS_FUNCTION "to_timestamp_without_timezone"
 
-#define DEFAULT_MAX_INTERVAL_MULTIPLIER 20
-#define DEFAULT_MAX_INTERVAL_MAX_BUCKET_WIDTH (PG_INT64_MAX / DEFAULT_MAX_INTERVAL_MULTIPLIER)
-
 /*switch to ts user for _timescaledb_internal access */
 #define SWITCH_TO_TS_USER(schemaname, newuid, saved_uid, saved_secctx)                             \
 	do                                                                                             \

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -25,7 +25,7 @@ extern Datum continuous_agg_refresh(PG_FUNCTION_ARGS);
 extern Datum continuous_agg_refresh_chunk(PG_FUNCTION_ARGS);
 extern void continuous_agg_calculate_merged_refresh_window(
 	const InternalTimeRange *refresh_window, const InvalidationStore *invalidations,
-	const int64 max_bucket_width, const ContinuousAggsBucketFunction *bucket_function,
+	const int64 bucket_width, const ContinuousAggsBucketFunction *bucket_function,
 	InternalTimeRange *merged_refresh_window);
 extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,


### PR DESCRIPTION
Our code occasionally mentions max_bucket_width. However, in practice, there is
no such thing. For fixed-sized buckets, bucket_width and max_bucket_width are
always the same, while for variable-sized buckets bucket_width is not used at
all (except the fact that it equals -1 to indicate that the bucket size is
variable).

This patch removes any use of max_bucket_width, except for arguments of:

- _timescaledb_internal.invalidation_process_hypertable_log()
- _timescaledb_internal.invalidation_process_cagg_log()

The signatures of these functions were not changed for backward compatibility
between access and data nodes, which can run different versions of TimescaleDB.