### PR TITLE
Fix subtract_integer_from_now on 32-bit platforms and improve error handling

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2230,8 +2230,11 @@ ts_chunk_show_chunks(PG_FUNCTION_ARGS)
 		ht = find_hypertable_from_table_or_cagg(hcache, relid, true);
 		Assert(ht != NULL);
 		time_dim = hyperspace_get_open_dimension(ht->space, 0);
-		Assert(time_dim != NULL);
-		time_type = ts_dimension_get_partition_type(time_dim);
+
+		if (time_dim)
+			time_type = ts_dimension_get_partition_type(time_dim);
+		else
+			time_type = InvalidOid;
 
 		if (!PG_ARGISNULL(1))
 			older_than = ts_time_value_from_arg(PG_GETARG_DATUM(1),
@@ -4061,7 +4064,10 @@ ts_chunk_drop_chunks(PG_FUNCTION_ARGS)
 	ht = find_hypertable_from_table_or_cagg(hcache, relid, false);
 	Assert(ht != NULL);
 	time_dim = hyperspace_get_open_dimension(ht->space, 0);
-	Assert(time_dim != NULL);
+
+	if (!time_dim)
+		elog(ERROR, "hypertable has no open partitioning dimension");
+
 	time_type = ts_dimension_get_partition_type(time_dim);
 
 	if (!PG_ARGISNULL(1))

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2391,6 +2391,11 @@ ts_hypertable_set_integer_now_func(PG_FUNCTION_ARGS)
 	ts_hypertable_permissions_check(table_relid, GetUserId());
 	hypertable = ts_hypertable_cache_get_cache_and_entry(table_relid, CACHE_FLAG_NONE, &hcache);
 
+	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(hypertable))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("custom time function not supported on internal compression table")));
+
 	/* validate that the open dimension uses numeric type */
 	open_dim = hyperspace_get_open_dimension(hypertable->space, 0);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -904,18 +904,24 @@ Datum
 ts_subtract_integer_from_now(PG_FUNCTION_ARGS)
 {
 	Oid ht_relid = PG_GETARG_OID(0);
-	Datum lag = PG_GETARG_INT64(1);
+	int64 lag = PG_GETARG_INT64(1);
 	Cache *hcache;
-	Hypertable *hypertable =
-		ts_hypertable_cache_get_cache_and_entry(ht_relid, CACHE_FLAG_NONE, &hcache);
-
-	const Dimension *dim = hyperspace_get_open_dimension(hypertable->space, 0);
-	Oid partitioning_type = ts_dimension_get_partition_type(dim);
-	Oid now_func = ts_get_integer_now_func(dim);
-	if (now_func == InvalidOid)
-		elog(ERROR, "could not find valid integer_now function for hypertable");
-	Assert(IS_INTEGER_TYPE(partitioning_type));
-	int64 res = ts_sub_integer_from_now(lag, partitioning_type, now_func);
+	Hypertable *ht = ts_hypertable_cache_get_cache_and_entry(ht_relid, CACHE_FLAG_NONE, &hcache);
+	const Dimension *dim = hyperspace_get_open_dimension(ht->space, 0);
 	ts_cache_release(hcache);
+
+	if (!dim)
+		elog(ERROR, "hypertable has no open partitioning dimension");
+
+	Oid partitioning_type = ts_dimension_get_partition_type(dim);
+
+	if (!IS_INTEGER_TYPE(partitioning_type))
+		elog(ERROR, "hypertable has no integer partitioning dimension");
+
+	Oid now_func = ts_get_integer_now_func(dim);
+	if (!OidIsValid(now_func))
+		elog(ERROR, "could not find valid integer_now function for hypertable");
+
+	int64 res = ts_sub_integer_from_now(lag, partitioning_type, now_func);
 	return Int64GetDatum(res);
 }

--- a/tsl/src/bgw_policy/policy_utils.c
+++ b/tsl/src/bgw_policy/policy_utils.c
@@ -108,6 +108,10 @@ const Dimension *
 get_open_dimension_for_hypertable(const Hypertable *ht)
 {
 	int32 mat_id = ht->fd.id;
+
+	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
+		elog(ERROR, "invalid operation on compressed hypertable");
+
 	const Dimension *open_dim = hyperspace_get_open_dimension(ht->space, 0);
 	Oid partitioning_type = ts_dimension_get_partition_type(open_dim);
 	if (IS_INTEGER_TYPE(partitioning_type))

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -145,6 +145,14 @@ policy_reorder_add(PG_FUNCTION_ARGS)
 	/* First verify that the hypertable corresponds to a valid table */
 	owner_id = ts_hypertable_permissions_check(ht_oid, GetUserId());
 
+	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot add reorder policy to compressed hypertable \"%s\"",
+						get_rel_name(ht_oid)),
+				 errhint("Please add the policy to the corresponding uncompressed hypertable "
+						 "instead.")));
+
 	if (hypertable_is_distributed(ht))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -952,6 +952,11 @@ cagg_validate_query(Query *query)
 
 		ht = ts_hypertable_cache_get_cache_and_entry(rte->relid, CACHE_FLAG_NONE, &hcache);
 
+		if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("hypertable is an internal compressed hypertable")));
+
 		/* there can only be one continuous aggregate per table */
 		switch (ts_continuous_agg_hypertable_status(ht->fd.id))
 		{

--- a/tsl/test/expected/chunk_utils_compression.out
+++ b/tsl/test/expected/chunk_utils_compression.out
@@ -134,3 +134,16 @@ SELECT show_chunks('public.table_to_compress');
 -------------
 (0 rows)
 
+-- test calling on internal compressed table
+SELECT
+  format('%I.%I', ht.schema_name, ht.table_name) AS "TABLENAME"
+FROM
+  _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
+      AND uncompress.table_name = 'table_to_compress') \gset
+\set ON_ERROR_STOP 0
+SELECT show_chunks(:'TABLENAME');
+ERROR:  invalid operation on compressed hypertable
+SELECT drop_chunks(:'TABLENAME',now());
+ERROR:  hypertable has no open partitioning dimension
+\set ON_ERROR_STOP 1

--- a/tsl/test/expected/continuous_aggs_errors.out
+++ b/tsl/test/expected/continuous_aggs_errors.out
@@ -675,3 +675,20 @@ WHERE view_name = 'i2980_cagg2'
 \gset
 SELECT add_compression_policy( :'MAT_TABLE_NAME', 13::integer);
 ERROR:  cannot add compression policy to materialized hypertable "_materialized_hypertable_14" 
+-- test error handling when trying to create on internal hypertable
+CREATE TABLE comp_ht_test(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('comp_ht_test','time');
+  table_name  
+--------------
+ comp_ht_test
+(1 row)
+
+ALTER TABLE comp_ht_test SET (timescaledb.compress);
+SELECT
+  format('%I.%I', ht.schema_name, ht.table_name) AS "INTERNALTABLE"
+FROM
+  _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
+      AND uncompress.table_name = 'comp_ht_test') \gset
+CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
+ERROR:  hypertable is an internal compressed hypertable

--- a/tsl/test/expected/reorder.out
+++ b/tsl/test/expected/reorder.out
@@ -1361,3 +1361,24 @@ SELECT reorder_chunk(chunk,'i3651_attmap') from show_chunks('i3651') chunk;
  
 (1 row)
 
+-- test error handling when trying to create on internal hypertable
+CREATE TABLE comp_ht_test(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('comp_ht_test','time');
+  table_name  
+--------------
+ comp_ht_test
+(1 row)
+
+ALTER TABLE comp_ht_test SET (timescaledb.compress);
+SELECT
+  format('%I.%I', ht.schema_name, ht.table_name) AS "INTERNALTABLE"
+FROM
+  _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
+      AND uncompress.table_name = 'comp_ht_test') \gset
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE INDEX internal_idx ON :INTERNALTABLE(_ts_meta_min_1);
+\set ON_ERROR_STOP 0
+SELECT add_reorder_policy(:'INTERNALTABLE','internal_idx');
+ERROR:  cannot add reorder policy to compressed hypertable "_compressed_hypertable_5"
+\set ON_ERROR_STOP 1

--- a/tsl/test/shared/expected/subtract_integer_from_now.out
+++ b/tsl/test/shared/expected/subtract_integer_from_now.out
@@ -1,0 +1,118 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- test on normal table
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now('pg_class', 1);
+ERROR:  table "pg_class" is not a hypertable
+\set ON_ERROR_STOP 1
+-- test on hypertable with non-int time dimension
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now('metrics', 1);
+ERROR:  hypertable has no integer partitioning dimension
+\set ON_ERROR_STOP 1
+SELECT
+  format('%I.%I', ht.schema_name, ht.table_name) AS "TABLENAME"
+FROM
+  _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
+      AND uncompress.table_name = 'metrics_compressed') \gset
+-- test on hypertable without dimensions
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now(:'TABLENAME', 1);
+ERROR:  hypertable has no open partitioning dimension
+\set ON_ERROR_STOP 1
+-- test on hypertable without now function
+CREATE TABLE subtract_int_no_func(time int NOT NULL);
+SELECT table_name FROM create_hypertable('subtract_int_no_func','time',chunk_time_interval:=10);
+      table_name      
+----------------------
+ subtract_int_no_func
+(1 row)
+
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int_no_func', 1);
+ERROR:  integer_now function not set
+\set ON_ERROR_STOP 1
+CREATE OR REPLACE FUNCTION sub_int2_now() RETURNS int2 AS $$ SELECT 2::int2; $$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION sub_int4_now() RETURNS int4 AS $$ SELECT 4::int4; $$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION sub_int8_now() RETURNS int8 AS $$ SELECT 8::int8; $$ LANGUAGE SQL IMMUTABLE;
+CREATE TABLE subtract_int2(time int2 NOT NULL);
+CREATE TABLE subtract_int4(time int4 NOT NULL);
+CREATE TABLE subtract_int8(time int8 NOT NULL);
+SELECT table_name FROM create_hypertable('subtract_int2', 'time', chunk_time_interval:=10);
+  table_name   
+---------------
+ subtract_int2
+(1 row)
+
+SELECT table_name FROM create_hypertable('subtract_int4', 'time', chunk_time_interval:=10);
+  table_name   
+---------------
+ subtract_int4
+(1 row)
+
+SELECT table_name FROM create_hypertable('subtract_int8', 'time', chunk_time_interval:=10);
+  table_name   
+---------------
+ subtract_int8
+(1 row)
+
+SELECT set_integer_now_func('subtract_int2', 'sub_int2_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT set_integer_now_func('subtract_int4', 'sub_int4_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT set_integer_now_func('subtract_int8', 'sub_int8_now');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int2', lag) AS sub FROM (VALUES (-10),(0),(2),(4),(8)) v(lag);
+ sub 
+-----
+  12
+   2
+   0
+  -2
+  -6
+(5 rows)
+
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int4', lag) AS sub FROM (VALUES (-10),(0),(2),(4),(8)) v(lag);
+ sub 
+-----
+  14
+   4
+   2
+   0
+  -4
+(5 rows)
+
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int8', lag) AS sub FROM (VALUES (-10),(0),(2),(4),(8)) v(lag);
+ sub 
+-----
+  18
+   8
+   6
+   4
+   0
+(5 rows)
+
+-- test set_integer_now_func on internal table
+\set ON_ERROR_STOP 0
+SELECT set_integer_now_func(:'TABLENAME', 'sub_int2_now');
+ERROR:  custom time function not supported on internal compression table
+\set ON_ERROR_STOP 1
+-- cleanup
+DROP TABLE subtract_int_no_func;
+DROP TABLE subtract_int2;
+DROP TABLE subtract_int4;
+DROP TABLE subtract_int8;

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -9,7 +9,8 @@ set(TEST_FILES_SHARED
     dist_fetcher_type.sql
     dist_gapfill.sql
     dist_insert.sql
-    dist_queries.sql)
+    dist_queries.sql
+    subtract_integer_from_now.sql)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   list(APPEND TEST_FILES_SHARED memoize.sql)

--- a/tsl/test/shared/sql/subtract_integer_from_now.sql
+++ b/tsl/test/shared/sql/subtract_integer_from_now.sql
@@ -1,0 +1,63 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- test on normal table
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now('pg_class', 1);
+\set ON_ERROR_STOP 1
+
+-- test on hypertable with non-int time dimension
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now('metrics', 1);
+\set ON_ERROR_STOP 1
+
+SELECT
+  format('%I.%I', ht.schema_name, ht.table_name) AS "TABLENAME"
+FROM
+  _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
+      AND uncompress.table_name = 'metrics_compressed') \gset
+
+-- test on hypertable without dimensions
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now(:'TABLENAME', 1);
+\set ON_ERROR_STOP 1
+
+-- test on hypertable without now function
+CREATE TABLE subtract_int_no_func(time int NOT NULL);
+SELECT table_name FROM create_hypertable('subtract_int_no_func','time',chunk_time_interval:=10);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int_no_func', 1);
+\set ON_ERROR_STOP 1
+
+CREATE OR REPLACE FUNCTION sub_int2_now() RETURNS int2 AS $$ SELECT 2::int2; $$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION sub_int4_now() RETURNS int4 AS $$ SELECT 4::int4; $$ LANGUAGE SQL IMMUTABLE;
+CREATE OR REPLACE FUNCTION sub_int8_now() RETURNS int8 AS $$ SELECT 8::int8; $$ LANGUAGE SQL IMMUTABLE;
+
+CREATE TABLE subtract_int2(time int2 NOT NULL);
+CREATE TABLE subtract_int4(time int4 NOT NULL);
+CREATE TABLE subtract_int8(time int8 NOT NULL);
+
+SELECT table_name FROM create_hypertable('subtract_int2', 'time', chunk_time_interval:=10);
+SELECT table_name FROM create_hypertable('subtract_int4', 'time', chunk_time_interval:=10);
+SELECT table_name FROM create_hypertable('subtract_int8', 'time', chunk_time_interval:=10);
+
+SELECT set_integer_now_func('subtract_int2', 'sub_int2_now');
+SELECT set_integer_now_func('subtract_int4', 'sub_int4_now');
+SELECT set_integer_now_func('subtract_int8', 'sub_int8_now');
+
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int2', lag) AS sub FROM (VALUES (-10),(0),(2),(4),(8)) v(lag);
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int4', lag) AS sub FROM (VALUES (-10),(0),(2),(4),(8)) v(lag);
+SELECT _timescaledb_internal.subtract_integer_from_now('subtract_int8', lag) AS sub FROM (VALUES (-10),(0),(2),(4),(8)) v(lag);
+
+-- test set_integer_now_func on internal table
+\set ON_ERROR_STOP 0
+SELECT set_integer_now_func(:'TABLENAME', 'sub_int2_now');
+\set ON_ERROR_STOP 1
+
+-- cleanup
+DROP TABLE subtract_int_no_func;
+DROP TABLE subtract_int2;
+DROP TABLE subtract_int4;
+DROP TABLE subtract_int8;

--- a/tsl/test/sql/chunk_utils_compression.sql
+++ b/tsl/test/sql/chunk_utils_compression.sql
@@ -44,3 +44,17 @@ SELECT drop_chunks(table_name::regclass, older_than=>'1 day'::interval)
 ORDER BY table_name DESC;
 SELECT show_chunks('public.uncompressed_table');
 SELECT show_chunks('public.table_to_compress');
+
+-- test calling on internal compressed table
+SELECT
+  format('%I.%I', ht.schema_name, ht.table_name) AS "TABLENAME"
+FROM
+  _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
+      AND uncompress.table_name = 'table_to_compress') \gset
+
+\set ON_ERROR_STOP 0
+SELECT show_chunks(:'TABLENAME');
+SELECT drop_chunks(:'TABLENAME',now());
+\set ON_ERROR_STOP 1
+

--- a/tsl/test/sql/reorder.sql
+++ b/tsl/test/sql/reorder.sql
@@ -254,3 +254,21 @@ CREATE UNIQUE INDEX i3651_attmap ON i3651(c1,c4);
 INSERT INTO i3651 VALUES('2000-01-01','foo','foo'),('2000-01-01','foo','bar');
 SELECT reorder_chunk(chunk,'i3651_attmap') from show_chunks('i3651') chunk;
 
+-- test error handling when trying to create on internal hypertable
+CREATE TABLE comp_ht_test(time timestamptz NOT NULL);
+SELECT table_name FROM create_hypertable('comp_ht_test','time');
+ALTER TABLE comp_ht_test SET (timescaledb.compress);
+
+SELECT
+  format('%I.%I', ht.schema_name, ht.table_name) AS "INTERNALTABLE"
+FROM
+  _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
+      AND uncompress.table_name = 'comp_ht_test') \gset
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE INDEX internal_idx ON :INTERNALTABLE(_ts_meta_min_1);
+\set ON_ERROR_STOP 0
+SELECT add_reorder_policy(:'INTERNALTABLE','internal_idx');
+\set ON_ERROR_STOP 1
+


### PR DESCRIPTION
This would trigger an assert when called on a hypertable without
integer time dimension. Found by sqlsmith.

Disable-check: commit-count
