### PR TITLE
Fix projection handling in gapfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #3808 Properly handle `max_retries` option
 * #3918 Fix DataNodeScan plans with one-time filter
+* #3939 Fix projection handling in time_bucket_gapfill
+
+**Thanks**
+* @erikhh for reporting an issue with time_bucket_gapfill
 
 ## 2.5.1 (2021-12-02)
 

--- a/tsl/test/shared/expected/gapfill-12.out
+++ b/tsl/test/shared/expected/gapfill-12.out
@@ -3136,3 +3136,50 @@ GROUP BY 1;
                            ->  Seq Scan on _hyper_X_X_chunk
 (10 rows)
 
+-- issue #3834
+-- test projection handling in gapfill
+CREATE TABLE i3834(time timestamptz NOT NULL, ship_id int, value float);
+SELECT table_name FROM create_hypertable('i3834','time');
+ table_name 
+------------
+ i3834
+(1 row)
+
+INSERT INTO i3834 VALUES ('2020-12-01 14:05:00+01',1,3.123), ('2020-12-01 14:05:00+01',2,4.123), ('2020-12-01 14:05:00+01',3,5.123);
+SELECT
+  time_bucket_gapfill('30000 ms'::interval, time) AS time,
+  ship_id,
+  interpolate (avg(value)),
+  'speedlog' AS source
+FROM
+  i3834
+WHERE
+  ship_id IN (1, 2)
+  AND time >= '2020-12-01 14:05:00+01'
+  AND time < '2020-12-01 14:10:00+01'
+GROUP BY 1,2;
+             time             | ship_id | interpolate |  source  
+------------------------------+---------+-------------+----------
+ Tue Dec 01 05:05:00 2020 PST |       1 |       3.123 | speedlog
+ Tue Dec 01 05:05:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:06:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:06:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:07:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:07:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:08:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:08:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:09:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:09:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:05:00 2020 PST |       2 |       4.123 | speedlog
+ Tue Dec 01 05:05:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:06:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:06:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:07:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:07:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:08:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:08:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:09:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:09:30 2020 PST |       2 |             | speedlog
+(20 rows)
+
+DROP TABLE i3834;

--- a/tsl/test/shared/expected/gapfill-13.out
+++ b/tsl/test/shared/expected/gapfill-13.out
@@ -3143,3 +3143,50 @@ GROUP BY 1;
                            ->  Seq Scan on _hyper_X_X_chunk
 (10 rows)
 
+-- issue #3834
+-- test projection handling in gapfill
+CREATE TABLE i3834(time timestamptz NOT NULL, ship_id int, value float);
+SELECT table_name FROM create_hypertable('i3834','time');
+ table_name 
+------------
+ i3834
+(1 row)
+
+INSERT INTO i3834 VALUES ('2020-12-01 14:05:00+01',1,3.123), ('2020-12-01 14:05:00+01',2,4.123), ('2020-12-01 14:05:00+01',3,5.123);
+SELECT
+  time_bucket_gapfill('30000 ms'::interval, time) AS time,
+  ship_id,
+  interpolate (avg(value)),
+  'speedlog' AS source
+FROM
+  i3834
+WHERE
+  ship_id IN (1, 2)
+  AND time >= '2020-12-01 14:05:00+01'
+  AND time < '2020-12-01 14:10:00+01'
+GROUP BY 1,2;
+             time             | ship_id | interpolate |  source  
+------------------------------+---------+-------------+----------
+ Tue Dec 01 05:05:00 2020 PST |       1 |       3.123 | speedlog
+ Tue Dec 01 05:05:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:06:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:06:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:07:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:07:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:08:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:08:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:09:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:09:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:05:00 2020 PST |       2 |       4.123 | speedlog
+ Tue Dec 01 05:05:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:06:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:06:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:07:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:07:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:08:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:08:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:09:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:09:30 2020 PST |       2 |             | speedlog
+(20 rows)
+
+DROP TABLE i3834;

--- a/tsl/test/shared/expected/gapfill-14.out
+++ b/tsl/test/shared/expected/gapfill-14.out
@@ -3143,3 +3143,50 @@ GROUP BY 1;
                            ->  Seq Scan on _hyper_X_X_chunk
 (10 rows)
 
+-- issue #3834
+-- test projection handling in gapfill
+CREATE TABLE i3834(time timestamptz NOT NULL, ship_id int, value float);
+SELECT table_name FROM create_hypertable('i3834','time');
+ table_name 
+------------
+ i3834
+(1 row)
+
+INSERT INTO i3834 VALUES ('2020-12-01 14:05:00+01',1,3.123), ('2020-12-01 14:05:00+01',2,4.123), ('2020-12-01 14:05:00+01',3,5.123);
+SELECT
+  time_bucket_gapfill('30000 ms'::interval, time) AS time,
+  ship_id,
+  interpolate (avg(value)),
+  'speedlog' AS source
+FROM
+  i3834
+WHERE
+  ship_id IN (1, 2)
+  AND time >= '2020-12-01 14:05:00+01'
+  AND time < '2020-12-01 14:10:00+01'
+GROUP BY 1,2;
+             time             | ship_id | interpolate |  source  
+------------------------------+---------+-------------+----------
+ Tue Dec 01 05:05:00 2020 PST |       1 |       3.123 | speedlog
+ Tue Dec 01 05:05:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:06:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:06:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:07:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:07:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:08:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:08:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:09:00 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:09:30 2020 PST |       1 |             | speedlog
+ Tue Dec 01 05:05:00 2020 PST |       2 |       4.123 | speedlog
+ Tue Dec 01 05:05:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:06:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:06:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:07:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:07:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:08:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:08:30 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:09:00 2020 PST |       2 |             | speedlog
+ Tue Dec 01 05:09:30 2020 PST |       2 |             | speedlog
+(20 rows)
+
+DROP TABLE i3834;

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -1421,3 +1421,25 @@ EXPLAIN (costs off) SELECT time_bucket_gapfill('52w', time, '2000-01-01', '2000-
 FROM metrics
 GROUP BY 1;
 
+-- issue #3834
+-- test projection handling in gapfill
+CREATE TABLE i3834(time timestamptz NOT NULL, ship_id int, value float);
+SELECT table_name FROM create_hypertable('i3834','time');
+
+INSERT INTO i3834 VALUES ('2020-12-01 14:05:00+01',1,3.123), ('2020-12-01 14:05:00+01',2,4.123), ('2020-12-01 14:05:00+01',3,5.123);
+
+SELECT
+  time_bucket_gapfill('30000 ms'::interval, time) AS time,
+  ship_id,
+  interpolate (avg(value)),
+  'speedlog' AS source
+FROM
+  i3834
+WHERE
+  ship_id IN (1, 2)
+  AND time >= '2020-12-01 14:05:00+01'
+  AND time < '2020-12-01 14:10:00+01'
+GROUP BY 1,2;
+
+DROP TABLE i3834;
+


### PR DESCRIPTION
When getting the next tuple from the subplan gapfill would apply
the projection to it which was incorrect since the subplan already
did the projection and the projection for the gapfill tuple has to
be done when the tuple is handed to the parent node.

Fixes #3834