### PR TITLE
Override the default ACL for public schema on PG15

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -61,6 +61,7 @@ trap cleanup EXIT
 if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
   cat <<EOF | ${PSQL} "$@" -U ${USER} -d template1 -v ECHO=none >/dev/null 2>&1
     SET client_min_messages=ERROR;
+    GRANT CREATE ON SCHEMA public TO PUBLIC;
     ALTER USER ${TEST_ROLE_SUPERUSER} WITH SUPERUSER;
     ALTER USER ${TEST_ROLE_CLUSTER_SUPERUSER} WITH SUPERUSER;
     ALTER USER ${TEST_ROLE_1} WITH CREATEDB CREATEROLE;

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -513,6 +513,18 @@ data_node_bootstrap_extension(TSConnection *conn)
 								  " WITH SCHEMA %s VERSION %s CASCADE",
 								  schema_name_quoted,
 								  quote_literal_cstr(ts_extension_get_version()));
+#if PG15_GE
+		/*
+		 * Since PG15, by default, non-superuser accounts are not allowed to
+		 * create tables in public schema of databases they don't own. This
+		 * default can be changed manually. The following query ensures that the
+		 * permissions are going to be the same regardless of the used PostgreSQL
+		 * version.
+		 *
+		 * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=b073c3cc
+		 */
+		remote_connection_cmdf_ok(conn, "GRANT CREATE ON SCHEMA public TO PUBLIC");
+#endif
 		return true;
 	}
 	else


### PR DESCRIPTION
Override the default ACL for public schema on PG15

Since PG15, by default, non-superuser accounts are not allowed to create
tables in public schema of databases they don't own. This default can be
changed manually. This patch ensures that the permissions are going to be the
same regardless of the used PostgreSQL version.

Without this patch, none of our tests pass on PG15 because they fail with the
"access denied to schema public" error. This is why runner.sh was modified.
Then, some other tests keep failing because when we call create_distributed_hypertable()
we create a new database on each of the data nodes, also not granting enough
permissions to non-privileged users. This is what the fix of data_node.c
addresses.

This is not necessarily the best approach possible, but it preserves the same
behavior on PostgreSQL >= 15 and PostgreSQL < 15. Maybe one day we will come up
with something better (especially when there will be no need to support PG < 15)
but until then the patch seems to be good enough.

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=b073c3cc