### PR TITLE
Optimize first/last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ accidentally triggering the load of a previous DB version.**
 **Features**
 * #3768 Allow ALTER TABLE ADD COLUMN with DEFAULT on compressed hypertable
 * #3769 Allow ALTER TABLE DROP COLUMN on compressed hypertable
+* #3943 Optimize first/last
 
 **Bugfixes**
 * #3808 Properly handle `max_retries` option
 * #3918 Fix DataNodeScan plans with one-time filter
+* #3938 Fix subtract_integer_from_now on 32-bit platforms and improve error handling
 * #3939 Fix projection handling in time_bucket_gapfill
 
 **Thanks**
 * @erikhh for reporting an issue with time_bucket_gapfill
+* @fvannee for reporting a first/last memory leak
 
 ## 2.5.1 (2021-12-02)
 

--- a/test/expected/agg_bookends-12.out
+++ b/test/expected/agg_bookends-12.out
@@ -150,6 +150,17 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (6 rows)
 
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: _hyper_1_1_chunk.gp
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _hyper_1_1_chunk.gp
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
+(6 rows)
+
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -749,6 +760,13 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
   2 | 20.1
 (2 rows)
 
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
+ gp |  last   
+----+---------
+  1 | testing
+  2 | testing
+(2 rows)
+
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -989,6 +1007,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 --check toasted col
 :PREFIX SELECT gp, left(last(strid, time), 10) FROM btest GROUP BY gp ORDER BY gp;
 :PREFIX SELECT gp, last(temp, strid) FROM btest GROUP BY gp ORDER BY gp;
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -1077,6 +1096,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 --check toasted col
 :PREFIX SELECT gp, left(last(strid, time), 10) FROM btest GROUP BY gp ORDER BY gp;
 :PREFIX SELECT gp, last(temp, strid) FROM btest GROUP BY gp ORDER BY gp;
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);

--- a/test/expected/agg_bookends-13.out
+++ b/test/expected/agg_bookends-13.out
@@ -155,6 +155,18 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: _hyper_1_1_chunk.gp
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _hyper_1_1_chunk.gp
+         Batches: 1 
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
+(7 rows)
+
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -756,6 +768,13 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
   2 | 20.1
 (2 rows)
 
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
+ gp |  last   
+----+---------
+  1 | testing
+  2 | testing
+(2 rows)
+
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -996,6 +1015,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 --check toasted col
 :PREFIX SELECT gp, left(last(strid, time), 10) FROM btest GROUP BY gp ORDER BY gp;
 :PREFIX SELECT gp, last(temp, strid) FROM btest GROUP BY gp ORDER BY gp;
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -1084,6 +1104,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 --check toasted col
 :PREFIX SELECT gp, left(last(strid, time), 10) FROM btest GROUP BY gp ORDER BY gp;
 :PREFIX SELECT gp, last(temp, strid) FROM btest GROUP BY gp ORDER BY gp;
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);

--- a/test/expected/agg_bookends-14.out
+++ b/test/expected/agg_bookends-14.out
@@ -155,6 +155,18 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
          ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
 (7 rows)
 
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Sort (actual rows=2 loops=1)
+   Sort Key: _hyper_1_1_chunk.gp
+   Sort Method: quicksort 
+   ->  HashAggregate (actual rows=2 loops=1)
+         Group Key: _hyper_1_1_chunk.gp
+         Batches: 1 
+         ->  Seq Scan on _hyper_1_1_chunk (actual rows=6 loops=1)
+(7 rows)
+
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -756,6 +768,13 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
   2 | 20.1
 (2 rows)
 
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
+ gp |  last   
+----+---------
+  1 | testing
+  2 | testing
+(2 rows)
+
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -996,6 +1015,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 --check toasted col
 :PREFIX SELECT gp, left(last(strid, time), 10) FROM btest GROUP BY gp ORDER BY gp;
 :PREFIX SELECT gp, last(temp, strid) FROM btest GROUP BY gp ORDER BY gp;
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);
@@ -1084,6 +1104,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 --check toasted col
 :PREFIX SELECT gp, left(last(strid, time), 10) FROM btest GROUP BY gp ORDER BY gp;
 :PREFIX SELECT gp, last(temp, strid) FROM btest GROUP BY gp ORDER BY gp;
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
 BEGIN;
 --check null value as last element
 INSERT INTO btest VALUES('2018-01-20T09:00:43', '2017-01-20T09:00:55', 2, NULL);

--- a/test/sql/include/agg_bookends_query.sql
+++ b/test/sql/include/agg_bookends_query.sql
@@ -24,6 +24,7 @@ SELECT setting, current_setting(setting) AS value from (VALUES ('timescaledb.ena
 --check toasted col
 :PREFIX SELECT gp, left(last(strid, time), 10) FROM btest GROUP BY gp ORDER BY gp;
 :PREFIX SELECT gp, last(temp, strid) FROM btest GROUP BY gp ORDER BY gp;
+:PREFIX SELECT gp, last(strid, temp) FROM btest GROUP BY gp ORDER BY gp;
 
 BEGIN;
 


### PR DESCRIPTION
This patch optimizes how first()/last() initialize the compare
function. Previously the compare function would be looked up for
every transition function call but since polymorphic types are
resolved at parse time for a specific aggregate instance the compare
function will not change during its lifetime. Additionally this
patch also fixes a memory leak when using first()/last() on
pointer types.
These changes lead to a roughly 2x speed improvement for first()/
last() and make the memory usage near-constant.

![image](https://user-images.githubusercontent.com/31455525/146695315-e1fad8fc-4da4-4d96-8c05-13cae66dcf36.png)


Fixes #3935