### PR TITLE
Fix segfault in add_compression_policy

### DIFF
--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -443,10 +443,15 @@ validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg
 		if (cagg == NULL)
 		{
 			ts_cache_release(hcache);
-			ereport(ERROR,
-					(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
-					 errmsg("\"%s\" is not a hypertable or a continuous aggregate",
-							get_rel_name(user_htoid))));
+			const char *relname = get_rel_name(user_htoid);
+			if (relname)
+				ereport(ERROR,
+						(errcode(ERRCODE_TS_HYPERTABLE_NOT_EXIST),
+						 errmsg("\"%s\" is not a hypertable or a continuous aggregate", relname)));
+			else
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_OBJECT),
+						 errmsg("object with id \"%u\" not found", user_htoid)));
 		}
 		*is_cagg = true;
 		mat_id = cagg->data.mat_hypertable_id;

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -121,7 +121,7 @@ ERROR:  job 1000 not found
 --errors with bad input for add/remove compression policy
 create view dummyv1 as select * from conditions limit 1;
 select add_compression_policy( 100 , compress_after=> '1 day'::interval);
-ERROR:  "(null)" is not a hypertable or a continuous aggregate
+ERROR:  object with id "100" not found
 select add_compression_policy( 'dummyv1', compress_after=> '1 day'::interval );
 ERROR:  "dummyv1" is not a hypertable or a continuous aggregate
 select remove_compression_policy( 100 );


### PR DESCRIPTION
Postgres snprintf before 89ad14cd787 will segfault on NULL char
pointers. This patch changes add_compression_policy to check for
NULL get_rel_name before reporting the error.

https://github.com/postgres/postgres/commit/89ad14cd787