### PR TITLE
Add support for ALTER SCHEMA command on multi-node

### DIFF
--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -423,12 +423,12 @@ dist_ddl_process_alter_object_schema(const ProcessUtilityArgs *args)
 {
 	AlterObjectSchemaStmt *stmt = castNode(AlterObjectSchemaStmt, args->parsetree);
 
-	/* ALTER object SET SCHEMA */
-	if (list_length(args->hypertable_list) != 1)
-		return;
-
 	if (stmt->objectType == OBJECT_TABLE)
 	{
+		/* ALTER object SET SCHEMA */
+		if (list_length(args->hypertable_list) != 1)
+			return;
+
 		/*
 		 * Hypertable oid is available in hypertable_list but
 		 * cannot be resolved here until standard utility hook will synchronize new
@@ -442,30 +442,54 @@ dist_ddl_process_alter_object_schema(const ProcessUtilityArgs *args)
 }
 
 static void
+dist_ddl_process_alter_owner_stmt(const ProcessUtilityArgs *args)
+{
+	AlterOwnerStmt *stmt = castNode(AlterOwnerStmt, args->parsetree);
+
+	if (stmt->objectType == OBJECT_SCHEMA)
+	{
+		/* ALTER SCHEMA OWNER TO */
+		dist_ddl_state_add_current_data_node_list();
+		dist_ddl_state_schedule(DIST_DDL_EXEC_ON_START, args);
+	}
+}
+
+static void
 dist_ddl_process_rename(const ProcessUtilityArgs *args)
 {
 	RenameStmt *stmt = castNode(RenameStmt, args->parsetree);
 
-	if (list_length(args->hypertable_list) != 1)
-		return;
-
-	if (stmt->renameType == OBJECT_TABLE)
+	switch (stmt->renameType)
 	{
-		/*
-		 * Hypertable oid is available in hypertable_list but
-		 * cannot be resolved here until standard utility hook will synchronize new
-		 * relation name and schema.
-		 *
-		 * Save oid for dist_ddl_end execution.
-		 */
-		dist_ddl_state.relid = linitial_oid(args->hypertable_list);
-		dist_ddl_state_schedule(DIST_DDL_EXEC_ON_END, args);
-		return;
-	}
+		case OBJECT_SCHEMA:
 
-	/* Only handles other renamings here (e.g., triggers) */
-	if (dist_ddl_state_set_hypertable(args))
-		dist_ddl_state_schedule(DIST_DDL_EXEC_ON_START, args);
+			/* ALTER SCHEMA RENAME TO */
+			dist_ddl_state_add_current_data_node_list();
+			dist_ddl_state_schedule(DIST_DDL_EXEC_ON_START, args);
+			break;
+
+		case OBJECT_TABLE:
+
+			/* ALTER TABLE RENAME TO */
+			if (list_length(args->hypertable_list) != 1)
+				break;
+			/*
+			 * Hypertable oid is available in hypertable_list but
+			 * cannot be resolved here until standard utility hook will synchronize new
+			 * relation name and schema.
+			 *
+			 * Save oid for dist_ddl_end execution.
+			 */
+			dist_ddl_state.relid = linitial_oid(args->hypertable_list);
+			dist_ddl_state_schedule(DIST_DDL_EXEC_ON_END, args);
+			break;
+
+		default:
+			/* Only handles other renamings here (e.g., triggers) */
+			if (dist_ddl_state_set_hypertable(args))
+				dist_ddl_state_schedule(DIST_DDL_EXEC_ON_START, args);
+			break;
+	}
 }
 
 static void
@@ -892,6 +916,7 @@ dist_ddl_process(const ProcessUtilityArgs *args)
 
 	/* Block unsupported operations on distributed hypertables and
 	 * decide on how to execute it. */
+
 	switch (tag)
 	{
 		case T_CreateSchemaStmt:
@@ -908,6 +933,10 @@ dist_ddl_process(const ProcessUtilityArgs *args)
 
 		case T_AlterObjectSchemaStmt:
 			dist_ddl_process_alter_object_schema(args);
+			break;
+
+		case T_AlterOwnerStmt:
+			dist_ddl_process_alter_owner_stmt(args);
 			break;
 
 		case T_RenameStmt:

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -1087,13 +1087,105 @@ nspname|usename
  
 (1 row)
 
+-- ALTER SCHEMA RENAME TO
+CREATE SCHEMA dist_schema;
+CREATE TABLE dist_schema.some_dist_table(time timestamptz, device int, color int, temp float);
+SELECT * FROM create_hypertable('dist_schema.some_dist_table', 'time', replication_factor => 3);
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name |   table_name    | created 
+---------------+-------------+-----------------+---------
+             4 | dist_schema | some_dist_table | t
+(1 row)
+
+ALTER SCHEMA dist_schema RENAME TO dist_schema_2;
+SELECT * FROM test.remote_exec(NULL, $$ SELECT schemaname, tablename FROM pg_tables WHERE tablename = 'some_dist_table' $$);
+NOTICE:  [data_node_1]:  SELECT schemaname, tablename FROM pg_tables WHERE tablename = 'some_dist_table' 
+NOTICE:  [data_node_1]:
+schemaname   |tablename      
+-------------+---------------
+dist_schema_2|some_dist_table
+(1 row)
+
+
+NOTICE:  [data_node_2]:  SELECT schemaname, tablename FROM pg_tables WHERE tablename = 'some_dist_table' 
+NOTICE:  [data_node_2]:
+schemaname   |tablename      
+-------------+---------------
+dist_schema_2|some_dist_table
+(1 row)
+
+
+NOTICE:  [data_node_3]:  SELECT schemaname, tablename FROM pg_tables WHERE tablename = 'some_dist_table' 
+NOTICE:  [data_node_3]:
+schemaname   |tablename      
+-------------+---------------
+dist_schema_2|some_dist_table
+(1 row)
+
+
+ remote_exec 
+-------------
+ 
+(1 row)
+
+-- ALTER SCHEMA OWNER TO
+ALTER SCHEMA dist_schema_2 OWNER TO :ROLE_1;
+SELECT * FROM test.remote_exec(NULL, $$
+SELECT s.nspname, u.usename
+FROM pg_catalog.pg_namespace s
+JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+WHERE s.nspname = 'dist_schema_2';
+$$);
+NOTICE:  [data_node_1]: 
+SELECT s.nspname, u.usename
+FROM pg_catalog.pg_namespace s
+JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+WHERE s.nspname = 'dist_schema_2'
+NOTICE:  [data_node_1]:
+nspname      |usename    
+-------------+-----------
+dist_schema_2|test_role_1
+(1 row)
+
+
+NOTICE:  [data_node_2]: 
+SELECT s.nspname, u.usename
+FROM pg_catalog.pg_namespace s
+JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+WHERE s.nspname = 'dist_schema_2'
+NOTICE:  [data_node_2]:
+nspname      |usename    
+-------------+-----------
+dist_schema_2|test_role_1
+(1 row)
+
+
+NOTICE:  [data_node_3]: 
+SELECT s.nspname, u.usename
+FROM pg_catalog.pg_namespace s
+JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+WHERE s.nspname = 'dist_schema_2'
+NOTICE:  [data_node_3]:
+nspname      |usename    
+-------------+-----------
+dist_schema_2|test_role_1
+(1 row)
+
+
+ remote_exec 
+-------------
+ 
+(1 row)
+
+DROP SCHEMA dist_schema_2 CASCADE;
+NOTICE:  drop cascades to table dist_schema_2.some_dist_table
 -- DROP column cascades to index drop
 CREATE TABLE some_dist_table(time timestamptz, device int, color int, temp float);
 SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor => 3);
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-             4 | public      | some_dist_table | t
+             5 | public      | some_dist_table | t
 (1 row)
 
 CREATE INDEX some_dist_device_idx ON some_dist_table (device);
@@ -1184,7 +1276,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-             6 | public      | some_dist_table | t
+             7 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1237,7 +1329,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-             7 | public      | some_dist_table | t
+             8 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1287,7 +1379,7 @@ SELECT * FROM create_distributed_hypertable('some_dist_table', 'time');
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-             8 | public      | some_dist_table | t
+             9 | public      | some_dist_table | t
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -1306,7 +1398,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-             9 | public      | some_dist_table | t
+            10 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1399,7 +1491,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-            10 | public      | some_dist_table | t
+            11 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1485,7 +1577,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-            11 | public      | some_dist_table | t
+            12 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1580,7 +1672,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-            12 | public      | some_dist_table | t
+            13 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1672,7 +1764,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-            13 | public      | some_dist_table | t
+            14 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1760,7 +1852,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-            14 | public      | some_dist_table | t
+            15 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1849,7 +1941,7 @@ SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor =>
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
-            15 | public      | some_dist_table | t
+            16 | public      | some_dist_table | t
 (1 row)
 
 BEGIN;
@@ -1943,14 +2035,14 @@ SELECT * FROM create_hypertable('disttable', 'time', replication_factor => 3);
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-            16 | public      | disttable  | t
+            17 | public      | disttable  | t
 (1 row)
 
 INSERT INTO disttable VALUES ('2017-01-01 06:01', 0, 1, 0.0);
 SELECT show_chunks('disttable');
                  show_chunks                  
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_16_6_chunk
+ _timescaledb_internal._dist_hyper_17_6_chunk
 (1 row)
 
 SELECT * FROM test.show_constraints('disttable');
@@ -1991,7 +2083,7 @@ SELECT show_chunks('disttable')
 NOTICE:  [data_node_1]:
 show_chunks                                 
 --------------------------------------------
-_timescaledb_internal._dist_hyper_16_6_chunk
+_timescaledb_internal._dist_hyper_17_6_chunk
 (1 row)
 
 
@@ -2018,7 +2110,7 @@ SELECT show_chunks('disttable')
 NOTICE:  [data_node_2]:
 show_chunks                                 
 --------------------------------------------
-_timescaledb_internal._dist_hyper_16_6_chunk
+_timescaledb_internal._dist_hyper_17_6_chunk
 (1 row)
 
 
@@ -2045,7 +2137,7 @@ SELECT show_chunks('disttable')
 NOTICE:  [data_node_3]:
 show_chunks                                 
 --------------------------------------------
-_timescaledb_internal._dist_hyper_16_6_chunk
+_timescaledb_internal._dist_hyper_17_6_chunk
 (1 row)
 
 
@@ -2102,7 +2194,7 @@ SELECT * FROM create_hypertable('disttable', 'time', replication_factor => 3);
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
-            17 | public      | disttable  | t
+            18 | public      | disttable  | t
 (1 row)
 
 CREATE INDEX disttable_device_idx ON disttable (device);

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -312,6 +312,25 @@ JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
 WHERE s.nspname = 'dist_schema_3';
 $$);
 
+-- ALTER SCHEMA RENAME TO
+CREATE SCHEMA dist_schema;
+CREATE TABLE dist_schema.some_dist_table(time timestamptz, device int, color int, temp float);
+SELECT * FROM create_hypertable('dist_schema.some_dist_table', 'time', replication_factor => 3);
+ALTER SCHEMA dist_schema RENAME TO dist_schema_2;
+SELECT * FROM test.remote_exec(NULL, $$ SELECT schemaname, tablename FROM pg_tables WHERE tablename = 'some_dist_table' $$);
+
+-- ALTER SCHEMA OWNER TO
+ALTER SCHEMA dist_schema_2 OWNER TO :ROLE_1;
+
+SELECT * FROM test.remote_exec(NULL, $$
+SELECT s.nspname, u.usename
+FROM pg_catalog.pg_namespace s
+JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+WHERE s.nspname = 'dist_schema_2';
+$$);
+
+DROP SCHEMA dist_schema_2 CASCADE;
+
 -- DROP column cascades to index drop
 CREATE TABLE some_dist_table(time timestamptz, device int, color int, temp float);
 SELECT * FROM create_hypertable('some_dist_table', 'time', replication_factor => 3);


### PR DESCRIPTION
This change adds support for `ALTER SCHEMA RENAME TO` and
`ALTER SCHEMA OWNER TO` commands to distributed database.

Issue: #3909