### PR TITLE
Don't display an error message when creating an empty CAGG

### DIFF
--- a/tsl/test/expected/continuous_aggs_variable_size_buckets.out
+++ b/tsl/test/expected/continuous_aggs_variable_size_buckets.out
@@ -1180,3 +1180,60 @@ NOTICE:  drop cascades to 3 other objects
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;
 DROP DATABASE :DATA_NODE_3;
+-- Test the specific code path of creating a CAGG on top of empty hypertable.
+CREATE TABLE conditions_empty(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT create_hypertable(
+  'conditions_empty', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+       create_hypertable        
+--------------------------------
+ (19,public,conditions_empty,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW conditions_summary_empty
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day) AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_empty
+GROUP BY city, bucket;
+NOTICE:  continuous aggregate "conditions_summary_empty" is already up-to-date
+SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
+FROM conditions_summary_empty
+ORDER by month, city;
+ city | month | min | max 
+------+-------+-----+-----
+(0 rows)
+
+-- The test above changes the record that gets added to the invalidation log
+-- for an empty table. Make sure it doesn't have any unintended side-effects
+-- and the refreshing works as expected.
+INSERT INTO conditions_empty (day, city, temperature) VALUES
+  ('2021-06-14', 'Moscow', 26),
+  ('2021-06-15', 'Moscow', 22),
+  ('2021-06-16', 'Moscow', 24),
+  ('2021-06-17', 'Moscow', 24),
+  ('2021-06-18', 'Moscow', 27),
+  ('2021-06-19', 'Moscow', 28),
+  ('2021-06-20', 'Moscow', 30),
+  ('2021-06-21', 'Moscow', 31),
+  ('2021-06-22', 'Moscow', 34),
+  ('2021-06-23', 'Moscow', 34),
+  ('2021-06-24', 'Moscow', 34),
+  ('2021-06-25', 'Moscow', 32),
+  ('2021-06-26', 'Moscow', 32),
+  ('2021-06-27', 'Moscow', 31);
+CALL refresh_continuous_aggregate('conditions_summary_empty', '2021-06-01', '2021-07-01');
+SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
+FROM conditions_summary_empty
+ORDER by month, city;
+  city  |   month    | min | max 
+--------+------------+-----+-----
+ Moscow | 2021-06-01 |  22 |  34
+(1 row)
+

--- a/tsl/test/sql/continuous_aggs_variable_size_buckets.sql
+++ b/tsl/test/sql/continuous_aggs_variable_size_buckets.sql
@@ -491,3 +491,54 @@ DROP TABLE conditions_dist CASCADE;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;
 DROP DATABASE :DATA_NODE_3;
+
+-- Test the specific code path of creating a CAGG on top of empty hypertable.
+
+CREATE TABLE conditions_empty(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+
+SELECT create_hypertable(
+  'conditions_empty', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+
+CREATE MATERIALIZED VIEW conditions_summary_empty
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day) AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_empty
+GROUP BY city, bucket;
+
+SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
+FROM conditions_summary_empty
+ORDER by month, city;
+
+-- The test above changes the record that gets added to the invalidation log
+-- for an empty table. Make sure it doesn't have any unintended side-effects
+-- and the refreshing works as expected.
+
+INSERT INTO conditions_empty (day, city, temperature) VALUES
+  ('2021-06-14', 'Moscow', 26),
+  ('2021-06-15', 'Moscow', 22),
+  ('2021-06-16', 'Moscow', 24),
+  ('2021-06-17', 'Moscow', 24),
+  ('2021-06-18', 'Moscow', 27),
+  ('2021-06-19', 'Moscow', 28),
+  ('2021-06-20', 'Moscow', 30),
+  ('2021-06-21', 'Moscow', 31),
+  ('2021-06-22', 'Moscow', 34),
+  ('2021-06-23', 'Moscow', 34),
+  ('2021-06-24', 'Moscow', 34),
+  ('2021-06-25', 'Moscow', 32),
+  ('2021-06-26', 'Moscow', 32),
+  ('2021-06-27', 'Moscow', 31);
+
+CALL refresh_continuous_aggregate('conditions_summary_empty', '2021-06-01', '2021-07-01');
+
+SELECT city, to_char(bucket, 'YYYY-MM-DD') AS month, min, max
+FROM conditions_summary_empty
+ORDER by month, city;


### PR DESCRIPTION
This is a follow-up to 95804069, "Monthly buckets support in CAGGs". In that
patch we didn't check the creation of a CAGG on top of an empty hypertable.
It works, but displays "ERROR: origin must be before the given date", which is
a bit misleading.

This happens because 95804069 didn't modify invalidation_threshold_compute()
in the same way as tsl_process_continuous_agg_viewstmt(). As a result,
compute_circumscribed_bucketed_refresh_window_for_months() calls
time_bucket_ng() for ts_time_get_min() argument. It doesn't work because
the minimum time is 4714-11-24 BC which is before any reasonable origin,
and the user sees corresponding error message.

This patch fixes the problem in the same way as 95804069 did and adds
a corresponding test.