### PR TITLE
Avoid double PQclear() in data fetchers

### DIFF
--- a/tsl/src/remote/row_by_row_fetcher.c
+++ b/tsl/src/remote/row_by_row_fetcher.c
@@ -174,7 +174,14 @@ row_by_row_fetcher_complete(RowByRowFetcher *fetcher)
 
 			if (!(PQresultStatus(res) == PGRES_SINGLE_TUPLE ||
 				  PQresultStatus(res) == PGRES_TUPLES_OK))
+			{
+				/* remote_result_elog will call PQclear() on the result, so
+				 * need to mark the response as NULL to avoid double
+				 * PQclear() */
+				pfree(response);
+				response = NULL;
 				remote_result_elog(res, ERROR);
+			}
 
 			if (PQresultStatus(res) == PGRES_TUPLES_OK)
 			{


### PR DESCRIPTION
The macro `remote_result_elog` is used in the cursor and row-by-row
fetchers and clears the result value using the function `PQclear()`
before rethrowing its error. However, this error is later captured to
clear the wrapping result value that holds a reference to the original
result. To avoid this double-clearing, set the response to NULL before
the error is thrown.