### PR TITLE
Fix crash in EXPLAIN VERBOSE on dist table

### DIFF
--- a/tsl/src/fdw/scan_exec.c
+++ b/tsl/src/fdw/scan_exec.c
@@ -449,7 +449,10 @@ fdw_scan_explain(ScanState *ss, List *fdw_private, ExplainState *es, TsFdwScanSt
 		char *sql;
 
 		ExplainPropertyText("Data node", server->servername, es);
-		ExplainPropertyText("Fetcher Type", explain_fetcher_type(fsstate->fetcher_type), es);
+
+		/* fsstate can be NULL, so check that first */
+		if (fsstate)
+			ExplainPropertyText("Fetcher Type", explain_fetcher_type(fsstate->fetcher_type), es);
 
 		if (chunk_oids != NIL)
 		{
@@ -474,7 +477,8 @@ fdw_scan_explain(ScanState *ss, List *fdw_private, ExplainState *es, TsFdwScanSt
 
 		ExplainPropertyText("Remote SQL", sql, es);
 
-		if (ts_guc_enable_remote_explain)
+		/* fsstate should be set up but better check again to avoid crashes */
+		if (ts_guc_enable_remote_explain && fsstate)
 		{
 			const char *data_node_explain =
 				get_data_node_explain(fsstate->query, fsstate->conn, es);

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -229,6 +229,102 @@ INSERT INTO disttable VALUES
        ('2018-07-01 08:01', 29, 1.5),
        ('2018-07-01 09:21', 90, 2.8),
        ('2018-07-01 08:21', 29, 1.2);
+-- EXPLAIN some updates/deletes to see what plans and explain output for
+-- remote operations look like
+EXPLAIN (VERBOSE, COSTS FALSE)
+UPDATE disttable SET temp = 3.7 WHERE device = 1;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Update on public.disttable
+   Update on public.disttable
+   Foreign Update on _timescaledb_internal._dist_hyper_1_1_chunk
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_1_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_2_chunk
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_2_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_3_chunk
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_3_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_4_chunk
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_4_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_5_chunk
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_5_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_6_chunk
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_6_chunk SET temp = $2 WHERE ctid = $1
+   ->  Seq Scan on public.disttable
+         Output: disttable."time", disttable.device, NULL::integer, '3.7'::double precision, disttable.ctid
+         Filter: (disttable.device = 1)
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_1_chunk
+         Output: _dist_hyper_1_1_chunk."time", _dist_hyper_1_1_chunk.device, '3.7'::double precision, _dist_hyper_1_1_chunk.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_2_chunk
+         Output: _dist_hyper_1_2_chunk."time", _dist_hyper_1_2_chunk.device, '3.7'::double precision, _dist_hyper_1_2_chunk.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_3_chunk
+         Output: _dist_hyper_1_3_chunk."time", _dist_hyper_1_3_chunk.device, '3.7'::double precision, _dist_hyper_1_3_chunk.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_4_chunk
+         Output: _dist_hyper_1_4_chunk."time", _dist_hyper_1_4_chunk.device, '3.7'::double precision, _dist_hyper_1_4_chunk.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_5_chunk
+         Output: _dist_hyper_1_5_chunk."time", _dist_hyper_1_5_chunk.device, '3.7'::double precision, _dist_hyper_1_5_chunk.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_6_chunk
+         Output: _dist_hyper_1_6_chunk."time", _dist_hyper_1_6_chunk.device, '3.7'::double precision, _dist_hyper_1_6_chunk.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ((device = 1)) FOR UPDATE
+(41 rows)
+
+EXPLAIN (VERBOSE, COSTS FALSE)
+DELETE FROM disttable WHERE device = 1;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Delete on public.disttable
+   Delete on public.disttable
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_1_chunk
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_2_chunk
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_3_chunk
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_4_chunk
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_5_chunk
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_6_chunk
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ctid = $1
+   ->  Seq Scan on public.disttable
+         Output: disttable.ctid
+         Filter: (disttable.device = 1)
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_1_chunk
+         Output: _dist_hyper_1_1_chunk.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_2_chunk
+         Output: _dist_hyper_1_2_chunk.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_3_chunk
+         Output: _dist_hyper_1_3_chunk.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_4_chunk
+         Output: _dist_hyper_1_4_chunk.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_5_chunk
+         Output: _dist_hyper_1_5_chunk.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_6_chunk
+         Output: _dist_hyper_1_6_chunk.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ((device = 1)) FOR UPDATE
+(41 rows)
+
 -- Test distributed ANALYZE.
 --
 -- First show no statistics

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -229,6 +229,102 @@ INSERT INTO disttable VALUES
        ('2018-07-01 08:01', 29, 1.5),
        ('2018-07-01 09:21', 90, 2.8),
        ('2018-07-01 08:21', 29, 1.2);
+-- EXPLAIN some updates/deletes to see what plans and explain output for
+-- remote operations look like
+EXPLAIN (VERBOSE, COSTS FALSE)
+UPDATE disttable SET temp = 3.7 WHERE device = 1;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Update on public.disttable
+   Update on public.disttable
+   Foreign Update on _timescaledb_internal._dist_hyper_1_1_chunk disttable_1
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_1_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_2_chunk disttable_2
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_2_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_3_chunk disttable_3
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_3_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_4_chunk disttable_4
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_4_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_5_chunk disttable_5
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_5_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_6_chunk disttable_6
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_6_chunk SET temp = $2 WHERE ctid = $1
+   ->  Seq Scan on public.disttable
+         Output: disttable."time", disttable.device, NULL::integer, '3.7'::double precision, disttable.ctid
+         Filter: (disttable.device = 1)
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_1_chunk disttable_1
+         Output: disttable_1."time", disttable_1.device, '3.7'::double precision, disttable_1.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_2_chunk disttable_2
+         Output: disttable_2."time", disttable_2.device, '3.7'::double precision, disttable_2.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_3_chunk disttable_3
+         Output: disttable_3."time", disttable_3.device, '3.7'::double precision, disttable_3.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_4_chunk disttable_4
+         Output: disttable_4."time", disttable_4.device, '3.7'::double precision, disttable_4.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_5_chunk disttable_5
+         Output: disttable_5."time", disttable_5.device, '3.7'::double precision, disttable_5.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_6_chunk disttable_6
+         Output: disttable_6."time", disttable_6.device, '3.7'::double precision, disttable_6.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT "time", device, ctid FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ((device = 1)) FOR UPDATE
+(41 rows)
+
+EXPLAIN (VERBOSE, COSTS FALSE)
+DELETE FROM disttable WHERE device = 1;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Delete on public.disttable
+   Delete on public.disttable
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_1_chunk disttable_1
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_2_chunk disttable_2
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_3_chunk disttable_3
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_4_chunk disttable_4
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_5_chunk disttable_5
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_6_chunk disttable_6
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ctid = $1
+   ->  Seq Scan on public.disttable
+         Output: disttable.ctid
+         Filter: (disttable.device = 1)
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_1_chunk disttable_1
+         Output: disttable_1.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_2_chunk disttable_2
+         Output: disttable_2.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_3_chunk disttable_3
+         Output: disttable_3.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_4_chunk disttable_4
+         Output: disttable_4.ctid
+         Data node: db_dist_hypertable_1
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_5_chunk disttable_5
+         Output: disttable_5.ctid
+         Data node: db_dist_hypertable_2
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ((device = 1)) FOR UPDATE
+   ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_6_chunk disttable_6
+         Output: disttable_6.ctid
+         Data node: db_dist_hypertable_3
+         Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ((device = 1)) FOR UPDATE
+(41 rows)
+
 -- Test distributed ANALYZE.
 --
 -- First show no statistics

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -229,6 +229,106 @@ INSERT INTO disttable VALUES
        ('2018-07-01 08:01', 29, 1.5),
        ('2018-07-01 09:21', 90, 2.8),
        ('2018-07-01 08:21', 29, 1.2);
+-- EXPLAIN some updates/deletes to see what plans and explain output for
+-- remote operations look like
+EXPLAIN (VERBOSE, COSTS FALSE)
+UPDATE disttable SET temp = 3.7 WHERE device = 1;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Update on public.disttable
+   Update on public.disttable disttable_1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_1_chunk disttable_2
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_1_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_2_chunk disttable_3
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_2_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_3_chunk disttable_4
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_3_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_4_chunk disttable_5
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_4_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_5_chunk disttable_6
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_5_chunk SET temp = $2 WHERE ctid = $1
+   Foreign Update on _timescaledb_internal._dist_hyper_1_6_chunk disttable_7
+     Remote SQL: UPDATE _timescaledb_internal._dist_hyper_1_6_chunk SET temp = $2 WHERE ctid = $1
+   ->  Result
+         Output: '3.7'::double precision, disttable.tableoid, disttable.ctid, (NULL::record)
+         ->  Append
+               ->  Seq Scan on public.disttable disttable_1
+                     Output: disttable_1.tableoid, disttable_1.ctid, NULL::record
+                     Filter: (disttable_1.device = 1)
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_1_chunk disttable_2
+                     Output: disttable_2.tableoid, disttable_2.ctid, disttable_2.*
+                     Data node: db_dist_hypertable_1
+                     Remote SQL: SELECT "time", device, temp, ctid FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ((device = 1))
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_2_chunk disttable_3
+                     Output: disttable_3.tableoid, disttable_3.ctid, disttable_3.*
+                     Data node: db_dist_hypertable_3
+                     Remote SQL: SELECT "time", device, temp, ctid FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ((device = 1))
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_3_chunk disttable_4
+                     Output: disttable_4.tableoid, disttable_4.ctid, disttable_4.*
+                     Data node: db_dist_hypertable_2
+                     Remote SQL: SELECT "time", device, temp, ctid FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ((device = 1))
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_4_chunk disttable_5
+                     Output: disttable_5.tableoid, disttable_5.ctid, disttable_5.*
+                     Data node: db_dist_hypertable_1
+                     Remote SQL: SELECT "time", device, temp, ctid FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ((device = 1))
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_5_chunk disttable_6
+                     Output: disttable_6.tableoid, disttable_6.ctid, disttable_6.*
+                     Data node: db_dist_hypertable_2
+                     Remote SQL: SELECT "time", device, temp, ctid FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ((device = 1))
+               ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_6_chunk disttable_7
+                     Output: disttable_7.tableoid, disttable_7.ctid, disttable_7.*
+                     Data node: db_dist_hypertable_3
+                     Remote SQL: SELECT "time", device, temp, ctid FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ((device = 1))
+(44 rows)
+
+EXPLAIN (VERBOSE, COSTS FALSE)
+DELETE FROM disttable WHERE device = 1;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Delete on public.disttable
+   Delete on public.disttable disttable_1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_1_chunk disttable_2
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_2_chunk disttable_3
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_3_chunk disttable_4
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_4_chunk disttable_5
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_5_chunk disttable_6
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ctid = $1
+   Foreign Delete on _timescaledb_internal._dist_hyper_1_6_chunk disttable_7
+     Remote SQL: DELETE FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ctid = $1
+   ->  Append
+         ->  Seq Scan on public.disttable disttable_1
+               Output: disttable_1.tableoid, disttable_1.ctid
+               Filter: (disttable_1.device = 1)
+         ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_1_chunk disttable_2
+               Output: disttable_2.tableoid, disttable_2.ctid
+               Data node: db_dist_hypertable_1
+               Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_1_chunk WHERE ((device = 1))
+         ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_2_chunk disttable_3
+               Output: disttable_3.tableoid, disttable_3.ctid
+               Data node: db_dist_hypertable_3
+               Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_2_chunk WHERE ((device = 1))
+         ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_3_chunk disttable_4
+               Output: disttable_4.tableoid, disttable_4.ctid
+               Data node: db_dist_hypertable_2
+               Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_3_chunk WHERE ((device = 1))
+         ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_4_chunk disttable_5
+               Output: disttable_5.tableoid, disttable_5.ctid
+               Data node: db_dist_hypertable_1
+               Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_4_chunk WHERE ((device = 1))
+         ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_5_chunk disttable_6
+               Output: disttable_6.tableoid, disttable_6.ctid
+               Data node: db_dist_hypertable_2
+               Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_5_chunk WHERE ((device = 1))
+         ->  Foreign Scan on _timescaledb_internal._dist_hyper_1_6_chunk disttable_7
+               Output: disttable_7.tableoid, disttable_7.ctid
+               Data node: db_dist_hypertable_3
+               Remote SQL: SELECT ctid FROM _timescaledb_internal._dist_hyper_1_6_chunk WHERE ((device = 1))
+(42 rows)
+
 -- Test distributed ANALYZE.
 --
 -- First show no statistics

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -169,6 +169,14 @@ INSERT INTO disttable VALUES
        ('2018-07-01 09:21', 90, 2.8),
        ('2018-07-01 08:21', 29, 1.2);
 
+-- EXPLAIN some updates/deletes to see what plans and explain output for
+-- remote operations look like
+EXPLAIN (VERBOSE, COSTS FALSE)
+UPDATE disttable SET temp = 3.7 WHERE device = 1;
+
+EXPLAIN (VERBOSE, COSTS FALSE)
+DELETE FROM disttable WHERE device = 1;
+
 -- Test distributed ANALYZE.
 --
 


### PR DESCRIPTION
The crash is occurring in "fdw_scan_explain" function because the
fsstate passed in is NULL and we try to access the "fetcher_type" field
from it in VERBOSE mode.

When we are doing EXPLAIN, we short circuit the init foreign scan calls
and that's why fsstate is not filled up.

Fixes #3960