### PR TITLE
Fix the build against REL_14_STABLE

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -213,6 +213,72 @@ get_vacuum_options(const VacuumStmt *stmt)
 		   (analyze ? VACOPT_ANALYZE : 0);
 }
 
+/*
+ * The number of arguments of pg_md5_hash() has changed in PG >= 14.2. At the
+ * moment of writing this used to be an upcoming release, thus PG_VERSION_NUM
+ * couldn't be used to distinguish between REL_14_1 and REL_14_STABLE.
+ *
+ * https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=3a0cced8
+ */
+#if PG14
+
+#include <common/cryptohash.h>
+#include <common/md5.h>
+
+static inline void
+bytesToHex(uint8 b[16], char *s)
+{
+	static const char *hex = "0123456789abcdef";
+	int q, w;
+
+	for (q = 0, w = 0; q < 16; q++)
+	{
+		s[w++] = hex[(b[q] >> 4) & 0x0F];
+		s[w++] = hex[b[q] & 0x0F];
+	}
+	s[w] = '\0';
+}
+
+static inline bool
+pg_md5_hash_compat(const void *buff, size_t len, char *hexsum, const char **errstr)
+{
+	uint8 sum[MD5_DIGEST_LENGTH];
+	pg_cryptohash_ctx *ctx;
+
+	*errstr = NULL;
+	ctx = pg_cryptohash_create(PG_MD5);
+	if (ctx == NULL)
+		return false;
+
+	if (pg_cryptohash_init(ctx) < 0 || pg_cryptohash_update(ctx, buff, len) < 0 ||
+		pg_cryptohash_final(ctx, sum, sizeof(sum)) < 0)
+	{
+		pg_cryptohash_free(ctx);
+		return false;
+	}
+
+	bytesToHex(sum, hexsum);
+	pg_cryptohash_free(ctx);
+	return true;
+}
+
+#elif PG14_LT
+
+#include <common/md5.h>
+static inline bool
+pg_md5_hash_compat(const void *buff, size_t len, char *hexsum, const char **errstr)
+{
+	*errstr = NULL;
+	return pg_md5_hash(buff, len, hexsum);
+}
+
+#else
+
+#include <common/md5.h>
+#define pg_md5_hash_compat(buff, len, hexsum, errstr) pg_md5_hash(buff, len, hexsum, errstr)
+
+#endif
+
 #if PG14_LT
 static inline int
 get_cluster_options(const ClusterStmt *stmt)

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -16,7 +16,6 @@
 #include <catalog/pg_foreign_server.h>
 #include <catalog/pg_user_mapping.h>
 #include <commands/defrem.h>
-#include <common/md5.h>
 #include <foreign/foreign.h>
 #include <libpq-events.h>
 #include <libpq/libpq.h>
@@ -1150,8 +1149,9 @@ make_user_path(const char *user_name, PathKind path_kind)
 	char ret_path[MAXPGPATH];
 	char hexsum[33];
 	StringInfo result;
+	const char *errstr;
 
-	pg_md5_hash(user_name, strlen(user_name), hexsum);
+	pg_md5_hash_compat(user_name, strlen(user_name), hexsum, &errstr);
 
 	if (strlcpy(ret_path, ts_guc_ssl_dir ? ts_guc_ssl_dir : DataDir, MAXPGPATH) > MAXPGPATH)
 		report_path_error(path_kind, user_name);


### PR DESCRIPTION
The number of arguments of pg_md5_hash() has changed in REL_14_STABLE.
This patch adds a corresponding compat.h version of the procedure.

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=3a0cced8