### PR TITLE
Timezones support in CAGGs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
     scan_iterator.c
     sort_transform.c
     subspace_store.c
+    timezones.c
     time_bucket.c
     time_utils.c
     custom_type_cache.c

--- a/src/func_cache.c
+++ b/src/func_cache.c
@@ -320,6 +320,15 @@ static FuncInfo funcinfo[] = {
 		.sort_transform = time_bucket_sort_transform,
 	},
 	{
+		.origin = ORIGIN_TIMESCALE_EXPERIMENTAL,
+		.is_bucketing_func = true,
+		.funcname = "time_bucket_ng",
+		.nargs = 3,
+		.arg_types = { INTERVALOID, TIMESTAMPTZOID, TEXTOID },
+		.group_estimate = time_bucket_group_estimate,
+		.sort_transform = time_bucket_sort_transform,
+	},
+	{
 		.origin = ORIGIN_TIMESCALE,
 		.is_bucketing_func = true,
 		.funcname = "time_bucket_gapfill",

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -499,30 +499,6 @@ ts_time_saturating_sub(int64 timeval, int64 interval, Oid timetype)
 	return timeval - interval;
 }
 
-/*
- * Rounds a time value to the beginning of the monthly bucket and adds the
- * given number of months. Basically the pracedure calculates the beginning
- * of the next montly bucket.
- */
-int64
-ts_time_bucket_and_add_months(int64 timeval, int32 bucket_width_months)
-{
-	Interval interval;
-	Datum val_new;
-	Datum val_old = ts_internal_to_time_value(timeval, DATEOID);
-
-	memset(&interval, 0, sizeof(interval));
-	interval.month = bucket_width_months;
-
-	val_new = DirectFunctionCall2(ts_time_bucket_ng_date, IntervalPGetDatum(&interval), val_old);
-	val_new = DirectFunctionCall1(timestamp_date,
-								  DirectFunctionCall2(date_pl_interval,
-													  val_new,
-													  IntervalPGetDatum(&interval)));
-
-	return ts_time_value_to_internal(val_new, DATEOID);
-}
-
 int64
 ts_subtract_integer_from_now_saturating(Oid now_func, int64 interval, Oid timetype)
 {

--- a/src/time_utils.h
+++ b/src/time_utils.h
@@ -85,7 +85,6 @@ extern TSDLLEXPORT int64 ts_time_get_noend(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_get_noend_or_max(Oid timetype);
 extern TSDLLEXPORT int64 ts_time_saturating_add(int64 timeval, int64 interval, Oid timetype);
 extern TSDLLEXPORT int64 ts_time_saturating_sub(int64 timeval, int64 interval, Oid timetype);
-extern TSDLLEXPORT int64 ts_time_bucket_and_add_months(int64 timeval, int32 bucket_width_months);
 extern TSDLLEXPORT int64 ts_subtract_integer_from_now_saturating(Oid now_func, int64 interval,
 																 Oid timetype);
 #ifdef TS_DEBUG

--- a/src/timezones.c
+++ b/src/timezones.c
@@ -1,0 +1,50 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <port.h>
+#include <pgtime.h>
+#include <datatype/timestamp.h>
+#include <utils/timestamp.h>
+#include <access/xact.h>
+#include "timezones.h"
+
+/* Checks if the given TZ name is valid. */
+bool
+ts_is_valid_timezone_name(const char *tz_name)
+{
+	pg_tz *tz;
+	int tzoff;
+	struct pg_tm tm;
+	fsec_t fsec;
+	const char *abbrev;
+	bool found = false;
+	TimestampTz now = GetCurrentTransactionStartTimestamp();
+	pg_tzenum *tzenum = pg_tzenumerate_start();
+
+	while (true)
+	{
+		tz = pg_tzenumerate_next(tzenum);
+		if (!tz)
+			break;
+
+		/*
+		 * Convert now() to time in this TZ and skip if conversion fails.
+		 * This check is the same that pg_timezone_names() does.
+		 */
+		if (timestamp2tm(now, &tzoff, &tm, &fsec, &abbrev, tz) != 0)
+			continue;
+
+		if ((!strcmp(tz_name, pg_get_timezone_name(tz))) || (abbrev && !strcmp(tz_name, abbrev)))
+		{
+			found = true;
+			break;
+		}
+	}
+
+	pg_tzenumerate_end(tzenum);
+	return found;
+}

--- a/src/timezones.h
+++ b/src/timezones.h
@@ -1,0 +1,14 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#ifndef TIMESCALEDB_TIMEZONES_H
+#define TIMESCALEDB_TIMEZONES_H
+
+#include "export.h"
+
+extern TSDLLEXPORT bool ts_is_valid_timezone_name(const char *tz_name);
+
+#endif /* TIMESCALEDB_TIMEZONES_H */

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -884,7 +884,6 @@ typedef struct FormData_continuous_agg
 	 * procedures instead, such as:
 	 * - ts_continuous_agg_bucket_width_variable
 	 * - ts_continuous_agg_bucket_width
-	 * - ts_bucket_function_to_bucket_width_in_months
 	 */
 	int64 bucket_width;
 	NameData direct_view_schema;

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -63,8 +63,8 @@ typedef struct ContinuousAggsBucketFunction
 	bool experimental;
 	/* Name of the bucketing function, e.g. "time_bucket" or "time_bucket_ng" */
 	char *name;
-	/* `bucket_width` argument of the function, e.g. "1 month" */
-	char *bucket_width;
+	/* `bucket_width` argument of the function */
+	Interval *bucket_width;
 	/* `origin` argument of the function provided by the user */
 	char *origin;
 	/* `timezone` argument of the function provided by the user */
@@ -158,7 +158,14 @@ extern ContinuousAgg *ts_continuous_agg_find_userview_name(const char *schema, c
 
 extern TSDLLEXPORT bool ts_continuous_agg_bucket_width_variable(const ContinuousAgg *agg);
 extern TSDLLEXPORT int64 ts_continuous_agg_bucket_width(const ContinuousAgg *agg);
-extern TSDLLEXPORT int32
-ts_bucket_function_to_bucket_width_in_months(const ContinuousAggsBucketFunction *agg);
+
+extern TSDLLEXPORT void
+ts_compute_inscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
+													  const ContinuousAggsBucketFunction *bf);
+extern TSDLLEXPORT void
+ts_compute_circumscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
+														  const ContinuousAggsBucketFunction *bf);
+extern TSDLLEXPORT int64 ts_compute_beginning_of_the_next_bucket_variable(
+	int64 timeval, const ContinuousAggsBucketFunction *bf);
 
 #endif /* TIMESCALEDB_CONTINUOUS_AGG_H */

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -311,9 +311,9 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 				 * instead of minimum date we use -infinity since time_bucket(-infinity)
 				 * is well-defined as -infinity.
 				 *
-				 * For more details see refresh.c, particularly:
-				 * - compute_inscribed_bucketed_refresh_window_for_months()
-				 * - compute_circumscribed_bucketed_refresh_window_for_months()
+				 * For more details see:
+				 * - ts_compute_inscribed_bucketed_refresh_window_variable()
+				 * - ts_compute_circumscribed_bucketed_refresh_window_variable()
 				 */
 				return ts_time_get_nobegin(refresh_window->type);
 			}
@@ -329,9 +329,8 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 
 			if (ts_continuous_agg_bucket_width_variable(cagg))
 			{
-				return ts_time_bucket_and_add_months(maxval,
-													 ts_bucket_function_to_bucket_width_in_months(
-														 cagg->bucket_function));
+				return ts_compute_beginning_of_the_next_bucket_variable(maxval,
+																		cagg->bucket_function);
 			}
 
 			int64 bucket_width = ts_continuous_agg_bucket_width(cagg);

--- a/tsl/src/continuous_aggs/refresh.h
+++ b/tsl/src/continuous_aggs/refresh.h
@@ -31,7 +31,4 @@ extern void continuous_agg_refresh_internal(const ContinuousAgg *cagg,
 											const InternalTimeRange *refresh_window,
 											const CaggRefreshCallContext callctx);
 
-extern InternalTimeRange compute_circumscribed_bucketed_refresh_window_for_months(
-	const InternalTimeRange *const refresh_window, const int32 bucket_width_months);
-
 #endif /* TIMESCALEDB_TSL_CONTINUOUS_AGGS_REFRESH_H */

--- a/tsl/test/expected/cagg_with_timezone.out
+++ b/tsl/test/expected/cagg_with_timezone.out
@@ -1,0 +1,840 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Make sure that timezone can't be used for types other that timestamptz
+CREATE TABLE conditions(
+  day timestamp NOT NULL, -- not timestamptz!
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT create_hypertable(
+  'conditions', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW conditions
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'Europe/Moscow') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions
+GROUP BY city, bucket
+WITH NO DATA;
+ERROR:  invalid input syntax for type timestamp: "Europe/Moscow" at character 178
+\set ON_ERROR_STOP 1
+DROP TABLE conditions CASCADE;
+CREATE TABLE conditions_tz(
+  day timestamptz NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT create_hypertable(
+  'conditions_tz', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+     create_hypertable      
+----------------------------
+ (2,public,conditions_tz,t)
+(1 row)
+
+INSERT INTO conditions_tz (day, city, temperature) VALUES
+  ('2021-06-14 00:00:00 MSK', 'Moscow', 26),
+  ('2021-06-15 00:00:00 MSK', 'Moscow', 22),
+  ('2021-06-16 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-17 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-18 00:00:00 MSK', 'Moscow', 27),
+  ('2021-06-19 00:00:00 MSK', 'Moscow', 28),
+  ('2021-06-20 00:00:00 MSK', 'Moscow', 30),
+  ('2021-06-21 00:00:00 MSK', 'Moscow', 31),
+  ('2021-06-22 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-23 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-24 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-25 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-26 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-27 00:00:00 MSK', 'Moscow', 31);
+\set ON_ERROR_STOP 0
+-- Check that the name of the timezone is validated
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'Europe/Ololondon') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+ERROR:  invalid timezone name "Europe/Ololondon"
+-- Check that buckets like '1 month 15 days' (fixed-sized + variable-sized) are not allowed
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month 15 days', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+ERROR:  invalid interval specified
+-- Check that only immutable expressions can be used as a timezone
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 day', day, city) AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+ERROR:  only immutable expressions allowed in time bucket function
+\set ON_ERROR_STOP 1
+-- Make sure it's possible to create an empty cagg (WITH NO DATA) and
+-- that all the information about the bucketing function will be saved
+-- to the TS catalog.
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+SELECT mat_hypertable_id AS cagg_id_tz, raw_hypertable_id AS ht_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_summary_tz'
+\gset
+SELECT bucket_width
+FROM _timescaledb_catalog.continuous_agg
+WHERE mat_hypertable_id = :cagg_id_tz;
+ bucket_width 
+--------------
+           -1
+(1 row)
+
+-- Make sure the timezone is saved in the catalog table
+SELECT experimental, name, bucket_width, origin, timezone
+FROM _timescaledb_catalog.continuous_aggs_bucket_function
+WHERE mat_hypertable_id = :cagg_id_tz;
+ experimental |      name      | bucket_width | origin | timezone 
+--------------+----------------+--------------+--------+----------
+ t            | time_bucket_ng | @ 1 mon      |        | MSK
+(1 row)
+
+-- Make sure that buckets with specified timezone are always treated as
+-- variable-sized, even if the interval is fixed (i.e. days and/or hours)
+CREATE MATERIALIZED VIEW conditions_summary_1w
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('7 days', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+SELECT mat_hypertable_id AS cagg_id_1w
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_summary_1w'
+\gset
+SELECT bucket_width
+FROM _timescaledb_catalog.continuous_agg
+WHERE mat_hypertable_id = :cagg_id_1w;
+ bucket_width 
+--------------
+           -1
+(1 row)
+
+-- Make sure the timezone is saved in the catalog table
+SELECT experimental, name, bucket_width, origin, timezone
+FROM _timescaledb_catalog.continuous_aggs_bucket_function
+WHERE mat_hypertable_id = :cagg_id_1w;
+ experimental |      name      | bucket_width | origin | timezone 
+--------------+----------------+--------------+--------+----------
+ t            | time_bucket_ng | @ 7 days     |        | MSK
+(1 row)
+
+-- Check the invalidation threshold
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+ to_char 
+---------
+(0 rows)
+
+-- Make sure the invalidation log is empty
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+ lowest | greatest 
+--------+----------
+(0 rows)
+
+-- Make sure truncating of the refresh window works
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-07-02 MSK', '2021-07-12 MSK');
+ERROR:  refresh window too small
+CALL refresh_continuous_aggregate('conditions_summary_1w', '2021-07-02 MSK', '2021-07-05 MSK');
+ERROR:  refresh window too small
+\set ON_ERROR_STOP 1
+-- Make sure refreshing works
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-06-01 MSK', '2021-07-01 MSK');
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-01 00:00:00 |  22 |  34
+(1 row)
+
+-- Check the invalidation threshold
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+       to_char       
+---------------------
+ 2021-07-01 00:00:00
+(1 row)
+
+-- The default origin is Saturday. Here we do refresh only for two full weeks
+-- in June in order to keep the invalidation threshold as it is.
+CALL refresh_continuous_aggregate('conditions_summary_1w', '2021-06-12 MSK', '2021-06-26 MSK');
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as week, min, max
+FROM conditions_summary_1w
+ORDER by week, city;
+  city  |        week         | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-12 00:00:00 |  22 |  27
+ Moscow | 2021-06-19 00:00:00 |  28 |  34
+(2 rows)
+
+-- Check the invalidation threshold
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+       to_char       
+---------------------
+ 2021-07-01 00:00:00
+(1 row)
+
+-- Make sure creating CAGGs without NO DATA works the same way
+CREATE MATERIALIZED VIEW conditions_summary_tz2
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_tz2"
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz2
+ORDER by month, city;
+  city  |        month        | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-01 00:00:00 |  22 |  34
+(1 row)
+
+-- Add some dummy data for two more months (no invalidations test case)
+INSERT INTO conditions_tz (day, city, temperature)
+SELECT ts, city, row_number() OVER ()
+FROM generate_series('2021-07-01 MSK' :: timestamptz, '2021-08-31 MSK', '3 day') as ts,
+     unnest(array['Moscow', 'Berlin']) as city;
+-- Double check the generated data
+SELECT to_char(day at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS'), city, temperature
+FROM conditions_tz
+WHERE day >= '2021-07-01 MSK'
+ORDER BY city DESC, day;
+       to_char       |  city  | temperature 
+---------------------+--------+-------------
+ 2021-07-01 00:00:00 | Moscow |           1
+ 2021-07-04 00:00:00 | Moscow |           2
+ 2021-07-07 00:00:00 | Moscow |           3
+ 2021-07-10 00:00:00 | Moscow |           4
+ 2021-07-13 00:00:00 | Moscow |           5
+ 2021-07-16 00:00:00 | Moscow |           6
+ 2021-07-19 00:00:00 | Moscow |           7
+ 2021-07-22 00:00:00 | Moscow |           8
+ 2021-07-25 00:00:00 | Moscow |           9
+ 2021-07-28 00:00:00 | Moscow |          10
+ 2021-07-31 00:00:00 | Moscow |          11
+ 2021-08-03 00:00:00 | Moscow |          12
+ 2021-08-06 00:00:00 | Moscow |          13
+ 2021-08-09 00:00:00 | Moscow |          14
+ 2021-08-12 00:00:00 | Moscow |          15
+ 2021-08-15 00:00:00 | Moscow |          16
+ 2021-08-18 00:00:00 | Moscow |          17
+ 2021-08-21 00:00:00 | Moscow |          18
+ 2021-08-24 00:00:00 | Moscow |          19
+ 2021-08-27 00:00:00 | Moscow |          20
+ 2021-08-30 00:00:00 | Moscow |          21
+ 2021-07-01 00:00:00 | Berlin |          22
+ 2021-07-04 00:00:00 | Berlin |          23
+ 2021-07-07 00:00:00 | Berlin |          24
+ 2021-07-10 00:00:00 | Berlin |          25
+ 2021-07-13 00:00:00 | Berlin |          26
+ 2021-07-16 00:00:00 | Berlin |          27
+ 2021-07-19 00:00:00 | Berlin |          28
+ 2021-07-22 00:00:00 | Berlin |          29
+ 2021-07-25 00:00:00 | Berlin |          30
+ 2021-07-28 00:00:00 | Berlin |          31
+ 2021-07-31 00:00:00 | Berlin |          32
+ 2021-08-03 00:00:00 | Berlin |          33
+ 2021-08-06 00:00:00 | Berlin |          34
+ 2021-08-09 00:00:00 | Berlin |          35
+ 2021-08-12 00:00:00 | Berlin |          36
+ 2021-08-15 00:00:00 | Berlin |          37
+ 2021-08-18 00:00:00 | Berlin |          38
+ 2021-08-21 00:00:00 | Berlin |          39
+ 2021-08-24 00:00:00 | Berlin |          40
+ 2021-08-27 00:00:00 | Berlin |          41
+ 2021-08-30 00:00:00 | Berlin |          42
+(42 rows)
+
+-- Make sure the invalidation threshold was unaffected
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+       to_char       
+---------------------
+ 2021-07-01 00:00:00
+(1 row)
+
+-- Make sure the invalidation log is still empty
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+ lowest | greatest 
+--------+----------
+(0 rows)
+
+-- Call refresh for two full buckets: 2021-07-01 and 2021-08-01
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-06-15 MSK', '2021-09-15 MSK');
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-01 00:00:00 |  22 |  34
+ Berlin | 2021-07-01 00:00:00 |  22 |  32
+ Moscow | 2021-07-01 00:00:00 |   1 |  11
+ Berlin | 2021-08-01 00:00:00 |  33 |  42
+ Moscow | 2021-08-01 00:00:00 |  12 |  21
+(5 rows)
+
+-- Make sure the invalidation threshold has changed
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+       to_char       
+---------------------
+ 2021-09-01 00:00:00
+(1 row)
+
+-- Make sure the invalidation log is still empty
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+ lowest | greatest 
+--------+----------
+(0 rows)
+
+-- Add more data below the invalidation threshold, make sure that the
+-- invalidation log is not empty, then do a refresh.
+INSERT INTO conditions_tz (day, city, temperature)
+SELECT ts :: timestamptz, city, (CASE WHEN city = 'Moscow' THEN -100 ELSE 100 END)
+FROM generate_series('2021-08-16 MSK' :: timestamptz, '2021-08-30 MSK', '1 day') as ts,
+     unnest(array['Moscow', 'Berlin']) as city;
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+       lowest        |      greatest       
+---------------------+---------------------
+ 2021-08-16 00:00:00 | 2021-08-30 00:00:00
+(1 row)
+
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-08-01 MSK', '2021-09-01 MSK');
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min  | max 
+--------+---------------------+------+-----
+ Moscow | 2021-06-01 00:00:00 |   22 |  34
+ Berlin | 2021-07-01 00:00:00 |   22 |  32
+ Moscow | 2021-07-01 00:00:00 |    1 |  11
+ Berlin | 2021-08-01 00:00:00 |   33 | 100
+ Moscow | 2021-08-01 00:00:00 | -100 |  21
+(5 rows)
+
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+ lowest | greatest 
+--------+----------
+(0 rows)
+
+-- Clean up
+DROP MATERIALIZED VIEW conditions_summary_tz;
+NOTICE:  drop cascades to 3 other objects
+DROP MATERIALIZED VIEW conditions_summary_1w;
+NOTICE:  drop cascades to 2 other objects
+-- Create a real-time aggregate
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_tz"
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min  | max 
+--------+---------------------+------+-----
+ Moscow | 2021-06-01 00:00:00 |   22 |  34
+ Berlin | 2021-07-01 00:00:00 |   22 |  32
+ Moscow | 2021-07-01 00:00:00 |    1 |  11
+ Berlin | 2021-08-01 00:00:00 |   33 | 100
+ Moscow | 2021-08-01 00:00:00 | -100 |  21
+(5 rows)
+
+-- Add some data to the hypertable and make sure they are visible in the cagg
+INSERT INTO conditions_tz (day, city, temperature) VALUES
+  ('2021-10-01 00:00:00 MSK', 'Moscow', 1),
+  ('2021-10-02 00:00:00 MSK', 'Moscow', 2),
+  ('2021-10-03 00:00:00 MSK', 'Moscow', 3),
+  ('2021-10-04 00:00:00 MSK', 'Moscow', 4),
+  ('2021-10-01 00:00:00 MSK', 'Berlin', 5),
+  ('2021-10-02 00:00:00 MSK', 'Berlin', 6),
+  ('2021-10-03 00:00:00 MSK', 'Berlin', 7),
+  ('2021-10-04 00:00:00 MSK', 'Berlin', 8);
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min  | max 
+--------+---------------------+------+-----
+ Moscow | 2021-06-01 00:00:00 |   22 |  34
+ Berlin | 2021-07-01 00:00:00 |   22 |  32
+ Moscow | 2021-07-01 00:00:00 |    1 |  11
+ Berlin | 2021-08-01 00:00:00 |   33 | 100
+ Moscow | 2021-08-01 00:00:00 | -100 |  21
+ Berlin | 2021-10-01 00:00:00 |    5 |   8
+ Moscow | 2021-10-01 00:00:00 |    1 |   4
+(7 rows)
+
+-- Refresh the cagg and make sure that the result of SELECT query didn't change
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-10-01 00:00:00 MSK', '2021-11-01 00:00:00 MSK');
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min  | max 
+--------+---------------------+------+-----
+ Moscow | 2021-06-01 00:00:00 |   22 |  34
+ Berlin | 2021-07-01 00:00:00 |   22 |  32
+ Moscow | 2021-07-01 00:00:00 |    1 |  11
+ Berlin | 2021-08-01 00:00:00 |   33 | 100
+ Moscow | 2021-08-01 00:00:00 | -100 |  21
+ Berlin | 2021-10-01 00:00:00 |    5 |   8
+ Moscow | 2021-10-01 00:00:00 |    1 |   4
+(7 rows)
+
+-- Add some more data, enable compression, compress the chunks and repeat the test
+INSERT INTO conditions_tz (day, city, temperature) VALUES
+  ('2021-11-01 00:00:00 MSK', 'Moscow', 11),
+  ('2021-11-02 00:00:00 MSK', 'Moscow', 12),
+  ('2021-11-03 00:00:00 MSK', 'Moscow', 13),
+  ('2021-11-04 00:00:00 MSK', 'Moscow', 14),
+  ('2021-11-01 00:00:00 MSK', 'Berlin', 15),
+  ('2021-11-02 00:00:00 MSK', 'Berlin', 16),
+  ('2021-11-03 00:00:00 MSK', 'Berlin', 17),
+  ('2021-11-04 00:00:00 MSK', 'Berlin', 18);
+ALTER TABLE conditions_tz SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'city'
+);
+SELECT compress_chunk(ch) FROM show_chunks('conditions_tz') AS ch;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_2_1_chunk
+ _timescaledb_internal._hyper_2_2_chunk
+ _timescaledb_internal._hyper_2_3_chunk
+ _timescaledb_internal._hyper_2_4_chunk
+ _timescaledb_internal._hyper_2_5_chunk
+ _timescaledb_internal._hyper_2_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+ _timescaledb_internal._hyper_2_13_chunk
+ _timescaledb_internal._hyper_2_14_chunk
+ _timescaledb_internal._hyper_2_19_chunk
+ _timescaledb_internal._hyper_2_20_chunk
+ _timescaledb_internal._hyper_2_21_chunk
+ _timescaledb_internal._hyper_2_22_chunk
+ _timescaledb_internal._hyper_2_23_chunk
+ _timescaledb_internal._hyper_2_24_chunk
+ _timescaledb_internal._hyper_2_25_chunk
+ _timescaledb_internal._hyper_2_26_chunk
+ _timescaledb_internal._hyper_2_27_chunk
+ _timescaledb_internal._hyper_2_28_chunk
+ _timescaledb_internal._hyper_2_29_chunk
+ _timescaledb_internal._hyper_2_30_chunk
+ _timescaledb_internal._hyper_2_31_chunk
+ _timescaledb_internal._hyper_2_32_chunk
+ _timescaledb_internal._hyper_2_33_chunk
+ _timescaledb_internal._hyper_2_34_chunk
+ _timescaledb_internal._hyper_2_35_chunk
+ _timescaledb_internal._hyper_2_36_chunk
+ _timescaledb_internal._hyper_2_37_chunk
+ _timescaledb_internal._hyper_2_38_chunk
+ _timescaledb_internal._hyper_2_39_chunk
+ _timescaledb_internal._hyper_2_42_chunk
+ _timescaledb_internal._hyper_2_43_chunk
+ _timescaledb_internal._hyper_2_44_chunk
+ _timescaledb_internal._hyper_2_45_chunk
+ _timescaledb_internal._hyper_2_46_chunk
+ _timescaledb_internal._hyper_2_47_chunk
+ _timescaledb_internal._hyper_2_48_chunk
+ _timescaledb_internal._hyper_2_49_chunk
+ _timescaledb_internal._hyper_2_50_chunk
+ _timescaledb_internal._hyper_2_51_chunk
+ _timescaledb_internal._hyper_2_55_chunk
+ _timescaledb_internal._hyper_2_56_chunk
+ _timescaledb_internal._hyper_2_57_chunk
+ _timescaledb_internal._hyper_2_58_chunk
+ _timescaledb_internal._hyper_2_60_chunk
+ _timescaledb_internal._hyper_2_61_chunk
+ _timescaledb_internal._hyper_2_62_chunk
+ _timescaledb_internal._hyper_2_63_chunk
+(53 rows)
+
+-- Data for 2021-11 is seen because the cagg is real-time
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min  | max 
+--------+---------------------+------+-----
+ Moscow | 2021-06-01 00:00:00 |   22 |  34
+ Berlin | 2021-07-01 00:00:00 |   22 |  32
+ Moscow | 2021-07-01 00:00:00 |    1 |  11
+ Berlin | 2021-08-01 00:00:00 |   33 | 100
+ Moscow | 2021-08-01 00:00:00 | -100 |  21
+ Berlin | 2021-10-01 00:00:00 |    5 |   8
+ Moscow | 2021-10-01 00:00:00 |    1 |   4
+ Berlin | 2021-11-01 00:00:00 |   15 |  18
+ Moscow | 2021-11-01 00:00:00 |   11 |  14
+(9 rows)
+
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-11-01 00:00:00 MSK', '2021-12-01 00:00:00 MSK');
+-- Data for 2021-11 is seen because the cagg was refreshed
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+  city  |        month        | min  | max 
+--------+---------------------+------+-----
+ Moscow | 2021-06-01 00:00:00 |   22 |  34
+ Berlin | 2021-07-01 00:00:00 |   22 |  32
+ Moscow | 2021-07-01 00:00:00 |    1 |  11
+ Berlin | 2021-08-01 00:00:00 |   33 | 100
+ Moscow | 2021-08-01 00:00:00 | -100 |  21
+ Berlin | 2021-10-01 00:00:00 |    5 |   8
+ Moscow | 2021-10-01 00:00:00 |    1 |   4
+ Berlin | 2021-11-01 00:00:00 |   15 |  18
+ Moscow | 2021-11-01 00:00:00 |   11 |  14
+(9 rows)
+
+-- Test for some more cases: single CAGG per HT, creating CAGG on top of an
+-- empty HT, buckets other than 1 month.
+CREATE TABLE conditions2(
+  day timestamptz NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT create_hypertable(
+  'conditions2', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable     
+--------------------------
+ (8,public,conditions2,t)
+(1 row)
+
+-- Create a real-time aggregate on top of empty HT
+CREATE MATERIALIZED VIEW conditions2_summary
+WITH (timescaledb.continuous) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('7 days', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions2
+GROUP BY city, bucket;
+NOTICE:  continuous aggregate "conditions2_summary" is already up-to-date
+INSERT INTO conditions2 (day, city, temperature) VALUES
+  ('2021-06-14 00:00:00 MSK', 'Moscow', 26),
+  ('2021-06-15 00:00:00 MSK', 'Moscow', 22),
+  ('2021-06-16 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-17 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-18 00:00:00 MSK', 'Moscow', 27),
+  ('2021-06-19 00:00:00 MSK', 'Moscow', 28),
+  ('2021-06-20 00:00:00 MSK', 'Moscow', 30),
+  ('2021-06-21 00:00:00 MSK', 'Moscow', 31),
+  ('2021-06-22 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-23 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-24 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-25 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-26 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-27 00:00:00 MSK', 'Moscow', 31);
+-- All data should be seen for a real-time aggregate
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions2_summary
+ORDER by month, city;
+  city  |        month        | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-12 00:00:00 |  22 |  27
+ Moscow | 2021-06-19 00:00:00 |  28 |  34
+ Moscow | 2021-06-26 00:00:00 |  31 |  32
+(3 rows)
+
+-- Refresh should work
+CALL refresh_continuous_aggregate('conditions2_summary', '2021-06-12 MSK', '2021-07-03 MSK');
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions2_summary
+ORDER by month, city;
+  city  |        month        | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-12 00:00:00 |  22 |  27
+ Moscow | 2021-06-19 00:00:00 |  28 |  34
+ Moscow | 2021-06-26 00:00:00 |  31 |  32
+(3 rows)
+
+-- New data should be seen
+INSERT INTO conditions2 (day, city, temperature) VALUES
+  ('2021-09-30 00:00:00 MSK', 'Moscow', 0),
+  ('2021-10-01 00:00:00 MSK', 'Moscow', 1),
+  ('2021-10-02 00:00:00 MSK', 'Moscow', 2),
+  ('2021-10-03 00:00:00 MSK', 'Moscow', 3),
+  ('2021-10-04 00:00:00 MSK', 'Moscow', 4),
+  ('2021-09-30 00:00:00 MSK', 'Berlin', 5),
+  ('2021-10-01 00:00:00 MSK', 'Berlin', 6),
+  ('2021-10-02 00:00:00 MSK', 'Berlin', 7),
+  ('2021-10-03 00:00:00 MSK', 'Berlin', 8),
+  ('2021-10-04 00:00:00 MSK', 'Berlin', 9);
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions2_summary
+ORDER by month, city;
+  city  |        month        | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-12 00:00:00 |  22 |  27
+ Moscow | 2021-06-19 00:00:00 |  28 |  34
+ Moscow | 2021-06-26 00:00:00 |  31 |  32
+ Berlin | 2021-09-25 00:00:00 |   5 |   6
+ Moscow | 2021-09-25 00:00:00 |   0 |   1
+ Berlin | 2021-10-02 00:00:00 |   7 |   9
+ Moscow | 2021-10-02 00:00:00 |   2 |   4
+(7 rows)
+
+-- Test caggs with monthly buckets on top of distributed hypertable
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\set DATA_NODE_1 :TEST_DBNAME _1
+\set DATA_NODE_2 :TEST_DBNAME _2
+\set DATA_NODE_3 :TEST_DBNAME _3
+SELECT (add_data_node (name, host => 'localhost', DATABASE => name)).*
+FROM (VALUES (:'DATA_NODE_1'), (:'DATA_NODE_2'), (:'DATA_NODE_3')) v (name);
+        node_name        |   host    | port  |        database         | node_created | database_created | extension_created 
+-------------------------+-----------+-------+-------------------------+--------------+------------------+-------------------
+ db_cagg_with_timezone_1 | localhost | 55432 | db_cagg_with_timezone_1 | t            | t                | t
+ db_cagg_with_timezone_2 | localhost | 55432 | db_cagg_with_timezone_2 | t            | t                | t
+ db_cagg_with_timezone_3 | localhost | 55432 | db_cagg_with_timezone_3 | t            | t                | t
+(3 rows)
+
+GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+CREATE TABLE conditions_dist(
+  day timestamptz NOT NULL,
+  temperature INT NOT NULL);
+SELECT table_name FROM create_distributed_hypertable('conditions_dist', 'day', chunk_time_interval => INTERVAL '1 day');
+   table_name    
+-----------------
+ conditions_dist
+(1 row)
+
+INSERT INTO conditions_dist(day, temperature)
+SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
+FROM generate_series('2010-01-01 00:00:00 MSK' :: timestamptz, '2010-03-01 00:00:00 MSK' :: timestamptz - interval '1 day', '1 day') as ts;
+CREATE MATERIALIZED VIEW conditions_dist_1m
+WITH (timescaledb.continuous) AS
+SELECT
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_dist
+GROUP BY bucket;
+NOTICE:  refreshing continuous aggregate "conditions_dist_1m"
+SELECT mat_hypertable_id AS cagg_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_dist_1m'
+\gset
+SELECT raw_hypertable_id AS ht_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_dist_1m'
+\gset
+SELECT bucket_width
+FROM _timescaledb_catalog.continuous_agg
+WHERE mat_hypertable_id = :cagg_id;
+ bucket_width 
+--------------
+           -1
+(1 row)
+
+SELECT experimental, name, bucket_width, origin, timezone
+FROM _timescaledb_catalog.continuous_aggs_bucket_function
+WHERE mat_hypertable_id = :cagg_id;
+ experimental |      name      | bucket_width | origin | timezone 
+--------------+----------------+--------------+--------+----------
+ t            | time_bucket_ng | @ 1 mon      |        | MSK
+(1 row)
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+        month        | min | max  
+---------------------+-----+------
+ 2010-01-01 00:00:00 | 101 | 1231
+ 2010-02-01 00:00:00 | 131 |  227
+(2 rows)
+
+-- Same test but with non-realtime, NO DATA aggregate and manual refresh
+CREATE MATERIALIZED VIEW conditions_dist_1m_manual
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_dist
+GROUP BY bucket
+WITH NO DATA;
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+ month | min | max 
+-------+-----+-----
+(0 rows)
+
+CALL refresh_continuous_aggregate('conditions_dist_1m_manual', '2010-01-01 00:00:00 MSK', '2010-03-01 00:00:00 MSK');
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+        month        | min | max  
+---------------------+-----+------
+ 2010-01-01 00:00:00 | 101 | 1231
+ 2010-02-01 00:00:00 | 131 |  227
+(2 rows)
+
+-- Check invalidation for caggs on top of distributed hypertable
+INSERT INTO conditions_dist(day, temperature) VALUES
+('2010-01-15 00:00:00 MSK', 999),
+('2010-02-15 00:00:00 MSK', -999),
+('2010-03-01 00:00:00 MSK', 15);
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+        month        | min | max  
+---------------------+-----+------
+ 2010-01-01 00:00:00 | 101 | 1231
+ 2010-02-01 00:00:00 | 131 |  227
+ 2010-03-01 00:00:00 |  15 |   15
+(3 rows)
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+        month        | min | max  
+---------------------+-----+------
+ 2010-01-01 00:00:00 | 101 | 1231
+ 2010-02-01 00:00:00 | 131 |  227
+(2 rows)
+
+CALL refresh_continuous_aggregate('conditions_dist_1m', '2010-01-01 00:00:00 MSK', '2010-04-01 00:00:00 MSK');
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+        month        | min  | max  
+---------------------+------+------
+ 2010-01-01 00:00:00 |  101 | 1231
+ 2010-02-01 00:00:00 | -999 |  227
+ 2010-03-01 00:00:00 |   15 |   15
+(3 rows)
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+        month        | min | max  
+---------------------+-----+------
+ 2010-01-01 00:00:00 | 101 | 1231
+ 2010-02-01 00:00:00 | 131 |  227
+(2 rows)
+
+CALL refresh_continuous_aggregate('conditions_dist_1m_manual', '2010-01-01 00:00:00 MSK', '2010-04-01 00:00:00 MSK');
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+        month        | min  | max  
+---------------------+------+------
+ 2010-01-01 00:00:00 |  101 | 1231
+ 2010-02-01 00:00:00 | -999 |  227
+ 2010-03-01 00:00:00 |   15 |   15
+(3 rows)
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+        month        | min  | max  
+---------------------+------+------
+ 2010-01-01 00:00:00 |  101 | 1231
+ 2010-02-01 00:00:00 | -999 |  227
+ 2010-03-01 00:00:00 |   15 |   15
+(3 rows)
+
+-- Check compatibility with compressed distributed hypertables
+ALTER MATERIALIZED VIEW conditions_dist_1m_manual SET ( timescaledb.compress );
+SELECT compress_chunk(ch)
+FROM show_chunks('conditions_dist_1m_manual') ch limit 1;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_12_201_chunk
+(1 row)
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+        month        | min  | max  
+---------------------+------+------
+ 2010-01-01 00:00:00 |  101 | 1231
+ 2010-02-01 00:00:00 | -999 |  227
+ 2010-03-01 00:00:00 |   15 |   15
+(3 rows)
+
+-- Clean up
+DROP TABLE conditions_dist CASCADE;
+NOTICE:  drop cascades to 5 other objects
+NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 3 other objects
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+DROP DATABASE :DATA_NODE_1;
+DROP DATABASE :DATA_NODE_2;
+DROP DATABASE :DATA_NODE_3;

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -44,6 +44,7 @@ set(TEST_FILES_DEBUG
     cagg_usage.sql
     cagg_policy_run.sql
     cagg_variable_size_buckets.sql
+    cagg_with_timezone.sql
     data_fetcher.sql
     data_node_bootstrap.sql
     data_node.sql

--- a/tsl/test/sql/cagg_with_timezone.sql
+++ b/tsl/test/sql/cagg_with_timezone.sql
@@ -1,0 +1,547 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Make sure that timezone can't be used for types other that timestamptz
+
+CREATE TABLE conditions(
+  day timestamp NOT NULL, -- not timestamptz!
+  city text NOT NULL,
+  temperature INT NOT NULL);
+
+SELECT create_hypertable(
+  'conditions', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW conditions
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'Europe/Moscow') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions
+GROUP BY city, bucket
+WITH NO DATA;
+\set ON_ERROR_STOP 1
+
+DROP TABLE conditions CASCADE;
+
+CREATE TABLE conditions_tz(
+  day timestamptz NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+
+SELECT create_hypertable(
+  'conditions_tz', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+
+INSERT INTO conditions_tz (day, city, temperature) VALUES
+  ('2021-06-14 00:00:00 MSK', 'Moscow', 26),
+  ('2021-06-15 00:00:00 MSK', 'Moscow', 22),
+  ('2021-06-16 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-17 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-18 00:00:00 MSK', 'Moscow', 27),
+  ('2021-06-19 00:00:00 MSK', 'Moscow', 28),
+  ('2021-06-20 00:00:00 MSK', 'Moscow', 30),
+  ('2021-06-21 00:00:00 MSK', 'Moscow', 31),
+  ('2021-06-22 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-23 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-24 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-25 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-26 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-27 00:00:00 MSK', 'Moscow', 31);
+
+\set ON_ERROR_STOP 0
+
+-- Check that the name of the timezone is validated
+
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'Europe/Ololondon') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+
+-- Check that buckets like '1 month 15 days' (fixed-sized + variable-sized) are not allowed
+
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month 15 days', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+
+-- Check that only immutable expressions can be used as a timezone
+
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 day', day, city) AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+
+\set ON_ERROR_STOP 1
+
+-- Make sure it's possible to create an empty cagg (WITH NO DATA) and
+-- that all the information about the bucketing function will be saved
+-- to the TS catalog.
+
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+
+SELECT mat_hypertable_id AS cagg_id_tz, raw_hypertable_id AS ht_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_summary_tz'
+\gset
+
+SELECT bucket_width
+FROM _timescaledb_catalog.continuous_agg
+WHERE mat_hypertable_id = :cagg_id_tz;
+
+-- Make sure the timezone is saved in the catalog table
+SELECT experimental, name, bucket_width, origin, timezone
+FROM _timescaledb_catalog.continuous_aggs_bucket_function
+WHERE mat_hypertable_id = :cagg_id_tz;
+
+-- Make sure that buckets with specified timezone are always treated as
+-- variable-sized, even if the interval is fixed (i.e. days and/or hours)
+
+CREATE MATERIALIZED VIEW conditions_summary_1w
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('7 days', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket
+WITH NO DATA;
+
+SELECT mat_hypertable_id AS cagg_id_1w
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_summary_1w'
+\gset
+
+SELECT bucket_width
+FROM _timescaledb_catalog.continuous_agg
+WHERE mat_hypertable_id = :cagg_id_1w;
+
+-- Make sure the timezone is saved in the catalog table
+SELECT experimental, name, bucket_width, origin, timezone
+FROM _timescaledb_catalog.continuous_aggs_bucket_function
+WHERE mat_hypertable_id = :cagg_id_1w;
+
+-- Check the invalidation threshold
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+
+-- Make sure the invalidation log is empty
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+
+-- Make sure truncating of the refresh window works
+\set ON_ERROR_STOP 0
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-07-02 MSK', '2021-07-12 MSK');
+CALL refresh_continuous_aggregate('conditions_summary_1w', '2021-07-02 MSK', '2021-07-05 MSK');
+\set ON_ERROR_STOP 1
+
+-- Make sure refreshing works
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-06-01 MSK', '2021-07-01 MSK');
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+-- Check the invalidation threshold
+
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+
+-- The default origin is Saturday. Here we do refresh only for two full weeks
+-- in June in order to keep the invalidation threshold as it is.
+CALL refresh_continuous_aggregate('conditions_summary_1w', '2021-06-12 MSK', '2021-06-26 MSK');
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as week, min, max
+FROM conditions_summary_1w
+ORDER by week, city;
+
+-- Check the invalidation threshold
+
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+
+-- Make sure creating CAGGs without NO DATA works the same way
+
+CREATE MATERIALIZED VIEW conditions_summary_tz2
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket;
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz2
+ORDER by month, city;
+
+-- Add some dummy data for two more months (no invalidations test case)
+INSERT INTO conditions_tz (day, city, temperature)
+SELECT ts, city, row_number() OVER ()
+FROM generate_series('2021-07-01 MSK' :: timestamptz, '2021-08-31 MSK', '3 day') as ts,
+     unnest(array['Moscow', 'Berlin']) as city;
+
+-- Double check the generated data
+SELECT to_char(day at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS'), city, temperature
+FROM conditions_tz
+WHERE day >= '2021-07-01 MSK'
+ORDER BY city DESC, day;
+
+-- Make sure the invalidation threshold was unaffected
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+
+-- Make sure the invalidation log is still empty
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+
+-- Call refresh for two full buckets: 2021-07-01 and 2021-08-01
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-06-15 MSK', '2021-09-15 MSK');
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+-- Make sure the invalidation threshold has changed
+SELECT to_char(_timescaledb_internal.to_timestamp(watermark) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS')
+FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
+WHERE hypertable_id = :ht_id;
+
+-- Make sure the invalidation log is still empty
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+
+-- Add more data below the invalidation threshold, make sure that the
+-- invalidation log is not empty, then do a refresh.
+INSERT INTO conditions_tz (day, city, temperature)
+SELECT ts :: timestamptz, city, (CASE WHEN city = 'Moscow' THEN -100 ELSE 100 END)
+FROM generate_series('2021-08-16 MSK' :: timestamptz, '2021-08-30 MSK', '1 day') as ts,
+     unnest(array['Moscow', 'Berlin']) as city;
+
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-08-01 MSK', '2021-09-01 MSK');
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+SELECT
+    to_char(_timescaledb_internal.to_timestamp(lowest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS lowest,
+    to_char(_timescaledb_internal.to_timestamp(greatest_modified_value) at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') AS greatest
+FROM _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
+WHERE hypertable_id = :ht_id;
+
+-- Clean up
+DROP MATERIALIZED VIEW conditions_summary_tz;
+DROP MATERIALIZED VIEW conditions_summary_1w;
+
+-- Create a real-time aggregate
+CREATE MATERIALIZED VIEW conditions_summary_tz
+WITH (timescaledb.continuous) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_tz
+GROUP BY city, bucket;
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+-- Add some data to the hypertable and make sure they are visible in the cagg
+INSERT INTO conditions_tz (day, city, temperature) VALUES
+  ('2021-10-01 00:00:00 MSK', 'Moscow', 1),
+  ('2021-10-02 00:00:00 MSK', 'Moscow', 2),
+  ('2021-10-03 00:00:00 MSK', 'Moscow', 3),
+  ('2021-10-04 00:00:00 MSK', 'Moscow', 4),
+  ('2021-10-01 00:00:00 MSK', 'Berlin', 5),
+  ('2021-10-02 00:00:00 MSK', 'Berlin', 6),
+  ('2021-10-03 00:00:00 MSK', 'Berlin', 7),
+  ('2021-10-04 00:00:00 MSK', 'Berlin', 8);
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+-- Refresh the cagg and make sure that the result of SELECT query didn't change
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-10-01 00:00:00 MSK', '2021-11-01 00:00:00 MSK');
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+-- Add some more data, enable compression, compress the chunks and repeat the test
+
+INSERT INTO conditions_tz (day, city, temperature) VALUES
+  ('2021-11-01 00:00:00 MSK', 'Moscow', 11),
+  ('2021-11-02 00:00:00 MSK', 'Moscow', 12),
+  ('2021-11-03 00:00:00 MSK', 'Moscow', 13),
+  ('2021-11-04 00:00:00 MSK', 'Moscow', 14),
+  ('2021-11-01 00:00:00 MSK', 'Berlin', 15),
+  ('2021-11-02 00:00:00 MSK', 'Berlin', 16),
+  ('2021-11-03 00:00:00 MSK', 'Berlin', 17),
+  ('2021-11-04 00:00:00 MSK', 'Berlin', 18);
+
+ALTER TABLE conditions_tz SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'city'
+);
+
+SELECT compress_chunk(ch) FROM show_chunks('conditions_tz') AS ch;
+
+-- Data for 2021-11 is seen because the cagg is real-time
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+CALL refresh_continuous_aggregate('conditions_summary_tz', '2021-11-01 00:00:00 MSK', '2021-12-01 00:00:00 MSK');
+
+-- Data for 2021-11 is seen because the cagg was refreshed
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_tz
+ORDER by month, city;
+
+-- Test for some more cases: single CAGG per HT, creating CAGG on top of an
+-- empty HT, buckets other than 1 month.
+
+CREATE TABLE conditions2(
+  day timestamptz NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+
+SELECT create_hypertable(
+  'conditions2', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+
+-- Create a real-time aggregate on top of empty HT
+CREATE MATERIALIZED VIEW conditions2_summary
+WITH (timescaledb.continuous) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('7 days', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions2
+GROUP BY city, bucket;
+
+INSERT INTO conditions2 (day, city, temperature) VALUES
+  ('2021-06-14 00:00:00 MSK', 'Moscow', 26),
+  ('2021-06-15 00:00:00 MSK', 'Moscow', 22),
+  ('2021-06-16 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-17 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-18 00:00:00 MSK', 'Moscow', 27),
+  ('2021-06-19 00:00:00 MSK', 'Moscow', 28),
+  ('2021-06-20 00:00:00 MSK', 'Moscow', 30),
+  ('2021-06-21 00:00:00 MSK', 'Moscow', 31),
+  ('2021-06-22 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-23 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-24 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-25 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-26 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-27 00:00:00 MSK', 'Moscow', 31);
+
+-- All data should be seen for a real-time aggregate
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions2_summary
+ORDER by month, city;
+
+-- Refresh should work
+CALL refresh_continuous_aggregate('conditions2_summary', '2021-06-12 MSK', '2021-07-03 MSK');
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions2_summary
+ORDER by month, city;
+
+-- New data should be seen
+INSERT INTO conditions2 (day, city, temperature) VALUES
+  ('2021-09-30 00:00:00 MSK', 'Moscow', 0),
+  ('2021-10-01 00:00:00 MSK', 'Moscow', 1),
+  ('2021-10-02 00:00:00 MSK', 'Moscow', 2),
+  ('2021-10-03 00:00:00 MSK', 'Moscow', 3),
+  ('2021-10-04 00:00:00 MSK', 'Moscow', 4),
+  ('2021-09-30 00:00:00 MSK', 'Berlin', 5),
+  ('2021-10-01 00:00:00 MSK', 'Berlin', 6),
+  ('2021-10-02 00:00:00 MSK', 'Berlin', 7),
+  ('2021-10-03 00:00:00 MSK', 'Berlin', 8),
+  ('2021-10-04 00:00:00 MSK', 'Berlin', 9);
+
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions2_summary
+ORDER by month, city;
+
+-- Test caggs with monthly buckets on top of distributed hypertable
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+\set DATA_NODE_1 :TEST_DBNAME _1
+\set DATA_NODE_2 :TEST_DBNAME _2
+\set DATA_NODE_3 :TEST_DBNAME _3
+
+SELECT (add_data_node (name, host => 'localhost', DATABASE => name)).*
+FROM (VALUES (:'DATA_NODE_1'), (:'DATA_NODE_2'), (:'DATA_NODE_3')) v (name);
+
+GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
+CREATE TABLE conditions_dist(
+  day timestamptz NOT NULL,
+  temperature INT NOT NULL);
+
+SELECT table_name FROM create_distributed_hypertable('conditions_dist', 'day', chunk_time_interval => INTERVAL '1 day');
+
+INSERT INTO conditions_dist(day, temperature)
+SELECT ts, date_part('month', ts)*100 + date_part('day', ts)
+FROM generate_series('2010-01-01 00:00:00 MSK' :: timestamptz, '2010-03-01 00:00:00 MSK' :: timestamptz - interval '1 day', '1 day') as ts;
+
+CREATE MATERIALIZED VIEW conditions_dist_1m
+WITH (timescaledb.continuous) AS
+SELECT
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_dist
+GROUP BY bucket;
+
+SELECT mat_hypertable_id AS cagg_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_dist_1m'
+\gset
+
+SELECT raw_hypertable_id AS ht_id
+FROM _timescaledb_catalog.continuous_agg
+WHERE user_view_name = 'conditions_dist_1m'
+\gset
+
+SELECT bucket_width
+FROM _timescaledb_catalog.continuous_agg
+WHERE mat_hypertable_id = :cagg_id;
+
+SELECT experimental, name, bucket_width, origin, timezone
+FROM _timescaledb_catalog.continuous_aggs_bucket_function
+WHERE mat_hypertable_id = :cagg_id;
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+
+-- Same test but with non-realtime, NO DATA aggregate and manual refresh
+
+CREATE MATERIALIZED VIEW conditions_dist_1m_manual
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+   timescaledb_experimental.time_bucket_ng('1 month', day, 'MSK') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_dist
+GROUP BY bucket
+WITH NO DATA;
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+
+CALL refresh_continuous_aggregate('conditions_dist_1m_manual', '2010-01-01 00:00:00 MSK', '2010-03-01 00:00:00 MSK');
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+
+-- Check invalidation for caggs on top of distributed hypertable
+
+INSERT INTO conditions_dist(day, temperature) VALUES
+('2010-01-15 00:00:00 MSK', 999),
+('2010-02-15 00:00:00 MSK', -999),
+('2010-03-01 00:00:00 MSK', 15);
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+
+CALL refresh_continuous_aggregate('conditions_dist_1m', '2010-01-01 00:00:00 MSK', '2010-04-01 00:00:00 MSK');
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+
+CALL refresh_continuous_aggregate('conditions_dist_1m_manual', '2010-01-01 00:00:00 MSK', '2010-04-01 00:00:00 MSK');
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m
+ORDER BY month;
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+
+-- Check compatibility with compressed distributed hypertables
+
+ALTER MATERIALIZED VIEW conditions_dist_1m_manual SET ( timescaledb.compress );
+
+SELECT compress_chunk(ch)
+FROM show_chunks('conditions_dist_1m_manual') ch limit 1;
+
+SELECT to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_dist_1m_manual
+ORDER BY month;
+
+-- Clean up
+DROP TABLE conditions_dist CASCADE;
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+DROP DATABASE :DATA_NODE_1;
+DROP DATABASE :DATA_NODE_2;
+DROP DATABASE :DATA_NODE_3;


### PR DESCRIPTION
This patch allows using timezones in CAGGs, for instance:

time_bucket_ng(bucket_size, ts, 'Europe/Moscow')

Both months/years and days/hours/minutes can be used in bucket_size.
The bucket size is considered variable-sized in all these cases
because DST affects days/hours/minutes as well.

CAGGs on top of distributed hypertables, compressed hypertables and
compressed distributed hypertables are supported as well.