### PR TITLE
Update syntactic attribute number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ accidentally triggering the load of a previous DB version.**
 * #3918 Fix DataNodeScan plans with one-time filter
 * #3938 Fix subtract_integer_from_now on 32-bit platforms and improve error handling
 * #3939 Fix projection handling in time_bucket_gapfill
+* #3979 Fix deparsing of index predicates
 
 **Thanks**
 * @erikhh for reporting an issue with time_bucket_gapfill
 * @fvannee for reporting a first/last memory leak
+* @kancsuki for reporting drop column and partial index creation not working
 
 ## 2.5.1 (2021-12-02)
 

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -107,7 +107,11 @@ adjust_expr_attnos(Oid ht_relid, IndexInfo *ii, Relation chunkrel)
 
 		char *attname = get_attname(ht_relid, var->varattno, false);
 		var->varattno = get_attnum(chunkrel->rd_id, attname);
-
+#if PG13_GE
+		var->varattnosyn = var->varattno;
+#else
+		var->varoattno = var->varattno;
+#endif
 		if (var->varattno == InvalidAttrNumber)
 			elog(ERROR, "index attribute %s not found in chunk", attname);
 	}

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -734,6 +734,34 @@ SELECT hypertable_constraint_name, constraint_name from _timescaledb_catalog.chu
 
 INSERT INTO t_hypertable AS h VALUES ( 1, '2020-01-01 00:01:00', 3.2) ON CONFLICT (id, time) DO UPDATE SET value = h.value + EXCLUDED.value;
 ROLLBACK;
+-- predicate reconstruction when attnos are different in hypertable and chunk
+CREATE TABLE p_hypertable (a integer not null, b integer, c integer);
+SELECT create_hypertable('p_hypertable', 'a', chunk_time_interval => int '3');
+     create_hypertable      
+----------------------------
+ (14,public,p_hypertable,t)
+(1 row)
+
+BEGIN;
+ALTER TABLE p_hypertable DROP COLUMN b, ADD COLUMN d boolean;
+CREATE INDEX idx_ht ON p_hypertable(a, c) WHERE d = FALSE;
+END;
+INSERT INTO p_hypertable(a, c, d) VALUES (1, 1, FALSE);
+\d+ _timescaledb_internal._hyper_14_28_chunk
+                     Table "_timescaledb_internal._hyper_14_28_chunk"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           | not null |         | plain   |              | 
+ c      | integer |           |          |         | plain   |              | 
+ d      | boolean |           |          |         | plain   |              | 
+Indexes:
+    "_hyper_14_28_chunk_idx_ht" btree (a, c) WHERE NOT d
+    "_hyper_14_28_chunk_p_hypertable_a_idx" btree (a DESC)
+Check constraints:
+    "constraint_34" CHECK (a >= 0 AND a < 3)
+Inherits: p_hypertable
+
+DROP TABLE p_hypertable;
 -- check none of our hooks interact badly with normal alter view handling
 CREATE VIEW v1 AS SELECT random();
 \set ON_ERROR_STOP 0

--- a/tsl/test/expected/plan_skip_scan-12.out
+++ b/tsl/test/expected/plan_skip_scan-12.out
@@ -1614,19 +1614,10 @@ CREATE INDEX skip_scan_expr_idx ON :TABLE((dev % 3));
    ->  Merge Append (actual rows=10020 loops=1)
          Sort Key: ((_hyper_1_1_chunk.dev % 3))
          ->  Index Scan using _hyper_1_1_chunk_skip_scan_expr_idx on _hyper_1_1_chunk (actual rows=2505 loops=1)
-         ->  Sort (actual rows=2505 loops=1)
-               Sort Key: ((_hyper_1_2_chunk.dev % 3))
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_1_2_chunk (actual rows=2505 loops=1)
-         ->  Sort (actual rows=2505 loops=1)
-               Sort Key: ((_hyper_1_3_chunk.dev % 3))
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_1_3_chunk (actual rows=2505 loops=1)
-         ->  Sort (actual rows=2505 loops=1)
-               Sort Key: ((_hyper_1_4_chunk.dev % 3))
-               Sort Method: quicksort 
-               ->  Seq Scan on _hyper_1_4_chunk (actual rows=2505 loops=1)
-(16 rows)
+         ->  Index Scan using _hyper_1_2_chunk_skip_scan_expr_idx on _hyper_1_2_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_3_chunk_skip_scan_expr_idx on _hyper_1_3_chunk (actual rows=2505 loops=1)
+         ->  Index Scan using _hyper_1_4_chunk_skip_scan_expr_idx on _hyper_1_4_chunk (actual rows=2505 loops=1)
+(7 rows)
 
 DROP INDEX skip_scan_expr_idx;
 CREATE INDEX ON :TABLE(dev_name);


### PR DESCRIPTION
When adjusting attribute numbers of chunk index, also adjust
varattnosyn which is used at the time of reconstructing index
definition.