### PR TITLE
Add exception to invalidation SQL functions

### DIFF
--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -194,6 +194,9 @@ tsl_invalidation_cagg_log_add_entry(PG_FUNCTION_ARGS)
 	int64 start_time = PG_GETARG_INT64(1);
 	int64 end_time = PG_GETARG_INT64(2);
 
+	if (end_time < start_time)
+		elog(ERROR, "cannot invalidate cagg, end time should be greater than start time");
+
 	invalidation_cagg_log_add_entry(mat_hypertable_id, start_time, end_time);
 
 	PG_RETURN_VOID();
@@ -213,6 +216,9 @@ tsl_invalidation_hyper_log_add_entry(PG_FUNCTION_ARGS)
 	int32 raw_hypertable_id = PG_GETARG_INT32(0);
 	int64 start_time = PG_GETARG_INT64(1);
 	int64 end_time = PG_GETARG_INT64(2);
+
+	if (end_time < start_time)
+		elog(ERROR, "cannot invalidate hypertable, end time should be greater than start time");
 
 	invalidation_hyper_log_add_entry(raw_hypertable_id, start_time, end_time);
 

--- a/tsl/test/expected/continuous_aggs_invalidation.out
+++ b/tsl/test/expected/continuous_aggs_invalidation.out
@@ -335,7 +335,6 @@ SELECT * FROM cagg_invals;
        5 |                   30 | 9223372036854775807
 (6 rows)
 
-	  
 -- There should be no hypertable invalidations initially:
 SELECT * FROM hyper_invals;
  hyper_id | start | end 
@@ -742,6 +741,14 @@ GROUP BY 1,2 WITH NO DATA;
 SELECT mat_hypertable_id AS cond_1_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_1' \gset
+-- Test manual invalidation error
+\if :IS_DISTRIBUTED
+\else
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.invalidation_cagg_log_add_entry(:cond_1_id, 1, 0);
+psql:include/continuous_aggs_invalidation_common.sql:433: ERROR:  cannot invalidate cagg, end time should be greater than start time
+\set ON_ERROR_STOP 1
+\endif
 -- Test invalidations with bucket size 1
 INSERT INTO conditions VALUES (0, 1, 1.0);
 SELECT * FROM hyper_invals;
@@ -916,7 +923,7 @@ CREATE table threshold_test (time int, value int);
 SELECT create_distributed_hypertable('threshold_test', 'time', chunk_time_interval => 4, replication_factor => 2);
 \else
 SELECT create_hypertable('threshold_test', 'time', chunk_time_interval => 4);
-psql:include/continuous_aggs_invalidation_common.sql:536: NOTICE:  adding not-null constraint to column "time"
+psql:include/continuous_aggs_invalidation_common.sql:544: NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
  (7,public,threshold_test,t)
@@ -947,11 +954,19 @@ ORDER BY 1,2;
 ---------------+-----------
 (0 rows)
 
+-- Test manual invalidation error
+\if :IS_DISTRIBUTED
+\else
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.invalidation_hyper_log_add_entry(:thresh_hyper_id, 1, 0);
+psql:include/continuous_aggs_invalidation_common.sql:569: ERROR:  cannot invalidate hypertable, end time should be greater than start time
+\set ON_ERROR_STOP 1
+\endif
 -- Test that threshold is initilized to min value when there's no data
 -- and we specify an infinite end. Note that the min value may differ
 -- depending on time type.
 CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:560: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:576: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
@@ -977,13 +992,13 @@ ORDER BY 1,2;
 -- Refresh where both the start and end of the window is above the
 -- max data value
 CALL refresh_continuous_aggregate('thresh_2', 14, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:580: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:596: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 SELECT watermark AS thresh_hyper_id_watermark
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id \gset
 -- Refresh where we start from the current watermark to infinity
 CALL refresh_continuous_aggregate('thresh_2', :thresh_hyper_id_watermark, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:587: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:603: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 -- Now refresh with max end of the window to test that the
 -- invalidation threshold is capped at the last bucket of data
 CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
@@ -1185,7 +1200,7 @@ INSERT INTO conditions VALUES(3, 1, 1.0);
 INSERT INTO conditions VALUES(4, 1, 1.0);
 INSERT INTO conditions VALUES(6, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_1', 10, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:709: NOTICE:  continuous aggregate "cond_1" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:725: NOTICE:  continuous aggregate "cond_1" is already up-to-date
 SELECT * FROM cagg_invals
 WHERE cagg_id = :cond_1_id;
  cagg_id | start |         end         
@@ -1211,7 +1226,7 @@ INSERT INTO conditions VALUES (40, 1, 1.0);
 -- Refresh to process invalidations, but outside the range of
 -- invalidations we inserted so that we don't clear them.
 CALL refresh_continuous_aggregate('cond_10', 50, 60);
-psql:include/continuous_aggs_invalidation_common.sql:730: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:746: NOTICE:  continuous aggregate "cond_10" is already up-to-date
 SELECT mat_hypertable_id AS cond_10_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_10' \gset
@@ -1251,16 +1266,16 @@ CALL refresh_continuous_aggregate('cond_10', 0, 200);
 SET timescaledb.materializations_per_refresh_window='foo';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:769: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:785: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "foo".
 SET timescaledb.materializations_per_refresh_window='2bar';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:772: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:788: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "2bar".
 SET timescaledb.materializations_per_refresh_window='-';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:776: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:792: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "-".
 \set VERBOSITY terse

--- a/tsl/test/expected/continuous_aggs_invalidation_dist_ht.out
+++ b/tsl/test/expected/continuous_aggs_invalidation_dist_ht.out
@@ -367,7 +367,6 @@ SELECT * FROM cagg_invals;
        5 |                   30 | 9223372036854775807
 (6 rows)
 
-	  
 -- There should be no hypertable invalidations initially:
 SELECT * FROM hyper_invals;
  hyper_id | start | end 
@@ -801,6 +800,13 @@ GROUP BY 1,2 WITH NO DATA;
 SELECT mat_hypertable_id AS cond_1_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_1' \gset
+-- Test manual invalidation error
+\if :IS_DISTRIBUTED
+\else
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.invalidation_cagg_log_add_entry(:cond_1_id, 1, 0);
+\set ON_ERROR_STOP 1
+\endif
 -- Test invalidations with bucket size 1
 INSERT INTO conditions VALUES (0, 1, 1.0);
 SELECT * FROM hyper_invals;
@@ -974,7 +980,7 @@ ORDER BY 1,2;
 CREATE table threshold_test (time int, value int);
 \if :IS_DISTRIBUTED
 SELECT create_distributed_hypertable('threshold_test', 'time', chunk_time_interval => 4, replication_factor => 2);
-psql:include/continuous_aggs_invalidation_common.sql:534: NOTICE:  adding not-null constraint to column "time"
+psql:include/continuous_aggs_invalidation_common.sql:542: NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
  (7,public,threshold_test,t)
@@ -1007,11 +1013,18 @@ ORDER BY 1,2;
 ---------------+-----------
 (0 rows)
 
+-- Test manual invalidation error
+\if :IS_DISTRIBUTED
+\else
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.invalidation_hyper_log_add_entry(:thresh_hyper_id, 1, 0);
+\set ON_ERROR_STOP 1
+\endif
 -- Test that threshold is initilized to min value when there's no data
 -- and we specify an infinite end. Note that the min value may differ
 -- depending on time type.
 CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:560: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:576: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
@@ -1037,13 +1050,13 @@ ORDER BY 1,2;
 -- Refresh where both the start and end of the window is above the
 -- max data value
 CALL refresh_continuous_aggregate('thresh_2', 14, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:580: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:596: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 SELECT watermark AS thresh_hyper_id_watermark
 FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id \gset
 -- Refresh where we start from the current watermark to infinity
 CALL refresh_continuous_aggregate('thresh_2', :thresh_hyper_id_watermark, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:587: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:603: NOTICE:  continuous aggregate "thresh_2" is already up-to-date
 -- Now refresh with max end of the window to test that the
 -- invalidation threshold is capped at the last bucket of data
 CALL refresh_continuous_aggregate('thresh_2', 0, NULL);
@@ -1245,7 +1258,7 @@ INSERT INTO conditions VALUES(3, 1, 1.0);
 INSERT INTO conditions VALUES(4, 1, 1.0);
 INSERT INTO conditions VALUES(6, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_1', 10, NULL);
-psql:include/continuous_aggs_invalidation_common.sql:709: NOTICE:  continuous aggregate "cond_1" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:725: NOTICE:  continuous aggregate "cond_1" is already up-to-date
 SELECT * FROM cagg_invals
 WHERE cagg_id = :cond_1_id;
  cagg_id | start |         end         
@@ -1271,7 +1284,7 @@ INSERT INTO conditions VALUES (40, 1, 1.0);
 -- Refresh to process invalidations, but outside the range of
 -- invalidations we inserted so that we don't clear them.
 CALL refresh_continuous_aggregate('cond_10', 50, 60);
-psql:include/continuous_aggs_invalidation_common.sql:730: NOTICE:  continuous aggregate "cond_10" is already up-to-date
+psql:include/continuous_aggs_invalidation_common.sql:746: NOTICE:  continuous aggregate "cond_10" is already up-to-date
 SELECT mat_hypertable_id AS cond_10_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_10' \gset
@@ -1314,17 +1327,17 @@ CALL refresh_continuous_aggregate('cond_10', 0, 200);
 SET timescaledb.materializations_per_refresh_window='foo';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:769: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:785: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "foo".
 SET timescaledb.materializations_per_refresh_window='2bar';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:772: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:788: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "2bar".
 SET timescaledb.materializations_per_refresh_window='-';
 INSERT INTO conditions VALUES (140, 1, 1.0);
 CALL refresh_continuous_aggregate('cond_10', 0, 200);
-psql:include/continuous_aggs_invalidation_common.sql:776: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
+psql:include/continuous_aggs_invalidation_common.sql:792: WARNING:  invalid value for session variable "timescaledb.materializations_per_refresh_window"
 DETAIL:  Expected an integer but current value is "-".
 \set VERBOSITY terse
 -- cleanup

--- a/tsl/test/sql/include/continuous_aggs_invalidation_common.sql
+++ b/tsl/test/sql/include/continuous_aggs_invalidation_common.sql
@@ -224,7 +224,7 @@ CALL refresh_continuous_aggregate('cond_20', 60, 100);
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 ORDER BY 1,2;
 SELECT * FROM cagg_invals;
-	  
+
 -- There should be no hypertable invalidations initially:
 SELECT * FROM hyper_invals;
 SELECT * FROM cagg_invals;
@@ -426,6 +426,14 @@ SELECT mat_hypertable_id AS cond_1_id
 FROM _timescaledb_catalog.continuous_agg
 WHERE user_view_name = 'cond_1' \gset
 
+-- Test manual invalidation error
+\if :IS_DISTRIBUTED
+\else
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.invalidation_cagg_log_add_entry(:cond_1_id, 1, 0);
+\set ON_ERROR_STOP 1
+\endif
+
 -- Test invalidations with bucket size 1
 INSERT INTO conditions VALUES (0, 1, 1.0);
 
@@ -553,6 +561,14 @@ WHERE user_view_name = 'thresh_2' \gset
 SELECT * FROM _timescaledb_catalog.continuous_aggs_invalidation_threshold
 WHERE hypertable_id = :thresh_hyper_id
 ORDER BY 1,2;
+
+-- Test manual invalidation error
+\if :IS_DISTRIBUTED
+\else
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.invalidation_hyper_log_add_entry(:thresh_hyper_id, 1, 0);
+\set ON_ERROR_STOP 1
+\endif
 
 -- Test that threshold is initilized to min value when there's no data
 -- and we specify an infinite end. Note that the min value may differ


### PR DESCRIPTION
Per Sven's sqlsmith run we got some assertion errors adding
invalidation for hypertables and continuous aggregates.

Fixed id adding the proper validation in the invalidation SQL functions
to check properly the parameters `start_time` and `end_time`.