### PR TITLE
Support continuous agg trigger on copy into compressed chunks

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -348,8 +348,8 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 		estate->es_result_relation_info = resultRelInfo;
 #endif
 
-		if (cis->compress_state != NULL)
-			check_resultRelInfo = cis->orig_result_relation_info;
+		if (cis->compress_info != NULL)
+			check_resultRelInfo = cis->compress_info->orig_result_relation_info;
 		else
 			check_resultRelInfo = resultRelInfo;
 
@@ -388,14 +388,14 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, void (*call
 				ExecConstraints(check_resultRelInfo, myslot, estate);
 			}
 
-			if (cis->compress_state)
+			if (cis->compress_info)
 			{
 				TupleTableSlot *compress_slot =
-					ts_cm_functions->compress_row_exec(cis->compress_state, myslot);
+					ts_cm_functions->compress_row_exec(cis->compress_info->compress_state, myslot);
 				/* After Row triggers do not work with compressed chunks. So
 				 * explicitly call cagg trigger here
 				 */
-				if (cis->has_cagg_trigger)
+				if (cis->compress_info->has_cagg_trigger)
 				{
 					Assert(ts_cm_functions->continuous_agg_call_invalidation_trigger);
 					HeapTupleTableSlot *hslot = (HeapTupleTableSlot *) myslot;

--- a/src/nodes/chunk_dispatch_state.c
+++ b/src/nodes/chunk_dispatch_state.c
@@ -163,7 +163,7 @@ chunk_dispatch_exec(CustomScanState *node)
 		 * the function that records invalidations directly as AFTER ROW
 		 * triggers do not work with compressed chunks.
 		 */
-		if (ts_continuous_aggs_find_by_raw_table_id(ht->fd.id))
+		if (cis->has_cagg_trigger)
 		{
 			Assert(ts_cm_functions->continuous_agg_call_invalidation_trigger);
 			HeapTupleTableSlot *hslot = (HeapTupleTableSlot *) orig_slot;

--- a/src/nodes/chunk_dispatch_state.c
+++ b/src/nodes/chunk_dispatch_state.c
@@ -115,8 +115,8 @@ chunk_dispatch_exec(CustomScanState *node)
 	 * just when the chunk changes.
 	 */
 #if PG14_LT
-	if (cis->compress_state != NULL)
-		estate->es_result_relation_info = cis->orig_result_relation_info;
+	if (cis->compress_info != NULL)
+		estate->es_result_relation_info = cis->compress_info->orig_result_relation_info;
 	else
 		estate->es_result_relation_info = cis->result_relation_info;
 #endif
@@ -127,43 +127,44 @@ chunk_dispatch_exec(CustomScanState *node)
 	if (cis->hyper_to_chunk_map != NULL)
 		slot = execute_attr_map_slot(cis->hyper_to_chunk_map->attrMap, slot, cis->slot);
 
-	if (cis->compress_state != NULL)
+	if (cis->compress_info != NULL)
 	{
 		/*
 		 * When the chunk is compressed, we redirect the insert to the internal compressed
 		 * chunk. However, any BEFORE ROW triggers defined on the chunk have to be executed
 		 * before we redirect the insert.
 		 */
-		if (cis->orig_result_relation_info->ri_TrigDesc &&
-			cis->orig_result_relation_info->ri_TrigDesc->trig_insert_before_row)
+		if (cis->compress_info->orig_result_relation_info->ri_TrigDesc &&
+			cis->compress_info->orig_result_relation_info->ri_TrigDesc->trig_insert_before_row)
 		{
 			bool skip_tuple;
-			skip_tuple = !ExecBRInsertTriggers(estate, cis->orig_result_relation_info, slot);
+			skip_tuple =
+				!ExecBRInsertTriggers(estate, cis->compress_info->orig_result_relation_info, slot);
 
 			if (skip_tuple)
 				return NULL;
 		}
 
 		if (cis->rel->rd_att->constr && cis->rel->rd_att->constr->has_generated_stored)
-			ExecComputeStoredGeneratedCompat(cis->orig_result_relation_info,
+			ExecComputeStoredGeneratedCompat(cis->compress_info->orig_result_relation_info,
 											 estate,
 											 slot,
 											 CMD_INSERT);
 
 		if (cis->rel->rd_att->constr)
-			ExecConstraints(cis->orig_result_relation_info, slot, estate);
+			ExecConstraints(cis->compress_info->orig_result_relation_info, slot, estate);
 
 #if PG14_LT
 		estate->es_result_relation_info = cis->result_relation_info;
 #endif
 		Assert(ts_cm_functions->compress_row_exec != NULL);
 		TupleTableSlot *orig_slot = slot;
-		slot = ts_cm_functions->compress_row_exec(cis->compress_state, slot);
+		slot = ts_cm_functions->compress_row_exec(cis->compress_info->compress_state, slot);
 		/* If we have cagg defined on the hypertable, we have to execute
 		 * the function that records invalidations directly as AFTER ROW
 		 * triggers do not work with compressed chunks.
 		 */
-		if (cis->has_cagg_trigger)
+		if (cis->compress_info->has_cagg_trigger)
 		{
 			Assert(ts_cm_functions->continuous_agg_call_invalidation_trigger);
 			HeapTupleTableSlot *hslot = (HeapTupleTableSlot *) orig_slot;

--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -717,6 +717,7 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 		/* need a way to convert from chunk tuple to compressed chunk tuple */
 		state->compress_state = ts_cm_functions->compress_row_init(htid, rel, compress_rel);
 		state->orig_result_relation_info = relinfo;
+		state->has_cagg_trigger = (ts_continuous_aggs_find_by_raw_table_id(htid) != NIL);
 	}
 	else
 	{

--- a/src/nodes/chunk_insert_state.h
+++ b/src/nodes/chunk_insert_state.h
@@ -15,6 +15,19 @@
 #include "cache.h"
 #include "cross_module_fn.h"
 
+/* Info related to compressed chunk
+ * Continuous aggregate triggers are called explicitly on
+ * compressed chunks after INSERTS as AFTER ROW insert triggers
+ * do now work with the PG infrastructure.
+ */
+typedef struct CompressChunkInsertState
+{
+	Relation compress_rel;					  /*compressed chunk */
+	ResultRelInfo *orig_result_relation_info; /*original chunk */
+	CompressSingleRowState *compress_state;
+	bool has_cagg_trigger; /* are there any continuous aggregate triggers */
+} CompressChunkInsertState;
+
 typedef struct ChunkInsertState
 {
 	Relation rel;
@@ -56,10 +69,7 @@ typedef struct ChunkInsertState
 	Oid user_id;
 
 	/* for tracking compressed chunks */
-	Relation compress_rel;
-	ResultRelInfo *orig_result_relation_info;
-	CompressSingleRowState *compress_state;
-	bool has_cagg_trigger;
+	CompressChunkInsertState *compress_info;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/src/nodes/chunk_insert_state.h
+++ b/src/nodes/chunk_insert_state.h
@@ -59,6 +59,7 @@ typedef struct ChunkInsertState
 	Relation compress_rel;
 	ResultRelInfo *orig_result_relation_info;
 	CompressSingleRowState *compress_state;
+	bool has_cagg_trigger;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -909,7 +909,17 @@ SELECT * FROM cagg_conditions ORDER BY 1;
  Sun Dec 27 16:00:00 2009 PST |   5 |  185
 (1 row)
 
--- direct insert into interal compressed hypertable should be blocked
+-- TEST cagg triggers with copy into compressed chunk
+COPY conditions FROM STDIN DELIMITER ',';
+--refresh cagg, should have updated info
+CALL refresh_continuous_aggregate('cagg_conditions', NULL, '2011-01-01 12:00:00-08' );
+SELECT * FROM cagg_conditions ORDER BY 1;
+             bkt              | cnt | sumb 
+------------------------------+-----+------
+ Sun Dec 27 16:00:00 2009 PST |   8 |  485
+(1 row)
+
+-- TEST direct insert into internal compressed hypertable should be blocked
 CREATE TABLE direct_insert(time timestamptz not null);
 SELECT table_name FROM create_hypertable('direct_insert','time');
   table_name   

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -909,7 +909,17 @@ SELECT * FROM cagg_conditions ORDER BY 1;
  Sun Dec 27 16:00:00 2009 PST |   5 |  185
 (1 row)
 
--- direct insert into interal compressed hypertable should be blocked
+-- TEST cagg triggers with copy into compressed chunk
+COPY conditions FROM STDIN DELIMITER ',';
+--refresh cagg, should have updated info
+CALL refresh_continuous_aggregate('cagg_conditions', NULL, '2011-01-01 12:00:00-08' );
+SELECT * FROM cagg_conditions ORDER BY 1;
+             bkt              | cnt | sumb 
+------------------------------+-----+------
+ Sun Dec 27 16:00:00 2009 PST |   8 |  485
+(1 row)
+
+-- TEST direct insert into internal compressed hypertable should be blocked
 CREATE TABLE direct_insert(time timestamptz not null);
 SELECT table_name FROM create_hypertable('direct_insert','time');
   table_name   

--- a/tsl/test/expected/compression_insert-14.out
+++ b/tsl/test/expected/compression_insert-14.out
@@ -909,7 +909,17 @@ SELECT * FROM cagg_conditions ORDER BY 1;
  Sun Dec 27 16:00:00 2009 PST |   5 |  185
 (1 row)
 
--- direct insert into interal compressed hypertable should be blocked
+-- TEST cagg triggers with copy into compressed chunk
+COPY conditions FROM STDIN DELIMITER ',';
+--refresh cagg, should have updated info
+CALL refresh_continuous_aggregate('cagg_conditions', NULL, '2011-01-01 12:00:00-08' );
+SELECT * FROM cagg_conditions ORDER BY 1;
+             bkt              | cnt | sumb 
+------------------------------+-----+------
+ Sun Dec 27 16:00:00 2009 PST |   8 |  485
+(1 row)
+
+-- TEST direct insert into internal compressed hypertable should be blocked
 CREATE TABLE direct_insert(time timestamptz not null);
 SELECT table_name FROM create_hypertable('direct_insert','time');
   table_name   

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -585,7 +585,18 @@ INSERT INTO conditions VALUES('2010-01-01 12:00:00-08', 10, 20);
 CALL refresh_continuous_aggregate('cagg_conditions', NULL, '2011-01-01 12:00:00-08' );
 SELECT * FROM cagg_conditions ORDER BY 1;
 
--- direct insert into interal compressed hypertable should be blocked
+-- TEST cagg triggers with copy into compressed chunk
+COPY conditions FROM STDIN DELIMITER ',';
+2010-01-01 11:16:00-05,100,100
+2010-01-01 11:17:00-05,100,100
+2010-01-01 11:18:00-05,100,100
+\.
+
+--refresh cagg, should have updated info
+CALL refresh_continuous_aggregate('cagg_conditions', NULL, '2011-01-01 12:00:00-08' );
+SELECT * FROM cagg_conditions ORDER BY 1;
+
+-- TEST direct insert into internal compressed hypertable should be blocked
 CREATE TABLE direct_insert(time timestamptz not null);
 SELECT table_name FROM create_hypertable('direct_insert','time');
 ALTER TABLE direct_insert SET(timescaledb.compress);


### PR DESCRIPTION
AFTER ROW triggers are not supported on compressed chunks.
Directly call the continuous aggregate trigger function for copies.

This fix is similar to PR 3764 that handles cagg triggers for
inserts into compressed chunks.

Disable-check: commit-count