### PR TITLE
Use cached Chunks for data node assignment

### DIFF
--- a/src/ts_catalog/chunk_data_node.c
+++ b/src/ts_catalog/chunk_data_node.c
@@ -193,6 +193,7 @@ ts_chunk_data_node_scan_by_node_internal(const char *node_name, tuple_found_func
 											   mctx);
 }
 
+/* Returns a List of ChunkDataNode structs. */
 List *
 ts_chunk_data_node_scan_by_chunk_id(int32 chunk_id, MemoryContext mctx)
 {

--- a/tsl/src/fdw/data_node_chunk_assignment.h
+++ b/tsl/src/fdw/data_node_chunk_assignment.h
@@ -29,7 +29,7 @@ typedef struct DataNodeChunkAssignment
 	Cost startup_cost;
 	Cost total_cost;
 	Relids chunk_relids;
-	List *chunk_oids;
+	List *chunks;
 	List *remote_chunk_ids;
 } DataNodeChunkAssignment;
 

--- a/tsl/src/fdw/relinfo.h
+++ b/tsl/src/fdw/relinfo.h
@@ -132,14 +132,17 @@ typedef struct TsFdwRelInfo
 #endif
 
 	/*
-	 * Moving averages of chunk size. We use them to compute the size for remote
-	 * chunks that don't have local statistics, e.g. because ANALYZE haven't
-	 * been run. Note that these values are adjusted for fill factor, i.e. they
-	 * correspond to a fill factor of 1.0. The fill factor for a particular
-	 * chunk is estimated separately.
+	 * Moving averages of chunk size, valid for the hypertable relinfo.
+	 * We use them to compute the size for remote chunks that don't have local
+	 * statistics, e.g. because ANALYZE haven't been run. Note that these values
+	 * are adjusted for fill factor, i.e. they correspond to a fill factor of
+	 * 1.0. The fill factor for a particular chunk is estimated separately.
 	 */
 	double average_chunk_pages;
 	double average_chunk_tuples;
+
+	/* Cached chunk data for the chunk relinfo. */
+	struct Chunk *chunk;
 } TsFdwRelInfo;
 
 extern TsFdwRelInfo *fdw_relinfo_create(PlannerInfo *root, RelOptInfo *rel, Oid server_oid,

--- a/tsl/src/fdw/scan_plan.c
+++ b/tsl/src/fdw/scan_plan.c
@@ -33,6 +33,7 @@
 #include "debug.h"
 #include "fdw_utils.h"
 #include "scan_exec.h"
+#include "chunk.h"
 
 /*
  * get_useful_pathkeys_for_relation
@@ -581,6 +582,17 @@ fdw_scan_info_init(ScanInfo *scaninfo, PlannerInfo *root, RelOptInfo *rel, Path 
 	/* Remember remote_exprs for possible use by PlanDirectModify */
 	fpinfo->final_remote_exprs = remote_where;
 
+	/* Build the chunk oid list for use by EXPLAIN. */
+	List *chunk_oids = NIL;
+	if (fpinfo->sca)
+	{
+		foreach (lc, fpinfo->sca->chunks)
+		{
+			Chunk *chunk = (Chunk *) lfirst(lc);
+			chunk_oids = lappend_oid(chunk_oids, chunk->table_id);
+		}
+	}
+
 	/*
 	 * Build the fdw_private list that will be available to the executor.
 	 * Items in the list must match order in enum FdwScanPrivateIndex.
@@ -589,7 +601,7 @@ fdw_scan_info_init(ScanInfo *scaninfo, PlannerInfo *root, RelOptInfo *rel, Path 
 							 retrieved_attrs,
 							 makeInteger(fpinfo->fetch_size),
 							 makeInteger(fpinfo->server->serverid),
-							 (fpinfo->sca != NULL ? list_copy(fpinfo->sca->chunk_oids) : NIL));
+							 chunk_oids);
 	Assert(!IS_JOIN_REL(rel));
 
 	if (IS_UPPER_REL(rel))


### PR DESCRIPTION
Before assigning chunks to data nodes, we have to look up the same
Chunk structs to estimate the chunk relation size. Cache them in chunk
RelOptInfos to avoid the costly lookup.

Part of #3890