### PR TITLE
Don't allow using buckets like '1 month 15 days' + some refactorings

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -204,28 +204,6 @@ ts_interval_value_to_internal(Datum time_val, Oid type_oid)
 	}
 }
 
-/*
- * Similar to ts_interval_value_to_internal() but for monthly interval returns
- * the number of months and *months=true. Otherwise returns *months=false and
- * the result of ts_interval_value_to_internal()
- */
-int64
-ts_interval_value_to_internal_or_months(Datum time_val, Oid type_oid, bool *months)
-{
-	if (type_oid == INTERVALOID)
-	{
-		Interval *interval = DatumGetIntervalP(time_val);
-		if (interval->month != 0)
-		{
-			*months = true;
-			return interval->month;
-		}
-	}
-
-	*months = false;
-	return ts_interval_value_to_internal(time_val, type_oid);
-}
-
 static int64
 ts_integer_to_internal(Datum time_val, Oid type_oid)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -62,8 +62,6 @@ extern int64 ts_time_value_to_internal_or_infinite(Datum time_val, Oid type_oid,
 												   TimevalInfinity *is_infinite_out);
 
 extern TSDLLEXPORT int64 ts_interval_value_to_internal(Datum time_val, Oid type_oid);
-extern TSDLLEXPORT int64 ts_interval_value_to_internal_or_months(Datum time_val, Oid type_oid,
-																 bool *months);
 
 /*
  * Convert a column from the internal time representation into the specified type

--- a/tsl/test/expected/continuous_aggs_variable_size_buckets.out
+++ b/tsl/test/expected/continuous_aggs_variable_size_buckets.out
@@ -29,6 +29,19 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-25', 'Moscow', 32),
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
+-- Check that buckets like '1 month 15 days' (fixed-sized + variable-sized) are not allowed
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW conditions_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month 15 days', day) AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions
+GROUP BY city, bucket
+WITH NO DATA;
+ERROR:  invalid interval specified
+\set ON_ERROR_STOP 1
 -- Make sure it's possible to create an empty cagg (WITH NO DATA) and
 -- that all the information about the bucketing function will be saved
 -- to the TS catalog.
@@ -62,7 +75,7 @@ FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id;
  experimental |      name      | bucket_width | origin | timezone 
 --------------+----------------+--------------+--------+----------
- t            | time_bucket_ng | 1 months     |        | 
+ t            | time_bucket_ng | @ 1 mon      |        | 
 (1 row)
 
 -- Check that there is no saved invalidation threshold before any refreshes
@@ -1071,7 +1084,7 @@ FROM _timescaledb_catalog.continuous_aggs_bucket_function
 WHERE mat_hypertable_id = :cagg_id;
  experimental |      name      | bucket_width | origin | timezone 
 --------------+----------------+--------------+--------+----------
- t            | time_bucket_ng | 1 months     |        | 
+ t            | time_bucket_ng | @ 1 mon      |        | 
 (1 row)
 
 SELECT * FROM conditions_dist_1m ORDER BY bucket;

--- a/tsl/test/sql/continuous_aggs_variable_size_buckets.sql
+++ b/tsl/test/sql/continuous_aggs_variable_size_buckets.sql
@@ -28,6 +28,19 @@ INSERT INTO conditions (day, city, temperature) VALUES
   ('2021-06-26', 'Moscow', 32),
   ('2021-06-27', 'Moscow', 31);
 
+-- Check that buckets like '1 month 15 days' (fixed-sized + variable-sized) are not allowed
+
+\set ON_ERROR_STOP 0
+CREATE MATERIALIZED VIEW conditions_summary
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month 15 days', day) AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions
+GROUP BY city, bucket
+WITH NO DATA;
+\set ON_ERROR_STOP 1
 
 -- Make sure it's possible to create an empty cagg (WITH NO DATA) and
 -- that all the information about the bucketing function will be saved


### PR DESCRIPTION
This is in fact a backport from the "Buckets with timezones" feature branch.
While working on the feature a bug was discovered. We allow creating buckets
like '1 month 15 days', i.e. fixed-sized + variable-sized, which is supposed to
be forbidden.

This patch fixes the bug and also simplifies the code a little. timezone_in /
timezone_out procedures are used instead of snprintf/scanf. Also, the
CAggTimebucketInfo structure was changed slightly. These changes are going to be
needed for timezones support anyway.