### PR TITLE
Ignore memoize test in pg14 snapshot

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -155,7 +155,7 @@ if event_type != "pull_request":
   # the stable branches of supported PG releases
   m["include"].append(build_debug_config({"pg":12,"snapshot":"snapshot"}))
   m["include"].append(build_debug_config({"pg":13,"snapshot":"snapshot"}))
-  m["include"].append(build_debug_config({"pg":14,"snapshot":"snapshot"}))
+  m["include"].append(build_debug_config({"pg":14,"snapshot":"snapshot", "installcheck_args": "IGNORES='memoize'"}))
 
 # generate command to set github action variable
 print(str.format("::set-output name=matrix::{0}",json.dumps(m)))


### PR DESCRIPTION
Upstream changed the explain output for the memoize node to include
an additional `Cache Mode` line. While we could adjust our test
runner to always ignore that line this would prevent us from testing
the cache mode in future tests.

https://github.com/postgres/postgres/commit/6c32c0977783fae217b5eaa1d22d26c96e5b0085