### PR TITLE
Add support for wildcards to SKIPS

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -46,19 +46,9 @@ TEST_ROLE_READ_ONLY=${TEST_ROLE_READ_ONLY:-test_role_read_only}
 shift
 
 # Drop test database and make it less verbose in case of dropping a
-# distributed database. Also revoke privileges granted when setting up
-# the template1 database. This has to be revoked since the user is
-# dropped from a different database.
+# distributed database.
 function cleanup {
-    ${PSQL} "$@" -U ${USER} -d template1 -v ECHO=none >/dev/null 2>&1 <<EOF
-REVOKE CREATE ON SCHEMA public FROM ${TEST_PGUSER};
-REVOKE CREATE ON SCHEMA public FROM ${TEST_ROLE_DEFAULT_PERM_USER};
-REVOKE CREATE ON SCHEMA public FROM ${TEST_ROLE_DEFAULT_PERM_USER_2};
-REVOKE CREATE ON SCHEMA public FROM ${TEST_ROLE_1};
-REVOKE CREATE ON SCHEMA public FROM ${TEST_ROLE_2};
-REVOKE CREATE ON SCHEMA public FROM ${TEST_ROLE_3};
-EOF
-    cat <<EOF | ${PSQL} "$@" -U $TEST_ROLE_SUPERUSER -d postgres -v ECHO=none >/dev/null 2>&1
+  cat <<EOF | ${PSQL} "$@" -U $TEST_ROLE_SUPERUSER -d postgres -v ECHO=none >/dev/null 2>&1
     SET client_min_messages=ERROR;
     DROP DATABASE "${TEST_DBNAME}";
 EOF
@@ -72,12 +62,20 @@ trap cleanup EXIT
 if mkdir ${TEST_OUTPUT_DIR}/.pg_init 2>/dev/null; then
   ${PSQL} "$@" -U ${USER} -d template1 -v ECHO=none >/dev/null 2>&1 <<EOF
     SET client_min_messages=ERROR;
-    GRANT CREATE ON SCHEMA public TO ${TEST_PGUSER};
-    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER};
-    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER_2};
-    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_1};
-    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_2};
-    GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_3};
+
+    DO \$\$
+      BEGIN
+        IF current_setting('server_version_num')::int >= 150000 THEN
+          GRANT CREATE ON SCHEMA public TO ${TEST_PGUSER};
+          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER};
+          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_DEFAULT_PERM_USER_2};
+          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_1};
+          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_2};
+          GRANT CREATE ON SCHEMA public TO ${TEST_ROLE_3};
+        END IF;
+      END
+    \$\$ LANGUAGE PLPGSQL;
+
     ALTER USER ${TEST_ROLE_SUPERUSER} WITH SUPERUSER;
     ALTER USER ${TEST_ROLE_CLUSTER_SUPERUSER} WITH SUPERUSER;
     ALTER USER ${TEST_ROLE_1} WITH CREATEDB CREATEROLE;


### PR DESCRIPTION
This patch adds suport for wildcards to the SKIPS environment
variable similar to wildcard support in TESTS.

This enables the following test invocations:

```
-- run all tsl tests expect background worker and multinode
make regresscheck-t SKIPS="*bgw* *dist*"
-- run cagg tests except background worker
make regresscheck-t TESTS="continuous_agg*" SKIPS="*bgw*"
```

Disable-check: commit-count
