### PR TITLE
Fix crash when execute add_data_node

### DIFF
--- a/tsl/test/t/005_add_data_node.pl
+++ b/tsl/test/t/005_add_data_node.pl
@@ -1,0 +1,38 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+use strict;
+use warnings;
+use PostgresNode;
+use AccessNode;
+use DataNode;
+use TestLib;
+use Test::More tests => 1;
+
+#
+# Make sure AN does not crash and produce correct error in case if the
+# DN is not properly configured.
+#
+# Issue:
+# https://github.com/timescale/timescaledb/issues/3951
+
+my $an = AccessNode->create('an');
+my $dn = get_new_node('dn');
+$dn->init();
+$dn->start();
+
+my $name = $dn->name;
+my $host = $dn->host;
+my $port = $dn->port;
+my ($ret, $stdout, $stderr) =
+  $an->psql('postgres',
+	"SELECT add_data_node('$name', host => '$host', port => $port)");
+like(
+	$stderr,
+	qr/extension "timescaledb" must be preloaded/,
+	'failure when adding data node');
+
+done_testing();
+
+1;

--- a/tsl/test/t/CMakeLists.txt
+++ b/tsl/test/t/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(PROVE_TEST_FILES 001_simple_multinode.pl 003_connections_privs.pl)
-set(PROVE_DEBUG_TEST_FILES 002_chunk_copy_move.pl 004_multinode_rdwr_1pc.pl)
+set(PROVE_DEBUG_TEST_FILES 002_chunk_copy_move.pl 004_multinode_rdwr_1pc.pl
+                           005_add_data_node.pl)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND PROVE_TEST_FILES ${PROVE_DEBUG_TEST_FILES})


### PR DESCRIPTION
On disconnect libpq will create a result object without
creating event data, which is usually done for a regular errors.

This fix handles this case and forces the result object to always
have have associated connection meta data.

Fix: #3951