### PR TITLE
Route delete on Hypertables through CustomScan

### DIFF
--- a/src/nodes/CMakeLists.txt
+++ b/src/nodes/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/chunk_dispatch_plan.c
     ${CMAKE_CURRENT_SOURCE_DIR}/chunk_dispatch_state.c
     ${CMAKE_CURRENT_SOURCE_DIR}/chunk_insert_state.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/hypertable_insert.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/hypertable_modify.c)
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})
 add_subdirectory(chunk_append)
 add_subdirectory(constraint_aware_append)

--- a/src/nodes/hypertable_modify.h
+++ b/src/nodes/hypertable_modify.h
@@ -3,8 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-APACHE for a copy of the license.
  */
-#ifndef TIMESCALEDB_HYPERTABLE_INSERT_H
-#define TIMESCALEDB_HYPERTABLE_INSERT_H
+#ifndef TIMESCALEDB_HYPERTABLE_MODIFY_H
+#define TIMESCALEDB_HYPERTABLE_MODIFY_H
 
 #include <postgres.h>
 #include <nodes/execnodes.h>
@@ -12,25 +12,25 @@
 
 #include "hypertable.h"
 
-typedef struct HypertableInsertPath
+typedef struct HypertableModifyPath
 {
 	CustomPath cpath;
 	/* A bitmapset to remember which subpaths are using data node dispatching. */
 	Bitmapset *distributed_insert_plans;
 	/* List of server oids for the hypertable's data nodes */
 	List *serveroids;
-} HypertableInsertPath;
+} HypertableModifyPath;
 
-typedef struct HypertableInsertState
+typedef struct HypertableModifyState
 {
 	CustomScanState cscan_state;
 	ModifyTable *mt;
 	List *serveroids;
 	FdwRoutine *fdwroutine;
-} HypertableInsertState;
+} HypertableModifyState;
 
-extern void ts_hypertable_insert_fixup_tlist(Plan *plan);
-extern Path *ts_hypertable_insert_path_create(PlannerInfo *root, ModifyTablePath *mtpath,
+extern void ts_hypertable_modify_fixup_tlist(Plan *plan);
+extern Path *ts_hypertable_modify_path_create(PlannerInfo *root, ModifyTablePath *mtpath,
 											  Hypertable *ht);
 
-#endif /* TIMESCALEDB_HYPERTABLE_INSERT_H */
+#endif /* TIMESCALEDB_HYPERTABLE_MODIFY_H */

--- a/test/expected/delete-12.out
+++ b/test/expected/delete-12.out
@@ -217,6 +217,7 @@ SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, serie
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (6 rows)
 
+BEGIN;
 DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
@@ -228,3 +229,23 @@ SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, serie
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (4 rows)
 
+ROLLBACK;
+BEGIN;
+DELETE FROM "two_Partitions"
+WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val()) RETURNING "timeCustom";
+     timeCustom      
+---------------------
+ 1257894002000000000
+ 1257894002000000000
+(2 rows)
+
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+     timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
+---------------------+-----------+----------+----------+----------+-------------
+ 1257894000000001000 | dev1      |      2.5 |        3 |          | 
+ 1257894001000000000 | dev1      |      3.5 |        4 |          | 
+ 1257894002000000000 | dev1      |      2.5 |        3 |          | 
+ 1257897600000000000 | dev1      |      4.5 |        5 |          | f
+(4 rows)
+
+ROLLBACK;

--- a/test/expected/delete-13.out
+++ b/test/expected/delete-13.out
@@ -217,6 +217,7 @@ SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, serie
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (6 rows)
 
+BEGIN;
 DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
@@ -228,3 +229,23 @@ SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, serie
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (4 rows)
 
+ROLLBACK;
+BEGIN;
+DELETE FROM "two_Partitions"
+WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val()) RETURNING "timeCustom";
+     timeCustom      
+---------------------
+ 1257894002000000000
+ 1257894002000000000
+(2 rows)
+
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+     timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
+---------------------+-----------+----------+----------+----------+-------------
+ 1257894000000001000 | dev1      |      2.5 |        3 |          | 
+ 1257894001000000000 | dev1      |      3.5 |        4 |          | 
+ 1257894002000000000 | dev1      |      2.5 |        3 |          | 
+ 1257897600000000000 | dev1      |      4.5 |        5 |          | f
+(4 rows)
+
+ROLLBACK;

--- a/test/expected/delete-14.out
+++ b/test/expected/delete-14.out
@@ -111,37 +111,38 @@ WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series
 EXPLAIN (costs off)
 DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Delete on "two_Partitions"
-   Delete on "two_Partitions" "two_Partitions_2"
-   Delete on _hyper_1_1_chunk "two_Partitions_3"
-   Delete on _hyper_1_2_chunk "two_Partitions_4"
-   Delete on _hyper_1_3_chunk "two_Partitions_5"
-   Delete on _hyper_1_4_chunk "two_Partitions_6"
-   ->  Hash Join
-         Hash Cond: ("two_Partitions".series_1 = "two_Partitions_1".series_1)
-         ->  Append
-               ->  Seq Scan on "two_Partitions" "two_Partitions_2"
-               ->  Seq Scan on _hyper_1_1_chunk "two_Partitions_3"
-               ->  Seq Scan on _hyper_1_2_chunk "two_Partitions_4"
-               ->  Seq Scan on _hyper_1_3_chunk "two_Partitions_5"
-               ->  Seq Scan on _hyper_1_4_chunk "two_Partitions_6"
-         ->  Hash
-               ->  HashAggregate
-                     Group Key: "two_Partitions_1".series_1
-                     ->  Append
-                           ->  Seq Scan on "two_Partitions" "two_Partitions_7"
-                                 Filter: (series_1 > (series_val())::double precision)
-                           ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_1_chunk "two_Partitions_8"
-                                 Index Cond: (series_1 > (series_val())::double precision)
-                           ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_2_chunk "two_Partitions_9"
-                                 Index Cond: (series_1 > (series_val())::double precision)
-                           ->  Index Scan using "_hyper_1_3_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_3_chunk "two_Partitions_10"
-                                 Index Cond: (series_1 > (series_val())::double precision)
-                           ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_4_chunk "two_Partitions_11"
-                                 Index Cond: (series_1 > (series_val())::double precision)
-(28 rows)
+                                                                       QUERY PLAN                                                                       
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on "two_Partitions"
+         Delete on "two_Partitions" "two_Partitions_2"
+         Delete on _hyper_1_1_chunk "two_Partitions_3"
+         Delete on _hyper_1_2_chunk "two_Partitions_4"
+         Delete on _hyper_1_3_chunk "two_Partitions_5"
+         Delete on _hyper_1_4_chunk "two_Partitions_6"
+         ->  Hash Join
+               Hash Cond: ("two_Partitions".series_1 = "two_Partitions_1".series_1)
+               ->  Append
+                     ->  Seq Scan on "two_Partitions" "two_Partitions_2"
+                     ->  Seq Scan on _hyper_1_1_chunk "two_Partitions_3"
+                     ->  Seq Scan on _hyper_1_2_chunk "two_Partitions_4"
+                     ->  Seq Scan on _hyper_1_3_chunk "two_Partitions_5"
+                     ->  Seq Scan on _hyper_1_4_chunk "two_Partitions_6"
+               ->  Hash
+                     ->  HashAggregate
+                           Group Key: "two_Partitions_1".series_1
+                           ->  Append
+                                 ->  Seq Scan on "two_Partitions" "two_Partitions_7"
+                                       Filter: (series_1 > (series_val())::double precision)
+                                 ->  Index Scan using "_hyper_1_1_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_1_chunk "two_Partitions_8"
+                                       Index Cond: (series_1 > (series_val())::double precision)
+                                 ->  Index Scan using "_hyper_1_2_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_2_chunk "two_Partitions_9"
+                                       Index Cond: (series_1 > (series_val())::double precision)
+                                 ->  Index Scan using "_hyper_1_3_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_3_chunk "two_Partitions_10"
+                                       Index Cond: (series_1 > (series_val())::double precision)
+                                 ->  Index Scan using "_hyper_1_4_chunk_two_Partitions_timeCustom_series_1_idx" on _hyper_1_4_chunk "two_Partitions_11"
+                                       Index Cond: (series_1 > (series_val())::double precision)
+(29 rows)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
      timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
@@ -154,6 +155,7 @@ SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, serie
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (6 rows)
 
+BEGIN;
 DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
@@ -165,3 +167,23 @@ SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, serie
  1257897600000000000 | dev1      |      4.5 |        5 |          | f
 (4 rows)
 
+ROLLBACK;
+BEGIN;
+DELETE FROM "two_Partitions"
+WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val()) RETURNING "timeCustom";
+     timeCustom      
+---------------------
+ 1257894002000000000
+ 1257894002000000000
+(2 rows)
+
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+     timeCustom      | device_id | series_0 | series_1 | series_2 | series_bool 
+---------------------+-----------+----------+----------+----------+-------------
+ 1257894000000001000 | dev1      |      2.5 |        3 |          | 
+ 1257894001000000000 | dev1      |      3.5 |        4 |          | 
+ 1257894002000000000 | dev1      |      2.5 |        3 |          | 
+ 1257897600000000000 | dev1      |      4.5 |        5 |          | f
+(4 rows)
+
+ROLLBACK;

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -316,7 +316,7 @@ SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
 -------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    CTE insert_cte
-     ->  Custom Scan (HypertableInsert) (actual rows=0 loops=1)
+     ->  Custom Scan (HypertableModify) (actual rows=0 loops=1)
            ->  Insert on one_space_test (actual rows=0 loops=1)
                  ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
                        ->  Result (actual rows=1 loops=1)
@@ -326,7 +326,7 @@ SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail;
                       QUERY PLAN                       
 -------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Append
@@ -338,7 +338,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i < 1;
                  QUERY PLAN                 
 --------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Result
@@ -348,7 +348,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i = 1;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Append
@@ -361,7 +361,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Index Scan using _hyper_5_13_chunk_chunk_assert_fail_i_idx on _hyper_5_13_chunk
@@ -372,7 +372,7 @@ INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time < 'infinity' LIMIT 1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -386,7 +386,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -397,7 +397,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -408,7 +408,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -436,7 +436,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time < 'infinity' LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -451,7 +451,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -463,7 +463,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -475,7 +475,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time > '-infinity' LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -499,7 +499,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time < 'infinity' LIMIT 1;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -514,7 +514,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -526,7 +526,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -538,7 +538,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time > '-infinity' LIMIT 1;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -615,7 +615,7 @@ WHERE NOT EXISTS (
 );
                      QUERY PLAN                      
 -----------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    InitPlan 1 (returns $0)
      ->  Result
            One-Time Filter: false

--- a/test/expected/insert-13.out
+++ b/test/expected/insert-13.out
@@ -316,7 +316,7 @@ SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
 -------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    CTE insert_cte
-     ->  Custom Scan (HypertableInsert) (actual rows=0 loops=1)
+     ->  Custom Scan (HypertableModify) (actual rows=0 loops=1)
            ->  Insert on one_space_test (actual rows=0 loops=1)
                  ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
                        ->  Result (actual rows=1 loops=1)
@@ -326,7 +326,7 @@ SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail;
                       QUERY PLAN                       
 -------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Append
@@ -338,7 +338,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i < 1;
                  QUERY PLAN                 
 --------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Result
@@ -348,7 +348,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i = 1;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Append
@@ -361,7 +361,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Index Scan using _hyper_5_13_chunk_chunk_assert_fail_i_idx on _hyper_5_13_chunk
@@ -372,7 +372,7 @@ INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time < 'infinity' LIMIT 1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -386,7 +386,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -397,7 +397,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -408,7 +408,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -436,7 +436,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time < 'infinity' LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -451,7 +451,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -463,7 +463,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -475,7 +475,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time > '-infinity' LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -499,7 +499,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time < 'infinity' LIMIT 1;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -514,7 +514,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -526,7 +526,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -538,7 +538,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time > '-infinity' LIMIT 1;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -615,7 +615,7 @@ WHERE NOT EXISTS (
 );
                      QUERY PLAN                      
 -----------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    InitPlan 1 (returns $0)
      ->  Result
            One-Time Filter: false

--- a/test/expected/insert-14.out
+++ b/test/expected/insert-14.out
@@ -316,7 +316,7 @@ SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
 -------------------------------------------------------------------------
  Result (actual rows=1 loops=1)
    CTE insert_cte
-     ->  Custom Scan (HypertableInsert) (actual rows=0 loops=1)
+     ->  Custom Scan (HypertableModify) (actual rows=0 loops=1)
            ->  Insert on one_space_test (never executed)
                  ->  Custom Scan (ChunkDispatch) (actual rows=1 loops=1)
                        ->  Result (actual rows=1 loops=1)
@@ -326,7 +326,7 @@ SELECT 1 \g | grep -v "Planning" | grep -v "Execution"
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail;
                       QUERY PLAN                       
 -------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Append
@@ -338,7 +338,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i < 1;
                  QUERY PLAN                 
 --------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Result
@@ -348,7 +348,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i = 1;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Append
@@ -361,7 +361,7 @@ EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_
 EXPLAIN (costs off) INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on chunk_assert_fail
          ->  Custom Scan (ChunkDispatch)
                ->  Index Scan using _hyper_5_13_chunk_chunk_assert_fail_i_idx on _hyper_5_13_chunk
@@ -372,7 +372,7 @@ INSERT INTO chunk_assert_fail SELECT i, j FROM chunk_assert_fail WHERE i > 1;
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time < 'infinity' LIMIT 1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -386,7 +386,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -397,7 +397,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -408,7 +408,7 @@ EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHER
 EXPLAIN (costs off) INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on one_space_test
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -436,7 +436,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time < 'infinity' LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -451,7 +451,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -463,7 +463,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -475,7 +475,7 @@ EXPLAIN (costs off) INSERT INTO timestamp_inf SELECT * FROM timestamp_inf
     WHERE time > '-infinity' LIMIT 1;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on timestamp_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -499,7 +499,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time < 'infinity' LIMIT 1;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -514,7 +514,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time >= 'infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -526,7 +526,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time <= '-infinity' LIMIT 1;
                     QUERY PLAN                    
 --------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -538,7 +538,7 @@ EXPLAIN (costs off) INSERT INTO date_inf SELECT * FROM date_inf
     WHERE time > '-infinity' LIMIT 1;
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on date_inf
          ->  Custom Scan (ChunkDispatch)
                ->  Limit
@@ -615,7 +615,7 @@ WHERE NOT EXISTS (
 );
                      QUERY PLAN                      
 -----------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    InitPlan 1 (returns $0)
      ->  Result
            One-Time Filter: false

--- a/test/expected/insert_many.out
+++ b/test/expected/insert_many.out
@@ -44,7 +44,7 @@ FROM many_partitions_test
 GROUP BY period, device;
                                                                   QUERY PLAN                                                                  
 ----------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on public.many_partitions_test_1m
          ->  Custom Scan (ChunkDispatch)
                Output: "*SELECT*".period, "*SELECT*".avg, "*SELECT*".device

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -321,7 +321,7 @@ INSERT INTO "3dim" VALUES('2017-01-21T09:00:01', 32.9, 'green', 'nyc'),
                          ('2017-01-21T09:00:47', 27.3, 'purple', 'la') RETURNING *;
                  QUERY PLAN                  
 ---------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on "3dim"
          ->  Custom Scan (ChunkDispatch)
                ->  Values Scan on "*VALUES*"
@@ -335,9 +335,9 @@ WITH "3dim_insert" AS (
 ) INSERT INTO "1dim" (SELECT time, temp FROM "3dim_insert" UNION SELECT time, temp FROM regular_insert);
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    CTE 3dim_insert
-     ->  Custom Scan (HypertableInsert)
+     ->  Custom Scan (HypertableModify)
            ->  Insert on "3dim"
                  ->  Custom Scan (ChunkDispatch)
                        ->  Result

--- a/test/expected/rowsecurity-12.out
+++ b/test/expected/rowsecurity-12.out
@@ -3813,7 +3813,7 @@ INSERT INTO t2 (SELECT * FROM t1);
 EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
                        QUERY PLAN                       
 --------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on t2
          ->  Custom Scan (ChunkDispatch)
                ->  Append

--- a/test/expected/rowsecurity-13.out
+++ b/test/expected/rowsecurity-13.out
@@ -3813,7 +3813,7 @@ INSERT INTO t2 (SELECT * FROM t1);
 EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
                           QUERY PLAN                          
 --------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on t2
          ->  Custom Scan (ChunkDispatch)
                ->  Append

--- a/test/expected/rowsecurity-14.out
+++ b/test/expected/rowsecurity-14.out
@@ -2282,18 +2282,19 @@ EXPLAIN (COSTS OFF) UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
 UPDATE bv1 SET b = 'yyy' WHERE a = 4 AND f_leak(b);
 NOTICE:  f_leak => a87ff679a2f3e71d9181a67b7542122c
 EXPLAIN (COSTS OFF) DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Delete on b1
-   Delete on b1 b1_1
-   Delete on _hyper_8_42_chunk b1_2
-   ->  Append
-         ->  Seq Scan on b1 b1_1
-               Filter: ((a > 0) AND (a = 6) AND ((a % 2) = 0) AND f_leak(b))
-         ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk b1_2
-               Index Cond: ((a > 0) AND (a = 6))
-               Filter: (((a % 2) = 0) AND f_leak(b))
-(9 rows)
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on b1
+         Delete on b1 b1_1
+         Delete on _hyper_8_42_chunk b1_2
+         ->  Append
+               ->  Seq Scan on b1 b1_1
+                     Filter: ((a > 0) AND (a = 6) AND ((a % 2) = 0) AND f_leak(b))
+               ->  Index Scan using _hyper_8_42_chunk_b1_a_idx on _hyper_8_42_chunk b1_2
+                     Index Cond: ((a > 0) AND (a = 6))
+                     Filter: (((a % 2) = 0) AND f_leak(b))
+(10 rows)
 
 DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
 NOTICE:  f_leak => 1679091c5a880faf6fb5e6087eb1b2dc
@@ -3797,7 +3798,7 @@ INSERT INTO t2 (SELECT * FROM t1);
 EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
                           QUERY PLAN                          
 --------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on t2
          ->  Custom Scan (ChunkDispatch)
                ->  Append

--- a/test/sql/delete.sql.in
+++ b/test/sql/delete.sql.in
@@ -36,6 +36,14 @@ WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series
 
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+BEGIN;
 DELETE FROM "two_Partitions"
 WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val());
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+ROLLBACK;
+
+BEGIN;
+DELETE FROM "two_Partitions"
+WHERE series_1 IN (SELECT series_1 FROM "two_Partitions" WHERE series_1 > series_val()) RETURNING "timeCustom";
+SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;
+ROLLBACK;

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -181,7 +181,7 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
                   QUERY PLAN                   
 -----------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -195,7 +195,7 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable
@@ -2756,7 +2756,7 @@ EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim DEFAULT VALUES;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.twodim
@@ -2788,7 +2788,7 @@ INSERT INTO twodim VALUES
        ('2019-02-10 17:11', 7, 3.2);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.twodim
@@ -2810,7 +2810,7 @@ INSERT INTO twodim VALUES
        ('2019-02-10 17:11', 7, 3.2);
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3)
@@ -4793,7 +4793,7 @@ SELECT create_distributed_hypertable('test_1702', 'time', 'id');
 EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=506)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=506)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..0.01 rows=1 width=506)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..0.01 rows=1 width=506)
@@ -4806,7 +4806,7 @@ INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
 EXPLAIN INSERT INTO test_1702(id, time) SELECT generate_series(2, 1500), current_timestamp;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..37.50 rows=1499 width=506)
+ Custom Scan (HypertableModify)  (cost=0.00..37.50 rows=1499 width=506)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..37.50 rows=1499 width=506)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..37.50 rows=1499 width=506)
@@ -4845,7 +4845,7 @@ SELECT create_distributed_hypertable('test_1702', 'time', 'id');
 EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=242)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=242)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..0.01 rows=1 width=242)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..0.01 rows=1 width=242)
@@ -5051,7 +5051,7 @@ SELECT time, device, temp_c FROM datatable
 RETURNING *;
                                                               QUERY PLAN                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..24.55 rows=970 width=24)
+ Custom Scan (HypertableModify)  (cost=0.00..24.55 rows=970 width=24)
    Output: disttable.id, disttable."time", disttable.device, disttable.temp_c
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -5111,7 +5111,7 @@ INSERT INTO disttable (time, device, temp_c, minmaxes)
 SELECT time, device, temp_c, minmaxes FROM datatable;
                                                                         QUERY PLAN                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..24.55 rows=970 width=56)
+ Custom Scan (HypertableModify)  (cost=0.00..24.55 rows=970 width=56)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable  (cost=0.00..24.55 rows=970 width=56)
@@ -5165,7 +5165,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5182,7 +5182,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable LIMIT 1;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5202,7 +5202,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable RETURNING *;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5338,7 +5338,7 @@ EXPLAIN VERBOSE
 INSERT INTO disttable VALUES ('2017-08-01 06:01', 1, 35.0) RETURNING *;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=28)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=28)
    Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -5397,7 +5397,7 @@ EXPLAIN VERBOSE
 INSERT INTO disttable VALUES ('2017-09-01 06:01', 5, 40.0) RETURNING *;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=28)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=28)
    Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -181,7 +181,7 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
                   QUERY PLAN                   
 -----------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -195,7 +195,7 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable
@@ -2755,7 +2755,7 @@ EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim DEFAULT VALUES;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.twodim
@@ -2787,7 +2787,7 @@ INSERT INTO twodim VALUES
        ('2019-02-10 17:11', 7, 3.2);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.twodim
@@ -2809,7 +2809,7 @@ INSERT INTO twodim VALUES
        ('2019-02-10 17:11', 7, 3.2);
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3)
@@ -4792,7 +4792,7 @@ SELECT create_distributed_hypertable('test_1702', 'time', 'id');
 EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=506)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=506)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..0.01 rows=1 width=506)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..0.01 rows=1 width=506)
@@ -4805,7 +4805,7 @@ INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
 EXPLAIN INSERT INTO test_1702(id, time) SELECT generate_series(2, 1500), current_timestamp;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..37.50 rows=1499 width=506)
+ Custom Scan (HypertableModify)  (cost=0.00..37.50 rows=1499 width=506)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..37.50 rows=1499 width=506)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..37.50 rows=1499 width=506)
@@ -4844,7 +4844,7 @@ SELECT create_distributed_hypertable('test_1702', 'time', 'id');
 EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=242)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=242)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..0.01 rows=1 width=242)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..0.01 rows=1 width=242)
@@ -5050,7 +5050,7 @@ SELECT time, device, temp_c FROM datatable
 RETURNING *;
                                                               QUERY PLAN                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..24.55 rows=970 width=24)
+ Custom Scan (HypertableModify)  (cost=0.00..24.55 rows=970 width=24)
    Output: disttable.id, disttable."time", disttable.device, disttable.temp_c
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -5110,7 +5110,7 @@ INSERT INTO disttable (time, device, temp_c, minmaxes)
 SELECT time, device, temp_c, minmaxes FROM datatable;
                                                                         QUERY PLAN                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..24.55 rows=970 width=56)
+ Custom Scan (HypertableModify)  (cost=0.00..24.55 rows=970 width=56)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable  (cost=0.00..24.55 rows=970 width=56)
@@ -5164,7 +5164,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5181,7 +5181,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable LIMIT 1;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5201,7 +5201,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable RETURNING *;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5337,7 +5337,7 @@ EXPLAIN VERBOSE
 INSERT INTO disttable VALUES ('2017-08-01 06:01', 1, 35.0) RETURNING *;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=28)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=28)
    Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -5396,7 +5396,7 @@ EXPLAIN VERBOSE
 INSERT INTO disttable VALUES ('2017-09-01 06:01', 5, 40.0) RETURNING *;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=28)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=28)
    Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -181,7 +181,7 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
                   QUERY PLAN                   
 -----------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -195,7 +195,7 @@ INSERT INTO disttable VALUES
        ('2017-01-01 06:01', 1, 1.1);
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable
@@ -2762,7 +2762,7 @@ EXPLAIN (VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO twodim DEFAULT VALUES;
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.twodim
@@ -2794,7 +2794,7 @@ INSERT INTO twodim VALUES
        ('2019-02-10 17:11', 7, 3.2);
                                                       QUERY PLAN                                                      
 ----------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.twodim
@@ -2816,7 +2816,7 @@ INSERT INTO twodim VALUES
        ('2019-02-10 17:11', 7, 3.2);
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable public.twodim
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    Remote SQL: INSERT INTO public.twodim("time", "Color", temp) VALUES ($1, $2, $3)
@@ -4799,7 +4799,7 @@ SELECT create_distributed_hypertable('test_1702', 'time', 'id');
 EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=506)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=506)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..0.01 rows=1 width=506)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..0.01 rows=1 width=506)
@@ -4812,7 +4812,7 @@ INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
 EXPLAIN INSERT INTO test_1702(id, time) SELECT generate_series(2, 1500), current_timestamp;
                                          QUERY PLAN                                          
 ---------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..37.50 rows=1499 width=506)
+ Custom Scan (HypertableModify)  (cost=0.00..37.50 rows=1499 width=506)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..37.50 rows=1499 width=506)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..37.50 rows=1499 width=506)
@@ -4851,7 +4851,7 @@ SELECT create_distributed_hypertable('test_1702', 'time', 'id');
 EXPLAIN INSERT INTO test_1702(id, time) VALUES('1', current_timestamp);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=242)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=242)
  Insert on distributed hypertable test_1702
    ->  Insert on test_1702  (cost=0.00..0.01 rows=1 width=242)
          ->  Custom Scan (DataNodeDispatch)  (cost=0.00..0.01 rows=1 width=242)
@@ -5057,7 +5057,7 @@ SELECT time, device, temp_c FROM datatable
 RETURNING *;
                                                               QUERY PLAN                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..24.55 rows=970 width=24)
+ Custom Scan (HypertableModify)  (cost=0.00..24.55 rows=970 width=24)
    Output: disttable.id, disttable."time", disttable.device, disttable.temp_c
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -5117,7 +5117,7 @@ INSERT INTO disttable (time, device, temp_c, minmaxes)
 SELECT time, device, temp_c, minmaxes FROM datatable;
                                                                         QUERY PLAN                                                                        
 ----------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..24.55 rows=970 width=56)
+ Custom Scan (HypertableModify)  (cost=0.00..24.55 rows=970 width=56)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable  (cost=0.00..24.55 rows=970 width=56)
@@ -5171,7 +5171,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5188,7 +5188,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable LIMIT 1;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5208,7 +5208,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM disttable RETURNING *;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
          ->  Custom Scan (DataNodeDispatch)
@@ -5344,7 +5344,7 @@ EXPLAIN VERBOSE
 INSERT INTO disttable VALUES ('2017-08-01 06:01', 1, 35.0) RETURNING *;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=28)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=28)
    Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
@@ -5403,7 +5403,7 @@ EXPLAIN VERBOSE
 INSERT INTO disttable VALUES ('2017-09-01 06:01', 5, 40.0) RETURNING *;
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..0.01 rows=1 width=28)
+ Custom Scan (HypertableModify)  (cost=0.00..0.01 rows=1 width=28)
    Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3

--- a/tsl/test/expected/dist_triggers.out
+++ b/tsl/test/expected/dist_triggers.out
@@ -490,7 +490,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM datatable;
                                                                   QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..33.55 rows=1570 width=24)
+ Custom Scan (HypertableModify)  (cost=0.00..33.55 rows=1570 width=24)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_triggers_1, db_dist_triggers_2, db_dist_triggers_3
    ->  Insert on public.disttable  (cost=0.00..33.55 rows=1570 width=24)
@@ -510,7 +510,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM datatable RETURNING *;
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..33.55 rows=1570 width=24)
+ Custom Scan (HypertableModify)  (cost=0.00..33.55 rows=1570 width=24)
    Output: disttable.id, disttable."time", disttable.device, disttable.temp_c
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_triggers_1, db_dist_triggers_2, db_dist_triggers_3
@@ -536,7 +536,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM datatable;
                                                               QUERY PLAN                                                              
 --------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..33.55 rows=1570 width=24)
+ Custom Scan (HypertableModify)  (cost=0.00..33.55 rows=1570 width=24)
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_triggers_1, db_dist_triggers_2, db_dist_triggers_3
    ->  Insert on public.disttable  (cost=0.00..33.55 rows=1570 width=24)
@@ -555,7 +555,7 @@ INSERT INTO disttable (time, device, temp_c)
 SELECT time, device, temp_c FROM datatable RETURNING *;
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)  (cost=0.00..33.55 rows=1570 width=24)
+ Custom Scan (HypertableModify)  (cost=0.00..33.55 rows=1570 width=24)
    Output: disttable.id, disttable."time", disttable.device, disttable.temp_c
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_triggers_1, db_dist_triggers_2, db_dist_triggers_3

--- a/tsl/test/expected/jit-12.out
+++ b/tsl/test/expected/jit-12.out
@@ -74,7 +74,7 @@ CALL refresh_continuous_aggregate('jit_device_summary', NULL, NULL);
 INSERT INTO jit_test VALUES('2017-01-20T09:00:01', 22.5) RETURNING *;
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    Output: jit_test."time", jit_test.temp
    ->  Insert on public.jit_test
          Output: jit_test."time", jit_test.temp
@@ -90,7 +90,7 @@ INSERT INTO jit_test VALUES ('2017-01-20T09:00:02', 2),
                             ('2017-01-20T09:00:04', 10);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on public.jit_test
          ->  Custom Scan (ChunkDispatch)
                Output: "*VALUES*".column1, NULL::integer, "*VALUES*".column2
@@ -116,7 +116,7 @@ SELECT * FROM jit_test WHERE temp > 5 and temp <= 10 ORDER BY time;
 INSERT INTO jit_test_interval (SELECT x, x / 2.3 FROM generate_series(0, 100) x) RETURNING *;
                                QUERY PLAN                                
 -------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    Output: jit_test_interval.id, jit_test_interval.temp
    ->  Insert on public.jit_test_interval
          Output: jit_test_interval.id, jit_test_interval.temp

--- a/tsl/test/expected/jit-13.out
+++ b/tsl/test/expected/jit-13.out
@@ -74,7 +74,7 @@ CALL refresh_continuous_aggregate('jit_device_summary', NULL, NULL);
 INSERT INTO jit_test VALUES('2017-01-20T09:00:01', 22.5) RETURNING *;
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    Output: jit_test."time", jit_test.temp
    ->  Insert on public.jit_test
          Output: jit_test."time", jit_test.temp
@@ -90,7 +90,7 @@ INSERT INTO jit_test VALUES ('2017-01-20T09:00:02', 2),
                             ('2017-01-20T09:00:04', 10);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on public.jit_test
          ->  Custom Scan (ChunkDispatch)
                Output: "*VALUES*".column1, NULL::integer, "*VALUES*".column2
@@ -116,7 +116,7 @@ SELECT * FROM jit_test WHERE temp > 5 and temp <= 10 ORDER BY time;
 INSERT INTO jit_test_interval (SELECT x, x / 2.3 FROM generate_series(0, 100) x) RETURNING *;
                                QUERY PLAN                                
 -------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    Output: jit_test_interval.id, jit_test_interval.temp
    ->  Insert on public.jit_test_interval
          Output: jit_test_interval.id, jit_test_interval.temp

--- a/tsl/test/expected/jit-14.out
+++ b/tsl/test/expected/jit-14.out
@@ -74,7 +74,7 @@ CALL refresh_continuous_aggregate('jit_device_summary', NULL, NULL);
 INSERT INTO jit_test VALUES('2017-01-20T09:00:01', 22.5) RETURNING *;
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    Output: jit_test."time", jit_test.temp
    ->  Insert on public.jit_test
          Output: jit_test."time", jit_test.temp
@@ -90,7 +90,7 @@ INSERT INTO jit_test VALUES ('2017-01-20T09:00:02', 2),
                             ('2017-01-20T09:00:04', 10);
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    ->  Insert on public.jit_test
          ->  Custom Scan (ChunkDispatch)
                Output: "*VALUES*".column1, NULL::integer, "*VALUES*".column2
@@ -116,7 +116,7 @@ SELECT * FROM jit_test WHERE temp > 5 and temp <= 10 ORDER BY time;
 INSERT INTO jit_test_interval (SELECT x, x / 2.3 FROM generate_series(0, 100) x) RETURNING *;
                                QUERY PLAN                                
 -------------------------------------------------------------------------
- Custom Scan (HypertableInsert)
+ Custom Scan (HypertableModify)
    Output: jit_test_interval.id, jit_test_interval.temp
    ->  Insert on public.jit_test_interval
          Output: jit_test_interval.id, jit_test_interval.temp


### PR DESCRIPTION
This patch changes DELETE handling for hypertables to have the
postgres ModifyTable node be wrapped in a custom HypertableModify
node. By itself this does not change DELETE handling for hypertables
but instead enables subsequent patches to implement e.g. chunk
exclusion for DELETE or DELETE on compressed chunks.
Since PG 14 codepath for INSERT is different from previous versions
this PR will only change the plan for PG14+.