### PR TITLE
Eliminate float rounding instabilities in interpolate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ accidentally triggering the load of a previous DB version.**
 * #3938 Fix subtract_integer_from_now on 32-bit platforms and improve error handling
 * #3939 Fix projection handling in time_bucket_gapfill
 * #3979 Fix deparsing of index predicates
+* #4015 Eliminate float rounding instabilities in interpolate
 
 **Thanks**
 * @erikhh for reporting an issue with time_bucket_gapfill
 * @fvannee for reporting a first/last memory leak
 * @kancsuki for reporting drop column and partial index creation not working
+* @mmouterde for reporting an issue with floats and interpolate
 
 ## 2.5.1 (2021-12-02)
 

--- a/tsl/src/nodes/gapfill/interpolate.c
+++ b/tsl/src/nodes/gapfill/interpolate.c
@@ -231,10 +231,22 @@ gapfill_interpolate_calculate(GapFillInterpolateColumnState *column, GapFillStat
 														DirectFunctionCall1(int8_numeric, y1)));
 			break;
 		case FLOAT4OID:
-			*value = Float4GetDatum(INTERPOLATE(x, x0, x1, DatumGetFloat4(y0), DatumGetFloat4(y1)));
+			/* Shortcircuit calculation when y0 == y1 for float because otherwise
+			 * output will be unstable for certain values due to float rounding. */
+			if (DatumGetFloat4(y0) == DatumGetFloat4(y1))
+				*value = y0;
+			else
+				*value =
+					Float4GetDatum(INTERPOLATE(x, x0, x1, DatumGetFloat4(y0), DatumGetFloat4(y1)));
 			break;
 		case FLOAT8OID:
-			*value = Float8GetDatum(INTERPOLATE(x, x0, x1, DatumGetFloat8(y0), DatumGetFloat8(y1)));
+			/* Shortcircuit calculation when y0 == y1 for float because otherwise
+			 * output will be unstable for certain values due to float rounding. */
+			if (DatumGetFloat8(y0) == DatumGetFloat8(y1))
+				*value = y0;
+			else
+				*value =
+					Float8GetDatum(INTERPOLATE(x, x0, x1, DatumGetFloat8(y0), DatumGetFloat8(y1)));
 			break;
 		default:
 

--- a/tsl/test/shared/expected/gapfill-12.out
+++ b/tsl/test/shared/expected/gapfill-12.out
@@ -3183,3 +3183,26 @@ GROUP BY 1,2;
 (20 rows)
 
 DROP TABLE i3834;
+-- issue #1528
+-- test float rounding for certain float values when start and end are identical
+SELECT
+  time_bucket_gapfill('1min'::interval, ts::timestamptz, '2019-11-05 2:20', '2019-11-05 2:30'),
+  interpolate(avg(20266.959547::float4)) AS float4,
+  interpolate(avg(20266.959547::float8)) AS float8
+FROM (VALUES ('2019-11-05 2:20'), ('2019-11-05 2:30')) v (ts)
+GROUP BY 1;
+     time_bucket_gapfill      |     float4      |    float8    
+------------------------------+-----------------+--------------
+ Tue Nov 05 02:20:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:21:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:22:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:23:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:24:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:25:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:26:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:27:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:28:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:29:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:30:00 2019 PST | 20266.958984375 | 20266.959547
+(11 rows)
+

--- a/tsl/test/shared/expected/gapfill-13.out
+++ b/tsl/test/shared/expected/gapfill-13.out
@@ -3190,3 +3190,26 @@ GROUP BY 1,2;
 (20 rows)
 
 DROP TABLE i3834;
+-- issue #1528
+-- test float rounding for certain float values when start and end are identical
+SELECT
+  time_bucket_gapfill('1min'::interval, ts::timestamptz, '2019-11-05 2:20', '2019-11-05 2:30'),
+  interpolate(avg(20266.959547::float4)) AS float4,
+  interpolate(avg(20266.959547::float8)) AS float8
+FROM (VALUES ('2019-11-05 2:20'), ('2019-11-05 2:30')) v (ts)
+GROUP BY 1;
+     time_bucket_gapfill      |     float4      |    float8    
+------------------------------+-----------------+--------------
+ Tue Nov 05 02:20:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:21:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:22:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:23:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:24:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:25:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:26:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:27:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:28:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:29:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:30:00 2019 PST | 20266.958984375 | 20266.959547
+(11 rows)
+

--- a/tsl/test/shared/expected/gapfill-14.out
+++ b/tsl/test/shared/expected/gapfill-14.out
@@ -3190,3 +3190,26 @@ GROUP BY 1,2;
 (20 rows)
 
 DROP TABLE i3834;
+-- issue #1528
+-- test float rounding for certain float values when start and end are identical
+SELECT
+  time_bucket_gapfill('1min'::interval, ts::timestamptz, '2019-11-05 2:20', '2019-11-05 2:30'),
+  interpolate(avg(20266.959547::float4)) AS float4,
+  interpolate(avg(20266.959547::float8)) AS float8
+FROM (VALUES ('2019-11-05 2:20'), ('2019-11-05 2:30')) v (ts)
+GROUP BY 1;
+     time_bucket_gapfill      |     float4      |    float8    
+------------------------------+-----------------+--------------
+ Tue Nov 05 02:20:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:21:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:22:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:23:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:24:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:25:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:26:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:27:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:28:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:29:00 2019 PST | 20266.958984375 | 20266.959547
+ Tue Nov 05 02:30:00 2019 PST | 20266.958984375 | 20266.959547
+(11 rows)
+

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -1443,3 +1443,12 @@ GROUP BY 1,2;
 
 DROP TABLE i3834;
 
+-- issue #1528
+-- test float rounding for certain float values when start and end are identical
+SELECT
+  time_bucket_gapfill('1min'::interval, ts::timestamptz, '2019-11-05 2:20', '2019-11-05 2:30'),
+  interpolate(avg(20266.959547::float4)) AS float4,
+  interpolate(avg(20266.959547::float8)) AS float8
+FROM (VALUES ('2019-11-05 2:20'), ('2019-11-05 2:30')) v (ts)
+GROUP BY 1;
+


### PR DESCRIPTION
When interpolating float values the result of the calculation
might be unstable for certain values when y0 and y1 are equal.
This patch short circuits the formula and returns y0 immediately
when y0 and y1 are identical.

Fixes #1528