### PR TITLE
Make pgtest input/output dir optional

### DIFF
--- a/test/pgtest/CMakeLists.txt
+++ b/test/pgtest/CMakeLists.txt
@@ -2,12 +2,17 @@ set(PG_REGRESS_DIR
     ${PG_SOURCE_DIR}/src/test/regress
     CACHE PATH "Path to PostgreSQL's regress directory")
 
+# input and output directory got removed in PG15
+set(PGTEST_DIRS ${PG_REGRESS_DIR}/data ${PG_REGRESS_DIR}/sql
+                ${PG_REGRESS_DIR}/expected)
+if(EXISTS ${PG_REGRESS_DIR}/input AND EXISTS ${PG_REGRESS_DIR}/output)
+  list(APPEND PGTEST_DIRS ${PG_REGRESS_DIR}/input ${PG_REGRESS_DIR}/output)
+endif()
+
 # Copy the input and output files from PostgreSQL's test suite. The test suite
 # generates some SQL scripts and output files from template source files and
 # require directories to be colocated
-file(COPY ${PG_REGRESS_DIR}/data ${PG_REGRESS_DIR}/input
-          ${PG_REGRESS_DIR}/output ${PG_REGRESS_DIR}/sql
-          ${PG_REGRESS_DIR}/expected DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY ${PGTEST_DIRS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 file(READ ${PG_REGRESS_DIR}/parallel_schedule PG_TEST_SCHEDULE)
 


### PR DESCRIPTION
PG15 removes the input and output directory from the pg regression
test files and moves those files into sql and output directories.
Currently cmake errors when those directories are not present in
PG_SOURCE_DIR. This patch makes those directories optional so cmake
does not fail when PG_SOURCE_DIR contains the checkout of a version
without these directories.

https://github.com/postgres/postgres/commit/d1029bb5
https://github.com/postgres/postgres/commit/dc9c3b0f