### PR TITLE
Update ts_extension_oid in transitioning state

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -169,11 +169,11 @@ extension_update_state()
 	extension_set_state(new_state);
 	/*
 	 * Update the extension oid. Note that it is only safe to run
-	 * get_extension_oid() when the extension state is 'CREATED', because
-	 * otherwise we might not be even able to do a catalog lookup because we
-	 * are not in transaction state, and the like.
+	 * get_extension_oid() when the extension state is 'CREATED' or
+	 * 'TRANSITIONING', because otherwise we might not be even able to do a
+	 * catalog lookup because we are not in transaction state, and the like.
 	 */
-	if (new_state == EXTENSION_STATE_CREATED)
+	if (new_state == EXTENSION_STATE_CREATED || new_state == EXTENSION_STATE_TRANSITIONING)
 	{
 		ts_extension_oid = get_extension_oid(EXTENSION_NAME, true /* missing_ok */);
 		Assert(ts_extension_oid != InvalidOid);


### PR DESCRIPTION
When executing the post-update scripts we get an assertion failure and
subsequent segfault because `ts_extension_oid` is still set to
`InvalidOid`. This happen because `ts_extension_oid` is not set up
until after the post-update state has finished, but we need to set it
up already in the extension transitioning state used during post-update
execution.

The reason for not setting up the `ts_extension_oid` is because we
cannot issue queries to the catalog, but this is possible already in
the post-update stage, so we add code to set up `ts_extension_oid`
already in this state.

Fixes #4009
