### PR TITLE
Fix ALTER TABLE EventTrigger initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ accidentally triggering the load of a previous DB version.**
 * #3939 Fix projection handling in time_bucket_gapfill
 * #3979 Fix deparsing of index predicates
 * #4015 Eliminate float rounding instabilities in interpolate
+* #4020 Fix ALTER TABLE EventTrigger initialization
 
 **Thanks**
 * @erikhh for reporting an issue with time_bucket_gapfill

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3267,6 +3267,7 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 				}
 				if (ht != NULL)
 				{
+					EventTriggerAlterTableStart(args->parsetree);
 					result = process_altertable_set_options(cmd, ht);
 				}
 				break;


### PR DESCRIPTION
When ALTER TABLE SET (timescaledb.compress) is executed, the
compression table is created as part of this command. But when
run as part of an extension installation the EventTrigger for
ALTER TABLE does not get initialized leading to a segfault.

Fixes #4017