### PR TITLE
Add successful_duration counters to job_stats

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -237,7 +237,10 @@ CREATE TABLE IF NOT EXISTS _timescaledb_internal.bgw_job_stat (
   total_failures bigint NOT NULL,
   total_crashes bigint NOT NULL,
   consecutive_failures int NOT NULL,
-  consecutive_crashes int NOT NULL
+  consecutive_crashes int NOT NULL,
+  max_successful_duration interval NOT NULL,
+  min_successful_duration interval NOT NULL,
+  total_successful_duration interval NOT NULL
 );
 
 --The job_stat table is not dumped by pg_dump on purpose because

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -76,7 +76,27 @@ SELECT ht.schema_name AS hypertable_schema,
   END AS next_start,
   js.total_runs,
   js.total_successes,
-  js.total_failures
+  js.total_failures,
+  CASE WHEN js.total_successes = 0 THEN
+	NULL
+  ELSE 
+  	js.total_successful_duration
+  END AS total_successful_duration,
+  CASE WHEN js.total_successes = 0 THEN
+	NULL
+  ELSE 
+  	js.max_successful_duration
+  END AS max_successful_duration,
+  CASE WHEN js.total_successes = 0 THEN
+	NULL
+  ELSE 
+  	js.min_successful_duration
+  END AS min_successful_duration,
+  CASE WHEN js.total_successes = 0 THEN
+	NULL
+  ELSE 
+	js.total_successful_duration / js.total_successes
+  END AS mean_successful_duration
 FROM _timescaledb_config.bgw_job j
   INNER JOIN _timescaledb_internal.bgw_job_stat js ON j.id = js.job_id
   LEFT JOIN _timescaledb_catalog.hypertable ht ON j.hypertable_id = ht.id

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -721,6 +721,9 @@ enum Anum_bgw_job_stat
 	Anum_bgw_job_stat_total_crashes,
 	Anum_bgw_job_stat_consecutive_failures,
 	Anum_bgw_job_stat_consecutive_crashes,
+	Anum_bgw_job_stat_total_successful_duration,
+	Anum_bgw_job_stat_max_successful_duration,
+	Anum_bgw_job_stat_min_successful_duration,
 	_Anum_bgw_job_stat_max,
 };
 
@@ -741,6 +744,9 @@ typedef struct FormData_bgw_job_stat
 	int64 total_crashes;
 	int32 consecutive_failures;
 	int32 consecutive_crashes;
+  Interval max_successful_duration;
+  Interval min_successful_duration;
+  Interval total_successful_duration;
 } FormData_bgw_job_stat;
 
 typedef FormData_bgw_job_stat *Form_bgw_job_stat;


### PR DESCRIPTION
Sometimes it is useful to know the min, max, mean and total run durations for (only) successful jobs.

This adds that.

I haven't added tests because it wasn't immediately obvious how the tests worked - happy to help there too.