### PR TITLE
Fix premature cache release call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ accidentally triggering the load of a previous DB version.**
 * #3979 Fix deparsing of index predicates
 * #4015 Eliminate float rounding instabilities in interpolate
 * #4020 Fix ALTER TABLE EventTrigger initialization
+* #4024 Fix premature cache release call
 
 **Thanks**
 * @erikhh for reporting an issue with time_bucket_gapfill

--- a/src/utils.c
+++ b/src/utils.c
@@ -886,7 +886,6 @@ ts_subtract_integer_from_now(PG_FUNCTION_ARGS)
 	Cache *hcache;
 	Hypertable *ht = ts_hypertable_cache_get_cache_and_entry(ht_relid, CACHE_FLAG_NONE, &hcache);
 	const Dimension *dim = hyperspace_get_open_dimension(ht->space, 0);
-	ts_cache_release(hcache);
 
 	if (!dim)
 		elog(ERROR, "hypertable has no open partitioning dimension");
@@ -901,5 +900,6 @@ ts_subtract_integer_from_now(PG_FUNCTION_ARGS)
 		elog(ERROR, "could not find valid integer_now function for hypertable");
 
 	int64 res = ts_sub_integer_from_now(lag, partitioning_type, now_func);
+	ts_cache_release(hcache);
 	return Int64GetDatum(res);
 }


### PR DESCRIPTION
The cache entry for a hypertable is created by calling
ts_hypertable_from_tupleinfo. This sets up the ht->space
structure, which in turn sets up the dimension information.
These structures are allocated in the cache's memory context.
The dimension information is accessed after the cache is
released in ts_subtract_integer_from_now. This PR fixes this
by releasing the cache before returning from the function.

Fixes #4014