### PR TITLE
Verify compression settings before enabling compression policy

### DIFF
--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -413,7 +413,6 @@ validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg
 	{
 		if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 		{
-			ts_cache_release(hcache);
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("compression not enabled on hypertable \"%s\"",
@@ -423,7 +422,6 @@ validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg
 		status = ts_continuous_agg_hypertable_status(ht->fd.id);
 		if ((status == HypertableIsMaterialization || status == HypertableIsMaterializationAndRaw))
 		{
-			ts_cache_release(hcache);
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("cannot add compression policy to materialized hypertable \"%s\" ",
@@ -460,7 +458,6 @@ validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg
 		found = policy_refresh_cagg_exists(mat_id);
 		if (!found)
 		{
-			ts_cache_release(hcache);
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("continuous aggregate policy does not exist for \"%s\"",
@@ -468,6 +465,14 @@ validate_compress_chunks_hypertable(Cache *hcache, Oid user_htoid, bool *is_cagg
 					 errmsg("setup a refresh policy for \"%s\" before setting up a compression "
 							"policy",
 							get_rel_name(user_htoid))));
+		}
+		if (!TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("compression not enabled on continuous aggregate \"%s\"",
+							get_rel_name(user_htoid)),
+					 errhint("Enable compression before adding a compression policy.")));
 		}
 	}
 	Assert(ht != NULL);

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -656,7 +656,9 @@ select add_continuous_aggregate_policy('i2980_cagg2', interval '10 day', interva
    1002
 (1 row)
 
---this one fails as i2980_cagg refresh policy is (NULL, NULL)
+SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
+ERROR:  compression not enabled on continuous aggregate "i2980_cagg"
+ALTER MATERIALIZED VIEW i2980_cagg SET ( timescaledb.compress );
 SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
 ERROR:  compress_after value for compression policy should be greater than the start of the refresh window of continuous aggregate policy for i2980_cagg
 SELECT add_continuous_aggregate_policy('i2980_cagg2', '10 day'::interval, '6 day'::interval);

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -568,13 +568,16 @@ SELECT time_bucket('1 day', time) as dayb, device_id,
 FROM metrics
 GROUP BY 1, 2
 WITH NO DATA;
-ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
 --can set compression policy only after setting up refresh policy --
 \set ON_ERROR_STOP 0
 SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
 ERROR:  setup a refresh policy for "metrics_cagg" before setting up a compression policy
-\set ON_ERROR_STOP 1
+--can set compression policy only after enabling compression --
 SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
+SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ; 
+ERROR:  compression not enabled on continuous aggregate "metrics_cagg"
+\set ON_ERROR_STOP 1
+ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ; 
  COMP_JOB 
 ----------

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -567,7 +567,8 @@ ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, timescaledb.comp
 
 --Errors with compression policy on caggs--
 select add_continuous_aggregate_policy('i2980_cagg2', interval '10 day', interval '2 day' ,'4h') AS job_id ;
---this one fails as i2980_cagg refresh policy is (NULL, NULL)
+SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
+ALTER MATERIALIZED VIEW i2980_cagg SET ( timescaledb.compress );
 SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
 
 SELECT add_continuous_aggregate_policy('i2980_cagg2', '10 day'::interval, '6 day'::interval);

--- a/tsl/test/sql/cagg_policy.sql
+++ b/tsl/test/sql/cagg_policy.sql
@@ -336,14 +336,17 @@ FROM metrics
 GROUP BY 1, 2
 WITH NO DATA;
 
-ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
-
 --can set compression policy only after setting up refresh policy --
 \set ON_ERROR_STOP 0
 SELECT add_compression_policy('metrics_cagg', '1 day'::interval);
+
+--can set compression policy only after enabling compression --
+SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
+SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ; 
 \set ON_ERROR_STOP 1
 
-SELECT add_continuous_aggregate_policy('metrics_cagg', '7 day'::interval, '1 day'::interval, '1 h'::interval) as "REFRESH_JOB" \gset
+ALTER MATERIALIZED VIEW metrics_cagg SET (timescaledb.compress);
+
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" ; 
 SELECT remove_compression_policy('metrics_cagg');
 SELECT add_compression_policy('metrics_cagg', '8 day'::interval) AS "COMP_JOB" \gset 


### PR DESCRIPTION
When a compression policy is added for a continuous
aggregate, verify that compression has been enabled, before
adding a policy.