### PR TITLE
Add coccinelle scripts for detecting use-after-free

### DIFF
--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -6,15 +6,16 @@ jobs:
   coccinelle:
     name: Coccinelle
     runs-on: ubuntu-latest
+    container:
+      # coccinelle version in ubuntu-latest (20.04) is too old so we run
+      # this in impish (21.10) container which has the version we need
+      image: ubuntu:impish
 
     steps:
     - name: Install Dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install software-properties-common
-        sudo add-apt-repository ppa:npalix/coccinelle
-        sudo apt-get update
-        sudo apt-get install coccinelle
+        apt-get update
+        apt-get -y install coccinelle
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@v2

--- a/coccinelle/hypertable_cache.cocci
+++ b/coccinelle/hypertable_cache.cocci
@@ -1,0 +1,57 @@
+// find hypertable uses after cache release
+@ cache_get @
+expression cache, ht, htid, relid, rv, schema, table, flags;
+position p;
+@@
+(
+ht = ts_hypertable_cache_get_entry(cache,...);
+|
+ht = ts_hypertable_cache_get_cache_and_entry(relid, flags, &cache);
+|
+ht = ts_hypertable_cache_get_entry_rv(cache, rv);
+|
+ht = ts_hypertable_cache_get_entry_with_table(cache, relid, schema, table, flags);
+|
+ht = ts_hypertable_cache_get_entry_by_id(cache, htid);
+)
+...
+ts_cache_release(cache)@p;
+...
+ht
+@ safelist1 depends on cache_get @
+expression cache_get.cache;
+position cache_get.p;
+@@
+ts_cache_release(cache)@p;
+(
+PG_RETURN_DATUM
+|
+aclcheck_error(...)
+|
+ereport(ERROR,...)
+)
+//
+// if variable gets reassigned it's not use after free
+//
+@ safelist2 depends on cache_get && !safelist1 @
+expression cache_get.cache;
+expression cache_get.ht;
+position cache_get.p;
+@@
+ts_cache_release(cache)@p;
+...
+(
+ht = ts_hypertable_cache_get_entry(...);
+|
+ht = ts_hypertable_cache_get_cache_and_entry(...);
+)
+// print context of matched use after free
+@ match depends on cache_get && !safelist1 && !safelist2 @
+expression cache_get.cache;
+expression cache_get.ht;
+position cache_get.p;
+position m;
+@@
+* ts_cache_release(cache)@p;
+...
+* ht@m

--- a/coccinelle/hypertable_cache2.cocci
+++ b/coccinelle/hypertable_cache2.cocci
@@ -1,0 +1,53 @@
+// find use after free bugs due to premature cache releases
+// this will find bugs of the following form:
+// ht = ts_hypertable_cache_get_entry(cache)
+// dim = hyperspace_get_open_dimension(ht->space, ...)
+// ts_cache_release(cache)
+// usage of dim after cache release
+@ cache_get @
+expression cache, htid, relid, rv, schema, table, flags;
+identifier dim, ht;
+position p;
+@@
+(
+ht = ts_hypertable_cache_get_entry(cache,...)
+|
+ht = ts_hypertable_cache_get_cache_and_entry(relid, flags, &cache)
+|
+ht = ts_hypertable_cache_get_entry_rv(cache, rv)
+|
+ht = ts_hypertable_cache_get_entry_with_table(cache, relid, schema, table, flags)
+|
+ht = ts_hypertable_cache_get_entry_by_id(cache, htid)
+)
+...
+(
+dim = hyperspace_get_open_dimension(ht->space, ...)
+|
+dim = ts_hyperspace_get_dimension(ht->space, ...)
+|
+dim = ts_hyperspace_get_dimension_by_name(ht->space, ...)
+|
+dim = ts_hyperspace_get_mutable_dimension_by_name(ht->space, ...)
+|
+dim = ts_hyperspace_get_dimension_by_id(ht->space, ...)
+)
+...
+ts_cache_release(cache)@p;
+...
+dim
+@ m1 depends on cache_get @
+expression cache_get.cache;
+position cache_get.p;
+@@
+ts_cache_release(cache)@p;
+PG_RETURN_DATUM
+@ m2 depends on cache_get && !m1 @
+expression cache_get.cache;
+identifier cache_get.dim;
+position cache_get.p;
+@@
+- ts_cache_release(cache)@p;
+...
++ /* dim used after calling ts_cache_release */
+dim

--- a/scripts/coccinelle.sh
+++ b/scripts/coccinelle.sh
@@ -1,12 +1,18 @@
-#!/bin/sh
+#!/bin/bash
+
+set -o pipefail
 
 SCRIPT_DIR=$(dirname "${0}")
-
+FAILED=false
 true > coccinelle.diff
 
 for f in "${SCRIPT_DIR}"/../coccinelle/*.cocci; do
 	find "${SCRIPT_DIR}"/.. -name '*.c' -exec spatch --very-quiet -sp_file "$f" {} + | tee -a coccinelle.diff
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    FAILED=true
+  fi
 done
 
-if [ -s coccinelle.diff ] ; then exit 1; fi
+if [ $FAILED = true ] || [ -s coccinelle.diff ] ; then exit 1; fi
 


### PR DESCRIPTION
This patch adds coccinelle scripts for detecting use-after-free
bugs in relation to ts_cache_release.

This will find code using the following pattern:
Use of the hypertable from cache after releasing the cache
and use of the dimension of the hypertable from a cache
after the cache was released.

This will detect bugs similar to #4024, #3106, #3104