### PR TITLE
Don't leak Chunks in classify_relation

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2612,6 +2612,26 @@ ts_chunk_get_by_relid(Oid relid, bool fail_if_not_found)
 	return chunk_get_by_name(schema, table, fail_if_not_found);
 }
 
+void
+ts_chunk_free(Chunk *chunk)
+{
+	if (chunk->cube)
+	{
+		ts_hypercube_free(chunk->cube);
+	}
+
+	if (chunk->constraints)
+	{
+		ChunkConstraints *c = chunk->constraints;
+		pfree(c->constraints);
+		pfree(c);
+	}
+
+	list_free(chunk->data_nodes);
+
+	pfree(chunk);
+}
+
 static const char *
 DatumGetInt32AsString(Datum datum)
 {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -148,6 +148,7 @@ extern TSDLLEXPORT Oid ts_chunk_create_table(const Chunk *chunk, const Hypertabl
 											 const char *tablespacename);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_id(int32 id, bool fail_if_not_found);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_relid(Oid relid, bool fail_if_not_found);
+extern TSDLLEXPORT void ts_chunk_free(Chunk *chunk);
 extern bool ts_chunk_exists(const char *schema_name, const char *table_name);
 extern Oid ts_chunk_get_relid(int32 chunk_id, bool missing_ok);
 extern Oid ts_chunk_get_schema_id(int32 chunk_id, bool missing_ok);

--- a/src/planner.c
+++ b/src/planner.c
@@ -523,6 +523,7 @@ classify_relation(const PlannerInfo *root, const RelOptInfo *rel, Hypertable **p
 					reltype = TS_REL_CHUNK;
 					ht = get_hypertable(chunk->hypertable_relid, CACHE_FLAG_NONE);
 					Assert(ht != NULL);
+					ts_chunk_free(chunk);
 				}
 			}
 			break;

--- a/src/ts_catalog/chunk_data_node.c
+++ b/src/ts_catalog/chunk_data_node.c
@@ -107,13 +107,13 @@ chunk_data_node_tuple_found(TupleInfo *ti, void *data)
 	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
 	Form_chunk_data_node form = (Form_chunk_data_node) GETSTRUCT(tuple);
 	ChunkDataNode *chunk_data_node;
-	ForeignServer *foreign_server = GetForeignServerByName(NameStr(form->node_name), false);
 	MemoryContext old;
 
 	old = MemoryContextSwitchTo(ti->mctx);
 	chunk_data_node = palloc(sizeof(ChunkDataNode));
 	memcpy(&chunk_data_node->fd, form, sizeof(FormData_chunk_data_node));
-	chunk_data_node->foreign_server_oid = foreign_server->serverid;
+	chunk_data_node->foreign_server_oid =
+		get_foreign_server_oid(NameStr(form->node_name), /* missing_ok = */ false);
 	*nodes = lappend(*nodes, chunk_data_node);
 	MemoryContextSwitchTo(old);
 

--- a/tsl/src/fdw/modify_plan.c
+++ b/tsl/src/fdw/modify_plan.c
@@ -68,6 +68,8 @@ get_chunk_data_nodes(Oid relid)
 		serveroids = lappend_oid(serveroids, cs->foreign_server_oid);
 	}
 
+	ts_chunk_free(chunk);
+
 	return serveroids;
 }
 

--- a/tsl/src/fdw/relinfo.c
+++ b/tsl/src/fdw/relinfo.c
@@ -116,17 +116,6 @@ fdw_relinfo_alloc(RelOptInfo *rel, TsFdwRelInfoType reltype)
 	return fpinfo;
 }
 
-static char *
-get_relation_qualified_name(Oid relid)
-{
-	StringInfo name = makeStringInfo();
-	const char *relname = get_rel_name(relid);
-	const char *namespace = get_namespace_name(get_rel_namespace(relid));
-	appendStringInfo(name, "%s.%s", quote_identifier(namespace), quote_identifier(relname));
-
-	return name->data;
-}
-
 static const double FILL_FACTOR_CURRENT_CHUNK = 0.5;
 static const double FILL_FACTOR_HISTORICAL_CHUNK = 1;
 
@@ -402,7 +391,10 @@ fdw_relinfo_create(PlannerInfo *root, RelOptInfo *rel, Oid server_oid, Oid local
 
 	fpinfo->relation_name = makeStringInfo();
 	refname = rte->eref->aliasname;
-	appendStringInfoString(fpinfo->relation_name, get_relation_qualified_name(rte->relid));
+	appendStringInfo(fpinfo->relation_name,
+					 "%s.%s",
+					 quote_identifier(get_namespace_name(get_rel_namespace(rte->relid))),
+					 quote_identifier(get_rel_name(rte->relid)));
 	if (*refname && strcmp(refname, get_rel_name(rte->relid)) != 0)
 		appendStringInfo(fpinfo->relation_name, " %s", quote_identifier(rte->eref->aliasname));
 


### PR DESCRIPTION
This function is called often, at least 4 times per chunk, so these add
up. Freeing these chunks allows us to save memory. Ideally, we should
fix the function not to look up the chunk anew each time.

Also make a couple other tweaks that reduce memory usage for planning.

Fixes https://github.com/timescale/timescaledb/issues/2486


For a simple query `explain delete from t where value = 1.1`, where `t` is a distributed hypertable with 106 partitions on two data nodes, the memory usage at query completion is reduced from 6.7 MB baseline to 5.5 MB with this patch.