### PR TITLE
Improve error message for compress_chunk

### DIFF
--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -31,6 +31,7 @@
 #include "errors.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
+#include "ts_catalog/continuous_agg.h"
 #include "ts_catalog/hypertable_compression.h"
 #include "create.h"
 #include "compress_utils.h"
@@ -123,6 +124,27 @@ compression_chunk_size_catalog_insert(int32 src_chunk_id, ChunkSize *src_size,
 }
 
 static void
+get_hypertable_or_cagg_name(Hypertable *ht, Name objname)
+{
+	ContinuousAggHypertableStatus status = ts_continuous_agg_hypertable_status(ht->fd.id);
+	if (status == HypertableIsNotContinuousAgg)
+		namestrcpy(objname, NameStr(ht->fd.table_name));
+	else if (status == HypertableIsMaterialization)
+	{
+		ContinuousAgg *cagg = ts_continuous_agg_find_by_mat_hypertable_id(ht->fd.id);
+		namestrcpy(objname, NameStr(cagg->data.user_view_name));
+	}
+	else
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("unexpected hypertable status for %s %d",
+						NameStr(ht->fd.table_name),
+						status)));
+	}
+}
+
+static void
 compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid, Oid chunk_relid)
 {
 	Hypertable *srcht = ts_hypertable_cache_get_entry(hcache, hypertable_relid, CACHE_FLAG_NONE);
@@ -132,14 +154,17 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 	ts_hypertable_permissions_check(srcht->main_table_relid, GetUserId());
 
 	if (!TS_HYPERTABLE_HAS_COMPRESSION_TABLE(srcht))
+	{
+		NameData cagg_ht_name;
+		get_hypertable_or_cagg_name(srcht, &cagg_ht_name);
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("compression not enabled on \"%s\"", NameStr(srcht->fd.table_name)),
-				 errdetail("It is not possible to compress chunks on a hypertable"
-						   " that does not have compression enabled."),
-				 errhint("Enable compression using ALTER TABLE with"
+				 errmsg("compression not enabled on \"%s\"", NameStr(cagg_ht_name)),
+				 errdetail("It is not possible to compress chunks on a hypertable or"
+						   " continuous aggregate that does not have compression enabled."),
+				 errhint("Enable compression using ALTER TABLE/MATERIALIZED VIEW with"
 						 " the timescaledb.compress option.")));
-
+	}
 	compress_ht = ts_hypertable_get_by_id(srcht->fd.compressed_hypertable_id);
 	if (compress_ht == NULL)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing compress hypertable")));

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -677,7 +677,17 @@ WHERE view_name = 'i2980_cagg2'
 \gset
 SELECT add_compression_policy( :'MAT_TABLE_NAME', 13::integer);
 ERROR:  cannot add compression policy to materialized hypertable "_materialized_hypertable_14" 
--- test error handling when trying to create on internal hypertable
+--TEST compressing cagg chunks without enabling compression
+SELECT count(*) FROM (select decompress_chunk(ch) FROM show_chunks('i2980_cagg2') ch ) q;
+ count 
+-------
+     1
+(1 row)
+
+ALTER MATERIALIZED VIEW i2980_cagg2 SET (timescaledb.compress = 'false');
+SELECT compress_chunk(ch) FROM show_chunks('i2980_cagg2') ch;
+ERROR:  compression not enabled on "i2980_cagg2"
+-- test error handling when trying to create cagg on internal hypertable
 CREATE TABLE comp_ht_test(time timestamptz NOT NULL);
 SELECT table_name FROM create_hypertable('comp_ht_test','time');
   table_name  

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -243,8 +243,8 @@ NOTICE:  chunk "_hyper_11_2_chunk" is already compressed
 select compress_chunk(ch1.schema_name|| '.' || ch1.table_name)
 FROM _timescaledb_catalog.chunk ch1, _timescaledb_catalog.hypertable ht where ch1.hypertable_id = ht.id and ht.table_name like 'non_compressed' ORDER BY ch1.id limit 1;
 ERROR:  compression not enabled on "non_compressed"
-DETAIL:  It is not possible to compress chunks on a hypertable that does not have compression enabled.
-HINT:  Enable compression using ALTER TABLE with the timescaledb.compress option.
+DETAIL:  It is not possible to compress chunks on a hypertable or continuous aggregate that does not have compression enabled.
+HINT:  Enable compression using ALTER TABLE/MATERIALIZED VIEW with the timescaledb.compress option.
 ALTER TABLE foo set (timescaledb.compress, timescaledb.compress_orderby = 'a', timescaledb.compress_segmentby = 'c');
 ERROR:  cannot change configuration on already compressed chunks
 DETAIL:  There are compressed chunks that prevent changing the existing compression configuration.

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -583,7 +583,12 @@ WHERE view_name = 'i2980_cagg2'
 \gset
 SELECT add_compression_policy( :'MAT_TABLE_NAME', 13::integer);
 
--- test error handling when trying to create on internal hypertable
+--TEST compressing cagg chunks without enabling compression
+SELECT count(*) FROM (select decompress_chunk(ch) FROM show_chunks('i2980_cagg2') ch ) q;
+ALTER MATERIALIZED VIEW i2980_cagg2 SET (timescaledb.compress = 'false');
+SELECT compress_chunk(ch) FROM show_chunks('i2980_cagg2') ch;
+
+-- test error handling when trying to create cagg on internal hypertable
 CREATE TABLE comp_ht_test(time timestamptz NOT NULL);
 SELECT table_name FROM create_hypertable('comp_ht_test','time');
 ALTER TABLE comp_ht_test SET (timescaledb.compress);


### PR DESCRIPTION
Fix the error message for compress chunks so that it
specifies the cagg name instead of the materialized
hypertable name.