### PR TITLE
Fix status for dropped chunks that have catalog entries

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -3030,6 +3030,7 @@ chunk_tuple_delete(TupleInfo *ti, DropBehavior behavior, bool preserve_chunk_cat
 
 		form.compressed_chunk_id = INVALID_CHUNK_ID;
 		form.dropped = true;
+		form.status = CHUNK_STATUS_DEFAULT;
 		new_tuple = chunk_formdata_make_tuple(&form, ts_scanner_get_tupledesc(ti));
 		ts_catalog_update_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti), new_tuple);
 		heap_freetuple(new_tuple);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -915,7 +915,7 @@ ORDER BY attname;
  timestamptz_column | COMPRESSION_ALGORITHM_DELTADELTA
 (14 rows)
 
---try to compress a hypertable that has a continuous aggregate
+--TEST try to compress a hypertable that has a continuous aggregate
 CREATE TABLE metrics(time timestamptz, device_id int, v1 float, v2 float);
 SELECT create_hypertable('metrics','time');
 NOTICE:  adding not-null constraint to column "time"
@@ -936,18 +936,19 @@ SELECT
   CASE WHEN true THEN 'foo' ELSE 'bar' END,
   COALESCE(NULL,'coalesce'),
   avg(v1) + avg(v2) AS avg1,
-  avg(v1+v2) AS avg2
+  avg(v1+v2) AS avg2, 
+  count(*) AS cnt
 FROM metrics
 GROUP BY 1 WITH NO DATA;
 CALL refresh_continuous_aggregate('cagg_expr', NULL, NULL);
 SELECT * FROM cagg_expr ORDER BY time LIMIT 5;
-             time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 
-------------------------------+-------+---------+----------------------------------------------+------+----------+------+------
- Fri Dec 31 16:00:00 1999 PST | Const |     4.3 | ("Sat Jan 01 00:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
- Sat Jan 01 16:00:00 2000 PST | Const |     4.3 | ("Sat Jan 01 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
- Sun Jan 02 16:00:00 2000 PST | Const |     4.3 | ("Sun Jan 02 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
- Mon Jan 03 16:00:00 2000 PST | Const |     4.3 | ("Mon Jan 03 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
- Tue Jan 04 16:00:00 2000 PST | Const |     4.3 | ("Tue Jan 04 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1
+             time             | const | numeric |                    first                     | case | coalesce | avg1 | avg2 | cnt  
+------------------------------+-------+---------+----------------------------------------------+------+----------+------+------+------
+ Fri Dec 31 16:00:00 1999 PST | Const |     4.3 | ("Sat Jan 01 00:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1 |  960
+ Sat Jan 01 16:00:00 2000 PST | Const |     4.3 | ("Sat Jan 01 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1 | 1440
+ Sun Jan 02 16:00:00 2000 PST | Const |     4.3 | ("Sun Jan 02 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1 | 1440
+ Mon Jan 03 16:00:00 2000 PST | Const |     4.3 | ("Mon Jan 03 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1 | 1440
+ Tue Jan 04 16:00:00 2000 PST | Const |     4.3 | ("Tue Jan 04 16:00:00 2000 PST",1,0.25,0.75) | foo  | coalesce |    1 |    1 | 1440
 (5 rows)
 
 ALTER TABLE metrics set(timescaledb.compress);
@@ -1520,3 +1521,69 @@ SELECT approximate_row_count('approx_count');
 (1 row)
 
 DROP TABLE approx_count;
+--TEST drop_chunks from a compressed hypertable (that has caggs defined).
+-- chunk metadata is still retained. verify correct status for chunk
+SELECT count(*)
+FROM (SELECT compress_chunk(ch) FROM show_chunks('metrics') ch ) q;
+ count 
+-------
+     2
+(1 row)
+
+SELECT drop_chunks('metrics', older_than=>'1 day'::interval);
+               drop_chunks                
+------------------------------------------
+ _timescaledb_internal._hyper_13_33_chunk
+ _timescaledb_internal._hyper_13_34_chunk
+(2 rows)
+
+SELECT
+   c.table_name as chunk_name,
+   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
+ORDER BY 1;
+     chunk_name     | chunk_status | dropped | comp_id 
+--------------------+--------------+---------+---------
+ _hyper_13_33_chunk |            0 | t       |        
+ _hyper_13_34_chunk |            0 | t       |        
+(2 rows)
+
+SELECT "time", cnt  FROM cagg_expr ORDER BY time LIMIT 5;
+             time             | cnt  
+------------------------------+------
+ Fri Dec 31 16:00:00 1999 PST |  960
+ Sat Jan 01 16:00:00 2000 PST | 1440
+ Sun Jan 02 16:00:00 2000 PST | 1440
+ Mon Jan 03 16:00:00 2000 PST | 1440
+ Tue Jan 04 16:00:00 2000 PST | 1440
+(5 rows)
+
+--now reload data into the dropped chunks region, then compress 
+-- then verify chunk status/dropped column 
+INSERT INTO metrics SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
+SELECT count(*)
+FROM (SELECT compress_chunk(ch) FROM show_chunks('metrics') ch) q;
+ count 
+-------
+     2
+(1 row)
+
+SELECT
+   c.table_name as chunk_name,
+   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
+ORDER BY 1;
+     chunk_name     | chunk_status | dropped | comp_id 
+--------------------+--------------+---------+---------
+ _hyper_13_33_chunk |            1 | f       |      64
+ _hyper_13_34_chunk |            1 | f       |      65
+(2 rows)
+
+SELECT count(*) FROM metrics;
+ count 
+-------
+ 12961
+(1 row)
+

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -1104,7 +1104,14 @@ ERROR:  operation not supported on hypertables that have compression enabled
 ALTER TABLE test_table_bigint ALTER COLUMN val TYPE float;
 ERROR:  operation not supported on hypertables that have compression enabled
 \set ON_ERROR_STOP 1
---create a cont agg view on the ht as well 
+--create a cont agg view on the ht with compressed chunks as well 
+SELECT compress_chunk(chunk, true) FROM
+( SELECT chunk FROM show_chunks('test_recomp_int') AS chunk ORDER BY chunk LIMIT 1 )q;
+                compress_chunk                
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_6_24_chunk
+(1 row)
+
 CREATE MATERIALIZED VIEW test_recomp_int_cont_view
 WITH (timescaledb.continuous,
       timescaledb.materialized_only=true)
@@ -1203,6 +1210,41 @@ WHERE time_bucket = 0 or time_bucket = 50 ORDER BY 1;
            0 |  80
           50 |  10
 (2 rows)
+
+--TEST drop one of the compressed chunks in test_recomp_int. The catalog
+--tuple for the chunk will be preserved since we have a cagg.
+-- Verify that status is accurate.
+SELECT
+   c.table_name as chunk_name,
+   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id and h.table_name = 'test_recomp_int' ORDER BY 1;
+       chunk_name       | chunk_status | dropped | comp_id 
+------------------------+--------------+---------+---------
+ _dist_hyper_6_24_chunk |            3 | f       |        
+ _dist_hyper_6_25_chunk |            1 | f       |        
+ _dist_hyper_6_26_chunk |            1 | f       |        
+ _dist_hyper_6_28_chunk |            0 | f       |        
+(4 rows)
+
+SELECT drop_chunks('test_recomp_int', older_than=> 20::bigint );
+                 drop_chunks                  
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_6_24_chunk
+(1 row)
+
+SELECT
+   c.table_name as chunk_name,
+   c.status as chunk_status, c.dropped, c.compressed_chunk_id as comp_id
+FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.chunk c
+WHERE h.id = c.hypertable_id and h.table_name = 'test_recomp_int' ORDER BY 1;
+       chunk_name       | chunk_status | dropped | comp_id 
+------------------------+--------------+---------+---------
+ _dist_hyper_6_24_chunk |            0 | t       |        
+ _dist_hyper_6_25_chunk |            1 | f       |        
+ _dist_hyper_6_26_chunk |            1 | f       |        
+ _dist_hyper_6_28_chunk |            0 | f       |        
+(4 rows)
 
 -- TEST drop should nuke everything
 DROP TABLE test_recomp_int CASCADE;


### PR DESCRIPTION

    
    Chunks that are dropped but preserve the catalog entries
    have an incorrect status when they are marked as dropped.
    This happens if the chunk was previously compressed and then
    gets dropped - the status in the catalog tuple reflects the
    compression status. This should be reset since the data is now
    dropped