### PR TITLE
Bugfix: make add_continuous_aggregate_policy() work with variable-sized buckets

### DIFF
--- a/tsl/test/expected/cagg_monthly.out
+++ b/tsl/test/expected/cagg_monthly.out
@@ -1250,3 +1250,66 @@ ORDER by month, city;
  Moscow | 2021-06-01 |  22 |  34
 (1 row)
 
+-- Make sure add_continuous_aggregate_policy() works
+CREATE TABLE conditions_policy(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT create_hypertable(
+  'conditions_policy', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+        create_hypertable        
+---------------------------------
+ (21,public,conditions_policy,t)
+(1 row)
+
+INSERT INTO conditions_policy (day, city, temperature) VALUES
+  ('2021-06-14', 'Moscow', 26),
+  ('2021-06-15', 'Moscow', 22),
+  ('2021-06-16', 'Moscow', 24),
+  ('2021-06-17', 'Moscow', 24),
+  ('2021-06-18', 'Moscow', 27),
+  ('2021-06-19', 'Moscow', 28),
+  ('2021-06-20', 'Moscow', 30),
+  ('2021-06-21', 'Moscow', 31),
+  ('2021-06-22', 'Moscow', 34),
+  ('2021-06-23', 'Moscow', 34),
+  ('2021-06-24', 'Moscow', 34),
+  ('2021-06-25', 'Moscow', 32),
+  ('2021-06-26', 'Moscow', 32),
+  ('2021-06-27', 'Moscow', 31);
+CREATE MATERIALIZED VIEW conditions_summary_policy
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 month', day) AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_policy
+GROUP BY city, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_policy"
+SELECT * FROM conditions_summary_policy;
+  city  |   bucket   | min | max 
+--------+------------+-----+-----
+ Moscow | 06-01-2021 |  22 |  34
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- Check for "policy refresh window too small" error
+SELECT add_continuous_aggregate_policy('conditions_summary_policy',
+    -- Historically, 1 month is just a synonym to 30 days here.
+    -- See interval_to_int64() and interval_to_int128().
+    start_offset => INTERVAL '2 months', 
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '1 hour');
+ERROR:  policy refresh window too small
+\set ON_ERROR_STOP 1
+SELECT add_continuous_aggregate_policy('conditions_summary_policy',
+    start_offset => INTERVAL '65 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '1 hour');
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1000
+(1 row)
+

--- a/tsl/test/expected/cagg_with_timezone.out
+++ b/tsl/test/expected/cagg_with_timezone.out
@@ -838,3 +838,71 @@ NOTICE:  drop cascades to 3 other objects
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;
 DROP DATABASE :DATA_NODE_3;
+-- Make sure add_continuous_aggregate_policy() works
+CREATE TABLE conditions_policy(
+  day TIMESTAMPTZ NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL);
+SELECT create_hypertable(
+  'conditions_policy', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+        create_hypertable        
+---------------------------------
+ (14,public,conditions_policy,t)
+(1 row)
+
+INSERT INTO conditions_policy (day, city, temperature) VALUES
+  ('2021-06-14 00:00:00 MSK', 'Moscow', 26),
+  ('2021-06-14 10:00:00 MSK', 'Moscow', 22),
+  ('2021-06-14 20:00:00 MSK', 'Moscow', 24),
+  ('2021-06-15 00:00:00 MSK', 'Moscow', 24),
+  ('2021-06-15 10:00:00 MSK', 'Moscow', 27),
+  ('2021-06-15 20:00:00 MSK', 'Moscow', 28),
+  ('2021-06-16 00:00:00 MSK', 'Moscow', 30),
+  ('2021-06-16 10:00:00 MSK', 'Moscow', 31),
+  ('2021-06-16 20:00:00 MSK', 'Moscow', 34),
+  ('2021-06-17 00:00:00 MSK', 'Moscow', 34),
+  ('2021-06-17 10:00:00 MSK', 'Moscow', 34),
+  ('2021-06-17 20:00:00 MSK', 'Moscow', 32),
+  ('2021-06-18 00:00:00 MSK', 'Moscow', 32),
+  ('2021-06-18 10:00:00 MSK', 'Moscow', 31),
+  ('2021-06-18 20:00:00 MSK', 'Moscow', 26);
+CREATE MATERIALIZED VIEW conditions_summary_policy
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT city,
+   timescaledb_experimental.time_bucket_ng('1 day', day, 'Europe/Moscow') AS bucket,
+   MIN(temperature),
+   MAX(temperature)
+FROM conditions_policy
+GROUP BY city, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_policy"
+SELECT city, to_char(bucket at time zone 'MSK', 'YYYY-MM-DD HH24:MI:SS') as month, min, max
+FROM conditions_summary_policy
+ORDER by month, city;
+  city  |        month        | min | max 
+--------+---------------------+-----+-----
+ Moscow | 2021-06-14 00:00:00 |  22 |  26
+ Moscow | 2021-06-15 00:00:00 |  24 |  28
+ Moscow | 2021-06-16 00:00:00 |  30 |  34
+ Moscow | 2021-06-17 00:00:00 |  32 |  34
+ Moscow | 2021-06-18 00:00:00 |  26 |  32
+(5 rows)
+
+\set ON_ERROR_STOP 0
+-- Check for "policy refresh window too small" error
+SELECT add_continuous_aggregate_policy('conditions_summary_policy',
+    start_offset => INTERVAL '2 days 23 hours',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '1 hour');
+ERROR:  policy refresh window too small
+\set ON_ERROR_STOP 1
+SELECT add_continuous_aggregate_policy('conditions_summary_policy',
+    start_offset => INTERVAL '3 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '1 hour');
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1000
+(1 row)
+


### PR DESCRIPTION
Variable-sized buckets don't work with CAGG policies:

```
SELECT add_continuous_aggregate_policy('conditions_summary_policy',
    start_offset => INTERVAL '65 days',
    end_offset => INTERVAL '1 day',
    schedule_interval => INTERVAL '1 hour');
ERROR:  bucket width is not defined for a variable bucket
```

This patch fixes it and adds corresponding tests.

Reported by Miranda Auhl <miranda@timescale.com>