### PR TITLE
Cache chunk data when performing chunk exclusion

### DIFF
--- a/src/hypertable_restrict_info.h
+++ b/src/hypertable_restrict_info.h
@@ -22,13 +22,13 @@ extern void ts_hypertable_restrict_info_add(HypertableRestrictInfo *hri, Planner
 extern bool ts_hypertable_restrict_info_has_restrictions(HypertableRestrictInfo *hri);
 
 /* Get a list of chunk oids for chunks whose constraints match the restriction clauses */
-extern List *ts_hypertable_restrict_info_get_chunk_oids(HypertableRestrictInfo *hri, Hypertable *ht,
-														LOCKMODE lockmode);
+extern Chunk **ts_hypertable_restrict_info_get_chunks(HypertableRestrictInfo *hri, Hypertable *ht,
+													  LOCKMODE lockmode, unsigned int *num_chunks);
 
-extern List *ts_hypertable_restrict_info_get_chunk_oids_ordered(HypertableRestrictInfo *hri,
-																Hypertable *ht, Chunk **chunks,
-																unsigned int num_chunks,
-																LOCKMODE lockmode,
-																List **nested_oids, bool reverse);
+extern Chunk **ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri,
+															  Hypertable *ht, Chunk **chunks,
+															  LOCKMODE lockmode, bool reverse,
+															  List **nested_oids,
+															  unsigned int *num_chunks);
 
 #endif /* TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H */

--- a/src/planner.h
+++ b/src/planner.h
@@ -14,6 +14,7 @@
 #include "export.h"
 #include "guc.h"
 
+typedef struct Chunk Chunk;
 typedef struct TsFdwRelInfo TsFdwRelInfo;
 typedef struct TimescaleDBPrivate
 {
@@ -26,6 +27,9 @@ typedef struct TimescaleDBPrivate
 	List *serverids;
 	Relids server_relids;
 	TsFdwRelInfo *fdw_relation_info;
+
+	/* Cached chunk data for the chunk relinfo. */
+	Chunk *chunk;
 } TimescaleDBPrivate;
 
 extern TSDLLEXPORT bool ts_rte_is_hypertable(const RangeTblEntry *rte, bool *isdistributed);

--- a/test/sql/include/join_query.sql
+++ b/test/sql/include/join_query.sql
@@ -487,14 +487,6 @@ SELECT * FROM t3;
 DELETE FROM t3 USING t3 t3_other WHERE t3.x = t3_other.x AND t3.y = t3_other.y;
 SELECT * FROM t3;
 
--- Test join against inheritance tree
-
-create temp table t2a () inherits (t2);
-
-insert into t2a values (200, 2001);
-
-select * from t1 left join t2 on (t1.a = t2.a);
-
 -- Test matching of column name with wrong alias
 
 -- select t1.x from t1 join t3 on (t1.a = t3.x);

--- a/tsl/src/fdw/data_node_chunk_assignment.c
+++ b/tsl/src/fdw/data_node_chunk_assignment.c
@@ -18,6 +18,7 @@
 #include "chunk.h"
 #include "ts_catalog/chunk_data_node.h"
 #include "relinfo.h"
+#include "planner.h"
 
 /*
  * Find an existing data node chunk assignment or initialize a new one.
@@ -58,7 +59,7 @@ DataNodeChunkAssignment *
 data_node_chunk_assignment_assign_chunk(DataNodeChunkAssignments *scas, RelOptInfo *chunkrel)
 {
 	DataNodeChunkAssignment *sca = get_or_create_sca(scas, chunkrel->serverid, NULL);
-	TsFdwRelInfo *chunk_private = fdw_relinfo_get(chunkrel);
+	TimescaleDBPrivate *chunk_private = ts_get_private_reloptinfo(chunkrel);
 	MemoryContext old;
 
 	/* Should never assign the same chunk twice */

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -494,25 +494,3 @@ SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
 CALL run_job(:compressjob_id);
 ERROR:  job 1001 has null config
 CONTEXT:  PL/pgSQL function _timescaledb_internal.policy_compression(integer,jsonb) line 21 at RAISE
--- Create a hypertable and add a rogue inherited table to it. 
-CREATE TABLE i165 (time timestamptz PRIMARY KEY);
-SELECT create_hypertable('i165','time');
- create_hypertable  
---------------------
- (23,public,i165,t)
-(1 row)
-
-ALTER TABLE i165 SET (timescaledb.compress);
-SELECT compress_chunk(show_chunks('i165'));
- compress_chunk 
-----------------
-(0 rows)
-
-CREATE TABLE extras (more_magic bool) INHERITS (i165);
-INSERT INTO i165 (time) VALUES
-       (generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'));
-\set VERBOSITY default
-SELECT * FROM i165;
-ERROR:  chunk not found
-DETAIL:  schema_name: public, table_name: extras
-\set VERBOSITY terse

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -282,15 +282,3 @@ SELECT config FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
 
 --should fail
 CALL run_job(:compressjob_id);
-
--- Create a hypertable and add a rogue inherited table to it. 
-CREATE TABLE i165 (time timestamptz PRIMARY KEY);
-SELECT create_hypertable('i165','time');
-ALTER TABLE i165 SET (timescaledb.compress);
-SELECT compress_chunk(show_chunks('i165'));
-CREATE TABLE extras (more_magic bool) INHERITS (i165);
-INSERT INTO i165 (time) VALUES
-       (generate_series(TIMESTAMP '2019-08-01', TIMESTAMP '2019-08-10', INTERVAL '10 minutes'));
-\set VERBOSITY default
-SELECT * FROM i165;
-\set VERBOSITY terse


### PR DESCRIPTION
We cache the Chunk structs in RelOptInfo private data. They are later
used to estimate the chunk sizes, check which data nodes they belong
to, et cetera. Looking up the chunks is expensive, so this change
speeds up the planning.

Part of https://github.com/timescale/timescaledb/pull/3890