### PR TITLE
Fix centos 8 package test

### DIFF
--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "centos:centos7", "centos:centos8" ]
+        image: [ "centos:centos7", "rockylinux:8" ]
         pg: [ 12, 13, 14 ]
         license: [ "TSL", "Apache"]
         include:


### PR DESCRIPTION
Since CentOS 8 went EOL in december last year most of the repository
URLs error out now. This patch switches the test to use Rockylinux
which is a drop in replacement for CentOS.