### PR TITLE
Fix privilege check in extension_load_without_preload

### DIFF
--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -186,7 +186,7 @@ extension_load_without_preload()
 		 */
 		/* Only privileged users can get the value of `config file` */
 
-		if (is_member_of_role(GetUserId(), ROLE_PG_READ_ALL_SETTINGS))
+		if (has_privs_of_role(GetUserId(), ROLE_PG_READ_ALL_SETTINGS))
 		{
 			char *config_file = GetConfigOptionByName("config_file", NULL, false);
 


### PR DESCRIPTION
The privilege check in extension_load_without_preload used
is_member_of_role which does not respect the inherit flag of
roles instead of has_privs_for_role.

For additional context:
https://www.postgresql.org/message-id/flat/CAGB%2BVh5RpzZroX-RKLXYWyTidpWX6%3DqcbMoVWERotAWh-_CeUQ%40mail.gmail.com#f08fc3998fad5d919c1660c6a1926158