### PR TITLE
Fix "nm: unknown argument -defined-only" error on MacOS

### DIFF
--- a/scripts/export_prefix_check.sh.in
+++ b/scripts/export_prefix_check.sh.in
@@ -9,7 +9,11 @@ fi
 DEFINED_ONLY="--defined-only"
 EXTERN_ONLY="--extern-only"
 
-if nm --help | grep -q llvm; then
+if nm --help | grep -q ' \-defined\-only'; then
+	# The flag can be either --defined-only or -defined-only
+	# depending on nm-llvm version. If there is " -defined-only"
+	# string in the --help output, we assume this is the right
+	# way to specify the flag.
     DEFINED_ONLY="-defined-only"
     EXTERN_ONLY="-extern-only"
 fi


### PR DESCRIPTION
On MacOS Monterey with LLVM 13.0.1 when executing export_prefix_check.sh
we get an error:

/usr/local/opt/llvm/bin/nm: error: : unknown argument '-defined-only',
did you mean '--defined-only'?

This patch adds a better check of which flag does `nm` expect.