### PR TITLE
Fix riinfo NULL handling in ANY construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ accidentally triggering the load of a previous DB version.**
 * #4015 Eliminate float rounding instabilities in interpolate
 * #4020 Fix ALTER TABLE EventTrigger initialization
 * #4024 Fix premature cache release call
+* #4069 Fix riinfo NULL handling in ANY construct
 
 **Thanks**
 * @erikhh for reporting an issue with time_bucket_gapfill
 * @fvannee for reporting a first/last memory leak
 * @kancsuki for reporting drop column and partial index creation not working
 * @mmouterde for reporting an issue with floats and interpolate
+* @carlocperez for reporting crash with NULL handling in ANY construct
 
 ## 2.5.1 (2021-12-02)
 

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -392,6 +392,10 @@ hypertable_restrict_info_add_expr(HypertableRestrictInfo *hri, PlannerInfo *root
 
 	c = (Const *) expr;
 
+	/* quick check for a NULL constant */
+	if (c->constisnull)
+		return false;
+
 	rte = rt_fetch(v->varno, root->parse->rtable);
 
 	columntype = get_atttype(rte->relid, dri->dimension->column_attno);

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -116,6 +116,22 @@ SELECT * FROM "int_part" WHERE object_id = 1;
  Fri Jan 20 09:00:01 2017 |         1 | 22.5
 (1 row)
 
+--check that queries with IN/ANY/= work for the "time" column
+SELECT * FROM "int_part" WHERE time IN (NULL);
+ time | object_id | temp 
+------+-----------+------
+(0 rows)
+
+SELECT * FROM "int_part" WHERE time = ANY (NULL);
+ time | object_id | temp 
+------+-----------+------
+(0 rows)
+
+SELECT * FROM "int_part" WHERE time = NULL;
+ time | object_id | temp 
+------+-----------+------
+(0 rows)
+
 --make sure this touches only one partititon
 EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
                                                QUERY PLAN                                                

--- a/test/sql/sql_query.sql
+++ b/test/sql/sql_query.sql
@@ -25,6 +25,12 @@ INSERT INTO "int_part" VALUES('2017-01-20T09:00:01', 2, 22.5);
 SELECT * FROM test.show_subtables('int_part');
 
 SELECT * FROM "int_part" WHERE object_id = 1;
+
+--check that queries with IN/ANY/= work for the "time" column
+SELECT * FROM "int_part" WHERE time IN (NULL);
+SELECT * FROM "int_part" WHERE time = ANY (NULL);
+SELECT * FROM "int_part" WHERE time = NULL;
+
 --make sure this touches only one partititon
 EXPLAIN (verbose ON, costs off) SELECT * FROM "int_part" WHERE object_id = 1;
 


### PR DESCRIPTION
If the ANY construct contains a singleton NULL then the logic in
"dimension_values_create_from_array" barfs causing a crash. Fix it
appropriately in the caller "hypertable_restrict_info_add_expr"
function.