### PR TITLE
Fix buffer overflow in partition scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ accidentally triggering the load of a previous DB version.**
 * #4020 Fix ALTER TABLE EventTrigger initialization
 * #4024 Fix premature cache release call
 * #4069 Fix riinfo NULL handling in ANY construct
+* #4073 Fix buffer overflow in partition scheme
 
 **Thanks**
 * @erikhh for reporting an issue with time_bucket_gapfill

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -1134,9 +1134,9 @@ build_hypertable_partition_info(Hypertable *ht, PlannerInfo *root, RelOptInfo *h
 	part_scheme->partnatts = ht->space->num_dimensions;
 	part_scheme->strategy = PARTITION_STRATEGY_MULTIDIM;
 	hyper_rel->nparts = nparts;
-	part_scheme->partopfamily = palloc0(nparts * sizeof(Oid));
-	part_scheme->partopcintype = palloc0(nparts * sizeof(Oid));
-	part_scheme->partcollation = palloc0(nparts * sizeof(Oid));
+	part_scheme->partopfamily = palloc0(part_scheme->partnatts * sizeof(Oid));
+	part_scheme->partopcintype = palloc0(part_scheme->partnatts * sizeof(Oid));
+	part_scheme->partcollation = palloc0(part_scheme->partnatts * sizeof(Oid));
 	hyper_rel->part_scheme = part_scheme;
 	hyper_rel->partexprs = get_hypertable_partexprs(ht, root->parse, hyper_rel->relid);
 	hyper_rel->nullable_partexprs = (List **) palloc0(sizeof(List *) * part_scheme->partnatts);


### PR DESCRIPTION
Reallocate the partitioning attributes arrays when forcing GROUP BY
aggregates down.

Fixes #4050