### PR TITLE
Don't use pg_temp in update scripts

### DIFF
--- a/sql/updates/2.0.0-rc3--2.0.0-rc4.sql
+++ b/sql/updates/2.0.0-rc3--2.0.0-rc4.sql
@@ -13,7 +13,7 @@ DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
 DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
 DROP FUNCTION IF EXISTS _timescaledb_internal.hypertable_from_main_table;
 
-CREATE TABLE pg_temp.hypertable_tmp
+CREATE TABLE _timescaledb_internal.hypertable_tmp
 AS SELECT * from _timescaledb_catalog.hypertable;
 
 --drop foreign keys on hypertable
@@ -29,7 +29,7 @@ ALTER TABLE _timescaledb_catalog.continuous_agg DROP CONSTRAINT continuous_agg_r
 ALTER TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold DROP CONSTRAINT continuous_aggs_invalidation_threshold_hypertable_id_fkey;
 ALTER TABLE _timescaledb_catalog.hypertable_compression DROP CONSTRAINT hypertable_compression_hypertable_id_fkey;
 
-CREATE TABLE pg_temp.tmp_hypertable_seq_value AS
+CREATE TABLE _timescaledb_internal.tmp_hypertable_seq_value AS
 SELECT last_value, is_called FROM _timescaledb_catalog.hypertable_id_seq;
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.hypertable;
 ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.hypertable_id_seq;
@@ -63,7 +63,7 @@ CREATE TABLE _timescaledb_catalog.hypertable(
 );
 ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq OWNED BY _timescaledb_catalog.hypertable.id;
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable_id_seq', '');
-SELECT setval('_timescaledb_catalog.hypertable_id_seq', last_value, is_called) FROM pg_temp.tmp_hypertable_seq_value;
+SELECT setval('_timescaledb_catalog.hypertable_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_hypertable_seq_value;
 
 INSERT INTO _timescaledb_catalog.hypertable
 ( id, schema_name, table_name, associated_schema_name, associated_table_prefix,
@@ -79,15 +79,15 @@ SELECT id, schema_name, table_name, associated_schema_name, associated_table_pre
        END,
        compressed_hypertable_id,
        replication_factor
-FROM pg_temp.hypertable_tmp;
+FROM _timescaledb_internal.hypertable_tmp;
  
 -- add self referential foreign key
 ALTER TABLE _timescaledb_catalog.hypertable ADD CONSTRAINT hypertable_compressed_hypertable_id_fkey FOREIGN KEY ( compressed_hypertable_id )
  REFERENCES _timescaledb_catalog.hypertable( id );
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.hypertable', '');
 --cleanup
-DROP TABLE pg_temp.hypertable_tmp;
-DROP TABLE pg_temp.tmp_hypertable_seq_value;
+DROP TABLE _timescaledb_internal.hypertable_tmp;
+DROP TABLE _timescaledb_internal.tmp_hypertable_seq_value;
 
 -- add all the other foreign keys
 ALTER TABLE _timescaledb_catalog.hypertable_data_node 

--- a/sql/updates/2.2.1--2.3.0.sql
+++ b/sql/updates/2.2.1--2.3.0.sql
@@ -1,8 +1,8 @@
 -- Recreate _timescaledb_catalog.chunk table --
-CREATE TABLE pg_temp.chunk_tmp
+CREATE TABLE _timescaledb_internal.chunk_tmp
 AS SELECT * from _timescaledb_catalog.chunk;
 
-CREATE TABLE pg_temp.tmp_chunk_seq_value AS
+CREATE TABLE _timescaledb_internal.tmp_chunk_seq_value AS
 SELECT last_value, is_called FROM _timescaledb_catalog.chunk_id_seq;
 
 --drop foreign keys on chunk table
@@ -53,14 +53,14 @@ SELECT id, hypertable_id, schema_name, table_name,
       ELSE 1
     END
   )
-FROM pg_temp.chunk_tmp;
+FROM _timescaledb_internal.chunk_tmp;
 
 --add indexes to the chunk table
 CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
 CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
 
 ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
-SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM pg_temp.tmp_chunk_seq_value;
+SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_chunk_seq_value;
 
 -- add self referential foreign key
 ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY ( compressed_chunk_id )
@@ -87,8 +87,8 @@ compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id
 REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE; 
 
 --cleanup
-DROP TABLE pg_temp.chunk_tmp;
-DROP TABLE pg_temp.tmp_chunk_seq_value;
+DROP TABLE _timescaledb_internal.chunk_tmp;
+DROP TABLE _timescaledb_internal.tmp_chunk_seq_value;
 
 GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
 GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -37,12 +37,12 @@ DROP FUNCTION IF EXISTS _timescaledb_internal.cagg_watermark(oid);
 -- in the first version of TimescaleDB and should have the correct
 -- initprivs, but we could use any other table that existed in the
 -- first installation.
-INSERT INTO pg_temp.saved_privs
+INSERT INTO _timescaledb_internal.saved_privs
      SELECT nspname, relname, relacl,
-       (SELECT tmpini FROM pg_temp.saved_privs
+       (SELECT tmpini FROM _timescaledb_internal.saved_privs
         WHERE tmpnsp = '_timescaledb_catalog' AND tmpname = 'chunk')
        FROM pg_class JOIN pg_namespace ns ON ns.oid = relnamespace
-         LEFT JOIN pg_temp.saved_privs ON tmpnsp = nspname AND tmpname = relname
+         LEFT JOIN _timescaledb_internal.saved_privs ON tmpnsp = nspname AND tmpname = relname
       WHERE relkind IN ('r', 'v') AND nspname IN ('_timescaledb_catalog', '_timescaledb_config')
         OR nspname = '_timescaledb_internal'
         AND relname IN ('hypertable_chunk_local_size', 'compressed_chunk_stats',
@@ -51,12 +51,12 @@ ON CONFLICT DO NOTHING;
 
 -- The above is good enough for tables and views. However sequences need to
 -- use the "chunk_id_seq" catalog sequence as a template
-INSERT INTO pg_temp.saved_privs
+INSERT INTO _timescaledb_internal.saved_privs
      SELECT nspname, relname, relacl,
-        (SELECT tmpini FROM pg_temp.saved_privs
+        (SELECT tmpini FROM _timescaledb_internal.saved_privs
 	     WHERE tmpnsp = '_timescaledb_catalog' AND tmpname = 'chunk_id_seq')
         FROM pg_class JOIN pg_namespace ns ON ns.oid = relnamespace
-		    LEFT JOIN pg_temp.saved_privs ON tmpnsp = nspname AND tmpname = relname
+		    LEFT JOIN _timescaledb_internal.saved_privs ON tmpnsp = nspname AND tmpname = relname
       WHERE relkind IN ('S') AND nspname IN ('_timescaledb_catalog', '_timescaledb_config')
         OR nspname = '_timescaledb_internal'
         AND relname IN ('hypertable_chunk_local_size', 'compressed_chunk_stats',
@@ -68,7 +68,7 @@ WITH to_update AS (
      SELECT objoid, tmpini
      FROM pg_class cl JOIN pg_namespace ns ON ns.oid = relnamespace
         JOIN pg_init_privs ip ON ip.objoid = cl.oid AND ip.objsubid = 0
-        JOIN pg_temp.saved_privs ON tmpnsp = nspname AND tmpname = relname)
+        JOIN _timescaledb_internal.saved_privs ON tmpnsp = nspname AND tmpname = relname)
 UPDATE pg_init_privs
    SET initprivs = tmpini
   FROM to_update
@@ -81,8 +81,8 @@ UPDATE pg_init_privs
 WITH to_update AS (
      SELECT cl.oid, tmpacl
      FROM pg_class cl JOIN pg_namespace ns ON ns.oid = relnamespace
-                      JOIN pg_temp.saved_privs ON tmpnsp = nspname AND tmpname = relname)
+                      JOIN _timescaledb_internal.saved_privs ON tmpnsp = nspname AND tmpname = relname)
 UPDATE pg_class cl SET relacl = tmpacl
   FROM to_update WHERE cl.oid = to_update.oid;
 
-DROP TABLE pg_temp.saved_privs;
+DROP TABLE _timescaledb_internal.saved_privs;

--- a/sql/updates/pre-update.sql
+++ b/sql/updates/pre-update.sql
@@ -34,7 +34,7 @@ LANGUAGE C VOLATILE;
 SELECT _timescaledb_internal.restart_background_workers();
 
 -- Table for ACL and initprivs of tables.
-CREATE TABLE pg_temp.saved_privs(
+CREATE TABLE _timescaledb_internal.saved_privs(
        tmpnsp name,
        tmpname name,
        tmpacl aclitem[],
@@ -44,7 +44,7 @@ CREATE TABLE pg_temp.saved_privs(
 -- We save away both the ACL and the initprivs for all tables and
 -- views in the extension (but not for chunks and internal objects) so
 -- that we can restore them to the proper state after the update.
-INSERT INTO pg_temp.saved_privs
+INSERT INTO _timescaledb_internal.saved_privs
 SELECT nspname, relname, relacl, initprivs
   FROM pg_class cl JOIN pg_namespace ns ON ns.oid = relnamespace
                    JOIN pg_init_privs ip ON ip.objoid = cl.oid AND ip.objsubid = 0


### PR DESCRIPTION
Scripts run under pgextwlist cannot use pg_temp so we replace
pg_temp usage in update scripts with _timescaledb_internal.