### PR TITLE
Report file name in TestEnsureErrors

### DIFF
--- a/test/src/test_utils.h
+++ b/test/src/test_utils.h
@@ -86,7 +86,7 @@ strip_path(const char *filename)
 		MemoryContextSwitchTo(oldctx);                                                             \
 		if (!this_has_panicked)                                                                    \
 		{                                                                                          \
-			elog(ERROR, "failed to panic @ line %d", __LINE__);                                    \
+			elog(ERROR, "failed to panic @ %s:%d", strip_path(__FILE__), __LINE__);                \
 		}                                                                                          \
 	} while (0)
 


### PR DESCRIPTION
This helps debug C tests.