### PR TITLE
Remove unused code from compression_api

### DIFF
--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -65,15 +65,6 @@ policy_compression_get_maxchunks_per_job(const Jsonb *config)
 	return (found && maxchunks > 0) ? maxchunks : 0;
 }
 
-bool
-policy_compression_get_verbose_log(const Jsonb *config)
-{
-	bool found;
-	bool verbose_log = ts_jsonb_get_bool_field(config, CONFIG_KEY_VERBOSE_LOG, &found);
-
-	return found ? verbose_log : false;
-}
-
 int32
 policy_compression_get_hypertable_id(const Jsonb *config)
 {

--- a/tsl/src/bgw_policy/job.h
+++ b/tsl/src/bgw_policy/job.h
@@ -16,7 +16,6 @@
 #include "bgw_policy/chunk_stats.h"
 
 /* Add config keys common across job types here */
-#define CONFIG_KEY_VERBOSE_LOG "verbose_log" /*used only by compression now*/
 
 typedef struct PolicyReorderData
 {

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -333,17 +333,7 @@ SELECT alter_job(id,config:=jsonb_set(config,'{maxchunks_to_compress}', '1'))
  (1004,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""hypertable_id"": 11, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
 (1 row)
 
-SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
- FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-                                                                              alter_job                                                                              
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- (1004,"@ 12 hours","@ 0",-1,"@ 1 hour",t,"{""verbose_log"": true, ""hypertable_id"": 11, ""compress_after"": ""@ 1 day"", ""maxchunks_to_compress"": 1}",-infinity)
-(1 row)
-
-set client_min_messages TO LOG;
 CALL run_job(:job_id);
-LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
-set client_min_messages TO NOTICE;
 SELECT count(*) FROM timescaledb_information.chunks
 WHERE hypertable_name = 'conditions' and is_compressed = true;
  count 

--- a/tsl/test/sql/compression_bgw.sql
+++ b/tsl/test/sql/compression_bgw.sql
@@ -205,11 +205,7 @@ SELECT add_compression_policy AS job_id
 -- job compresses only 1 chunk at a time --
 SELECT alter_job(id,config:=jsonb_set(config,'{maxchunks_to_compress}', '1'))
  FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
- FROM _timescaledb_config.bgw_job WHERE id = :job_id;
-set client_min_messages TO LOG;
 CALL run_job(:job_id);
-set client_min_messages TO NOTICE;
 
 SELECT count(*) FROM timescaledb_information.chunks
 WHERE hypertable_name = 'conditions' and is_compressed = true;


### PR DESCRIPTION
Function policy_compression_get_verbose_log was still
defined in compression_api.c but never called anywhere in the code.
Also update test compression_bgw