### PR TITLE
Add missing OS-information in telemetry

### DIFF
--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -385,6 +385,7 @@ build_telemetry_report()
 	JsonbValue key;
 	JsonbValue *result;
 	TelemetryStats relstats;
+	VersionOSInfo osinfo;
 
 	pushJsonbValue(&parse_state, WJB_BEGIN_OBJECT, NULL);
 
@@ -400,6 +401,18 @@ build_telemetry_report()
 	ts_jsonb_add_str(parse_state,
 					 REQ_INSTALL_TIME,
 					 format_iso8601(ts_telemetry_metadata_get_install_timestamp()));
+	ts_jsonb_add_str(parse_state, REQ_INSTALL_METHOD, TIMESCALEDB_INSTALL_METHOD);
+
+	if (ts_version_get_os_info(&osinfo))
+	{
+		ts_jsonb_add_str(parse_state, REQ_OS, osinfo.sysname);
+		ts_jsonb_add_str(parse_state, REQ_OS_VERSION, osinfo.version);
+		ts_jsonb_add_str(parse_state, REQ_OS_RELEASE, osinfo.release);
+		if (osinfo.has_pretty_version)
+			ts_jsonb_add_str(parse_state, REQ_OS_VERSION_PRETTY, osinfo.pretty_version);
+	}
+	else
+		ts_jsonb_add_str(parse_state, REQ_OS, "Unknown");
 
 	ts_jsonb_add_str(parse_state, REQ_PS_VERSION, get_pgversion_string());
 	ts_jsonb_add_str(parse_state, REQ_TS_VERSION, TIMESCALEDB_VERSION_MOD);

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -368,10 +368,14 @@ WHERE key != 'os_name_pretty';
 ------------------------------
  db_uuid
  license
+ os_name
  relations
+ os_release
+ os_version
  data_volume
  db_metadata
  build_os_name
+ install_method
  installed_time
  last_tuned_time
  build_os_version
@@ -389,7 +393,7 @@ WHERE key != 'os_name_pretty';
  num_user_defined_actions
  build_architecture_bit_size
  num_continuous_aggs_policies
-(23 rows)
+(27 rows)
 
 CREATE MATERIALIZED VIEW telemetry_report AS
 SELECT t FROM get_telemetry_report() t;


### PR DESCRIPTION
Some telemetry fields were removed by mistake as part of an earlier
refactoring. Add back the missing fields that provide information
about the operating system.