### PR TITLE
Update remote plan costs to PG14 code base

### DIFF
--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -542,6 +542,7 @@ static CustomScanMethods data_node_scan_plan_methods = {
 typedef struct DataNodeScanPath
 {
 	CustomPath cpath;
+	List *dns_private;
 } DataNodeScanPath;
 
 static Plan *
@@ -690,6 +691,7 @@ data_node_scan_upper_path_create(PlannerInfo *root, RelOptInfo *rel, PathTarget 
 	scanpath->cpath.path.startup_cost = startup_cost;
 	scanpath->cpath.path.total_cost = total_cost;
 	scanpath->cpath.path.pathkeys = pathkeys;
+	scanpath->dns_private = private;
 
 	return &scanpath->cpath.path;
 }

--- a/tsl/src/fdw/estimate.c
+++ b/tsl/src/fdw/estimate.c
@@ -8,6 +8,7 @@
 #include <nodes/nodeFuncs.h>
 #include <optimizer/cost.h>
 #include <optimizer/clauses.h>
+#include <optimizer/pathnode.h>
 #include <optimizer/prep.h>
 #include <optimizer/tlist.h>
 #include <optimizer/paths.h>
@@ -81,156 +82,6 @@ get_aggsplit(PlannerInfo *root, RelOptInfo *rel)
 	pg_unreachable();
 }
 
-static void
-get_upper_rel_estimate(PlannerInfo *root, RelOptInfo *rel, CostEstimate *ce)
-{
-	TsFdwRelInfo *fpinfo = fdw_relinfo_get(rel);
-	TsFdwRelInfo *ofpinfo = fdw_relinfo_get(fpinfo->outerrel);
-	AggClauseCosts aggcosts;
-	double input_rows;
-	int num_group_cols;
-	double num_groups = 1;
-
-	/* Make sure the core code set the pathtarget. */
-	Assert(rel->reltarget != NULL);
-
-	/*
-	 * This cost model is mixture of costing done for sorted and
-	 * hashed aggregates in cost_agg().  We are not sure which
-	 * strategy will be considered at remote side, thus for
-	 * simplicity, we put all startup related costs in startup_cost
-	 * and all finalization and run cost are added in total_cost.
-	 *
-	 * Also, core does not care about costing HAVING expressions and
-	 * adding that to the costs.  So similarly, here too we are not
-	 * considering remote and local conditions for costing.
-	 */
-
-	/* Get rows from input rel */
-	input_rows = ofpinfo->rows;
-
-	/* Collect statistics about aggregates for estimating costs. */
-	MemSet(&aggcosts, 0, sizeof(AggClauseCosts));
-
-	if (root->parse->hasAggs)
-	{
-		/* Get the aggsplit to use in order to support push-down of partial
-		 * aggregation */
-		AggSplit aggsplit = get_aggsplit(root, rel);
-
-		get_agg_clause_costs_compat(root, (Node *) fpinfo->grouped_tlist, aggsplit, &aggcosts);
-	}
-
-	/* Get number of grouping columns and possible number of groups */
-	num_group_cols = list_length(root->parse->groupClause);
-	num_groups = estimate_num_groups_compat(root,
-											get_sortgrouplist_exprs(root->parse->groupClause,
-																	fpinfo->grouped_tlist),
-											input_rows,
-											NULL,
-											NULL);
-
-	/*
-	 * Get the retrieved_rows and rows estimates.  If there are HAVING
-	 * quals, account for their selectivity.
-	 */
-	if (root->parse->havingQual)
-	{
-		/* Factor in the selectivity of the remotely-checked quals */
-		ce->retrieved_rows = clamp_row_est(
-			num_groups * clauselist_selectivity(root, fpinfo->remote_conds, 0, JOIN_INNER, NULL));
-		/* Factor in the selectivity of the locally-checked quals */
-		ce->rows = clamp_row_est(ce->retrieved_rows * fpinfo->local_conds_sel);
-	}
-	else
-	{
-		/*
-		 * Number of rows expected from data node will be same as
-		 * that of number of groups.
-		 */
-		ce->rows = ce->retrieved_rows = num_groups;
-	}
-
-	/* Use width estimate made by the core code. */
-	ce->width = rel->reltarget->width;
-
-	/*-----
-	 * Startup cost includes:
-	 *	  1. Startup cost for underneath input * relation
-	 *	  2. Cost of performing aggregation, per cost_agg()
-	 *	  3. Startup cost for PathTarget eval
-	 *-----
-	 */
-	ce->startup_cost = ofpinfo->rel_startup_cost;
-	ce->startup_cost += rel->reltarget->cost.startup;
-	ce->startup_cost += aggcosts.transCost.startup;
-	ce->startup_cost += aggcosts.transCost.per_tuple * input_rows;
-	ce->startup_cost += aggcosts.finalCost.startup;
-	ce->startup_cost += (cpu_operator_cost * num_group_cols) * input_rows;
-
-	/*-----
-	 * Run time cost includes:
-	 *	  1. Run time cost of underneath input relation, adjusted for
-	 *	     tlist replacement by apply_scanjoin_target_to_paths()
-	 *	  2. Run time cost of performing aggregation, per cost_agg()
-	 *-----
-	 */
-	ce->run_cost = ofpinfo->rel_total_cost - ofpinfo->rel_startup_cost;
-	ce->run_cost += rel->reltarget->cost.per_tuple * input_rows;
-	ce->run_cost += aggcosts.finalCost.per_tuple * num_groups;
-	ce->run_cost += cpu_tuple_cost * num_groups;
-
-	/* Account for the eval cost of HAVING quals, if any */
-	if (root->parse->havingQual)
-	{
-		QualCost remote_cost;
-
-		/* Add in the eval cost of the remotely-checked quals */
-		cost_qual_eval(&remote_cost, fpinfo->remote_conds, root);
-		ce->startup_cost += remote_cost.startup;
-		ce->run_cost += remote_cost.per_tuple * num_groups;
-		/* Add in the eval cost of the locally-checked quals */
-		ce->startup_cost += fpinfo->local_conds_cost.startup;
-		ce->run_cost += fpinfo->local_conds_cost.per_tuple * ce->retrieved_rows;
-	}
-
-	/* Add in tlist eval cost for each output row */
-	ce->startup_cost += rel->reltarget->cost.startup;
-	ce->run_cost += rel->reltarget->cost.per_tuple * ce->rows;
-}
-
-static void
-get_base_rel_estimate(PlannerInfo *root, RelOptInfo *rel, CostEstimate *ce)
-{
-	TsFdwRelInfo *fpinfo = fdw_relinfo_get(rel);
-
-	ce->rows = rel->rows;
-	ce->width = rel->reltarget->width;
-
-	/* Back into an estimate of the number of retrieved rows. */
-	ce->retrieved_rows = clamp_row_est(ce->rows / fpinfo->local_conds_sel);
-
-	/* Clamp retrieved rows estimates to at most rel->tuples. */
-	ce->retrieved_rows = Min(ce->retrieved_rows, rel->tuples);
-
-	/*
-	 * Cost as though this were a seqscan, which is pessimistic.  We
-	 * effectively imagine the local_conds are being evaluated
-	 * remotely, too.
-	 */
-	ce->startup_cost = 0;
-	ce->run_cost = 0;
-	ce->run_cost += seq_page_cost * rel->pages;
-
-	ce->startup_cost += rel->baserestrictcost.startup;
-	ce->cpu_per_tuple = cpu_tuple_cost + rel->baserestrictcost.per_tuple;
-	ce->run_cost += ce->cpu_per_tuple * rel->tuples;
-
-	/* Add in tlist eval cost for each output row */
-	ce->startup_cost += rel->reltarget->cost.startup;
-	ce->run_cost += rel->reltarget->cost.per_tuple * ce->rows;
-}
-
 #define REL_HAS_CACHED_COSTS(fpinfo)                                                               \
 	((fpinfo)->rel_startup_cost >= 0 && (fpinfo)->rel_total_cost >= 0 &&                           \
 	 (fpinfo)->rel_retrieved_rows >= 0)
@@ -285,53 +136,312 @@ adjust_foreign_grouping_path_cost(PlannerInfo *root, List *pathkeys, double retr
 
 /*
  * fdw_estimate_path_cost_size
- *		Get cost and size estimates for a foreign scan on given foreign
- *		relation either a base relation or an upper relation containing
- *		foreign relations. Estimate rows using whatever statistics we have
- *      locally, in a way similar to ordinary tables.
+ *		Get cost and size estimates for a foreign scan on given foreign relation
+ *		either a base relation or a join between foreign relations or an upper
+ *		relation containing foreign relations.
  *
+ * param_join_conds are the parameterization clauses with outer relations.
  * pathkeys specify the expected sort order if any for given path being costed.
+ * fpextra specifies additional post-scan/join-processing steps such as the
+ * final sort and the LIMIT restriction.
  *
- * The function returns the cost and size estimates in p_row, p_width,
+ * The function returns the cost and size estimates in p_rows, p_width,
  * p_startup_cost and p_total_cost variables.
  */
 void
-fdw_estimate_path_cost_size(PlannerInfo *root, RelOptInfo *rel, List *pathkeys, double *p_rows,
+fdw_estimate_path_cost_size(PlannerInfo *root, RelOptInfo *foreignrel, List *param_join_conds,
+							List *pathkeys, TsFdwPathExtraData *fpextra, double *p_rows,
 							int *p_width, Cost *p_startup_cost, Cost *p_total_cost)
 {
-	TsFdwRelInfo *fpinfo = fdw_relinfo_get(rel);
-	CostEstimate ce = {
-		/*
-		 * Use rows/width estimates made by set_baserel_size_estimates() for
-		 * base foreign relations.
-		 */
-		.rows = rel->rows,
-		.width = rel->reltarget->width,
-	};
+	TsFdwRelInfo *fpinfo = fdw_relinfo_get(foreignrel);
+	double rows;
+	double retrieved_rows;
+	int width;
+	Cost startup_cost;
+	Cost total_cost;
+	Cost run_cost = 0;
 
-	if (IS_JOIN_REL(rel))
+	/* Make sure the core code has set up the relation's reltarget */
+	Assert(foreignrel->reltarget);
+
+	if (IS_JOIN_REL(foreignrel))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("foreign joins are not supported")));
 
 	/*
-	 * We will come here again and again with different set of pathkeys
-	 * that caller wants to cost. We don't need to calculate the cost of
-	 * bare scan each time. Instead, use the costs if we have cached them
-	 * already.
+	 * We don't support join conditions in this mode (hence, no
+	 * parameterized paths can be made).
+	 */
+	Assert(param_join_conds == NIL);
+
+	/*
+	 * In Timescale, we should be relying on local ANALYZE statistics because
+	 * they get updated with remote stats appropriately
+	 *
+	 * We will come here again and again with different set of pathkeys or
+	 * additional post-scan/join-processing steps that caller wants to
+	 * cost.  We don't need to calculate the cost/size estimates for the
+	 * underlying scan, join, or grouping each time.  Instead, use those
+	 * estimates if we have cached them already.
 	 */
 	if (REL_HAS_CACHED_COSTS(fpinfo))
 	{
-		ce.rows = fpinfo->rows;
-		ce.width = fpinfo->width;
-		ce.startup_cost = fpinfo->rel_startup_cost;
-		ce.run_cost = fpinfo->rel_total_cost - fpinfo->rel_startup_cost;
-		ce.retrieved_rows = fpinfo->rel_retrieved_rows;
+		Assert(fpinfo->rel_retrieved_rows >= 0);
+
+		rows = fpinfo->rows;
+		retrieved_rows = fpinfo->rel_retrieved_rows;
+		width = fpinfo->width;
+		startup_cost = fpinfo->rel_startup_cost;
+		run_cost = fpinfo->rel_total_cost - fpinfo->rel_startup_cost;
+
+		/*
+		 * If we estimate the costs of a foreign scan or a foreign join
+		 * with additional post-scan/join-processing steps, the scan or
+		 * join costs obtained from the cache wouldn't yet contain the
+		 * eval costs for the final scan/join target, which would've been
+		 * updated by apply_scanjoin_target_to_paths(); add the eval costs
+		 * now.
+		 */
+		if (fpextra && !IS_UPPER_REL(foreignrel))
+		{
+			/* Shouldn't get here unless we have LIMIT */
+			Assert(fpextra->has_limit);
+			Assert(foreignrel->reloptkind == RELOPT_BASEREL ||
+				   foreignrel->reloptkind == RELOPT_JOINREL);
+			startup_cost += foreignrel->reltarget->cost.startup;
+			run_cost += foreignrel->reltarget->cost.per_tuple * rows;
+		}
 	}
-	else if (IS_UPPER_REL(rel))
-		get_upper_rel_estimate(root, rel, &ce);
+	else if (IS_JOIN_REL(foreignrel))
+	{
+		TsFdwRelInfo *fpinfo_i;
+		TsFdwRelInfo *fpinfo_o;
+		QualCost join_cost;
+		QualCost remote_conds_cost;
+		double nrows;
+
+		/* Use rows/width estimates made by the core code. */
+		rows = foreignrel->rows;
+		width = foreignrel->reltarget->width;
+
+		/* For join we expect inner and outer relations set */
+		Assert(fpinfo->innerrel && fpinfo->outerrel);
+
+		fpinfo_i = fdw_relinfo_get(fpinfo->innerrel);
+		fpinfo_o = fdw_relinfo_get(fpinfo->outerrel);
+
+		/* Estimate of number of rows in cross product */
+		nrows = fpinfo_i->rows * fpinfo_o->rows;
+
+		/*
+		 * Back into an estimate of the number of retrieved rows.  Just in
+		 * case this is nuts, clamp to at most nrows.
+		 */
+		retrieved_rows = clamp_row_est(rows / fpinfo->local_conds_sel);
+		retrieved_rows = Min(retrieved_rows, nrows);
+
+		/*
+		 * The cost of foreign join is estimated as cost of generating
+		 * rows for the joining relations + cost for applying quals on the
+		 * rows.
+		 */
+
+		/*
+		 * Calculate the cost of clauses pushed down to the foreign server
+		 */
+		cost_qual_eval(&remote_conds_cost, fpinfo->remote_conds, root);
+		/* Calculate the cost of applying join clauses */
+		cost_qual_eval(&join_cost, fpinfo->joinclauses, root);
+
+		/*
+		 * Startup cost includes startup cost of joining relations and the
+		 * startup cost for join and other clauses. We do not include the
+		 * startup cost specific to join strategy (e.g. setting up hash
+		 * tables) since we do not know what strategy the foreign server
+		 * is going to use.
+		 */
+		startup_cost = fpinfo_i->rel_startup_cost + fpinfo_o->rel_startup_cost;
+		startup_cost += join_cost.startup;
+		startup_cost += remote_conds_cost.startup;
+		startup_cost += fpinfo->local_conds_cost.startup;
+
+		/*
+		 * Run time cost includes:
+		 *
+		 * 1. Run time cost (total_cost - startup_cost) of relations being
+		 * joined
+		 *
+		 * 2. Run time cost of applying join clauses on the cross product
+		 * of the joining relations.
+		 *
+		 * 3. Run time cost of applying pushed down other clauses on the
+		 * result of join
+		 *
+		 * 4. Run time cost of applying nonpushable other clauses locally
+		 * on the result fetched from the foreign server.
+		 */
+		run_cost = fpinfo_i->rel_total_cost - fpinfo_i->rel_startup_cost;
+		run_cost += fpinfo_o->rel_total_cost - fpinfo_o->rel_startup_cost;
+		run_cost += nrows * join_cost.per_tuple;
+		nrows = clamp_row_est(nrows * fpinfo->joinclause_sel);
+		run_cost += nrows * remote_conds_cost.per_tuple;
+		run_cost += fpinfo->local_conds_cost.per_tuple * retrieved_rows;
+
+		/* Add in tlist eval cost for each output row */
+		startup_cost += foreignrel->reltarget->cost.startup;
+		run_cost += foreignrel->reltarget->cost.per_tuple * rows;
+	}
+	else if (IS_UPPER_REL(foreignrel))
+	{
+		RelOptInfo *outerrel = fpinfo->outerrel;
+		TsFdwRelInfo *ofpinfo;
+		AggClauseCosts aggcosts;
+		double input_rows;
+		int numGroupCols;
+		double numGroups = 1;
+
+		/* The upper relation should have its outer relation set */
+		Assert(outerrel);
+		/* and that outer relation should have its reltarget set */
+		Assert(outerrel->reltarget);
+
+		/*
+		 * This cost model is mixture of costing done for sorted and
+		 * hashed aggregates in cost_agg().  We are not sure which
+		 * strategy will be considered at remote side, thus for
+		 * simplicity, we put all startup related costs in startup_cost
+		 * and all finalization and run cost are added in total_cost.
+		 */
+
+		ofpinfo = fdw_relinfo_get(outerrel);
+
+		/* Get rows from input rel */
+		input_rows = ofpinfo->rows;
+
+		/* Collect statistics about aggregates for estimating costs. */
+		MemSet(&aggcosts, 0, sizeof(AggClauseCosts));
+		if (root->parse->hasAggs)
+		{
+			/*
+			 * Get the aggsplit to use in order to support push-down of partial
+			 * aggregation
+			 */
+			AggSplit aggsplit = get_aggsplit(root, foreignrel);
+
+			get_agg_clause_costs_compat(root, (Node *) fpinfo->grouped_tlist, aggsplit, &aggcosts);
+		}
+
+		/* Get number of grouping columns and possible number of groups */
+		numGroupCols = list_length(root->parse->groupClause);
+		numGroups = estimate_num_groups_compat(root,
+											   get_sortgrouplist_exprs(root->parse->groupClause,
+																	   fpinfo->grouped_tlist),
+											   input_rows,
+											   NULL,
+											   NULL);
+
+		/*
+		 * Get the retrieved_rows and rows estimates.  If there are HAVING
+		 * quals, account for their selectivity.
+		 */
+		if (root->parse->havingQual)
+		{
+			/* Factor in the selectivity of the remotely-checked quals */
+			retrieved_rows = clamp_row_est(
+				numGroups *
+				clauselist_selectivity(root, fpinfo->remote_conds, 0, JOIN_INNER, NULL));
+			/* Factor in the selectivity of the locally-checked quals */
+			rows = clamp_row_est(retrieved_rows * fpinfo->local_conds_sel);
+		}
+		else
+		{
+			/*
+			 * Number of rows expected from data node will be same as
+			 * that of number of groups.
+			 */
+			rows = retrieved_rows = numGroups;
+		}
+
+		/* Use width estimate made by the core code. */
+		width = foreignrel->reltarget->width;
+
+		/*-----
+		 * Startup cost includes:
+		 *	  1. Startup cost for underneath input relation, adjusted for
+		 *	     tlist replacement by apply_scanjoin_target_to_paths()
+		 *	  2. Cost of performing aggregation, per cost_agg()
+		 *-----
+		 */
+		startup_cost = ofpinfo->rel_startup_cost;
+		startup_cost += outerrel->reltarget->cost.startup;
+		startup_cost += aggcosts.transCost.startup;
+		startup_cost += aggcosts.transCost.per_tuple * input_rows;
+		startup_cost += aggcosts.finalCost.startup;
+		startup_cost += (cpu_operator_cost * numGroupCols) * input_rows;
+
+		/*-----
+		 * Run time cost includes:
+		 *	  1. Run time cost of underneath input relation, adjusted for
+		 *	     tlist replacement by apply_scanjoin_target_to_paths()
+		 *	  2. Run time cost of performing aggregation, per cost_agg()
+		 *-----
+		 */
+		run_cost = ofpinfo->rel_total_cost - ofpinfo->rel_startup_cost;
+		run_cost += outerrel->reltarget->cost.per_tuple * input_rows;
+		run_cost += aggcosts.finalCost.per_tuple * numGroups;
+		run_cost += cpu_tuple_cost * numGroups;
+
+		/* Account for the eval cost of HAVING quals, if any */
+		if (root->parse->havingQual)
+		{
+			QualCost remote_cost;
+
+			/* Add in the eval cost of the remotely-checked quals */
+			cost_qual_eval(&remote_cost, fpinfo->remote_conds, root);
+			startup_cost += remote_cost.startup;
+			run_cost += remote_cost.per_tuple * numGroups;
+			/* Add in the eval cost of the locally-checked quals */
+			startup_cost += fpinfo->local_conds_cost.startup;
+			run_cost += fpinfo->local_conds_cost.per_tuple * retrieved_rows;
+		}
+
+		/* Add in tlist eval cost for each output row */
+		startup_cost += foreignrel->reltarget->cost.startup;
+		run_cost += foreignrel->reltarget->cost.per_tuple * rows;
+	}
 	else
-		get_base_rel_estimate(root, rel, &ce);
+	{
+		Cost cpu_per_tuple;
+
+		/* Use rows/width estimates made by set_baserel_size_estimates. */
+		rows = foreignrel->rows;
+		width = foreignrel->reltarget->width;
+
+		/*
+		 * Back into an estimate of the number of retrieved rows.  Just in
+		 * case this is nuts, clamp to at most foreignrel->tuples.
+		 */
+		retrieved_rows = clamp_row_est(rows / fpinfo->local_conds_sel);
+		retrieved_rows = Min(retrieved_rows, foreignrel->tuples);
+
+		/*
+		 * Cost as though this were a seqscan, which is pessimistic.  We
+		 * effectively imagine the local_conds are being evaluated
+		 * remotely, too.
+		 */
+		startup_cost = 0;
+		run_cost = 0;
+		run_cost += seq_page_cost * foreignrel->pages;
+
+		startup_cost += foreignrel->baserestrictcost.startup;
+		cpu_per_tuple = cpu_tuple_cost + foreignrel->baserestrictcost.per_tuple;
+		run_cost += cpu_per_tuple * foreignrel->tuples;
+
+		/* Add in tlist eval cost for each output row */
+		startup_cost += foreignrel->reltarget->cost.startup;
+		run_cost += foreignrel->reltarget->cost.per_tuple * rows;
+	}
 
 	/*
 	 * Without remote estimates, we have no real way to estimate the cost
@@ -344,45 +454,71 @@ fdw_estimate_path_cost_size(PlannerInfo *root, RelOptInfo *rel, List *pathkeys, 
 	 */
 	if (pathkeys != NIL)
 	{
-		if (IS_UPPER_REL(rel))
+		if (IS_UPPER_REL(foreignrel))
 		{
-			Assert(rel->reloptkind == RELOPT_UPPER_REL ||
-				   rel->reloptkind == RELOPT_OTHER_UPPER_REL);
-
-			/* FIXME: Currently don't have a way to pass on limit here */
-			const double limit_tuples = -1;
-
+			Assert(fpinfo->stage == UPPERREL_GROUP_AGG ||
+				   fpinfo->stage == UPPERREL_PARTIAL_GROUP_AGG);
 			adjust_foreign_grouping_path_cost(root,
 											  pathkeys,
-											  ce.retrieved_rows,
-											  ce.width,
-											  limit_tuples,
-											  &ce.startup_cost,
-											  &ce.run_cost);
+											  retrieved_rows,
+											  width,
+											  fpextra ? fpextra->limit_tuples : -1,
+											  &startup_cost,
+											  &run_cost);
 		}
 		else
 		{
-			ce.startup_cost *= DEFAULT_FDW_SORT_MULTIPLIER;
-			ce.run_cost *= DEFAULT_FDW_SORT_MULTIPLIER;
+			startup_cost *= DEFAULT_FDW_SORT_MULTIPLIER;
+			run_cost *= DEFAULT_FDW_SORT_MULTIPLIER;
 		}
 	}
 
-	ce.total_cost = ce.startup_cost + ce.run_cost;
+	total_cost = startup_cost + run_cost;
+
+	/* Adjust the cost estimates if we have LIMIT */
+	if (fpextra && fpextra->has_limit)
+	{
+		adjust_limit_rows_costs(&rows,
+								&startup_cost,
+								&total_cost,
+								fpextra->offset_est,
+								fpextra->count_est);
+		retrieved_rows = rows;
+	}
 
 	/*
-	 * Cache the costs for scans without any pathkeys
-	 * before adding the costs for transferring data from the data node.
-	 * These costs are useful for costing the join between this relation and
-	 * another foreign relation or to calculate the costs of paths with
-	 * pathkeys for this relation, when the costs can not be obtained from the
-	 * data node. This function will be called at least once for every
-	 * foreign relation without pathkeys.
+	 * If this includes the final sort step, the given target, which will be
+	 * applied to the resulting path, might have different expressions from
+	 * the foreignrel's reltarget (see make_sort_input_target()); adjust tlist
+	 * eval costs.
 	 */
-	if (!REL_HAS_CACHED_COSTS(fpinfo) && pathkeys == NIL)
+	if (fpextra && fpextra->has_final_sort && fpextra->target != foreignrel->reltarget)
 	{
-		fpinfo->rel_startup_cost = ce.startup_cost;
-		fpinfo->rel_total_cost = ce.total_cost;
-		fpinfo->rel_retrieved_rows = ce.retrieved_rows;
+		QualCost oldcost = foreignrel->reltarget->cost;
+		QualCost newcost = fpextra->target->cost;
+
+		startup_cost += newcost.startup - oldcost.startup;
+		total_cost += newcost.startup - oldcost.startup;
+		total_cost += (newcost.per_tuple - oldcost.per_tuple) * rows;
+	}
+
+	/*
+	 * Cache the retrieved rows and cost estimates for scans, joins, or
+	 * groupings without any parameterization, pathkeys, or additional
+	 * post-scan/join-processing steps, before adding the costs for
+	 * transferring data from the foreign server.  These estimates are useful
+	 * for costing remote joins involving this relation or costing other
+	 * remote operations on this relation such as remote sorts and remote
+	 * LIMIT restrictions, when the costs can not be obtained from the foreign
+	 * server.  This function will be called at least once for every foreign
+	 * relation without any parameterization, pathkeys, or additional
+	 * post-scan/join-processing steps.
+	 */
+	if (pathkeys == NIL && param_join_conds == NIL && fpextra == NULL)
+	{
+		fpinfo->rel_retrieved_rows = retrieved_rows;
+		fpinfo->rel_startup_cost = startup_cost;
+		fpinfo->rel_total_cost = total_cost;
 	}
 
 	/*
@@ -391,14 +527,36 @@ fdw_estimate_path_cost_size(PlannerInfo *root, RelOptInfo *rel, List *pathkeys, 
 	 * (fdw_tuple_cost per retrieved row), and local manipulation of the data
 	 * (cpu_tuple_cost per retrieved row).
 	 */
-	ce.startup_cost += fpinfo->fdw_startup_cost;
-	ce.total_cost += fpinfo->fdw_startup_cost;
-	ce.total_cost += fpinfo->fdw_tuple_cost * ce.retrieved_rows;
-	ce.total_cost += cpu_tuple_cost * ce.retrieved_rows;
+	startup_cost += fpinfo->fdw_startup_cost;
+	total_cost += fpinfo->fdw_startup_cost;
+	total_cost += fpinfo->fdw_tuple_cost * retrieved_rows;
+	total_cost += cpu_tuple_cost * retrieved_rows;
+
+	/*
+	 * If we have LIMIT, we should prefer performing the restriction remotely
+	 * rather than locally, as the former avoids extra row fetches from the
+	 * remote that the latter might cause.  But since the core code doesn't
+	 * account for such fetches when estimating the costs of the local
+	 * restriction (see create_limit_path()), there would be no difference
+	 * between the costs of the local restriction and the costs of the remote
+	 * restriction estimated above if we don't use remote estimates (except
+	 * for the case where the foreignrel is a grouping relation, the given
+	 * pathkeys is not NIL, and the effects of a bounded sort for that rel is
+	 * accounted for in costing the remote restriction).  Tweak the costs of
+	 * the remote restriction to ensure we'll prefer it if LIMIT is a useful
+	 * one.
+	 */
+	if (fpextra && fpextra->has_limit && fpextra->limit_tuples > 0 &&
+		fpextra->limit_tuples < fpinfo->rows)
+	{
+		Assert(fpinfo->rows > 0);
+		total_cost -= (total_cost - startup_cost) * 0.05 * (fpinfo->rows - fpextra->limit_tuples) /
+					  fpinfo->rows;
+	}
 
 	/* Return results. */
-	*p_rows = ce.rows;
-	*p_width = ce.width;
-	*p_startup_cost = ce.startup_cost;
-	*p_total_cost = ce.total_cost;
+	*p_rows = rows;
+	*p_width = width;
+	*p_startup_cost = startup_cost;
+	*p_total_cost = total_cost;
 }

--- a/tsl/src/fdw/estimate.h
+++ b/tsl/src/fdw/estimate.h
@@ -9,9 +9,11 @@
 #include <postgres.h>
 #include <nodes/pathnodes.h>
 #include <optimizer/cost.h>
+#include "fdw/relinfo.h"
 
-extern void fdw_estimate_path_cost_size(PlannerInfo *root, RelOptInfo *rel, List *pathkeys,
-										double *p_rows, int *p_width, Cost *p_startup_cost,
-										Cost *p_total_cost);
+extern void fdw_estimate_path_cost_size(PlannerInfo *root, RelOptInfo *foreignrel,
+										List *param_join_conds, List *pathkeys,
+										TsFdwPathExtraData *fpextra, double *p_rows, int *p_width,
+										Cost *p_startup_cost, Cost *p_total_cost);
 
 #endif /* TIMESCALEDB_TSL_FDW_ESTIMATE_H */

--- a/tsl/src/fdw/relinfo.c
+++ b/tsl/src/fdw/relinfo.c
@@ -498,6 +498,8 @@ fdw_relinfo_create(PlannerInfo *root, RelOptInfo *rel, Oid server_oid, Oid local
 	fdw_estimate_path_cost_size(root,
 								rel,
 								NIL,
+								NIL,
+								NULL,
 								&fpinfo->rows,
 								&fpinfo->width,
 								&fpinfo->startup_cost,

--- a/tsl/src/fdw/scan_plan.h
+++ b/tsl/src/fdw/scan_plan.h
@@ -52,5 +52,7 @@ extern void fdw_create_upper_paths(TsFdwRelInfo *input_fpinfo, PlannerInfo *root
 								   UpperRelationKind stage, RelOptInfo *input_rel,
 								   RelOptInfo *output_rel, void *extra,
 								   CreateUpperPathFunc create_paths);
+extern Expr *find_em_expr_for_input_target(PlannerInfo *root, EquivalenceClass *ec,
+										   PathTarget *target);
 
 #endif /* TIMESCALEDB_TSL_FDW_SCAN_PLAN_H */

--- a/tsl/test/expected/dist_query.out
+++ b/tsl/test/expected/dist_query.out
@@ -1082,19 +1082,19 @@ LIMIT 10
                            Data node: data_node_1
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
@@ -2159,19 +2159,19 @@ LIMIT 10
                            Data node: data_node_1
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
@@ -2954,19 +2954,19 @@ LIMIT 10
                            Data node: data_node_1
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
@@ -4000,19 +4000,19 @@ LIMIT 10
                            Data node: data_node_1
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
@@ -5106,19 +5106,19 @@ LIMIT 10
                            Data node: data_node_1
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
+                           Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
@@ -6184,8 +6184,8 @@ LIMIT 10
 
 ######### LIMIT push down cases
 
-                                                                    QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t."time"
    ->  Nested Loop
@@ -6199,19 +6199,19 @@ LIMIT 10
                            Data node: data_node_1
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
+                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
+                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
                            Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
-                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5])
+                           Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test

--- a/tsl/test/shared/expected/dist_fetcher_type.out
+++ b/tsl/test/shared/expected/dist_fetcher_type.out
@@ -25,27 +25,27 @@ explain (verbose, costs off)
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
 where t1.id = t2.id + 1
 limit 1;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: 1
-   ->  Nested Loop
+   ->  Merge Join
          Output: 1
-         Join Filter: (t1.id = (t2.id + 1))
+         Merge Cond: (t1.id = ((t2.id + 1)))
          ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1
                Output: t1.id
                Data node: data_node_1
                Fetcher Type: Cursor
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+               Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST
          ->  Materialize
-               Output: t2.id
+               Output: t2.id, ((t2.id + 1))
                ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t2
-                     Output: t2.id
+                     Output: t2.id, (t2.id + 1)
                      Data node: data_node_1
                      Fetcher Type: Cursor
                      Chunks: _dist_hyper_X_X_chunk
-                     Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+                     Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY (id + 1) ASC NULLS LAST
 (19 rows)
 
 set timescaledb.remote_data_fetcher = 'rowbyrow';
@@ -57,27 +57,27 @@ explain (verbose, costs off)
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
 where t1.id = t2.id + 1
 limit 1;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: 1
-   ->  Nested Loop
+   ->  Merge Join
          Output: 1
-         Join Filter: (t1.id = (t2.id + 1))
+         Merge Cond: (t1.id = ((t2.id + 1)))
          ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1
                Output: t1.id
                Data node: data_node_1
                Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+               Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST
          ->  Materialize
-               Output: t2.id
+               Output: t2.id, ((t2.id + 1))
                ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t2
-                     Output: t2.id
+                     Output: t2.id, (t2.id + 1)
                      Data node: data_node_1
                      Fetcher Type: Row by row
                      Chunks: _dist_hyper_X_X_chunk
-                     Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
+                     Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY (id + 1) ASC NULLS LAST
 (19 rows)
 
 -- Check once again that 'auto' is used after 'rowbyrow'.


### PR DESCRIPTION
The remote DataNodeScan and FDW costing model was based on the
underlying PG11 code base. A lot of changes have occurred in PG since
then. So, update the costing model to the latest code base. We will
make further modifications on top of this for our specific use cases
soon.

Includes updates to the plans which now push order by clauses to the
datanodes in more cases.