### PR TITLE
Fix RENAME TO/SET SCHEMA on distributed hypertable

### DIFF
--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -1223,9 +1223,6 @@ dist_ddl_end(EventTriggerData *command)
 	{
 		HypertableType type = dist_ddl_state_get_hypertable_type();
 
-		if (type == HYPERTABLE_DISTRIBUTED)
-			dist_ddl_error_raise_unsupported();
-
 		/* Ensure this operation is executed by the access node session. */
 		if (type == HYPERTABLE_DISTRIBUTED_MEMBER)
 			dist_ddl_error_if_not_allowed_data_node_session();

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -452,6 +452,16 @@ NOTICE:  adding not-null constraint to column "time"
 TRUNCATE non_disttable1, non_disttable2;
 -- Truncating one distributed hypertable should be OK
 TRUNCATE disttable;
+-- RENAME TO
+ALTER TABLE disttable RENAME TO disttable2;
+ALTER TABLE disttable2 RENAME TO disttable;
+-- SET SCHEMA
+ALTER TABLE disttable SET SCHEMA some_schema;
+ALTER TABLE some_schema.disttable SET SCHEMA public;
+\set ON_ERROR_STOP 0
+ALTER TABLE disttable SET SCHEMA some_unexist_schema;
+ERROR:  schema "some_unexist_schema" does not exist
+\set ON_ERROR_STOP 1
 -- Test unsupported operations on distributed hypertable
 \set ON_ERROR_STOP 0
 -- test set_replication_factor on non-hypertable
@@ -471,12 +481,6 @@ ERROR:  operation not supported on distributed hypertable
 TRUNCATE disttable, non_disttable2;
 ERROR:  operation not supported on distributed hypertable
 CLUSTER disttable USING disttable_description_idx;
-ERROR:  operation not supported on distributed hypertable
-ALTER TABLE disttable RENAME TO disttable2;
-ERROR:  operation not supported on distributed hypertable
-ALTER TABLE disttable SET SCHEMA some_unexist_schema;
-ERROR:  schema "some_unexist_schema" does not exist
-ALTER TABLE disttable SET SCHEMA some_schema;
 ERROR:  operation not supported on distributed hypertable
 DROP TABLE non_disttable1, disttable;
 ERROR:  cannot drop a hypertable along with other objects

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -100,6 +100,17 @@ TRUNCATE non_disttable1, non_disttable2;
 -- Truncating one distributed hypertable should be OK
 TRUNCATE disttable;
 
+-- RENAME TO
+ALTER TABLE disttable RENAME TO disttable2;
+ALTER TABLE disttable2 RENAME TO disttable;
+
+-- SET SCHEMA
+ALTER TABLE disttable SET SCHEMA some_schema;
+ALTER TABLE some_schema.disttable SET SCHEMA public;
+\set ON_ERROR_STOP 0
+ALTER TABLE disttable SET SCHEMA some_unexist_schema;
+\set ON_ERROR_STOP 1
+
 -- Test unsupported operations on distributed hypertable
 \set ON_ERROR_STOP 0
 
@@ -117,10 +128,6 @@ TRUNCATE disttable, non_disttable1;
 TRUNCATE disttable, non_disttable2;
 
 CLUSTER disttable USING disttable_description_idx;
-
-ALTER TABLE disttable RENAME TO disttable2;
-ALTER TABLE disttable SET SCHEMA some_unexist_schema;
-ALTER TABLE disttable SET SCHEMA some_schema;
 
 DROP TABLE non_disttable1, disttable;
 DROP TABLE disttable, non_disttable2;


### PR DESCRIPTION
This PR fixes ON_END logic for distributed DDL execution
by removing old leftover check, which marked those commands
as unsupported.

Fix: #4106