### PR TITLE
Fix segfault on INSERT in distributed hypertables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+## Unreleased
+
+**Bugfixes**
+* #4122 Fix segfault on INSERT into distributed hypertable
+
 ## 2.6.0 (2022-02-16)
 This release is medium priority for upgrade. We recommend that you upgrade at the next available opportunity.
 

--- a/tsl/src/nodes/data_node_dispatch.c
+++ b/tsl/src/nodes/data_node_dispatch.c
@@ -902,8 +902,11 @@ handle_returning(DataNodeDispatchState *sds)
 	Assert(sds->state == SD_RETURNING);
 	oldcontext = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 
-	/* No returning projection, which means we are done */
-	if (NULL == rri->ri_projectReturning)
+	/*
+	 * When all chunks are pruned rri will be NULL and there is nothing to do.
+	 * Without returning projection, nothing to do here either.
+	 */
+	if (!rri || !rri->ri_projectReturning)
 	{
 		Assert(!HAS_RETURNING(sds));
 		Assert(NIL == sds->responses);

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -5949,6 +5949,27 @@ ERROR:  [db_dist_hypertable_3]: column "my_column" contains null values
 DELETE FROM test;
 ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
 DROP TABLE test;
+-- Test insert into distributed hypertable with pruned chunks
+CREATE TABLE pruned_chunks_1(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_1', 'time', 'sensor_id');
+   table_name    
+-----------------
+ pruned_chunks_1
+(1 row)
+
+INSERT INTO pruned_chunks_1 VALUES  ('2020-12-09',1,32.2);
+CREATE TABLE pruned_chunks_2(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+-- Convert the table to a distributed hypertable
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_2', 'time', 'sensor_id');
+   table_name    
+-----------------
+ pruned_chunks_2
+(1 row)
+
+insert into pruned_chunks_2 select * from pruned_chunks_1;
+insert into pruned_chunks_2 select * from pruned_chunks_1 WHERE time > '2022-01-01';
+DROP TABLE pruned_chunks_1;
+DROP TABLE pruned_chunks_2;
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -5948,6 +5948,27 @@ ERROR:  [db_dist_hypertable_3]: column "my_column" of relation "_dist_hyper_35_1
 DELETE FROM test;
 ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
 DROP TABLE test;
+-- Test insert into distributed hypertable with pruned chunks
+CREATE TABLE pruned_chunks_1(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_1', 'time', 'sensor_id');
+   table_name    
+-----------------
+ pruned_chunks_1
+(1 row)
+
+INSERT INTO pruned_chunks_1 VALUES  ('2020-12-09',1,32.2);
+CREATE TABLE pruned_chunks_2(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+-- Convert the table to a distributed hypertable
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_2', 'time', 'sensor_id');
+   table_name    
+-----------------
+ pruned_chunks_2
+(1 row)
+
+insert into pruned_chunks_2 select * from pruned_chunks_1;
+insert into pruned_chunks_2 select * from pruned_chunks_1 WHERE time > '2022-01-01';
+DROP TABLE pruned_chunks_1;
+DROP TABLE pruned_chunks_2;
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -5955,6 +5955,27 @@ ERROR:  [db_dist_hypertable_3]: column "my_column" of relation "_dist_hyper_35_1
 DELETE FROM test;
 ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
 DROP TABLE test;
+-- Test insert into distributed hypertable with pruned chunks
+CREATE TABLE pruned_chunks_1(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_1', 'time', 'sensor_id');
+   table_name    
+-----------------
+ pruned_chunks_1
+(1 row)
+
+INSERT INTO pruned_chunks_1 VALUES  ('2020-12-09',1,32.2);
+CREATE TABLE pruned_chunks_2(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+-- Convert the table to a distributed hypertable
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_2', 'time', 'sensor_id');
+   table_name    
+-----------------
+ pruned_chunks_2
+(1 row)
+
+insert into pruned_chunks_2 select * from pruned_chunks_1;
+insert into pruned_chunks_2 select * from pruned_chunks_1 WHERE time > '2022-01-01';
+DROP TABLE pruned_chunks_1;
+DROP TABLE pruned_chunks_2;
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -1971,6 +1971,24 @@ ALTER TABLE test ALTER COLUMN my_column SET NOT NULL;
 
 DROP TABLE test;
 
+-- Test insert into distributed hypertable with pruned chunks
+
+CREATE TABLE pruned_chunks_1(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_1', 'time', 'sensor_id');
+
+INSERT INTO pruned_chunks_1 VALUES  ('2020-12-09',1,32.2);
+
+CREATE TABLE pruned_chunks_2(time TIMESTAMPTZ NOT NULL, sensor_id INTEGER, value FLOAT);
+
+-- Convert the table to a distributed hypertable
+SELECT table_name FROM create_distributed_hypertable('pruned_chunks_2', 'time', 'sensor_id');
+
+insert into pruned_chunks_2 select * from pruned_chunks_1;
+insert into pruned_chunks_2 select * from pruned_chunks_1 WHERE time > '2022-01-01';
+
+DROP TABLE pruned_chunks_1;
+DROP TABLE pruned_chunks_2;
+
 -- Cleanup
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;


### PR DESCRIPTION
When inserting in a distributed hypertable with a query on a
distributed hypertable a segfault would occur when all the chunks
on the query would get pruned.