### PR TITLE
Improve planner error messages regarding nodes

### DIFF
--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -168,7 +168,7 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 			children = castNode(MergeAppendPath, subpath)->subpaths;
 			break;
 		default:
-			elog(ERROR, "invalid child of chunk append: %u", nodeTag(subpath));
+			elog(ERROR, "invalid child of chunk append: %s", ts_get_node_name((Node *) subpath));
 			break;
 	}
 

--- a/src/nodes/chunk_append/planner.c
+++ b/src/nodes/chunk_append/planner.c
@@ -337,8 +337,7 @@ ts_chunk_append_get_scan_plan(Plan *plan)
 			return NULL;
 			break;
 		default:
-			elog(ERROR, "invalid child of chunk append: %u", nodeTag(plan));
-			return NULL;
-			break;
+			elog(ERROR, "invalid child of chunk append: %s", ts_get_node_name((Node *) plan));
 	}
+	pg_unreachable();
 }

--- a/src/nodes/constraint_aware_append/constraint_aware_append.c
+++ b/src/nodes/constraint_aware_append/constraint_aware_append.c
@@ -190,7 +190,9 @@ ca_append_begin(CustomScanState *node, EState *estate, int eflags)
 			 */
 			return;
 		default:
-			elog(ERROR, "invalid child of constraint-aware append: %u", nodeTag(subplan));
+			elog(ERROR,
+				 "invalid child of constraint-aware append: %s",
+				 ts_get_node_name((Node *) subplan));
 	}
 
 	/*
@@ -257,7 +259,9 @@ ca_append_begin(CustomScanState *node, EState *estate, int eflags)
 				break;
 			}
 			default:
-				elog(ERROR, "invalid child of constraint-aware append: %u", nodeTag(plan));
+				elog(ERROR,
+					 "invalid child of constraint-aware append: %s",
+					 ts_get_node_name((Node *) plan));
 				break;
 		}
 	}
@@ -406,8 +410,8 @@ constraint_aware_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPa
 			break;
 		default:
 			elog(ERROR,
-				 "invalid child of constraint-aware append: %u",
-				 nodeTag(linitial(custom_plans)));
+				 "invalid child of constraint-aware append: %s",
+				 ts_get_node_name((Node *) linitial(custom_plans)));
 			break;
 	}
 
@@ -454,7 +458,9 @@ constraint_aware_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPa
 				break;
 			}
 			default:
-				elog(ERROR, "invalid child of constraint-aware append: %u", nodeTag(plan));
+				elog(ERROR,
+					 "invalid child of constraint-aware append: %s",
+					 ts_get_node_name((Node *) plan));
 				break;
 		}
 	}
@@ -513,7 +519,9 @@ ts_constraint_aware_append_path_create(PlannerInfo *root, Path *subpath)
 		case T_MergeAppendPath:
 			break;
 		default:
-			elog(ERROR, "invalid child of constraint-aware append: %u", nodeTag(subpath));
+			elog(ERROR,
+				 "invalid child of constraint-aware append: %s",
+				 ts_get_node_name((Node *) subpath));
 			break;
 	}
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -944,8 +944,58 @@ ts_relation_size(Oid relid)
 const char *
 ts_get_node_name(Node *node)
 {
+	/* tags are defined in nodes/nodes.h postgres source */
 	switch (nodeTag(node))
 	{
+		/*
+		 * plan nodes (plannodes.h)
+		 */
+		NODE_CASE(Plan);
+		NODE_CASE(Result);
+		NODE_CASE(ProjectSet);
+		NODE_CASE(ModifyTable);
+		NODE_CASE(Append);
+		NODE_CASE(MergeAppend);
+		NODE_CASE(RecursiveUnion);
+		NODE_CASE(BitmapAnd);
+		NODE_CASE(BitmapOr);
+		NODE_CASE(Scan);
+		NODE_CASE(SeqScan);
+		NODE_CASE(SampleScan);
+		NODE_CASE(IndexScan);
+		NODE_CASE(IndexOnlyScan);
+		NODE_CASE(BitmapIndexScan);
+		NODE_CASE(BitmapHeapScan);
+		NODE_CASE(TidScan);
+		NODE_CASE(SubqueryScan);
+		NODE_CASE(FunctionScan);
+		NODE_CASE(ValuesScan);
+		NODE_CASE(TableFuncScan);
+		NODE_CASE(CteScan);
+		NODE_CASE(NamedTuplestoreScan);
+		NODE_CASE(WorkTableScan);
+		NODE_CASE(ForeignScan);
+		NODE_CASE(CustomScan);
+		NODE_CASE(Join);
+		NODE_CASE(NestLoop);
+		NODE_CASE(MergeJoin);
+		NODE_CASE(HashJoin);
+		NODE_CASE(Material);
+		NODE_CASE(Sort);
+		NODE_CASE(Group);
+		NODE_CASE(Agg);
+		NODE_CASE(WindowAgg);
+		NODE_CASE(Unique);
+		NODE_CASE(Gather);
+		NODE_CASE(GatherMerge);
+		NODE_CASE(Hash);
+		NODE_CASE(SetOp);
+		NODE_CASE(LockRows);
+		NODE_CASE(Limit);
+
+		/*
+		 * planner nodes (pathnodes.h)
+		 */
 		NODE_CASE(IndexPath);
 		NODE_CASE(BitmapHeapPath);
 		NODE_CASE(BitmapAndPath);
@@ -977,6 +1027,7 @@ ts_get_node_name(Node *node)
 		NODE_CASE(LockRowsPath);
 		NODE_CASE(ModifyTablePath);
 		NODE_CASE(LimitPath);
+
 		case T_Path:
 			switch (castNode(Path, node)->pathtype)
 			{
@@ -991,8 +1042,10 @@ ts_get_node_name(Node *node)
 				default:
 					return psprintf("Path (%d)", castNode(Path, node)->pathtype);
 			}
+
 		case T_CustomPath:
 			return psprintf("CustomPath (%s)", castNode(CustomPath, node)->methods->CustomName);
+
 		default:
 			return psprintf("Node (%d)", nodeTag(node));
 	}


### PR DESCRIPTION
Change error messages when unexpected nodes are encountered to
actually show the node name instead of the node id.