### PR TITLE
Fixes to smoke update tests

### DIFF
--- a/scripts/test_update_smoke.sh
+++ b/scripts/test_update_smoke.sh
@@ -41,11 +41,12 @@ DUMPFILE="$SCRATCHDIR/smoke.dump"
 UPGRADE_OUT="$SCRATCHDIR/upgrade.out"
 CLEAN_OUT="$SCRATCHDIR/clean.out"
 RESTORE_OUT="$SCRATCHDIR/restore.out"
-TEST_VERSION=${TEST_VERSION:-v6}
+TEST_VERSION=${TEST_VERSION:-v7}
 UPDATE_FROM_TAG=${UPDATE_FROM_TAG:-1.7.4}
 UPDATE_TO_TAG=${UPDATE_TO_TAG:-2.0.1}
 # We do not have superuser privileges when running smoke tests.
 WITH_SUPERUSER=false
+WITH_ROLES=false
 
 while getopts "ds:t:" opt;
 do
@@ -68,7 +69,7 @@ echo "**** pg_dump at   " `which pg_dump`
 echo "**** pg_restore at" `which pg_restore`
 
 # Extra options to pass to psql
-PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_CHUNK=false"
+PGOPTS="-v TEST_VERSION=${TEST_VERSION} -v WITH_SUPERUSER=${WITH_SUPERUSER} -v WITH_ROLES=false -v WITH_CHUNK=false"
 PSQL="psql -qX $PGOPTS"
 
 # If we are providing a URI for the connection, we parse it here and

--- a/test/sql/updates/cleanup.constraints.sql
+++ b/test/sql/updates/cleanup.constraints.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\ir cleanup.bigint.sql
-\ir cleanup.constraints.sql
-\ir cleanup.timestamp.sql
+ALTER TABLE "two_Partitions"
+  DROP CONSTRAINT IF EXISTS two_Partitions_device_id_2_fkey;
 
+DROP TABLE IF EXISTS devices;

--- a/test/sql/updates/cleanup.continuous_aggs.v2.sql
+++ b/test/sql/updates/cleanup.continuous_aggs.v2.sql
@@ -15,12 +15,6 @@ SELECT extversion < '2.0.0' AS has_refresh_mat_view,
   FROM pg_extension
  WHERE extname = 'timescaledb' \gset
 
-\if :has_create_mat_view
-\set :DROP_CAGG DROP MATERIALIZED VIEW
-\else
-\set :DROP_CAGG DROP VIEW
-\endif
-
 \if :has_continuous_aggs_policy
 SELECT remove_continuous_aggregate_policy('mat_drop');
 \endif
@@ -40,14 +34,17 @@ DROP VIEW mat_conflict;
 \endif
 
 DROP TABLE conflict_test;
+
 \if :has_create_mat_view
 DROP MATERIALIZED VIEW mat_inttime;
+DROP MATERIALIZED VIEW mat_inttime2;
 \else
 DROP VIEW mat_inttime;
+DROP VIEW mat_inttime2;
 \endif
 
 DROP FUNCTION integer_now_test;
-DROP TABLE int_time_test;
+DROP TABLE IF EXISTS int_time_test;
 
 \if :has_create_mat_view
 DROP MATERIALIZED VIEW mat_inval;
@@ -75,6 +72,12 @@ DROP SCHEMA cagg;
 DROP MATERIALIZED VIEW mat_before;
 \else
 DROP VIEW mat_before;
+\endif
+
+\if :has_create_mat_view
+DROP MATERIALIZED VIEW rename_cols;
+\else
+DROP VIEW rename_cols;
 \endif
 
 DROP TABLE conditions_before;

--- a/test/sql/updates/cleanup.multinode.sql
+++ b/test/sql/updates/cleanup.multinode.sql
@@ -2,7 +2,5 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\ir cleanup.bigint.sql
-\ir cleanup.constraints.sql
-\ir cleanup.timestamp.sql
-
+DROP TABLE disthyper;
+SELECT drop_data_node('dn1');

--- a/test/sql/updates/cleanup.timestamp.sql
+++ b/test/sql/updates/cleanup.timestamp.sql
@@ -2,7 +2,4 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\ir cleanup.bigint.sql
-\ir cleanup.constraints.sql
-\ir cleanup.timestamp.sql
-
+DROP TABLE IF EXISTS PUBLIC.hyper_timestamp;

--- a/test/sql/updates/cleanup.v7.sql
+++ b/test/sql/updates/cleanup.v7.sql
@@ -2,7 +2,5 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-\ir cleanup.bigint.sql
-\ir cleanup.constraints.sql
-\ir cleanup.timestamp.sql
-
+\ir cleanup.v6.sql
+\ir cleanup.multinode.sql

--- a/test/sql/updates/post.v6.sql
+++ b/test/sql/updates/post.v6.sql
@@ -9,5 +9,7 @@
 \ir post.compression.sql
 \ir post.continuous_aggs.v2.sql
 \ir post.policies.sql
+\if :WITH_SUPERUSER
 \ir post.sequences.sql
+\endif
 \ir post.functions.sql

--- a/test/sql/updates/post.v7.sql
+++ b/test/sql/updates/post.v7.sql
@@ -9,5 +9,7 @@
 \ir post.compression.sql
 \ir post.continuous_aggs.v2.sql
 \ir post.policies.sql
+\if :WITH_SUPERUSER
 \ir post.sequences.sql
+\endif
 \ir post.functions.sql


### PR DESCRIPTION
Smoke tests where missing critical files and some tests had changed
since last run and did not handle update smoke tests, so fixing all
necessary issues.