### PR TITLE
Improve restriction scanning during hypertable expansion

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -165,9 +165,8 @@ CREATE TABLE _timescaledb_catalog.chunk_constraint (
   UNIQUE (chunk_id, constraint_name)
 );
 
+CREATE INDEX chunk_constraint_dimension_slice_id_idx ON _timescaledb_catalog.chunk_constraint (dimension_slice_id);
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_constraint', '');
-
-CREATE INDEX chunk_constraint_chunk_id_dimension_slice_id_idx ON _timescaledb_catalog.chunk_constraint (chunk_id, dimension_slice_id);
 
 CREATE SEQUENCE _timescaledb_catalog.chunk_constraint_name;
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -3,3 +3,5 @@ RETURNS TABLE (total_size BIGINT, heap_size BIGINT, index_size BIGINT, toast_siz
 AS '@MODULE_PATHNAME@', 'ts_relation_size' LANGUAGE C VOLATILE;
 
 DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP INDEX IF EXISTS _timescaledb_catalog.chunk_constraint_chunk_id_dimension_slice_id_idx;
+CREATE INDEX chunk_constraint_dimension_slice_id_idx ON _timescaledb_catalog.chunk_constraint (dimension_slice_id);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -1,2 +1,4 @@
 DROP VIEW _timescaledb_internal.hypertable_chunk_local_size;
 DROP FUNCTION _timescaledb_internal.relation_size(relation REGCLASS);
+DROP INDEX _timescaledb_catalog.chunk_constraint_dimension_slice_id_idx;
+CREATE INDEX chunk_constraint_chunk_id_dimension_slice_id_idx ON _timescaledb_catalog.chunk_constraint (chunk_id, dimension_slice_id);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1541,7 +1541,7 @@ ts_chunk_build_from_tuple_and_stub(Chunk **chunkptr, TupleInfo *ti, const ChunkS
 	}
 	else
 	{
-		ScanIterator it = ts_dimension_slice_scan_iterator_create(ti->mctx);
+		ScanIterator it = ts_dimension_slice_scan_iterator_create(NULL, ti->mctx);
 		chunk->cube = ts_hypercube_from_constraints(chunk->constraints, &it);
 		ts_scan_iterator_close(&it);
 	}
@@ -2314,7 +2314,7 @@ ts_chunk_get_window(int32 dimension_id, int64 point, int count, MemoryContext mc
 				continue;
 			chunk->constraints = ts_chunk_constraint_scan_by_chunk_id(chunk->fd.id, 1, mctx);
 
-			it = ts_dimension_slice_scan_iterator_create(mctx);
+			it = ts_dimension_slice_scan_iterator_create(NULL, mctx);
 			chunk->cube = ts_hypercube_from_constraints(chunk->constraints, &it);
 			ts_scan_iterator_close(&it);
 

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -367,14 +367,13 @@ ts_chunk_constraint_scan_iterator_set_slice_id(ScanIterator *it, int32 slice_id)
 {
 	it->ctx.index = catalog_get_index(ts_catalog_get(),
 									  CHUNK_CONSTRAINT,
-									  CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX);
+									  CHUNK_CONSTRAINT_DIMENSION_SLICE_ID_IDX);
 	ts_scan_iterator_scan_key_reset(it);
-	ts_scan_iterator_scan_key_init(
-		it,
-		Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_dimension_slice_id,
-		BTEqualStrategyNumber,
-		F_INT4EQ,
-		Int32GetDatum(slice_id));
+	ts_scan_iterator_scan_key_init(it,
+								   Anum_chunk_constraint_dimension_slice_id_idx_dimension_slice_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(slice_id));
 }
 
 void
@@ -382,10 +381,10 @@ ts_chunk_constraint_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id)
 {
 	it->ctx.index = catalog_get_index(ts_catalog_get(),
 									  CHUNK_CONSTRAINT,
-									  CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX);
+									  CHUNK_CONSTRAINT_CHUNK_ID_CONSTRAINT_NAME_IDX);
 	ts_scan_iterator_scan_key_reset(it);
 	ts_scan_iterator_scan_key_init(it,
-								   Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_chunk_id,
+								   Anum_chunk_constraint_chunk_id_constraint_name_idx_chunk_id,
 								   BTEqualStrategyNumber,
 								   F_INT4EQ,
 								   Int32GetDatum(chunk_id));

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -76,20 +76,25 @@ extern int ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSli
 extern int ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
 
 extern TSDLLEXPORT DimensionSlice *ts_dimension_slice_nth_latest_slice(int32 dimension_id, int n);
-extern TSDLLEXPORT int
-ts_dimension_slice_oldest_valid_chunk_for_reorder(int32 job_id, int32 dimension_id,
-												  StrategyNumber start_strategy, int64 start_value,
-												  StrategyNumber end_strategy, int64 end_value);
+extern TSDLLEXPORT int32 ts_dimension_slice_oldest_valid_chunk_for_reorder(
+	int32 job_id, int32 dimension_id, StrategyNumber start_strategy, int64 start_value,
+	StrategyNumber end_strategy, int64 end_value);
 extern TSDLLEXPORT List *ts_dimension_slice_get_chunkids_to_compress(
 	int32 dimension_id, StrategyNumber start_strategy, int64 start_value,
 	StrategyNumber end_strategy, int64 end_value, bool compress, bool recompress, int32 numchunks);
 
 extern DimensionSlice *ts_dimension_slice_from_tuple(TupleInfo *ti);
-extern ScanIterator ts_dimension_slice_scan_iterator_create(MemoryContext result_mcxt);
+extern ScanIterator ts_dimension_slice_scan_iterator_create(const ScanTupLock *tuplock,
+															MemoryContext result_mcxt);
 extern void ts_dimension_slice_scan_iterator_set_slice_id(ScanIterator *it, int32 slice_id,
 														  const ScanTupLock *tuplock);
 extern DimensionSlice *ts_dimension_slice_scan_iterator_get_by_id(ScanIterator *it, int32 slice_id,
 																  const ScanTupLock *tuplock);
+
+extern int ts_dimension_slice_scan_iterator_set_range(ScanIterator *it, int32 dimension_id,
+													  StrategyNumber start_strategy,
+													  int64 start_value,
+													  StrategyNumber end_strategy, int64 end_value);
 
 #define dimension_slice_insert(slice) ts_dimension_slice_insert_multi(&(slice), 1)
 

--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -67,7 +67,8 @@ ts_dimension_vec_sort(DimensionVec **vecptr)
 {
 	DimensionVec *vec = *vecptr;
 
-	qsort(vec->slices, vec->num_slices, sizeof(DimensionSlice *), cmp_slices);
+	if (vec->num_slices > 1)
+		qsort(vec->slices, vec->num_slices, sizeof(DimensionSlice *), cmp_slices);
 
 	return vec;
 }
@@ -77,7 +78,8 @@ ts_dimension_vec_sort_reverse(DimensionVec **vecptr)
 {
 	DimensionVec *vec = *vecptr;
 
-	qsort(vec->slices, vec->num_slices, sizeof(DimensionSlice *), cmp_slices_reverse);
+	if (vec->num_slices > 1)
+		qsort(vec->slices, vec->num_slices, sizeof(DimensionSlice *), cmp_slices_reverse);
 
 	return vec;
 }

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -159,7 +159,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length = _MAX_CHUNK_CONSTRAINT_INDEX,
 		.names = (char *[]) {
 			[CHUNK_CONSTRAINT_CHUNK_ID_CONSTRAINT_NAME_IDX] = "chunk_constraint_chunk_id_constraint_name_key",
-			[CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX] = "chunk_constraint_chunk_id_dimension_slice_id_idx",
+			[CHUNK_CONSTRAINT_DIMENSION_SLICE_ID_IDX] = "chunk_constraint_dimension_slice_id_idx",
 		},
 	},
 	[CHUNK_INDEX] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -442,15 +442,14 @@ typedef FormData_chunk_constraint *Form_chunk_constraint;
 enum
 {
 	CHUNK_CONSTRAINT_CHUNK_ID_CONSTRAINT_NAME_IDX = 0,
-	CHUNK_CONSTRAINT_CHUNK_ID_DIMENSION_SLICE_ID_IDX,
+	CHUNK_CONSTRAINT_DIMENSION_SLICE_ID_IDX,
 	_MAX_CHUNK_CONSTRAINT_INDEX,
 };
 
-enum Anum_chunk_constraint_chunk_id_dimension_slice_id_idx
+enum Anum_chunk_constraint_dimension_slice_id_idx
 {
-	Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_chunk_id = 1,
-	Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_dimension_slice_id,
-	_Anum_chunk_constraint_chunk_id_dimension_slice_id_idx_max,
+	Anum_chunk_constraint_dimension_slice_id_idx_dimension_slice_id = 1,
+	_Anum_chunk_constraint_dimension_slice_id_idx_max,
 };
 
 enum Anum_chunk_constraint_chunk_id_constraint_name_idx

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -870,9 +870,9 @@ SELECT * FROM test.show_constraints(format('%I.%I', :'CHUNK_SCHEMA', :'CHUNK_NAM
 SELECT * FROM original_chunk_constraints_metadata;
  chunk_id | dimension_slice_id |      constraint_name      | hypertable_constraint_name 
 ----------+--------------------+---------------------------+----------------------------
-       10 |                 15 | constraint_15             | 
        10 |                    | 10_1_chunkapi_device_fkey | chunkapi_device_fkey
        10 |                    | 10_2_chunkapi_pkey        | chunkapi_pkey
+       10 |                 15 | constraint_15             | 
 (3 rows)
 
 SELECT
@@ -885,9 +885,9 @@ INNER JOIN _timescaledb_catalog.chunk ch ON (con.chunk_id = ch.id)
 WHERE ch.schema_name = :'CHUNK_SCHEMA' AND ch.table_name = :'CHUNK_NAME';
  chunk_id | dimension_slice_id |      constraint_name      | hypertable_constraint_name 
 ----------+--------------------+---------------------------+----------------------------
-       11 |                 16 | constraint_16             | 
        11 |                    | 11_3_chunkapi_device_fkey | chunkapi_device_fkey
        11 |                    | 11_4_chunkapi_pkey        | chunkapi_pkey
+       11 |                 16 | constraint_16             | 
 (3 rows)
 
 DROP TABLE original_chunk_constraints;


### PR DESCRIPTION
Improve the performance of metadata scanning during hypertable
expansion.

When a hypertable is expanded to include all children chunks, only the
chunks that match the query restrictions are included. To find the
matching chunks, the planner first scans for all matching dimension
slices. The chunks that reference those slices are the chunks to
include in the expansion.

This change optimizes the scanning for slices by avoiding repeated
open/close of the dimension slice metadata table and index.

At the same time, related dimension slice scanning functions have been
refactored along the same line.

An index on the chunk constraint metadata table is also changed to
allow scanning on dimension_slice_id. Previously, dimension_slice_id
was the second key in the index, which made scans on this key less
efficient.