### PR TITLE
Ignore invalid relid when deleting hypertable

### DIFF
--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1182,3 +1182,33 @@ WHERE reltablespace in
 DROP TABLE test2 CASCADE;
 NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_17_104_chunk
 DROP TABLESPACE tablespace2;
+-- Create a table with a compressed table and then delete the
+-- compressed table and see that the drop of the hypertable does not
+-- generate an error. This scenario can be triggered if an extension
+-- is created with compressed hypertables since the tables are dropped
+-- as part of the drop of the extension.
+CREATE TABLE issue4140("time" timestamptz NOT NULL, device_id int);
+SELECT create_hypertable('issue4140', 'time');
+    create_hypertable    
+-------------------------
+ (18,public,issue4140,t)
+(1 row)
+
+ALTER TABLE issue4140 SET(timescaledb.compress);
+SELECT format('%I.%I', schema_name, table_name)::regclass AS ctable
+FROM _timescaledb_catalog.hypertable
+WHERE id = (SELECT compressed_hypertable_id FROM _timescaledb_catalog.hypertable WHERE table_name = 'issue4140') \gset
+SELECT timescaledb_pre_restore();
+ timescaledb_pre_restore 
+-------------------------
+ t
+(1 row)
+
+DROP TABLE :ctable;
+SELECT timescaledb_post_restore();
+ timescaledb_post_restore 
+--------------------------
+ t
+(1 row)
+
+DROP TABLE issue4140;


### PR DESCRIPTION
When running `performDeletion` is necessary to have a valid relation
id, but when doing a lookup using `ts_hypertable_get_by_id` this might
actually return a hypertable entry pointing to a table that does not
exist because it has been deleted previously. In this case, only the
catalog entry should be removed, but it is not necessary to delete the
actual table.

This scenario can occur if both the hypertable and a compressed table
are deleted as part of running a `sql_drop` event, for example, if a
compressed hypertable is defined inside an extension. In this case, the
compressed hypertable (indeed all tables) will be deleted first, and
the lookup of the compressed hypertable will find it in the metadata
but a lookup of the actual table will fail since the table does not
exist.

Fixes #4140
