### PR TITLE
Add initial support for upper rels

### DIFF
--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -521,10 +521,6 @@ data_node_scan_create_upper_paths(PlannerInfo *root, UpperRelationKind stage, Re
 
 	fpinfo = fdw_relinfo_get(input_rel);
 
-	/* Verify that this is a data node rel */
-	if (NULL == fpinfo || fpinfo->type != TS_FDW_RELINFO_HYPERTABLE_DATA_NODE)
-		return;
-
 	fdw_create_upper_paths(fpinfo,
 						   root,
 						   stage,

--- a/tsl/src/fdw/fdw.c
+++ b/tsl/src/fdw/fdw.c
@@ -342,20 +342,19 @@ plan_foreign_modify(PlannerInfo *root, ModifyTable *plan, Index result_relation,
  *
  * Right now, we only support aggregate, grouping and having clause pushdown.
  */
-static void
+void
 get_foreign_upper_paths(PlannerInfo *root, UpperRelationKind stage, RelOptInfo *input_rel,
 						RelOptInfo *output_rel, void *extra)
 {
 	TsFdwRelInfo *fpinfo = input_rel->fdw_private ? fdw_relinfo_get(input_rel) : NULL;
 
-	if (fpinfo == NULL)
-		return;
-
-	/* We abuse the FDW API's GetForeignUpperPaths callback because, for some
+	/*
+	 * We abuse the FDW API's GetForeignUpperPaths callback because, for some
 	 * reason, the regular create_upper_paths_hook is never called for
 	 * partially grouped rels, so we cannot use if for server rels. See end of
-	 * PostgreSQL planner.c:create_partial_grouping_paths(). */
-	if (fpinfo->type == TS_FDW_RELINFO_HYPERTABLE_DATA_NODE)
+	 * PostgreSQL planner.c:create_partial_grouping_paths().
+	 */
+	if (fpinfo && fpinfo->type == TS_FDW_RELINFO_HYPERTABLE_DATA_NODE)
 		data_node_scan_create_upper_paths(root, stage, input_rel, output_rel, extra);
 	else
 		fdw_create_upper_paths(fpinfo,

--- a/tsl/src/fdw/fdw.h
+++ b/tsl/src/fdw/fdw.h
@@ -12,5 +12,7 @@
 
 extern Datum timescaledb_fdw_handler(PG_FUNCTION_ARGS);
 extern Datum timescaledb_fdw_validator(PG_FUNCTION_ARGS);
+extern void get_foreign_upper_paths(PlannerInfo *root, UpperRelationKind stage,
+									RelOptInfo *input_rel, RelOptInfo *output_rel, void *extra);
 
 #endif /* TIMESCALEDB_TSL_FDW_FDW_H */

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -55,6 +55,14 @@ tsl_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptIn
 							void *extra)
 {
 	bool dist_ht = false;
+
+	/*
+	 * Certain stages like UPPERREL_SETOP do not have an input_rel passed in. So we
+	 * check for those cases before trying to get more upper paths
+	 */
+	if (!input_rel)
+		return;
+
 	switch (input_reltype)
 	{
 		case TS_REL_HYPERTABLE:
@@ -64,6 +72,7 @@ tsl_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptIn
 				data_node_scan_create_upper_paths(root, stage, input_rel, output_rel, extra);
 			break;
 		default:
+			get_foreign_upper_paths(root, stage, input_rel, output_rel, extra);
 			break;
 	}
 

--- a/tsl/test/expected/debug_notice.out
+++ b/tsl/test/expected/debug_notice.out
@@ -217,6 +217,24 @@ Pruned paths:
 	CustomPath (DataNodeScanPath) [rel type: DATA_NODE, kind: OTHER_UPPER_REL, parent's base rels: hyper] rows=1 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
 
 
+DEBUG:  Upper rel stage ORDERED:
+RELOPTINFO [rel name: UPPER_REL, type: UPPER_REL, kind: UPPER_REL, base rel names: ] rows=0 width=0
+Path list:
+	MergeAppendPath [rel type: UPPER_REL, kind: UPPER_REL, parent's base rels: ] rows=5 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+		CustomPath (DataNodeScanPath) [rel type: DATA_NODE, kind: OTHER_UPPER_REL, parent's base rels: hyper] rows=1 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+		CustomPath (DataNodeScanPath) [rel type: DATA_NODE, kind: OTHER_UPPER_REL, parent's base rels: hyper] rows=3 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+		CustomPath (DataNodeScanPath) [rel type: DATA_NODE, kind: OTHER_UPPER_REL, parent's base rels: hyper] rows=1 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+
+
+DEBUG:  Upper rel stage FINAL:
+RELOPTINFO [rel name: UPPER_REL, type: UPPER_REL, kind: UPPER_REL, base rel names: ] rows=0 width=0
+Path list:
+	MergeAppendPath [rel type: UPPER_REL, kind: UPPER_REL, parent's base rels: ] rows=5 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+		CustomPath (DataNodeScanPath) [rel type: DATA_NODE, kind: OTHER_UPPER_REL, parent's base rels: hyper] rows=1 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+		CustomPath (DataNodeScanPath) [rel type: DATA_NODE, kind: OTHER_UPPER_REL, parent's base rels: hyper] rows=3 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+		CustomPath (DataNodeScanPath) [rel type: DATA_NODE, kind: OTHER_UPPER_REL, parent's base rels: hyper] rows=1 with pathkeys: ((hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time, hyper.time), (hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device, hyper.device))
+
+
              time             | device | temp 
 ------------------------------+--------+------
  Thu Apr 19 13:01:00 2018 PDT |      1 |  7.6


### PR DESCRIPTION
ORDER BYs and LIMITs clauses (and others) are represented via UPPERREL
entries during the planning process. Our code didn't handle all these
upper rel entries properly. Add initial support for that so that these
could be pushed down to the datanodes. To start off we are supporting
queries that have one datanode involved.

We will need costing changes in a follow on patch to get the full
benefits of supporting these upperrels.