### PR TITLE
Allow ANALYZE command on a data node directly

### DIFF
--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -853,6 +853,11 @@ dist_ddl_process_vacuum(const ProcessUtilityArgs *args)
 {
 	VacuumStmt *stmt = castNode(VacuumStmt, args->parsetree);
 
+	/* Allow execution of VACUUM/ANALYZE commands on a data node without
+	 * enabling timescaledb.enable_client_ddl_on_data_nodes GUC */
+	if (dist_util_membership() != DIST_MEMBER_ACCESS_NODE)
+		return;
+
 	if (!dist_ddl_state_set_hypertable(args))
 		return;
 

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -2422,6 +2422,22 @@ DROP INDEX disttable_device_idx;
 ERROR:  [data_node_1]: index "disttable_device_idx" does not exist
 \set ON_ERROR_STOP 1
 DROP TABLE disttable;
+-- Ensure VACUUM/ANALYZE commands can be run on a data node
+-- without enabling timescaledb.enable_client_ddl_on_data_nodes guc
+CREATE TABLE disttable(time timestamptz NOT NULL, device int);
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', replication_factor => 3);
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+            19 | public      | disttable  | t
+(1 row)
+
+\c :MY_DB1
+ANALYZE disttable;
+ANALYZE;
+VACUUM disttable;
+VACUUM;
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+DROP TABLE disttable;
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :MY_DB1;

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -677,6 +677,18 @@ DROP INDEX disttable_device_idx;
 
 DROP TABLE disttable;
 
+-- Ensure VACUUM/ANALYZE commands can be run on a data node
+-- without enabling timescaledb.enable_client_ddl_on_data_nodes guc
+CREATE TABLE disttable(time timestamptz NOT NULL, device int);
+SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', replication_factor => 3);
+\c :MY_DB1
+ANALYZE disttable;
+ANALYZE;
+VACUUM disttable;
+VACUUM;
+\c :TEST_DBNAME :ROLE_SUPERUSER;
+DROP TABLE disttable;
+
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :MY_DB1;


### PR DESCRIPTION
Allow execution of VACUUM/ANALYZE commands on a data node without
enabling timescaledb.enable_client_ddl_on_data_nodes GUC

Fix #4157