### PR TITLE
Fix memory handling during scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #4122 Fix segfault on INSERT into distributed hypertable
+* #4161 Fix memory handling during scans
+
+**Thanks**
+* @abrownsword for reporting a crash in the telemetry reporter
 
 ## 2.6.0 (2022-02-16)
 This release is medium priority for upgrade. We recommend that you upgrade at the next available opportunity.

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -252,9 +252,9 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 				prev_chunk_oid = chunk->table_id;
 			}
 
+			MemoryContextSwitchTo(work_mcxt);
 			/* Only one chunk should match */
 			Assert(ts_scan_iterator_next(&chunk_it) == NULL);
-			MemoryContextSwitchTo(work_mcxt);
 		}
 	}
 

--- a/src/scan_iterator.c
+++ b/src/scan_iterator.c
@@ -44,7 +44,7 @@ ts_scan_iterator_scan_key_init(ScanIterator *iterator, AttrNumber attributeNumbe
 	 * sure the scan key is initialized on the long-lived scankey memory
 	 * context.
 	 */
-	oldmcxt = MemoryContextSwitchTo(iterator->scankey_mcxt);
+	oldmcxt = MemoryContextSwitchTo(iterator->ctx.internal.scan_mcxt);
 	ScanKeyInit(&iterator->scankey[iterator->ctx.nkeys++],
 				attributeNumber,
 				strategy,
@@ -56,7 +56,5 @@ ts_scan_iterator_scan_key_init(ScanIterator *iterator, AttrNumber attributeNumbe
 TSDLLEXPORT void
 ts_scan_iterator_rescan(ScanIterator *iterator)
 {
-	MemoryContext oldmcxt = MemoryContextSwitchTo(iterator->scankey_mcxt);
 	ts_scanner_rescan(&iterator->ctx, NULL);
-	MemoryContextSwitchTo(oldmcxt);
 }

--- a/src/scan_iterator.c
+++ b/src/scan_iterator.c
@@ -56,5 +56,7 @@ ts_scan_iterator_scan_key_init(ScanIterator *iterator, AttrNumber attributeNumbe
 TSDLLEXPORT void
 ts_scan_iterator_rescan(ScanIterator *iterator)
 {
+	MemoryContext oldmcxt = MemoryContextSwitchTo(iterator->scankey_mcxt);
 	ts_scanner_rescan(&iterator->ctx, NULL);
+	MemoryContextSwitchTo(oldmcxt);
 }

--- a/src/scan_iterator.h
+++ b/src/scan_iterator.h
@@ -18,7 +18,6 @@ typedef struct ScanIterator
 {
 	ScannerCtx ctx;
 	TupleInfo *tinfo;
-	MemoryContext scankey_mcxt;
 	ScanKeyData scankey[EMBEDDED_SCAN_KEY_SIZE];
 } ScanIterator;
 
@@ -28,6 +27,7 @@ typedef struct ScanIterator
 		.ctx = {                                                                                   \
 			.internal = {													\
 				.ended = true,											\
+				.scan_mcxt = CurrentMemoryContext,						\
 			},															\
 			.table = catalog_get_table_id(ts_catalog_get(), catalog_table_id),                     \
 			.nkeys = 0,                                                                            \
@@ -35,8 +35,7 @@ typedef struct ScanIterator
 			.lockmode = lock_mode,                                                                 \
 			.result_mctx = mctx,                                                                   \
 			.flags = SCANNER_F_NOFLAGS,									\
-		},																\
-		.scankey_mcxt = CurrentMemoryContext, \
+		}, \
 	}
 
 static inline TupleInfo *
@@ -78,9 +77,7 @@ ts_scan_iterator_alloc_result(const ScanIterator *iterator, Size size)
 static inline void
 ts_scan_iterator_start_scan(ScanIterator *iterator)
 {
-	MemoryContext oldmcxt = MemoryContextSwitchTo(iterator->scankey_mcxt);
 	ts_scanner_start_scan(&(iterator)->ctx);
-	MemoryContextSwitchTo(oldmcxt);
 }
 
 static inline TupleInfo *

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -85,6 +85,12 @@ typedef struct InternalScannerCtx
 {
 	TupleInfo tinfo;
 	ScanDesc scan;
+	/*
+	 * PG scan functions must be called on a memory context that lives
+	 * throughout the entire scan. Use the scan_mcxt to ensure that
+	 * functions aren't called on, e.g., a per-tuple context.
+	 */
+	MemoryContext scan_mcxt;
 	bool registered_snapshot;
 	bool started;
 	bool ended;

--- a/src/telemetry/stats.c
+++ b/src/telemetry/stats.c
@@ -338,13 +338,10 @@ get_chunk_compression_stats(StatsContext *statsctx, const Chunk *chunk,
 							Form_compression_chunk_size compr_stats)
 {
 	TupleInfo *ti;
-	MemoryContext oldmcxt;
 
 	if (!ts_chunk_is_compressed(chunk))
 		return false;
 
-	/* Need to execute the scan functions on the long-lived memory context */
-	oldmcxt = MemoryContextSwitchTo(statsctx->compressed_chunk_stats_iterator.scankey_mcxt);
 	ts_scan_iterator_scan_key_reset(&statsctx->compressed_chunk_stats_iterator);
 	ts_scan_iterator_scan_key_init(&statsctx->compressed_chunk_stats_iterator,
 								   Anum_compression_chunk_size_pkey_chunk_id,
@@ -353,7 +350,6 @@ get_chunk_compression_stats(StatsContext *statsctx, const Chunk *chunk,
 								   Int32GetDatum(chunk->fd.id));
 	ts_scan_iterator_start_or_restart_scan(&statsctx->compressed_chunk_stats_iterator);
 	ti = ts_scan_iterator_next(&statsctx->compressed_chunk_stats_iterator);
-	MemoryContextSwitchTo(oldmcxt);
 
 	if (ti)
 	{


### PR DESCRIPTION
Scan functions cannot be called on a per-tuple memory context as they
might allocate data that need to live until the end of the scan. Fix
this in a couple of places to ensure correct memory handling.

Fixes #4148, #4145
Disable-Check: Commit-Count