### PR TITLE
Trigger Sqlsmith tests manually or by push to branch 

### DIFF
--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     # run daily 20:00 on master branch
     - cron: '0 2 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - sqlsmith
 jobs:
   regress:
     name: SQLsmith PG${{ matrix.pg }}


### PR DESCRIPTION
Add workflow events to allow manually running Sqlsmith tests or when
pushing to the 'sqlsmith' branch. This is useful when submitting PRs
that one wants to run extra checks on, including Sqlsmith.