### PR TITLE
Cache whether a rel is a chunk in classify_relation     

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2684,6 +2684,22 @@ ts_chunk_exists_relid(Oid relid)
 }
 
 /*
+ * Returns 0 if there is no chunk with such reloid.
+ */
+int32
+ts_chunk_get_hypertable_id_by_relid(Oid relid)
+{
+	FormData_chunk form;
+
+	if (chunk_simple_scan_by_relid(relid, &form, /* missing_ok = */ true))
+	{
+		return form.hypertable_id;
+	}
+
+	return 0;
+}
+
+/*
  * Get the relid of a chunk given its ID.
  */
 Oid

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -148,6 +148,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_by_id(int32 id, bool fail_if_not_found);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_relid(Oid relid, bool fail_if_not_found);
 extern TSDLLEXPORT void ts_chunk_free(Chunk *chunk);
 extern bool ts_chunk_exists(const char *schema_name, const char *table_name);
+extern TSDLLEXPORT int32 ts_chunk_get_hypertable_id_by_relid(Oid relid);
 extern Oid ts_chunk_get_relid(int32 chunk_id, bool missing_ok);
 extern Oid ts_chunk_get_schema_id(int32 chunk_id, bool missing_ok);
 extern bool ts_chunk_get_id(const char *schema, const char *table, int32 *chunk_id,


### PR DESCRIPTION
Cache whether a rel is a chunk in classify_relation

Use a per-query hash table for this. This speeds up the repeated calls
to classify_relation by avoiding the costly chunk lookup.

Fixes https://github.com/timescale/timescaledb/issues/4044