### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,4 @@
-- [ ] Add [CHANGELOG](https://github.com/timescale/timescaledb/blob/master/CHANGELOG.md) updates
+- [ ] Add [CHANGELOG](https://github.com/timescale/timescaledb/blob/main/CHANGELOG.md) updates
 - [ ] Needs [documentation](https://github.com/timescale/docs) updates
 
 Fixes #<issue number>.
@@ -13,7 +13,7 @@ Checklist for a pull request:
 - Try to follow [the seven rules of a great Git commit
 message](https://chris.beams.io/posts/git-commit/).
 - Ideally, the PR should be merged as a single commit.
-- Rebase on latest master code.
+- Rebase on latest main code.
 - Reference the issue(s) resolved with Fixes #<issue number>, or
   Closes #<issue number>.
 - Make sure the PR has appropriate CHANGELOG updates, including thanks

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -9,7 +9,7 @@
 name: ABI Test
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -2,7 +2,7 @@
 name: APT ARM64 packages
 on:
   schedule:
-    # run daily 0:00 on master branch
+    # run daily 0:00 on main branch
     - cron: '0 0 * * *'
   push:
     tags:
@@ -64,7 +64,7 @@ jobs:
       run: |
         # read expected version from version.config
         # version will only be a proper version in a release branch so we use update_from_version
-        # as fallback for master
+        # as fallback for main
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -2,7 +2,7 @@
 name: APT packages
 on:
   schedule:
-    # run daily 0:00 on master branch
+    # run daily 0:00 on main branch
     - cron: '0 0 * * *'
   push:
     tags:
@@ -60,7 +60,7 @@ jobs:
       run: |
         # read expected version from version.config
         # version will only be a proper version in a release branch so we use update_from_version
-        # as fallback for master
+        # as fallback for main
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else
@@ -79,7 +79,7 @@ jobs:
 
     - name: Test Downgrade
       run: |
-        # since this runs nightly on master we have to get the previous version from the last released version and not current branch
+        # since this runs nightly on main we have to get the previous version from the last released version and not current branch
         prev_version=$(wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
         sudo -u postgres psql -X -c "ALTER EXTENSION timescaledb UPDATE TO '${prev_version}';SELECT extname,extversion,version() FROM pg_extension WHERE extname='timescaledb';"
         installed_version=$(sudo -u postgres psql -X -t -c "SELECT extversion FROM pg_extension WHERE extname='timescaledb';" | sed -e 's! !!g')

--- a/.github/workflows/ci_summary.yaml
+++ b/.github/workflows/ci_summary.yaml
@@ -1,7 +1,7 @@
 name: CI Summary
 on:
   schedule:
-    # run daily 8:00 CET on master branch
+    # run daily 8:00 CET on main branch
     - cron: '0 7 * * *'
 jobs:
   ci_summary:

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -1,7 +1,7 @@
 name: Code style
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/cron-tests.yaml
+++ b/.github/workflows/cron-tests.yaml
@@ -1,7 +1,7 @@
 name: Additional tests
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -1,7 +1,7 @@
 name: Homebrew
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     tags:

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -1,7 +1,7 @@
 name: Regression Linux i386
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -1,7 +1,7 @@
 name: Regression
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -1,7 +1,7 @@
 name: Memory tests
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -2,7 +2,7 @@ name: Pull Request Validation
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-    branches: [master]
+    branches: [master, main]
 jobs:
   # Count the number of commits in a pull request. This can be
   # disabled by adding a trailer line of the following form to the

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -1,7 +1,7 @@
 name: RPM packages
 on:
   schedule:
-    # run daily 0:00 on master branch
+    # run daily 0:00 on main branch
     - cron: '0 0 * * *'
   push:
     tags:
@@ -64,7 +64,7 @@ jobs:
       run: |
         # read expected version from version.config
         # version will only be a proper version in a release branch so we use update_from_version
-        # as fallback for master
+        # as fallback for main
         if grep '^version = [0-9.]\+$' version.config; then
           version=$(grep '^version = ' version.config | sed -e 's!^version = !!')
         else
@@ -84,7 +84,7 @@ jobs:
 
     - name: Test Downgrade
       run: |
-        # since this runs nightly on master we have to get the previous version from the last released version and not current branch
+        # since this runs nightly on main we have to get the previous version from the last released version and not current branch
         prev_version=$(wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')
         yum downgrade -y timescaledb-2${{ matrix.pkg_suffix }}-postgresql-${{ matrix.pg }}-${prev_version}
         sudo -u postgres psql -X -c "ALTER EXTENSION timescaledb UPDATE TO '${prev_version}';SELECT extname,extversion,version() FROM pg_extension WHERE extname='timescaledb';"

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -1,7 +1,7 @@
 name: Sanitizer test
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -1,7 +1,7 @@
 name: SQLsmith
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 2 * * *'
   workflow_dispatch:
   push:

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -1,7 +1,7 @@
 name: Test Update and Downgrade
 on:
   schedule:
-    # run daily 20:00 on master branch
+    # run daily 20:00 on main branch
     - cron: '0 20 * * *'
   push:
     branches:

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -2,7 +2,7 @@
 name: Windows Packages
 on:
   schedule:
-    # run daily 0:00 on master branch
+    # run daily 0:00 on main branch
     - cron: '0 0 * * *'
   push:
     tags:
@@ -31,7 +31,7 @@ jobs:
       id: version
       run: |
         # version will only be a proper version in a release branch so we use update_from_version
-        # as fallback for master
+        # as fallback for main
         if (grep '^version = [0-9.]\+$' version.config)
         {
           $version=grep '^version = ' version.config | sed -e 's!^version = !!'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 notifications:
   slack:
-    if: (type = cron) AND (branch = master)
+    if: (type = cron) AND (branch = main)
     on_success: change
     on_failure: always
     template:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ contributions.
 
 ## Getting and building TimescaleDB
 
-Please follow our README for [instructions on installing from source](https://github.com/timescale/timescaledb/blob/master/README.md#option-3---from-source).
+Please follow our README for [instructions on installing from source](https://github.com/timescale/timescaledb/blob/main/README.md#option-3---from-source).
 
 ## Style guide
 
@@ -74,8 +74,8 @@ our [Style Guide](docs/StyleGuide.md).
       repeating the commit message is preferred, which is done automatically
       by GitHub when it creates the pull request.
 
-    * Rebase your local feature branch against master (`git fetch origin`,
-      then `git rebase origin/master`) to make sure you're
+    * Rebase your local feature branch against main (`git fetch origin`,
+      then `git rebase origin/main`) to make sure you're
       submitting your changes on top of the newest version of our code.
 
     * When finalizing your PR (i.e., it has been approved for merging),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 |Linux/macOS|Linux i386|Windows|Coverity|Code Coverage|
 |:---:|:---:|:---:|:---:|:---:|
-|[![Build Status Linux/macOS](https://github.com/timescale/timescaledb/workflows/Regression/badge.svg?event=schedule)](https://github.com/timescale/timescaledb/actions?query=workflow%3ARegression+branch%3Amaster)|[![Build Status Linux i386](https://github.com/timescale/timescaledb/workflows/Regression%20Linux%20i386/badge.svg?branch=master&event=schedule)](https://github.com/timescale/timescaledb/actions?query=workflow%3A%22Regression+Linux+i386%22+branch%3Amaster)|[![Windows build status](https://ci.appveyor.com/api/projects/status/15sqkl900t04hywu/branch/master?svg=true)](https://ci.appveyor.com/project/timescale/timescaledb/branch/master)|[![Coverity Scan Build Status](https://scan.coverity.com/projects/timescale-timescaledb/badge.svg)](https://scan.coverity.com/projects/timescale-timescaledb)|[![Code Coverage](https://codecov.io/gh/timescale/timescaledb/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/timescale/timescaledb)
+|[![Build Status Linux/macOS](https://github.com/timescale/timescaledb/workflows/Regression/badge.svg?event=schedule)](https://github.com/timescale/timescaledb/actions?query=workflow%3ARegression+branch%3Amaster)|[![Build Status Linux i386](https://github.com/timescale/timescaledb/workflows/Regression%20Linux%20i386/badge.svg?branch=main&event=schedule)](https://github.com/timescale/timescaledb/actions?query=workflow%3A%22Regression+Linux+i386%22+branch%3Amaster)|[![Windows build status](https://ci.appveyor.com/api/projects/status/15sqkl900t04hywu/branch/main?svg=true)](https://ci.appveyor.com/project/timescale/timescaledb/branch/main)|[![Coverity Scan Build Status](https://scan.coverity.com/projects/timescale-timescaledb/badge.svg)](https://scan.coverity.com/projects/timescale-timescaledb)|[![Code Coverage](https://codecov.io/gh/timescale/timescaledb/branch/main/graphs/badge.svg?branch=main)](https://codecov.io/gh/timescale/timescaledb)
 
 
 ## TimescaleDB
@@ -27,12 +27,12 @@ these other resources:
 
 For reference and clarity, all code files in this repository reference
 licensing in their header (either the Apache-2-open-source license
-or [Timescale License (TSL)](https://github.com/timescale/timescaledb/blob/master/tsl/LICENSE-TIMESCALE)
+or [Timescale License (TSL)](https://github.com/timescale/timescaledb/blob/main/tsl/LICENSE-TIMESCALE)
 ). Apache-2 licensed binaries can be built by passing `-DAPACHE_ONLY=1` to `bootstrap`.
 
-[Contributors welcome.](https://github.com/timescale/timescaledb/blob/master/CONTRIBUTING.md)
+[Contributors welcome.](https://github.com/timescale/timescaledb/blob/main/CONTRIBUTING.md)
 
-(To build TimescaleDB from source, see instructions in [_Building from source_](https://github.com/timescale/timescaledb/blob/master/docs/BuildSource.md).)
+(To build TimescaleDB from source, see instructions in [_Building from source_](https://github.com/timescale/timescaledb/blob/main/docs/BuildSource.md).)
 
 ### Using TimescaleDB
 
@@ -134,7 +134,7 @@ queries, automating common operational tasks and reducing management overhead.
 We recommend following our detailed [installation instructions](https://tsdb.co/GitHubTimescaleInstall).
 
 To build from source, see instructions
-[here](https://github.com/timescale/timescaledb/blob/master/docs/BuildSource.md).
+[here](https://github.com/timescale/timescaledb/blob/main/docs/BuildSource.md).
 
 
 ## Resources
@@ -173,6 +173,6 @@ multiple workers.
 
 ### Contributing
 
-- [Contributor instructions](https://github.com/timescale/timescaledb/blob/master/CONTRIBUTING.md)
-- [Code style guide](https://github.com/timescale/timescaledb/blob/master/docs/StyleGuide.md)
+- [Contributor instructions](https://github.com/timescale/timescaledb/blob/main/CONTRIBUTING.md)
+- [Code style guide](https://github.com/timescale/timescaledb/blob/main/docs/StyleGuide.md)
 

--- a/docs/BuildSource.md
+++ b/docs/BuildSource.md
@@ -4,7 +4,7 @@
 
 If you are building from source for **non-development purposes**
 (i.e., you want to run TimescaleDB, not submit a patch), you should
-**always use a release-tagged commit and not build from `master`**.
+**always use a release-tagged commit and not build from `main`**.
 See the Releases tab for the latest release.
 
 **Prerequisites**:
@@ -37,7 +37,7 @@ Please see our [additional configuration instructions](https://docs.timescale.co
 
 If you are building from source for **non-development purposes**
 (i.e., you want to run TimescaleDB, not submit a patch), you should
-**always use a release-tagged commit and not build from `master`**.
+**always use a release-tagged commit and not build from `main`**.
 See the Releases tab for the latest release.
 
 **Prerequisites**:

--- a/test/sql/updates/README.md
+++ b/test/sql/updates/README.md
@@ -10,7 +10,7 @@ scenarios:
 - ALTER EXTENSION UPDATE
 
 # CONTAINER_CLEAN_RERUN:
-- install master
+- install main
 - run test setup script
 
 # CONTAINER_CLEAN_RESTORE:

--- a/tsl/test/t/004_multinode_rdwr_1pc.pl
+++ b/tsl/test/t/004_multinode_rdwr_1pc.pl
@@ -25,7 +25,7 @@ my $backup_name = 'my_backup';
 # Take backup
 $an->backup($backup_name);
 
-# Create streaming standby linking to master
+# Create streaming standby linking to access node
 my $an_standby = AccessNode->get_new_node('an_standby_1');
 $an_standby->init_from_backup($an, $backup_name, has_streaming => 1);
 $an_standby->start;


### PR DESCRIPTION
Following what many communities already did we agreed in renaming the
`master` branch to `main`.

Resources:
- https://sfconservancy.org/news/2020/jun/23/gitbranchname/
- https://postgr.es/m/20200615182235.x7lch5n6kcjq4aue@alap3.anarazel.de

Closes #4163