### PR TITLE
Scan less chunk metadata when planning ForeignModify

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -2666,6 +2666,15 @@ ts_chunk_id_from_relid(PG_FUNCTION_ARGS)
 	PG_RETURN_INT32(last_id);
 }
 
+int32
+ts_chunk_get_id_by_relid(Oid relid)
+{
+	FormData_chunk form;
+
+	chunk_simple_scan_by_relid(relid, &form, /* missing_ok = */ false);
+	return form.id;
+}
+
 bool
 ts_chunk_exists_relid(Oid relid)
 {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -152,6 +152,7 @@ extern Oid ts_chunk_get_relid(int32 chunk_id, bool missing_ok);
 extern Oid ts_chunk_get_schema_id(int32 chunk_id, bool missing_ok);
 extern bool ts_chunk_get_id(const char *schema, const char *table, int32 *chunk_id,
 							bool missing_ok);
+extern TSDLLEXPORT int32 ts_chunk_get_id_by_relid(Oid relid);
 extern bool ts_chunk_exists_relid(Oid relid);
 extern TSDLLEXPORT int ts_chunk_num_of_chunks_created_after(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_exists_with_compression(int32 hypertable_id);

--- a/tsl/src/fdw/modify_plan.c
+++ b/tsl/src/fdw/modify_plan.c
@@ -54,21 +54,21 @@ get_update_attrs(RangeTblEntry *rte)
 static List *
 get_chunk_data_nodes(Oid relid)
 {
-	Chunk *chunk = ts_chunk_get_by_relid(relid, false);
+	int32 chunk_id = ts_chunk_get_id_by_relid(relid);
+	Assert(chunk_id != 0);
+
+	List *chunk_data_nodes = ts_chunk_data_node_scan_by_chunk_id(chunk_id, CurrentMemoryContext);
 	List *serveroids = NIL;
 	ListCell *lc;
 
-	if (NULL == chunk)
-		return NIL;
-
-	foreach (lc, chunk->data_nodes)
+	foreach (lc, chunk_data_nodes)
 	{
-		ChunkDataNode *cs = lfirst(lc);
+		ChunkDataNode *data_node = lfirst(lc);
 
-		serveroids = lappend_oid(serveroids, cs->foreign_server_oid);
+		serveroids = lappend_oid(serveroids, data_node->foreign_server_oid);
 	}
 
-	ts_chunk_free(chunk);
+	list_free(chunk_data_nodes);
 
 	return serveroids;
 }


### PR DESCRIPTION
Instead of loading the entire Chunk struct, just look up the data
nodes. This improves the performance of planning of UPDATEs
of distributed hypertables.