### PR TITLE
Fix remote EXPLAIN with parameterized queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #4122 Fix segfault on INSERT into distributed hypertable
 * #4161 Fix memory handling during scans
+* #3974 Fix remote EXPLAIN with parameterized queries
 
 **Thanks**
 * @abrownsword for reporting a crash in the telemetry reporter
+* @daydayup863 for reporting issue with remote explain
 
 ## 2.6.0 (2022-02-16)
 This release is medium priority for upgrade. We recommend that you upgrade at the next available opportunity.

--- a/tsl/src/fdw/scan_exec.c
+++ b/tsl/src/fdw/scan_exec.c
@@ -480,8 +480,13 @@ fdw_scan_explain(ScanState *ss, List *fdw_private, ExplainState *es, TsFdwScanSt
 		/* fsstate should be set up but better check again to avoid crashes */
 		if (ts_guc_enable_remote_explain && fsstate)
 		{
-			const char *data_node_explain =
-				get_data_node_explain(fsstate->query, fsstate->conn, es);
+			char *data_node_explain;
+
+			/* EXPLAIN barfs on parameterized queries, so check that first */
+			if (fsstate->num_params >= 1)
+				data_node_explain = "Unavailable due to parameterized query";
+			else
+				data_node_explain = get_data_node_explain(fsstate->query, fsstate->conn, es);
 			ExplainPropertyText("Remote EXPLAIN", data_node_explain, es);
 		}
 	}


### PR DESCRIPTION
In certain multi-node queries, we end up using a parameterized query
on the datanodes. If "timescaledb.enable_remote_explain" is enabled we
run an EXPLAIN on the datanode with the remote query. EXPLAIN doesn't
work with parameterized queries. So, we check for that case and avoid
invoking a remote EXPLAIN if so.

Fixes #3974

Reported and test case provided by @daydayup863