### PR TITLE
Set minimum required cmake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.10)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
cmake > 3.10 is not packaged for some of the platforms we build
packages eg old ubuntu and debian version. Currently we modify
the CMakeLists.txt in those build environments and set the
minimum version to 3.10 already, which proofes that timescaledb
builds fine with cmake 3.10.