### PR TITLE
Fix owner change for distributed hypertable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The release also includes several bug fixes. Telemetry reports now include new a
 * #4015 Eliminate float rounding instabilities in interpolate
 * #4019 Update ts_extension_oid in transitioning state
 * #4073 Fix buffer overflow in partition scheme
+* #4180 ALTER TABLE OWNER TO does not work for distributed hypertable
 
 **Improvements**
 * Query planning performance is improved for hypertables with a large number of chunks.

--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -780,6 +780,7 @@ dist_ddl_process_alter_table(const ProcessUtilityArgs *args)
 			case AT_AlterColumnType:
 				exec_type = set_alter_table_exec_type(exec_type, DIST_DDL_EXEC_ON_END);
 				break;
+			case AT_ChangeOwner:
 			case AT_ReplaceRelOptions:
 			case AT_ResetRelOptions:
 			case AT_SetRelOptions:

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -462,6 +462,52 @@ ALTER TABLE some_schema.disttable SET SCHEMA public;
 ALTER TABLE disttable SET SCHEMA some_unexist_schema;
 ERROR:  schema "some_unexist_schema" does not exist
 \set ON_ERROR_STOP 1
+-- OWNER TO
+RESET ROLE;
+ALTER TABLE disttable OWNER TO :ROLE_2;
+SELECT tableowner FROM pg_tables WHERE tablename = 'disttable';
+ tableowner  
+-------------
+ test_role_2
+(1 row)
+
+SELECT * FROM test.remote_exec(NULL, $$
+SELECT tableowner FROM pg_tables WHERE tablename = 'disttable';
+$$);
+NOTICE:  [data_node_1]: 
+SELECT tableowner FROM pg_tables WHERE tablename = 'disttable'
+NOTICE:  [data_node_1]:
+tableowner 
+-----------
+test_role_2
+(1 row)
+
+
+NOTICE:  [data_node_2]: 
+SELECT tableowner FROM pg_tables WHERE tablename = 'disttable'
+NOTICE:  [data_node_2]:
+tableowner 
+-----------
+test_role_2
+(1 row)
+
+
+NOTICE:  [data_node_3]: 
+SELECT tableowner FROM pg_tables WHERE tablename = 'disttable'
+NOTICE:  [data_node_3]:
+tableowner 
+-----------
+test_role_2
+(1 row)
+
+
+ remote_exec 
+-------------
+ 
+(1 row)
+
+ALTER TABLE disttable OWNER TO :ROLE_1;
+SET ROLE :ROLE_1;
 -- Test unsupported operations on distributed hypertable
 \set ON_ERROR_STOP 0
 -- test set_replication_factor on non-hypertable

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -111,6 +111,18 @@ ALTER TABLE some_schema.disttable SET SCHEMA public;
 ALTER TABLE disttable SET SCHEMA some_unexist_schema;
 \set ON_ERROR_STOP 1
 
+-- OWNER TO
+RESET ROLE;
+ALTER TABLE disttable OWNER TO :ROLE_2;
+
+SELECT tableowner FROM pg_tables WHERE tablename = 'disttable';
+SELECT * FROM test.remote_exec(NULL, $$
+SELECT tableowner FROM pg_tables WHERE tablename = 'disttable';
+$$);
+
+ALTER TABLE disttable OWNER TO :ROLE_1;
+SET ROLE :ROLE_1;
+
 -- Test unsupported operations on distributed hypertable
 \set ON_ERROR_STOP 0
 


### PR DESCRIPTION
Allow ALTER TABLE OWNER TO command to be used with distributed
hypertable.

Fix #4180