### PR TITLE
Abort sessions after extension reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ accidentally triggering the load of a previous DB version.**
 * #4122 Fix segfault on INSERT into distributed hypertable
 * #4161 Fix memory handling during scans
 * #3974 Fix remote EXPLAIN with parameterized queries
+* #4192 Abort sessions after extension reload
 
 **Thanks**
 * @abrownsword for reporting a crash in the telemetry reporter


### PR DESCRIPTION
If a session is started and loads (and caches, by OID) functions in the
extension to use them in, for example, a `SELECT` query on a continuous
aggregate, the extension will be marked as loaded internally.

If an `ALTER EXTENSION` is then executed in a separate session, it will
update `pg_extension` to hold the new version, and any other sessions
will see this as the new version, including the session that already
loaded the previous version of the shared library.

Since the pre-update session has loaded some functions from the old
version already, running the same queries with the old named functions
will trigger a reload of the new version of the shared library to get
the new functions (same name, but different OID), but since this has
already been loaded in a different version, it will trigger an error
that GUC variables are re-defined.

Further queries after that will then corrupt the database causing a
crash.

This commit fixes this by recording the version loaded rather than if
it has been loaded and check that the version did not change after a
query has been analyzed (in the `post_analyze_hook`). If the version
changed, it will generate a fatal error to force an abort of the
session.

Fixes #4191