### PR TITLE
Use virtual tuples in row-by-row fetcher

### DIFF
--- a/tsl/src/fdw/scan_exec.c
+++ b/tsl/src/fdw/scan_exec.c
@@ -283,23 +283,12 @@ TupleTableSlot *
 fdw_scan_iterate(ScanState *ss, TsFdwScanState *fsstate)
 {
 	TupleTableSlot *slot = ss->ss_ScanTupleSlot;
-	HeapTuple tuple;
 	DataFetcher *fetcher = fsstate->fetcher;
 
 	if (NULL == fetcher)
 		fetcher = create_data_fetcher(ss, fsstate);
 
-	tuple = fetcher->funcs->get_next_tuple(fetcher);
-
-	if (NULL == tuple)
-		return ExecClearTuple(slot);
-
-	/*
-	 * Return the next tuple. Must force the tuple into the slot since
-	 * CustomScan initializes ss_ScanTupleSlot to a VirtualTupleTableSlot
-	 * while we're storing a HeapTuple.
-	 */
-	ExecForceStoreHeapTuple(tuple, slot, false);
+	fetcher->funcs->store_next_tuple(fetcher, slot);
 
 	return slot;
 }

--- a/tsl/src/remote/cursor_fetcher.c
+++ b/tsl/src/remote/cursor_fetcher.c
@@ -50,8 +50,7 @@ static void cursor_fetcher_send_fetch_request(DataFetcher *df);
 static int cursor_fetcher_fetch_data(DataFetcher *df);
 static void cursor_fetcher_set_fetch_size(DataFetcher *df, int fetch_size);
 static void cursor_fetcher_set_tuple_memcontext(DataFetcher *df, MemoryContext mctx);
-static HeapTuple cursor_fetcher_get_next_tuple(DataFetcher *df);
-static HeapTuple cursor_fetcher_get_tuple(DataFetcher *df, int row);
+static void cursor_fetcher_store_next_tuple(DataFetcher *df, TupleTableSlot *slot);
 static void cursor_fetcher_rewind(DataFetcher *df);
 static void cursor_fetcher_close(DataFetcher *df);
 
@@ -60,8 +59,7 @@ static DataFetcherFuncs funcs = {
 	.fetch_data = cursor_fetcher_fetch_data,
 	.set_fetch_size = cursor_fetcher_set_fetch_size,
 	.set_tuple_mctx = cursor_fetcher_set_tuple_memcontext,
-	.get_next_tuple = cursor_fetcher_get_next_tuple,
-	.get_tuple = cursor_fetcher_get_tuple,
+	.store_next_tuple = cursor_fetcher_store_next_tuple,
 	.rewind = cursor_fetcher_rewind,
 	.close = cursor_fetcher_close,
 };
@@ -384,20 +382,12 @@ cursor_fetcher_fetch_data(DataFetcher *df)
 	return cursor_fetcher_fetch_data_complete(cursor);
 }
 
-static HeapTuple
-cursor_fetcher_get_tuple(DataFetcher *df, int row)
+static void
+cursor_fetcher_store_next_tuple(DataFetcher *df, TupleTableSlot *slot)
 {
 	CursorFetcher *cursor = cast_fetcher(CursorFetcher, df);
 
-	return data_fetcher_get_tuple(&cursor->state, row);
-}
-
-static HeapTuple
-cursor_fetcher_get_next_tuple(DataFetcher *df)
-{
-	CursorFetcher *cursor = cast_fetcher(CursorFetcher, df);
-
-	return data_fetcher_get_next_tuple(&cursor->state);
+	data_fetcher_store_next_tuple(&cursor->state, slot);
 }
 
 static void

--- a/tsl/src/remote/data_fetcher.h
+++ b/tsl/src/remote/data_fetcher.h
@@ -28,8 +28,7 @@ typedef struct DataFetcherFuncs
 	/* Set the fetch (batch) size */
 	void (*set_fetch_size)(DataFetcher *data_fetcher, int fetch_size);
 	void (*set_tuple_mctx)(DataFetcher *data_fetcher, MemoryContext mctx);
-	HeapTuple (*get_next_tuple)(DataFetcher *data_fetcher);
-	HeapTuple (*get_tuple)(DataFetcher *data_fetcher, int row);
+	void (*store_next_tuple)(DataFetcher *data_fetcher, TupleTableSlot *slot);
 	void (*rewind)(DataFetcher *data_fetcher);
 	void (*close)(DataFetcher *data_fetcher);
 } DataFetcherFuncs;
@@ -67,8 +66,8 @@ extern void data_fetcher_init(DataFetcher *df, TSConnection *conn, const char *s
 							  StmtParams *params, Relation rel, ScanState *ss,
 							  List *retrieved_attrs);
 
-extern HeapTuple data_fetcher_get_tuple(DataFetcher *df, int row);
-extern HeapTuple data_fetcher_get_next_tuple(DataFetcher *df);
+extern void data_fetcher_store_tuple(DataFetcher *df, int row, TupleTableSlot *slot);
+extern void data_fetcher_store_next_tuple(DataFetcher *df, TupleTableSlot *slot);
 extern void data_fetcher_set_fetch_size(DataFetcher *df, int fetch_size);
 extern void data_fetcher_set_tuple_mctx(DataFetcher *df, MemoryContext mctx);
 extern void data_fetcher_validate(DataFetcher *df);

--- a/tsl/src/remote/tuplefactory.h
+++ b/tsl/src/remote/tuplefactory.h
@@ -21,8 +21,11 @@ extern TupleFactory *tuplefactory_create_for_tupdesc(TupleDesc tupdesc, bool for
 extern TupleFactory *tuplefactory_create_for_rel(Relation rel, List *retrieved_attrs);
 extern TupleFactory *tuplefactory_create_for_scan(ScanState *ss, List *retrieved_attrs);
 extern HeapTuple tuplefactory_make_tuple(TupleFactory *tf, PGresult *res, int row, int format);
+extern ItemPointer tuplefactory_make_virtual_tuple(TupleFactory *tf, PGresult *res, int row,
+												   int format, Datum *values, bool *nulls);
 extern bool tuplefactory_is_binary(TupleFactory *tf);
 extern void tuplefactory_set_per_tuple_mctx_reset(TupleFactory *tf, bool reset);
 extern void tuplefactory_reset_mctx(TupleFactory *tf);
+extern int tuplefactory_get_nattrs(TupleFactory *tf);
 
 #endif /* TIMESCALEDB_TSL_REMOTE_TUPLEFACTORY_H */


### PR DESCRIPTION
We needlessly form/deform the heap tuples currently. Sometimes we do
need heap tuples when we have row marks and need a ctid (UPDATE RETURNING),
but not in this case. The implementation has three parts:

1. Change data fetcher interface to store a tuple into given slot
instead of returning a heap tuple.

2. Expose the creation of virtual tuple in tuple factory.

3. Use these facilities in row-by-row fetcher.

This gives some small speedup. It will become more important in the
future, as other parts of row-by-row fetcher are optimized.