### PR TITLE
Move the check to a more appropriate place

### DIFF
--- a/tsl/src/fdw/data_node_scan_exec.c
+++ b/tsl/src/fdw/data_node_scan_exec.c
@@ -66,15 +66,6 @@ data_node_scan_next(CustomScanState *node)
 	slot = fdw_scan_iterate(&node->ss, &sss->fsstate);
 	MemoryContextSwitchTo(oldcontext);
 
-	/* Raise an error when system column is requsted, eg. tableoid */
-	if (sss->systemcol && !TupIsNull(slot))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("system columns are not accessible on distributed hypertables with current "
-						"settings"),
-				 errhint("Set timescaledb.enable_per_data_node_queries=false to query system "
-						 "columns.")));
-
 	return slot;
 }
 

--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -634,6 +634,15 @@ data_node_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *best_
 		bms_free(attrs_used);
 	}
 
+	/* Raise an error when system column is requsted, eg. tableoid */
+	if (scaninfo.systemcol)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("system columns are not accessible on distributed hypertables with current "
+						"settings"),
+				 errhint("Set timescaledb.enable_per_data_node_queries=false to query system "
+						 "columns.")));
+
 	/* Should have determined the fetcher type by now. */
 	Assert(ts_data_node_fetcher_scan_type != AutoFetcherType);
 


### PR DESCRIPTION
Before, we would complain that we don't support fetching the system
columns with per-data node queries enabled, but still execute the code
that fetches it. Don't do this and complain earlier.