### PR TITLE
Release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,22 @@ accidentally triggering the load of a previous DB version.**
 * #4169 Add support for chunk exclusion on DELETE to PG14
 * #4209 Add support for chunk exclusion on UPDATE to PG14
 
+## 2.6.1 (2022-04-11)
+This release is patch release. We recommend that you upgrade at the next available opportunity.
+
 **Bugfixes**
-* #3974 Fix remote EXPLAIN with parameterized queries
+* #4121 Fix RENAME TO/SET SCHEMA on distributed hypertable
 * #4122 Fix segfault on INSERT into distributed hypertable
-* #4161 Fix memory handling during scans
-* #4192 Abort sessions after extension reload
+* #4142 Ignore invalid relid when deleting hypertable
 * #4159 Fix ADD COLUMN IF NOT EXISTS error on compressed hypertable
+* #4161 Fix memory handling during scans
+* #4176 Fix remote EXPLAIN with parameterized queries
+* #4181 Fix spelling errors and omissions
+* #4186 Fix owner change for distributed hypertable
+* #4192 Abort sessions after extension reload
+* #4193 Fix relcache callback handling causing crashes
+* #4199 Remove signal-unsafe calls from signal handlers
+* #4219 Do not modify aggregation state in finalize
 
 **Thanks**
 * @abrownsword for reporting a crash in the telemetry reporter

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -33,7 +33,8 @@ set(MOD_FILES
     updates/2.4.2--2.5.0.sql
     updates/2.5.0--2.5.1.sql
     updates/2.5.1--2.5.2.sql
-    updates/2.5.2--2.6.0.sql)
+    updates/2.5.2--2.6.0.sql
+    updates/2.6.0--2.6.1.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.7.0-dev
-update_from_version = 2.6.0
+update_from_version = 2.6.1
 downgrade_to_version = 2.6.0


### PR DESCRIPTION
This release is patch release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* #3974 Fix remote EXPLAIN with parameterized queries
* #4122 Fix segfault on INSERT into distributed hypertable
* #4142 Ignore invalid relid when deleting hypertable
* #4159 Fix ADD COLUMN IF NOT EXISTS error on compressed hypertable
* #4161 Fix memory handling during scans
* #4186 Fix owner change for distributed hypertable
* #4192 Abort sessions after extension reload
* #4193 Fix relcache callback handling causing crashes

**Thanks**
* @abrownsword for reporting a crash in the telemetry reporter
* @daydayup863 for reporting issue with remote explain