### PR TITLE
Fix TRUNCATE error as non-owner on hypertable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ accidentally triggering the load of a previous DB version.**
 * #4169 Add support for chunk exclusion on DELETE to PG14
 * #4209 Add support for chunk exclusion on UPDATE to PG14
 
+**Bugfixes**
+* #4225 Fix TRUNCATE error as non-owner on hypertable
+
 ## 2.6.1 (2022-04-11)
 This release is patch release. We recommend that you upgrade at the next available opportunity.
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1061,8 +1061,6 @@ process_truncate(ProcessUtilityArgs *args)
 
 						agg_status = ts_continuous_agg_hypertable_status(ht->fd.id);
 
-						ts_hypertable_permissions_check_by_id(ht->fd.id);
-
 						if ((agg_status & HypertableIsMaterialization) != 0)
 							ereport(ERROR,
 									(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -231,3 +231,36 @@ SELECT * FROM truncate_normal, truncate_nested;
 -------+-------
 (0 rows)
 
+-- test TRUNCATE can be performed by a user 
+-- with TRUNCATE privilege who is not table owner
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE ROLE owner WITH LOGIN;
+CREATE ROLE truncator WITH LOGIN;
+CREATE DATABASE test_trunc_ht OWNER owner;
+\c test_trunc_ht :ROLE_SUPERUSER
+SET client_min_messages = ERROR;
+CREATE EXTENSION timescaledb;
+RESET client_min_messages;
+\c test_trunc_ht owner
+CREATE TABLE test_hypertable (time TIMESTAMP WITHOUT TIME ZONE NOT NULL, value DOUBLE PRECISION);
+SELECT create_hypertable('test_hypertable', 'time');
+      create_hypertable       
+------------------------------
+ (1,public,test_hypertable,t)
+(1 row)
+
+-- fail since we don't have TRUNCATE privileges yet
+\set ON_ERROR_STOP 0
+\c test_trunc_ht truncator
+TRUNCATE TABLE test_hypertable;
+ERROR:  permission denied for table test_hypertable
+\set ON_ERROR_STOP 1
+\c test_trunc_ht owner
+GRANT TRUNCATE ON test_hypertable TO truncator;
+-- now succeed after privilege was granted
+\c test_trunc_ht truncator;
+TRUNCATE TABLE test_hypertable;
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DROP DATABASE test_trunc_ht;
+DROP ROLE owner;
+DROP ROLE truncator;


### PR DESCRIPTION
Stop throwing error "must be owner of hypertable" when a user with
TRUNCATE privilege on the hypertable attempts to TRUNCATE.

Previously we had a check that required TRUNCATE to only be
performed by the table owner, not taking into account the user's
TRUNCATE privilege, which is sufficient to allow this operation.

Fixes #4183