### PR TITLE
Fix Coverity defect 376602

### DIFF
--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -734,8 +734,8 @@ ts_dimension_slice_scan_iterator_get_by_id(ScanIterator *it, int32 slice_id,
 	ts_scan_iterator_start_or_restart_scan(it);
 	ti = ts_scan_iterator_next(it);
 	Assert(ti);
-	Assert(ts_scan_iterator_next(it) == NULL);
-	return ts_dimension_slice_from_tuple(ti);
+	Assert(ts_scan_iterator_next(it) == NULL); /* This is a heavy call, consider removing it */
+	return ti ? ts_dimension_slice_from_tuple(ti) : NULL;
 }
 
 DimensionSlice *

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -221,7 +221,7 @@ simple8brle_serialized_recv(StringInfo buffer)
 	data->num_elements = num_elements;
 	data->num_blocks = num_blocks;
 
-	for (i = 0; i < data->num_blocks + num_selector_slots; i++)
+	for (i = 0; i < num_blocks + num_selector_slots; i++)
 		data->slots[i] = pq_getmsgint64(buffer);
 
 	return data;


### PR DESCRIPTION
Fix the potential NULL pointer dereference in
ts_dimension_slice_scan_iterator_get_by_id().