### PR TITLE
Don't export local reorder function

### DIFF
--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -597,7 +597,7 @@ loader_process_utility_hook(PlannedStmt *pstmt, const char *query_string,
 }
 
 static void
-timescale_shmem_startup_hook(void)
+timescaledb_shmem_startup_hook(void)
 {
 	if (prev_shmem_startup_hook)
 		prev_shmem_startup_hook();
@@ -656,7 +656,7 @@ _PG_init(void)
 	prev_shmem_startup_hook = shmem_startup_hook;
 
 	post_parse_analyze_hook = post_analyze_hook;
-	shmem_startup_hook = timescale_shmem_startup_hook;
+	shmem_startup_hook = timescaledb_shmem_startup_hook;
 
 	/* register utility hook to handle a distributed database drop */
 	prev_ProcessUtility_hook = ProcessUtility_hook;

--- a/src/planner.c
+++ b/src/planner.c
@@ -1277,8 +1277,8 @@ replace_hypertable_modify_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 }
 
 static void
-timescale_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage, RelOptInfo *input_rel,
-								  RelOptInfo *output_rel, void *extra)
+timescaledb_create_upper_paths_hook(PlannerInfo *root, UpperRelationKind stage,
+									RelOptInfo *input_rel, RelOptInfo *output_rel, void *extra)
 {
 	Query *parse = root->parse;
 	bool partials_found = false;
@@ -1471,7 +1471,7 @@ _planner_init(void)
 	get_relation_info_hook = timescaledb_get_relation_info_hook;
 
 	prev_create_upper_paths_hook = create_upper_paths_hook;
-	create_upper_paths_hook = timescale_create_upper_paths_hook;
+	create_upper_paths_hook = timescaledb_create_upper_paths_hook;
 }
 
 void


### PR DESCRIPTION
Change reorder_rel function to not be exported and also removes the
timescale_ function name prefix from local functions.

Disable-check: commit-count

