### PR TITLE
Function telemetry

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -19,22 +19,32 @@
 typedef enum TelemetryLevel
 {
 	TELEMETRY_OFF,
+	TELEMETRY_NO_FUNCTIONS,
 	TELEMETRY_BASIC,
 } TelemetryLevel;
 
 /* Define which level means on. We use this object to have at least one object
  * of type TelemetryLevel in the code, otherwise pgindent won't work for the
  * type */
-static const TelemetryLevel on_level = TELEMETRY_BASIC;
+static const TelemetryLevel on_level = TELEMETRY_NO_FUNCTIONS;
 
 bool
 ts_telemetry_on()
 {
-	return ts_guc_telemetry_level == on_level;
+	return ts_guc_telemetry_level >= on_level;
+}
+
+bool
+ts_function_telemetry_on()
+{
+	return ts_guc_telemetry_level > TELEMETRY_NO_FUNCTIONS;
 }
 
 static const struct config_enum_entry telemetry_level_options[] = {
-	{ "off", TELEMETRY_OFF, false }, { "basic", TELEMETRY_BASIC, false }, { NULL, 0, false }
+	{ "off", TELEMETRY_OFF, false },
+	{ "no_functions", TELEMETRY_NO_FUNCTIONS, false },
+	{ "basic", TELEMETRY_BASIC, false },
+	{ NULL, 0, false }
 };
 #endif
 

--- a/src/guc.h
+++ b/src/guc.h
@@ -12,6 +12,7 @@
 
 #ifdef USE_TELEMETRY
 extern bool ts_telemetry_on(void);
+extern bool ts_function_telemetry_on(void);
 #endif
 
 extern bool ts_guc_enable_optimizations;

--- a/src/loader/CMakeLists.txt
+++ b/src/loader/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     bgw_counter.c
     bgw_launcher.c
     bgw_interface.c
+    function_telemetry.c
     lwlocks.c
     seclabel.c)
 

--- a/src/loader/function_telemetry.c
+++ b/src/loader/function_telemetry.c
@@ -1,0 +1,69 @@
+
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <fmgr.h>
+
+#include <port/atomics.h>
+#include <storage/lwlock.h>
+#include <storage/shmem.h>
+
+#include "loader/function_telemetry.h"
+
+// Function telemetry hash table size. Sized to be large enough that we're
+// unlikely to run out of entries, but small enough that it won't have a
+// noticeable impact.
+#define FN_TELEMETRY_HASH_SIZE 10000
+
+static FnTelemetryRendezvous rendezvous;
+
+void
+ts_function_telemetry_shmem_startup()
+{
+	FnTelemetryRendezvous **rendezvous_ptr;
+	HASHCTL hash_info;
+	HTAB *function_telemetry_hash;
+	LWLock **lock;
+	bool found;
+
+	// NOTE: dshash would be better once it's stable
+	hash_info.keysize = sizeof(Oid);
+	hash_info.entrysize = sizeof(FnTelemetryHashEntry);
+
+	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+
+	/*
+	 * GetNamedLWLockTranche must only be run once on windows, otherwise it
+	 * segfaults. Since the shmem_startup_hook is run on every backend, we use
+	 * a ShmemInitStruct to detect if this function has been called before.
+	 */
+	lock = ShmemInitStruct("fn_telemetry_detect_first_run", sizeof(LWLock *), &found);
+	if (!found)
+		*lock = &(GetNamedLWLockTranche(FN_TELEMETRY_LWLOCK_TRANCHE_NAME))->lock;
+
+	function_telemetry_hash = ShmemInitHash("timescaledb function telemetry hash",
+											FN_TELEMETRY_HASH_SIZE,
+											FN_TELEMETRY_HASH_SIZE,
+											&hash_info,
+											HASH_ELEM | HASH_BLOBS);
+	LWLockRelease(AddinShmemInitLock);
+
+	rendezvous.lock = *lock;
+	rendezvous.function_counts = function_telemetry_hash;
+
+	rendezvous_ptr =
+		(FnTelemetryRendezvous **) find_rendezvous_variable(RENDEZVOUS_FUNCTION_TELEMENTRY);
+	*rendezvous_ptr = &rendezvous;
+}
+
+void
+ts_function_telemetry_shmem_alloc()
+{
+	Size size = hash_estimate_size(FN_TELEMETRY_HASH_SIZE, sizeof(FnTelemetryHashEntry));
+	RequestAddinShmemSpace(add_size(size, sizeof(LWLock *)));
+	RequestNamedLWLockTranche(FN_TELEMETRY_LWLOCK_TRANCHE_NAME, 1);
+}

--- a/src/loader/function_telemetry.h
+++ b/src/loader/function_telemetry.h
@@ -1,0 +1,30 @@
+
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#ifndef TIMESCALEDB_LOADER_FUNCTION_TELEMETRY_H
+#define TIMESCALEDB_LOADER_FUNCTION_TELEMETRY_H
+
+#define RENDEZVOUS_FUNCTION_TELEMENTRY "ts_function_telemetry"
+#define FN_TELEMETRY_LWLOCK_TRANCHE_NAME "ts_fn_telemetry_lwlock_tranche"
+
+typedef struct FnTelemetryRendezvous
+{
+	LWLock *lock;
+	HTAB *function_counts;
+} FnTelemetryRendezvous;
+
+typedef struct FnTelemetryHashEntry
+{
+	Oid key;
+	pg_atomic_uint64 count;
+} FnTelemetryHashEntry;
+
+extern void ts_function_telemetry_shmem_startup(void);
+
+extern void ts_function_telemetry_shmem_alloc(void);
+
+#endif /* TIMESCALEDB_LOADER_FUNCTION_TELEMETRY_H */

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -30,6 +30,7 @@
 #include "extension_constants.h"
 
 #include "loader/loader.h"
+#include "loader/function_telemetry.h"
 #include "loader/bgw_counter.h"
 #include "loader/bgw_interface.h"
 #include "loader/bgw_launcher.h"
@@ -606,6 +607,7 @@ timescaledb_shmem_startup_hook(void)
 	ts_bgw_counter_shmem_startup();
 	ts_bgw_message_queue_shmem_startup();
 	ts_lwlocks_shmem_startup();
+	ts_function_telemetry_shmem_startup();
 }
 
 static void
@@ -634,6 +636,7 @@ _PG_init(void)
 	ts_bgw_counter_setup_gucs();
 	ts_bgw_interface_register_api_version();
 	ts_seclabel_init();
+	ts_function_telemetry_shmem_alloc();
 
 	/* This is a safety-valve variable to prevent loading the full extension */
 	DefineCustomBoolVariable(GUC_DISABLE_LOAD_NAME,

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -67,6 +67,10 @@
 #include <utils/hashutils.h>
 #endif
 
+#ifdef USE_TELEMETRY
+#include "telemetry/functions.h"
+#endif
+
 /* define parameters necessary to generate the baserel info hash table interface */
 typedef struct BaserelInfoEntry
 {
@@ -430,6 +434,9 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 
 		if (ts_extension_is_loaded())
 		{
+#ifdef USE_TELEMETRY
+			ts_telemetry_function_info_gather(parse);
+#endif
 			/*
 			 * Preprocess the hypertables in the query and warm up the caches.
 			 */

--- a/src/telemetry/CMakeLists.txt
+++ b/src/telemetry/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Add all *.c to sources in upperlevel directory
 set(SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/stats.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/functions.c ${CMAKE_CURRENT_SOURCE_DIR}/stats.c
     ${CMAKE_CURRENT_SOURCE_DIR}/telemetry_metadata.c
     ${CMAKE_CURRENT_SOURCE_DIR}/telemetry.c)
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})

--- a/src/telemetry/functions.c
+++ b/src/telemetry/functions.c
@@ -1,0 +1,423 @@
+
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+#include <fmgr.h>
+
+#include <access/genam.h>
+#include <access/htup_details.h>
+#include <access/table.h>
+#include <catalog/indexing.h>
+#include <catalog/pg_depend.h>
+#include <catalog/pg_extension.h>
+#include <catalog/pg_proc.h>
+#include <commands/extension.h>
+#include <nodes/nodeFuncs.h>
+#include <port/atomics.h>
+#include <storage/lwlock.h>
+#include <utils/hsearch.h>
+#include <utils/fmgroids.h>
+
+#include <utils/regproc.h>
+
+#include "functions.h"
+
+#include "guc.h"
+#include "loader/function_telemetry.h"
+
+static bool skip_telemetry = false;
+static LWLock *function_counts_lock = NULL;
+static HTAB *function_counts;
+
+/***************************
+ * Telemetry draining code *
+ ***************************/
+
+typedef struct AllowedFnHashEntry
+{
+	Oid fn;
+} AllowedFnHashEntry;
+
+// Get a HTAB of AllowedFnHashEntrys containing all and only those functions
+// that are withing visible_extensions. This function should be equivalent to
+// the SQL
+//     SELECT objid
+//     FROM pg_catalog.pg_depend, pg_catalog.pg_extension extension
+//      WHERE refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass
+//        AND refobjid = extension.oid
+//        AND deptype = 'e'
+//        AND extname IN ('timescaledb','promscale','timescaledb_toolkit')
+//        AND classid = 'pg_catalog.pg_proc'::regclass;
+static HTAB *
+allowed_extension_functions(const char **visible_extensions, int num_visible_extensions)
+{
+	HASHCTL hash_info = {
+		.keysize = sizeof(Oid),
+		.entrysize = sizeof(AllowedFnHashEntry),
+	};
+	HTAB *allowed_fns =
+		hash_create("fn telemetry allowed_functions", 1000, &hash_info, HASH_ELEM | HASH_BLOBS);
+
+	Relation depRel = table_open(DependRelationId, AccessShareLock);
+
+	Oid *visible_extension_ids = palloc(num_visible_extensions * sizeof(Oid));
+
+	// get the Oid for each of the visible extensions
+	for (int i = 0; i < num_visible_extensions; i++)
+		visible_extension_ids[i] = get_extension_oid(visible_extensions[i], true);
+
+	// go through the objects owned by each visible extension, and store the
+	// ones that are functions in the set.
+	for (int i = 0; i < num_visible_extensions; i++)
+	{
+		HeapTuple tup;
+		ScanKeyData key[2];
+		SysScanDesc scan;
+		Oid extension_id = visible_extension_ids[i];
+
+		if (extension_id == InvalidOid)
+			continue;
+
+		// Look in the (referenced object class, referenced object) index for
+		// the allowed extensions.
+		ScanKeyInit(&key[0],
+					Anum_pg_depend_refclassid,
+					BTEqualStrategyNumber,
+					F_OIDEQ,
+					ObjectIdGetDatum(ExtensionRelationId));
+		ScanKeyInit(&key[1],
+					Anum_pg_depend_refobjid,
+					BTEqualStrategyNumber,
+					F_OIDEQ,
+					ObjectIdGetDatum(extension_id));
+
+		scan = systable_beginscan(depRel, DependReferenceIndexId, true, NULL, 2, key);
+
+		while (HeapTupleIsValid(tup = systable_getnext(scan)))
+		{
+			Form_pg_depend deprec = (Form_pg_depend) GETSTRUCT(tup);
+			// Filter for those objects that have an extension dependencies
+			// exist in pg_proc, those are the functions that live in the extension
+			if (deprec->deptype == 'e' && deprec->classid == ProcedureRelationId)
+			{
+				AllowedFnHashEntry *entry =
+					hash_search(allowed_fns, &deprec->objid, HASH_ENTER, NULL);
+				entry->fn = deprec->objid;
+			}
+		}
+
+		systable_endscan(scan);
+	}
+
+	table_close(depRel, AccessShareLock);
+
+	return allowed_fns;
+}
+
+static fn_telemetry_entry_vec *
+read_shared_map()
+{
+	HASH_SEQ_STATUS hash_seq;
+	long i;
+	long num_entries = hash_get_num_entries(function_counts);
+	fn_telemetry_entry_vec *entries =
+		fn_telemetry_entry_vec_create(CurrentMemoryContext, num_entries);
+
+	LWLockAcquire(function_counts_lock, LW_SHARED);
+
+	hash_seq_init(&hash_seq, function_counts);
+	// limit to num_entries so we don't hold the lock for a realloc
+	for (i = 0; i < num_entries; i++)
+	{
+		FnTelemetryEntry entry;
+		FnTelemetryHashEntry *hash_entry = hash_seq_search(&hash_seq);
+		if (!hash_entry)
+			break;
+
+		entry.fn = hash_entry->key;
+		/*
+		 * We never remove entries here, merely set their counts to 0. At
+		 * steady-state we expect the functions used by most workloads to be
+		 * effectively constant, so by keeping the hashmap entries allocated we
+		 * reduce contention during the telemetry-gathering stage. If memory
+		 * usage become an issue we can delete based off some heuristic, eg. if
+		 * the count starts out as 0.
+		 */
+		entry.count = pg_atomic_read_u64(&hash_entry->count);
+		if (entry.count != 0)
+			fn_telemetry_entry_vec_append(entries, entry);
+	}
+	if (i == num_entries)
+		hash_seq_term(&hash_seq);
+
+	LWLockRelease(function_counts_lock);
+
+	return entries;
+}
+
+/*
+ * Read the function telemetry shared-memory hashmap for telemetry send.
+ *
+ * This function gathers (function_id, count) pairs from the shared hashmap,
+ * and filters the set for the functions we're allowed to send back.
+ *
+ * In general, we should never send telemetry information about any functions
+ * except for core functions and those is a specified list of extensions
+ * (when originally written, the set of related_extensions along with
+ * timescaledb itself), so this function is designed to make it difficult to do
+ * so.
+ *
+ * @param visible_extensions list of extensions whose functions should be
+ *                           returned
+ * @param num_visible_extensions length of visible_extensions
+ * @return vector of FnTelemetryEntry containing (function_id, count)s for the
+ *         functions in visible_extensions.
+ *
+ */
+fn_telemetry_entry_vec *
+ts_function_telemetry_read(const char **visible_extensions, int num_visible_extensions)
+{
+	fn_telemetry_entry_vec *entries_to_send;
+	fn_telemetry_entry_vec *all_entries;
+	HTAB *allowed_ext_fns;
+
+	if (!function_counts)
+		return NULL;
+
+	all_entries = read_shared_map();
+	entries_to_send =
+		fn_telemetry_entry_vec_create(CurrentMemoryContext, all_entries->num_elements);
+	allowed_ext_fns = allowed_extension_functions(visible_extensions, num_visible_extensions);
+
+	for (uint32 i = 0; i < all_entries->num_elements; i++)
+	{
+		FnTelemetryEntry *entry = fn_telemetry_entry_vec_at(all_entries, i);
+		bool is_builtin = entry->fn >= 1 && entry->fn <= 9999;
+		bool is_visible = is_builtin || hash_search(allowed_ext_fns, &entry->fn, HASH_FIND, NULL);
+		if (is_visible)
+			fn_telemetry_entry_vec_append(entries_to_send, *entry);
+	}
+
+	return entries_to_send;
+}
+
+/*
+ * Reset the counts in the function telemetry shared-memory hashmap.
+ *
+ * This function resets the shared function counts after we send back telemetry
+ * in preparation for the next recording cycle. Note that there is no way to
+ * atomically read and reset the counts in the shared hashmap, so writes that
+ * occur between sending the old counts and reseting for the next cycle will be
+ * lost. Since this this telemetry is only ever an approximation of reality, we
+ * believe this loss is acceptable considering that the alternatives are
+ * resetting the counts whenever the telemetry is read (potentially even more
+ * lossy), or holding the lock for the entire telemetry send (to long a
+ * contention window).
+ */
+void
+ts_function_telemetry_reset_counts()
+{
+	HASH_SEQ_STATUS hash_seq;
+	if (!function_counts)
+		return;
+
+	LWLockAcquire(function_counts_lock, LW_SHARED);
+
+	hash_seq_init(&hash_seq, function_counts);
+	// limit to num_entries so we don't hold the lock for a realloc
+	while (true)
+	{
+		FnTelemetryHashEntry *hash_entry = hash_seq_search(&hash_seq);
+		if (!hash_entry)
+			break;
+
+		/*
+		 * We never remove entries here, merely set their counts to 0. At
+		 * steady-state we expect the functions used by most workloads to be
+		 * effectively constant, so by keeping the hashmap entries allocated we
+		 * reduce contention during the telemetry-gathering stage. If memory
+		 * usage become an issue we can delete based off some heuristic, eg. if
+		 * the count starts out as 0, though we will have to use a stronger
+		 * lock.
+		 */
+		pg_atomic_write_u64(&hash_entry->count, 0);
+	}
+
+	LWLockRelease(function_counts_lock);
+
+	return;
+}
+
+/****************************
+ * Telemetry gathering code *
+ ****************************/
+
+static bool
+function_telemetry_increment(Oid func_id, HTAB **local_counts)
+{
+	FnTelemetryEntry *entry;
+	bool found;
+
+	// if this is the first function we've seen initialize local_counts
+	if (!*local_counts)
+	{
+		HASHCTL hash_info = {
+			.keysize = sizeof(Oid),
+			.entrysize = sizeof(FnTelemetryEntry),
+		};
+		*local_counts =
+			hash_create("fn telemetry local function hash", 10, &hash_info, HASH_ELEM | HASH_BLOBS);
+	}
+
+	entry = hash_search(*local_counts, &func_id, HASH_ENTER, &found);
+	if (!found)
+		entry->count = 0;
+
+	entry->count += 1;
+
+	return true;
+}
+
+static bool
+function_gather_checker(Oid func_id, void *context)
+{
+	function_telemetry_increment(func_id, context);
+	return false;
+}
+
+static bool
+function_gather_walker(Node *node, void *context)
+{
+	bool end_early;
+
+	if (node == NULL)
+		return false;
+
+	end_early = check_functions_in_node(node, function_gather_checker, context);
+	if (end_early)
+		return true;
+
+	if (IsA(node, Query))
+	{
+		/* Recurse into subselects */
+		return query_tree_walker((Query *) node, function_gather_walker, context, 0);
+	}
+	return expression_tree_walker(node, function_gather_walker, context);
+}
+
+static HTAB *
+record_function_counts(Query *query)
+{
+	HTAB *query_function_counts = NULL;
+	query_tree_walker(query, function_gather_walker, &query_function_counts, 0);
+	return query_function_counts;
+}
+
+/*
+ * Store a map of (function_oid, count) into shared memory so it can be seen by
+ * the telemetry worker. This insertion works in two phases:
+ *   1. Under a SHARED lock, we increment the counts of all those functions that
+ *      are already present in the map, using atomic fetch-add to prevent races.
+ *   2. Under an EXCLUSIVE lock, we insert entries for all those functions that
+ *      were not already in the map.
+ * At steady state we expect that vast majority the time all the functions a
+ * query uses will already be in the shared map, so this strategy should
+ * minimize contention between queries.
+ *
+ * @param query_function_counts A hashtable of FnTelemetryEntry storing
+ *                              function usage counts
+ */
+static void
+store_function_counts_in_shared_mem(HTAB *query_function_counts)
+{
+	HASH_SEQ_STATUS hash_seq;
+	FnTelemetryEntry *local_entry = NULL;
+	fn_telemetry_entry_vec missing_entries;
+	fn_telemetry_entry_vec_init(&missing_entries, CurrentMemoryContext, 0);
+
+	/*
+	 * Increment the counts of any functions already in the table under a
+	 * shared lock; the atomicity of increments will handle concurrency.
+	 */
+	LWLockAcquire(function_counts_lock, LW_SHARED);
+	hash_seq_init(&hash_seq, query_function_counts);
+
+	while ((local_entry = hash_seq_search(&hash_seq)))
+	{
+		FnTelemetryHashEntry *shared_entry =
+			hash_search(function_counts, &local_entry->fn, HASH_FIND, NULL);
+
+		if (shared_entry)
+			pg_atomic_fetch_add_u64(&shared_entry->count, local_entry->count);
+		else
+			fn_telemetry_entry_vec_append(&missing_entries, *local_entry);
+	}
+
+	LWLockRelease(function_counts_lock);
+
+	/*
+	 * If any functions did not have an entries create them under an
+	 * exclusive lock
+	 */
+	if (missing_entries.num_elements > 0)
+	{
+		LWLockAcquire(function_counts_lock, LW_EXCLUSIVE);
+		for (uint32 i = 0; i < missing_entries.num_elements; i++)
+		{
+			bool found = false;
+			FnTelemetryEntry *missing_entry = fn_telemetry_entry_vec_at(&missing_entries, i);
+			FnTelemetryHashEntry *shared_entry =
+				hash_search(function_counts, &missing_entry->fn, HASH_ENTER_NULL, &found);
+
+			if (!shared_entry)
+				break;
+
+			if (found)
+				pg_atomic_fetch_add_u64(&shared_entry->count, missing_entry->count);
+			else
+				pg_atomic_init_u64(&shared_entry->count, missing_entry->count);
+		}
+		LWLockRelease(function_counts_lock);
+	}
+}
+
+/*
+ * Gather function usage telemetry for a query.
+ *
+ * This function walks a query looking for function Oids, counts their
+ * occurrence, and stores the (function_id, count) set into the shared-memory
+ * function telemetry hashtable for later processing by the telemetry background
+ * worker.
+ */
+void
+ts_telemetry_function_info_gather(Query *query)
+{
+	HTAB *query_function_counts;
+
+	if (skip_telemetry || !ts_function_telemetry_on())
+		return;
+
+	// At the first time through initialize the shared state
+	if (function_counts == NULL)
+	{
+		FnTelemetryRendezvous **rendezvous =
+			(FnTelemetryRendezvous **) find_rendezvous_variable(RENDEZVOUS_FUNCTION_TELEMENTRY);
+
+		if (*rendezvous == NULL)
+		{
+			skip_telemetry = true;
+			return;
+		}
+
+		function_counts = (*rendezvous)->function_counts;
+		function_counts_lock = (*rendezvous)->lock;
+	}
+
+	query_function_counts = record_function_counts(query);
+
+	if (query_function_counts)
+		store_function_counts_in_shared_mem(query_function_counts);
+}

--- a/src/telemetry/functions.h
+++ b/src/telemetry/functions.h
@@ -1,0 +1,30 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_TELEMETRY_FUNCTIONS_H
+#define TIMESCALEDB_TELEMETRY_FUNCTIONS_H
+
+#include <postgres.h>
+
+typedef struct FnTelemetryEntry
+{
+	Oid fn;
+	uint64 count;
+} FnTelemetryEntry;
+
+#define VEC_PREFIX fn_telemetry_entry
+#define VEC_ELEMENT_TYPE FnTelemetryEntry
+#define VEC_DECLARE 1
+#define VEC_DEFINE 1
+#define VEC_SCOPE static inline
+#include <adts/vec.h>
+
+extern void ts_telemetry_function_info_gather(Query *query);
+
+extern fn_telemetry_entry_vec *ts_function_telemetry_read(const char **visible_extensions,
+														  int num_visible_extensions);
+extern void ts_function_telemetry_reset_counts(void);
+
+#endif /* TIMESCALEDB_TELEMETRY_FUNCTIONS_H */

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -375,6 +375,7 @@ WHERE key != 'os_name_pretty';
  data_volume
  db_metadata
  build_os_name
+ functions_used
  install_method
  installed_time
  last_tuned_time
@@ -393,7 +394,7 @@ WHERE key != 'os_name_pretty';
  num_user_defined_actions
  build_architecture_bit_size
  num_continuous_aggs_policies
-(27 rows)
+(28 rows)
 
 CREATE MATERIALIZED VIEW telemetry_report AS
 SELECT t FROM get_telemetry_report() t;
@@ -459,6 +460,107 @@ SELECT :'installed_time' = :'installed_time2' AS equal, length(:'installed_time'
 (1 row)
 
 RESET datestyle;
+-- test function call telemetry
+CREATE FUNCTION not_visible_in_telemetry() RETURNS INT AS $$
+    SELECT 1;
+$$ LANGUAGE SQL;
+-- drain old function call telemetry so we have fixed out put;
+SELECT FROM get_telemetry_report();
+--
+(1 row)
+
+-- call some arbirary functions
+SELECT 1 + 1, not_visible_in_telemetry(), 1 + 1, abs(-1), not_visible_in_telemetry()
+WHERE 1 + 1 = 2;
+ ?column? | not_visible_in_telemetry | ?column? | abs | not_visible_in_telemetry 
+----------+--------------------------+----------+-----+--------------------------
+        2 |                        1 |        2 |   1 |                        1
+(1 row)
+
+-- call some aggregates
+SELECT min(not_visible_in_telemetry()), sum(not_visible_in_telemetry());
+ min | sum 
+-----+-----
+   1 |   1
+(1 row)
+
+-- check that we can record from a prepared statement
+PREPARE record_from_prepared AS SELECT 1 - 1;
+-- execute 10 times to make sure turning it into generic plan works
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+EXECUTE record_from_prepared;
+ ?column? 
+----------
+        0
+(1 row)
+
+DEALLOCATE record_from_prepared;
+SELECT get_telemetry_report()->'functions_used';
+                                                                                                        ?column?                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"abs(integer)": 1, "min(integer)": 1, "sum(integer)": 1, "get_telemetry_report()": 1, "int4eq(integer,integer)": 1, "int4mi(integer,integer)": 11, "int4pl(integer,integer)": 3, "jsonb_object_field(jsonb,text)": 1}
+(1 row)
+
+-- check the report again to see if resetting works
+SELECT get_telemetry_report()->'functions_used';
+                              ?column?                              
+--------------------------------------------------------------------
+ {"get_telemetry_report()": 1, "jsonb_object_field(jsonb,text)": 1}
+(1 row)
+
 \c :TEST_DBNAME :ROLE_SUPERUSER
 TRUNCATE _timescaledb_catalog.metadata;
 SET timescaledb.telemetry_level=off;
@@ -483,3 +585,7 @@ SELECT key from _timescaledb_catalog.metadata;
 -----
 (0 rows)
 
+\set ON_ERROR_STOP 0
+-- test that the telemetry gathering code doesn't break nonexistent statements
+EXECUTE noexistent_statement;
+ERROR:  prepared statement "noexistent_statement" does not exist

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -3,6 +3,8 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 --telemetry tests that require a community license
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+-- function call info size is too variable for this test, so disable it
+SET timescaledb.telemetry_level='no_functions';
 SELECT setseed(1);
  setseed 
 ---------

--- a/tsl/test/sql/telemetry_stats.sql
+++ b/tsl/test/sql/telemetry_stats.sql
@@ -5,6 +5,9 @@
 --telemetry tests that require a community license
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 
+-- function call info size is too variable for this test, so disable it
+SET timescaledb.telemetry_level='no_functions';
+
 SELECT setseed(1);
 
 -- Create a materialized view from the telemetry report so that we


### PR DESCRIPTION
This PR extends our telemetry system with function call telemetry. It gathers function call-counts from all queries, and send back counts for those functions that are built in or from our related extensions.

See [the RFC](https://docs.google.com/document/d/1wy_ma4RzCNceCDkR6HAC1NPZffdHJTOWTy4QhGPsXsY/edit#heading=h.6bq5eesegmp8) (internal link) for more details.