### PR TITLE
Fix compress_chunk error message

### DIFF
--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -98,7 +98,7 @@ static void
 get_hypertable_or_cagg_name(Hypertable *ht, Name objname)
 {
 	ContinuousAggHypertableStatus status = ts_continuous_agg_hypertable_status(ht->fd.id);
-	if (status == HypertableIsNotContinuousAgg)
+	if (status == HypertableIsNotContinuousAgg || status == HypertableIsRawTable)
 		namestrcpy(objname, NameStr(ht->fd.table_name));
 	else if (status == HypertableIsMaterialization)
 	{

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -704,3 +704,7 @@ FROM
       AND uncompress.table_name = 'comp_ht_test') \gset
 CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
 ERROR:  hypertable is an internal compressed hypertable
+--TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
+--Check error handling for this case
+SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
+ERROR:  compression not enabled on "i2980"

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -602,3 +602,6 @@ FROM
 
 CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
 
+--TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
+--Check error handling for this case
+SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;


### PR DESCRIPTION
When we have a hypertable with a cagg defined on it,
a call to the compress_chunk with the hypertable's chunk
returns an unexpected status error. Fix the error message
to return "compression not enabled"