### PR TITLE
Fix flaky dist grant tests

### DIFF
--- a/test/runner.sh
+++ b/test/runner.sh
@@ -100,6 +100,7 @@ export TEST_DBNAME
 
 # we strip out any output between <exclude_from_test></exclude_from_test>
 # and the part about memory usage in EXPLAIN ANALYZE output of Sort nodes
+# also ignore the Postgres rehashing catalog debug messages from 'src/backend/utils/cache/catcache.c'
 ${PSQL} -U ${TEST_PGUSER} \
      -v ON_ERROR_STOP=1 \
      -v VERBOSITY=terse \
@@ -127,4 +128,9 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
      -v TEST_SUPPORT_FILE=${TEST_SUPPORT_FILE} \
-     "$@" -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' -e 's! Memory: [0-9]\{1,\}kB!!' -e 's! Memory Usage: [0-9]\{1,\}kB!!' -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!'
+     "$@" -d ${TEST_DBNAME} 2>&1 | \
+          sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
+               -e 's! Memory: [0-9]\{1,\}kB!!' \
+               -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
+               -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
+          grep -v 'DEBUG:  rehashing catalog cache id'

--- a/test/runner_shared.sh
+++ b/test/runner_shared.sh
@@ -60,6 +60,7 @@ cd ${EXE_DIR}/sql
 
 # we strip out any output between <exclude_from_test></exclude_from_test>
 # and the part about memory usage in EXPLAIN ANALYZE output of Sort nodes
+# also ignore the Postgres rehashing catalog debug messages from 'src/backend/utils/cache/catcache.c'
 ${PSQL} -U ${TEST_PGUSER} \
      -v ON_ERROR_STOP=1 \
      -v VERBOSITY=terse \
@@ -73,4 +74,10 @@ ${PSQL} -U ${TEST_PGUSER} \
      -v ROLE_DEFAULT_PERM_USER_2=${TEST_ROLE_DEFAULT_PERM_USER_2} \
      -v MODULE_PATHNAME="'timescaledb-${EXT_VERSION}'" \
      -v TSL_MODULE_PATHNAME="'timescaledb-tsl-${EXT_VERSION}'" \
-     "$@" -d ${TEST_DBNAME} 2>&1 | sed -e '/<exclude_from_test>/,/<\/exclude_from_test>/d'  -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' -e 's! Memory: [0-9]\{1,\}kB!!' -e 's! Memory Usage: [0-9]\{1,\}kB!!' -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!'
+     "$@" -d ${TEST_DBNAME} 2>&1 | \
+          sed  -e '/<exclude_from_test>/,/<\/exclude_from_test>/d' \
+               -e 's!_[0-9]\{1,\}_[0-9]\{1,\}_chunk!_X_X_chunk!g' \
+               -e 's! Memory: [0-9]\{1,\}kB!!' \
+               -e 's! Memory Usage: [0-9]\{1,\}kB!!' \
+               -e 's! Average  Peak Memory: [0-9]\{1,\}kB!!' | \
+          grep -v 'DEBUG:  rehashing catalog cache id'

--- a/tsl/test/expected/dist_grant-12.out
+++ b/tsl/test/expected/dist_grant-12.out
@@ -1042,7 +1042,6 @@ DEBUG:  [data1]: GRANT ALL ON DATABASE db_dist_grant_1 TO cluster_super_user
 DEBUG:  [data2]: GRANT ALL ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT ALL ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT ALL ON DATABASE db_dist_grant_4 TO cluster_super_user 
-DEBUG:  rehashing catalog cache id 77 for pg_user_mapping; 5 tups, 2 buckets
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user 
@@ -1126,7 +1125,6 @@ DEBUG:  skipping dist DDL on object: REVOKE ALL ON SCHEMA public FROM default_pe
 GRANT ALL ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON SCHEMA public TO default_perm_user;
 REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
-DEBUG:  rehashing catalog cache id 7 for pg_attribute; 257 tups, 128 buckets
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;

--- a/tsl/test/expected/dist_grant-13.out
+++ b/tsl/test/expected/dist_grant-13.out
@@ -1042,7 +1042,6 @@ DEBUG:  [data1]: GRANT ALL ON DATABASE db_dist_grant_1 TO cluster_super_user
 DEBUG:  [data2]: GRANT ALL ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT ALL ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT ALL ON DATABASE db_dist_grant_4 TO cluster_super_user 
-DEBUG:  rehashing catalog cache id 77 for pg_user_mapping; 5 tups, 2 buckets
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user 
@@ -1126,7 +1125,6 @@ DEBUG:  skipping dist DDL on object: REVOKE ALL ON SCHEMA public FROM default_pe
 GRANT ALL ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON SCHEMA public TO default_perm_user;
 REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
-DEBUG:  rehashing catalog cache id 7 for pg_attribute; 257 tups, 128 buckets
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;

--- a/tsl/test/expected/dist_grant-14.out
+++ b/tsl/test/expected/dist_grant-14.out
@@ -1042,7 +1042,6 @@ DEBUG:  [data1]: GRANT ALL ON DATABASE db_dist_grant_1 TO cluster_super_user
 DEBUG:  [data2]: GRANT ALL ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT ALL ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT ALL ON DATABASE db_dist_grant_4 TO cluster_super_user 
-DEBUG:  rehashing catalog cache id 78 for pg_user_mapping; 5 tups, 2 buckets
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user 
@@ -1129,7 +1128,6 @@ DEBUG:  skipping dist DDL on object: REVOKE ALL ON SCHEMA public FROM default_pe
 GRANT ALL ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON SCHEMA public TO default_perm_user;
 REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
-DEBUG:  rehashing catalog cache id 7 for pg_attribute; 257 tups, 128 buckets
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;


### PR DESCRIPTION
Commit 9b180915 introduce some tests that are a bit flaky because are
checking a DEBUG message from Postgres catcache rehashing.
    
Fixed it by teaching our test runner to ignore this Postgres DEBUG
message.
