### PR TITLE
Fix logic bug in init_privs query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ accidentally triggering the load of a previous DB version.**
 * #4209 Add support for chunk exclusion on UPDATE to PG14
 
 **Bugfixes**
-* #4225 Fix TRUNCATE error as non-owner on hypertable
 * #3899 Fix segfault in Continuous Aggregates
+* #4225 Fix TRUNCATE error as non-owner on hypertable
+* #4259 Fix logic bug in extension update script
 
 ## 2.6.1 (2022-04-11)
 This release is patch release. We recommend that you upgrade at the next available opportunity.

--- a/sql/updates/pre-update.sql
+++ b/sql/updates/pre-update.sql
@@ -47,10 +47,12 @@ CREATE TABLE _timescaledb_internal.saved_privs(
 INSERT INTO _timescaledb_internal.saved_privs
 SELECT nspname, relname, relacl, initprivs
   FROM pg_class cl JOIN pg_namespace ns ON ns.oid = relnamespace
-                   JOIN pg_init_privs ip ON ip.objoid = cl.oid AND ip.objsubid = 0
-WHERE classoid = 'pg_class'::regclass
-  AND nspname IN ('_timescaledb_catalog', '_timescaledb_config')
-   OR nspname = '_timescaledb_internal'
-  AND relname IN ('hypertable_chunk_local_size', 'compressed_chunk_stats',
-                  'bgw_job_stat', 'bgw_policy_chunk_stats');
+                   JOIN pg_init_privs ip ON ip.objoid = cl.oid AND ip.objsubid = 0 AND ip.classoid = 'pg_class'::regclass
+WHERE
+  nspname IN ('_timescaledb_catalog', '_timescaledb_config')
+  OR (
+    relname IN ('hypertable_chunk_local_size', 'compressed_chunk_stats', 'bgw_job_stat', 'bgw_policy_chunk_stats')
+    AND nspname = '_timescaledb_internal'
+  )
+;
 


### PR DESCRIPTION
The query to get the list of saved privileges during extension
upgrade had a bug and only applying the classoid restriction
for a subset of the entries when it should have been applied to
all returned rows leading to a failure during extension update
when init privileges for other classoids existed on any of the
relevant objects.