### PR TITLE
Ignore spelling fixes in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,5 @@
 34edba16a9385a4b0353e8e07a19dba98d7e3fb9
 # Run pg_format on SQL files
 3f5872ec61650519e2c5e6fe1dfb60d07696cac7
+# Fix various misspellings
+68aec9593c0f37dddbaa4f2e2b34a9ba3f5b11d9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ accidentally triggering the load of a previous DB version.**
 * #4225 Fix TRUNCATE error as non-owner on hypertable
 * #4259 Fix logic bug in extension update script
 
+**Thanks**
+* @jsoref for fixing various misspellings in code, comments and documentation
+
 ## 2.6.1 (2022-04-11)
 This release is patch release. We recommend that you upgrade at the next available opportunity.
 


### PR DESCRIPTION
This patch adds the spelling fix commit to the git blame ignore
list and adds a thank you to the changelog for the author.
The git blame change couldnt be done in the spelling PR because
it references the commit hash.