### PR TITLE
NFC. Enable DecompressChunk node to skip some input columns

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.h
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.h
@@ -43,12 +43,12 @@ typedef struct DecompressChunkPath
 	CustomPath cpath;
 	CompressionInfo *info;
 	/*
-	 * varattno_map maps targetlist entries of the compressed scan
-	 * to tuple attribute number of the uncompressed chunk
-	 * negative values are special columns in the compressed scan
-	 * that do not have a representation in the uncompressed chunk
+	 * decompression_map maps targetlist entries of the compressed scan to tuple
+	 * attribute number of the uncompressed chunk. Negative values are special
+	 * columns in the compressed scan that do not have a representation in the
+	 * uncompressed chunk, but are still used for decompression.
 	 */
-	List *varattno_map;
+	List *decompression_map;
 	List *compressed_pathkeys;
 	bool needs_sequence_num;
 	bool reverse;

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -56,7 +56,7 @@ make_compressed_scan_meta_targetentry(DecompressChunkPath *path, char *column_na
 	 */
 	Assert(get_atttype(path->info->compressed_rte->relid, compressed_attno) == INT4OID);
 	scan_var = makeVar(path->info->compressed_rel->relid, compressed_attno, INT4OID, -1, 0, 0);
-	path->varattno_map = lappend_int(path->varattno_map, id);
+	path->decompression_map = lappend_int(path->decompression_map, id);
 
 	return makeTargetEntry((Expr *) scan_var, tle_index, NULL, false);
 }
@@ -110,7 +110,7 @@ make_compressed_scan_targetentry(DecompressChunkPath *path, AttrNumber ht_attno,
 						   -1,
 						   0,
 						   0);
-	path->varattno_map = lappend_int(path->varattno_map, chunk_attno);
+	path->decompression_map = lappend_int(path->decompression_map, chunk_attno);
 
 	return makeTargetEntry((Expr *) scan_var, tle_index, NULL, false);
 }
@@ -131,7 +131,7 @@ build_scan_tlist(DecompressChunkPath *path)
 	TargetEntry *tle;
 	int bit;
 
-	path->varattno_map = NIL;
+	path->decompression_map = NIL;
 
 	/* add count column */
 	tle = make_compressed_scan_meta_targetentry(path,
@@ -382,7 +382,7 @@ decompress_chunk_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *pat
 	settings = list_make3_int(dcpath->info->hypertable_id,
 							  dcpath->info->chunk_rte->relid,
 							  dcpath->reverse);
-	cscan->custom_private = list_make2(settings, dcpath->varattno_map);
+	cscan->custom_private = list_make2(settings, dcpath->decompression_map);
 
 	return &cscan->scan.plan;
 }


### PR DESCRIPTION
No functional change.

This refactoring adds explicit output attnos to the metadata of column
decompression, enabling DecompressChunk node to skip some input columns
of the compressed scan. This is ultimately needed to support physical
targetlists in compressed scan.

Part of #4234