### PR TITLE
Continuous Aggregates finals form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ If you use compression with a non-default collation on a segmentby-column you mi
 * #4259 Fix logic bug in extension update script
 * #4236 Fix potential wrong order of results for compressed hypertable with a non-default collation
 * #4255 Fix option "timescaledb.create_group_indexes"
+* #4269 Fix bad Continuous Aggregate view definition reported in #4233
 * #4300 Fix refresh window cap for cagg refresh policy
 * #4330 Add GUC "bgw_launcher_poll_time"
 

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -444,13 +444,13 @@ ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO LOG;
 SELECT * FROM new_name;
- time_bucket |      agg_2_2       
--------------+--------------------
-           0 | \x0000000000000003
-           3 | \x0000000000000003
-           6 | \x0000000000000003
-           9 | \x0000000000000003
-          12 | \x0000000000000003
+ time_bucket | count 
+-------------+-------
+           0 |     3
+           3 |     3
+           6 |     3
+           9 |     3
+          12 |     3
 (5 rows)
 
 SELECT * FROM drop_chunks_view ORDER BY 1;
@@ -470,7 +470,7 @@ CREATE MATERIALIZED VIEW new_name_view
     timescaledb.continuous,
     timescaledb.materialized_only=true
   )
-AS SELECT time_bucket('6', time_bucket), COUNT(agg_2_2)
+AS SELECT time_bucket('6', time_bucket), COUNT("count")
     FROM new_name
     GROUP BY 1 WITH NO DATA;
 psql:include/cagg_ddl_common.sql:326: ERROR:  hypertable is a continuous aggregate materialization table
@@ -1512,7 +1512,7 @@ SELECT * FROM test.show_columns(' _timescaledb_internal._partial_view_35');
 ----------+--------------------------+---------
  location | text                     | f
  bucket   | timestamp with time zone | f
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_35');
@@ -1520,7 +1520,7 @@ SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_
 ----------+--------------------------+---------
  location | text                     | f
  bucket   | timestamp with time zone | t
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 ALTER MATERIALIZED VIEW conditions_daily RENAME COLUMN bucket to "time";
@@ -1547,7 +1547,7 @@ SELECT * FROM test.show_columns(' _timescaledb_internal._partial_view_35');
 ----------+--------------------------+---------
  location | text                     | f
  time     | timestamp with time zone | f
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_35');
@@ -1555,7 +1555,7 @@ SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_
 ----------+--------------------------+---------
  location | text                     | f
  time     | timestamp with time zone | t
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 -- This will rebuild the materialized view and should succeed.
@@ -1848,39 +1848,35 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"PART_VIEW_NAME"
-                        View "_timescaledb_internal._partial_view_47"
- Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
----------+--------------------------+-----------+----------+---------+----------+-------------
- bucket  | timestamp with time zone |           |          |         | plain    | 
- amount  | integer                  |           |          |         | plain    | 
- agg_3_3 | bytea                    |           |          |         | extended | 
- agg_3_4 | bytea                    |           |          |         | extended | 
- var_3_5 | integer                  |           |          |         | plain    | 
- agg_4_6 | bytea                    |           |          |         | extended | 
+                         View "_timescaledb_internal._partial_view_47"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
 View definition:
  SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
     transactions.amount,
-    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_3,
-    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_4,
-    transactions.amount AS var_3_5,
-    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_4_6
+        CASE
+            WHEN transactions.amount < 0 THEN 0 - sum(transactions.fiat_value)
+            ELSE sum(transactions.fiat_value)
+        END AS cashflow,
+    transactions.amount + sum(transactions.fiat_value) AS cashflow2
    FROM transactions
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
                           Table "_timescaledb_internal._materialized_hypertable_47"
- Column  |           Type           | Collation | Nullable | Default | Storage  | Stats target | Description 
----------+--------------------------+-----------+----------+---------+----------+--------------+-------------
- bucket  | timestamp with time zone |           | not null |         | plain    |              | 
- amount  | integer                  |           |          |         | plain    |              | 
- agg_3_3 | bytea                    |           |          |         | extended |              | 
- agg_3_4 | bytea                    |           |          |         | extended |              | 
- var_3_5 | integer                  |           |          |         | plain    |              | 
- agg_4_6 | bytea                    |           |          |         | extended |              | 
+  Column   |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
+-----------+--------------------------+-----------+----------+---------+---------+--------------+-------------
+ bucket    | timestamp with time zone |           | not null |         | plain   |              | 
+ amount    | integer                  |           |          |         | plain   |              | 
+ cashflow  | bigint                   |           |          |         | plain   |              | 
+ cashflow2 | bigint                   |           |          |         | plain   |              | 
 Indexes:
     "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
     "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
-    "_materialized_hypertable_47_var_3_5_bucket_idx" btree (var_3_5, bucket DESC)
 Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
 Child tables: _timescaledb_internal._hyper_47_52_chunk,
@@ -1897,13 +1893,9 @@ Child tables: _timescaledb_internal._hyper_47_52_chunk,
 View definition:
  SELECT _materialized_hypertable_47.bucket,
     _materialized_hypertable_47.amount,
-        CASE
-            WHEN _materialized_hypertable_47.var_3_5 < 0 THEN 0 - _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_3, NULL::bigint)
-            ELSE _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_4, NULL::bigint)
-        END AS cashflow,
-    _materialized_hypertable_47.var_3_5 + _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_4_6, NULL::bigint) AS cashflow2
-   FROM _timescaledb_internal._materialized_hypertable_47
-  GROUP BY _materialized_hypertable_47.bucket, _materialized_hypertable_47.amount;
+    _materialized_hypertable_47.cashflow,
+    _materialized_hypertable_47.cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_47;
 
 SELECT * FROM cashflows;
             bucket            | amount | cashflow | cashflow2 

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -476,13 +476,13 @@ ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SET client_min_messages TO LOG;
 SELECT * FROM new_name;
- time_bucket |      agg_2_2       
--------------+--------------------
-           0 | \x0000000000000003
-           3 | \x0000000000000003
-           6 | \x0000000000000003
-           9 | \x0000000000000003
-          12 | \x0000000000000003
+ time_bucket | count 
+-------------+-------
+           0 |     3
+           3 |     3
+           6 |     3
+           9 |     3
+          12 |     3
 (5 rows)
 
 SELECT * FROM drop_chunks_view ORDER BY 1;
@@ -502,7 +502,7 @@ CREATE MATERIALIZED VIEW new_name_view
     timescaledb.continuous,
     timescaledb.materialized_only=true
   )
-AS SELECT time_bucket('6', time_bucket), COUNT(agg_2_2)
+AS SELECT time_bucket('6', time_bucket), COUNT("count")
     FROM new_name
     GROUP BY 1 WITH NO DATA;
 psql:include/cagg_ddl_common.sql:326: ERROR:  hypertable is a continuous aggregate materialization table
@@ -1550,7 +1550,7 @@ SELECT * FROM test.show_columns(' _timescaledb_internal._partial_view_35');
 ----------+--------------------------+---------
  location | text                     | f
  bucket   | timestamp with time zone | f
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_35');
@@ -1558,7 +1558,7 @@ SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_
 ----------+--------------------------+---------
  location | text                     | f
  bucket   | timestamp with time zone | t
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 ALTER MATERIALIZED VIEW conditions_daily RENAME COLUMN bucket to "time";
@@ -1585,7 +1585,7 @@ SELECT * FROM test.show_columns(' _timescaledb_internal._partial_view_35');
 ----------+--------------------------+---------
  location | text                     | f
  time     | timestamp with time zone | f
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_35');
@@ -1593,7 +1593,7 @@ SELECT * FROM test.show_columns('_timescaledb_internal._materialized_hypertable_
 ----------+--------------------------+---------
  location | text                     | f
  time     | timestamp with time zone | t
- agg_3_3  | bytea                    | f
+ avg      | double precision         | f
 (3 rows)
 
 -- This will rebuild the materialized view and should succeed.
@@ -1886,39 +1886,35 @@ View definition:
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"PART_VIEW_NAME"
-                        View "_timescaledb_internal._partial_view_47"
- Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
----------+--------------------------+-----------+----------+---------+----------+-------------
- bucket  | timestamp with time zone |           |          |         | plain    | 
- amount  | integer                  |           |          |         | plain    | 
- agg_3_3 | bytea                    |           |          |         | extended | 
- agg_3_4 | bytea                    |           |          |         | extended | 
- var_3_5 | integer                  |           |          |         | plain    | 
- agg_4_6 | bytea                    |           |          |         | extended | 
+                         View "_timescaledb_internal._partial_view_47"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
 View definition:
  SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
     transactions.amount,
-    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_3,
-    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_4,
-    transactions.amount AS var_3_5,
-    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_4_6
+        CASE
+            WHEN transactions.amount < 0 THEN 0 - sum(transactions.fiat_value)
+            ELSE sum(transactions.fiat_value)
+        END AS cashflow,
+    transactions.amount + sum(transactions.fiat_value) AS cashflow2
    FROM transactions
   GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
 
 \d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
                           Table "_timescaledb_internal._materialized_hypertable_47"
- Column  |           Type           | Collation | Nullable | Default | Storage  | Stats target | Description 
----------+--------------------------+-----------+----------+---------+----------+--------------+-------------
- bucket  | timestamp with time zone |           | not null |         | plain    |              | 
- amount  | integer                  |           |          |         | plain    |              | 
- agg_3_3 | bytea                    |           |          |         | extended |              | 
- agg_3_4 | bytea                    |           |          |         | extended |              | 
- var_3_5 | integer                  |           |          |         | plain    |              | 
- agg_4_6 | bytea                    |           |          |         | extended |              | 
+  Column   |           Type           | Collation | Nullable | Default | Storage | Stats target | Description 
+-----------+--------------------------+-----------+----------+---------+---------+--------------+-------------
+ bucket    | timestamp with time zone |           | not null |         | plain   |              | 
+ amount    | integer                  |           |          |         | plain   |              | 
+ cashflow  | bigint                   |           |          |         | plain   |              | 
+ cashflow2 | bigint                   |           |          |         | plain   |              | 
 Indexes:
     "_materialized_hypertable_47_amount_bucket_idx" btree (amount, bucket DESC)
     "_materialized_hypertable_47_bucket_idx" btree (bucket DESC)
-    "_materialized_hypertable_47_var_3_5_bucket_idx" btree (var_3_5, bucket DESC)
 Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_47 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
 Child tables: _timescaledb_internal._hyper_47_52_chunk,
@@ -1935,13 +1931,9 @@ Child tables: _timescaledb_internal._hyper_47_52_chunk,
 View definition:
  SELECT _materialized_hypertable_47.bucket,
     _materialized_hypertable_47.amount,
-        CASE
-            WHEN _materialized_hypertable_47.var_3_5 < 0 THEN 0 - _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_3, NULL::bigint)
-            ELSE _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_3_4, NULL::bigint)
-        END AS cashflow,
-    _materialized_hypertable_47.var_3_5 + _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_47.agg_4_6, NULL::bigint) AS cashflow2
-   FROM _timescaledb_internal._materialized_hypertable_47
-  GROUP BY _materialized_hypertable_47.bucket, _materialized_hypertable_47.amount;
+    _materialized_hypertable_47.cashflow,
+    _materialized_hypertable_47.cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_47;
 
 SELECT * FROM cashflows;
             bucket            | amount | cashflow | cashflow2 

--- a/tsl/test/expected/cagg_errors_deprecated.out
+++ b/tsl/test/expected/cagg_errors_deprecated.out
@@ -19,59 +19,59 @@ select table_name from create_hypertable( 'conditions', 'timec');
  conditions
 (1 row)
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
 ERROR:  unrecognized parameter "timescaledb.myfill"
 --valid PG option
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, check_option = LOCAL )
 as
 select * from conditions , mat_t1 WITH NO DATA;
 ERROR:  unsupported combination of storage parameters
 DETAIL:  A continuous aggregate does not support standard storage parameters.
 HINT:  Use only parameters with the "timescaledb." prefix when creating a continuous aggregate.
 -- join multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
 group by location WITH NO DATA;
 ERROR:  only one hypertable allowed in continuous aggregate view
 -- join multiple tables WITH explicit JOIN
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select location, count(*) from conditions JOIN mat_t1 ON true
 where conditions.location = mat_t1.c
 group by location WITH NO DATA;
 ERROR:  only one hypertable allowed in continuous aggregate view
 -- LATERAL multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select location, count(*) from conditions,
 LATERAL (Select * from mat_t1 where c = conditions.location) q
 group by location WITH NO DATA;
 ERROR:  only one hypertable allowed in continuous aggregate view
 --non-hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select a, count(*) from mat_t1
 group by a WITH NO DATA;
 ERROR:  table "mat_t1" is not a hypertable
 -- no group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select count(*) from conditions  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
 -- no time_bucket in group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select count(*) from conditions group by location WITH NO DATA;
 ERROR:  continuous aggregate view must include a valid time bucket function
 -- with valid query in a CTE
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 with m1 as (
 Select location, count(*) from conditions
@@ -80,66 +80,114 @@ select * from m1 WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
 --with DISTINCT ON
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  DISTINCT / DISTINCT ON queries are not supported by continuous aggregates.
+--aggregate with DISTINCT
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select time_bucket('1week', timec),
+ count(location) , sum(distinct temperature) from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
+--aggregate with FILTER
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select time_bucket('1week', timec),
+ sum(temperature) filter ( where humidity > 20 ) from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
+-- aggregate with filter in having clause
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select time_bucket('1week', timec), max(temperature)
+from conditions
+ group by time_bucket('1week', timec) , location
+ having sum(temperature) filter ( where humidity > 20 ) > 50 WITH NO DATA;
+ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
 -- time_bucket on non partitioning column of hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 --time_bucket on expression
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
 ERROR:  time bucket function must reference a hypertable dimension column
 --multiple time_bucket functions
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
 ERROR:  continuous aggregate view cannot contain multiple time bucket functions
 --time_bucket using additional args
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
 ERROR:  continuous aggregate view must include a valid time bucket function
 --time_bucket using non-const for first argument
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( timeinterval, timec) , location WITH NO DATA;
 ERROR:  only immutable expressions allowed in time bucket function
 HINT:  Use an immutable expression as first argument to the time bucket function.
+-- ordered set aggr
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select mode() within group( order by humidity)
+from conditions
+ group by time_bucket('1week', timec)  WITH NO DATA;
+ERROR:  aggregates with FILTER / DISTINCT / ORDER BY are not supported
 --window function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  Window functions are not supported by continuous aggregates.
---aggregate without combine function but stable function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+--aggregate without combine function
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select json_agg(location)
 from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
+ERROR:  aggregates which are not parallelizable are not supported
+;
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select sum(humidity), avg(temperature), array_agg(location)
+from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+ERROR:  aggregates which are not parallelizable are not supported
+;
+-- userdefined aggregate without combine function
+CREATE AGGREGATE newavg (
+   sfunc = int4_avg_accum, basetype = int4, stype = _int8,
+   finalfunc = int8_avg,
+   initcond1 = '{0,0}'
+);
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select sum(humidity), newavg(temperature::int4)
+from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+ERROR:  aggregates which are not parallelizable are not supported
 ;
 -- using subqueries
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
@@ -147,7 +195,7 @@ from
 from conditions ) q
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
@@ -156,7 +204,7 @@ from conditions
 ERROR:  invalid continuous aggregate query
 HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
 --using limit /limit offset
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -165,7 +213,7 @@ limit 10  WITH NO DATA;
 ERROR:  invalid continuous aggregate query
 DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -175,7 +223,7 @@ ERROR:  invalid continuous aggregate query
 DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
 --using ORDER BY in view defintion
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -185,7 +233,7 @@ ERROR:  invalid continuous aggregate query
 DETAIL:  ORDER BY is not supported in queries defining continuous aggregates.
 HINT:  Use ORDER BY clauses in SELECTS from the continuous aggregate view instead.
 --using FETCH
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -196,28 +244,28 @@ DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous
 HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE WITH NO DATA;
 ERROR:  FOR KEY SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR SHARE WITH NO DATA;
 ERROR:  FOR SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE WITH NO DATA;
 ERROR:  FOR UPDATE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -225,7 +273,7 @@ from conditions
 FOR NO KEY UPDATE WITH NO DATA;
 ERROR:  FOR NO KEY UPDATE is not allowed with GROUP BY clause
 --tablesample clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
@@ -233,14 +281,14 @@ from conditions tablesample bernoulli(0.2)
  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
 -- ONLY in from clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location  WITH NO DATA;
 ERROR:  invalid continuous aggregate view
 --grouping sets and variants
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -248,7 +296,7 @@ from conditions
 ERROR:  invalid continuous aggregate query
 DETAIL:  GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by continuous aggregates
 HINT:  Define multiple continuous aggregates with different grouping levels.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
@@ -259,21 +307,29 @@ HINT:  Define multiple continuous aggregates with different grouping levels.
 --NO immutable functions -- check all clauses
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location   WITH NO DATA;
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select sum(humidity), min(location)
+from conditions
+group by time_bucket('1week', timec)
+having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08' WITH NO DATA;
+ERROR:  only immutable functions supported in continuous aggregate view
+HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec) WITH NO DATA;
 ERROR:  only immutable functions supported in continuous aggregate view
 HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum( temperature ), min(location)
 from conditions
@@ -306,7 +362,7 @@ SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
 
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum( b), min(c)
 from rowsec_tab
@@ -638,7 +694,3 @@ FROM
       AND uncompress.table_name = 'comp_ht_test') \gset
 CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
 ERROR:  hypertable is an internal compressed hypertable
---TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
---Check error handling for this case
-SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
-ERROR:  compression not enabled on "i2980"

--- a/tsl/test/expected/cagg_query-12.out
+++ b/tsl/test/expected/cagg_query-12.out
@@ -84,29 +84,23 @@ set enable_hashagg = false;
 -- group by, we will still need a sort
 :EXPLAIN
 select * from mat_m1 order by sumh, sumt, minl, timec ;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
-   Sort Key: (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), _materialized_hypertable_2.timec
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+   Sort Key: _materialized_hypertable_2.sumh, _materialized_hypertable_2.sumt, _materialized_hypertable_2.minl, _materialized_hypertable_2.timec
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -121,7 +115,7 @@ select * from mat_m1 order by sumh, sumt, minl, timec ;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(35 rows)
+(29 rows)
 
 :EXPLAIN
 select * from regview order by timec desc;
@@ -151,29 +145,23 @@ select * from regview order by timec desc;
 -- This should prevent an additional sort after GroupAggregate
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -188,33 +176,27 @@ select * from mat_m1 order by timec desc, location;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(35 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec desc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -229,33 +211,27 @@ select * from mat_m1 order by location, timec desc;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(35 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec asc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -270,30 +246,24 @@ select * from mat_m1 order by location, timec asc;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(35 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -309,38 +279,32 @@ select * from mat_m1 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(33 rows)
+(27 rows)
 
 -- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
 :EXPLAIN
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                 QUERY PLAN                                                                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
          Hash Cond: (l.locname = _materialized_hypertable_2.location)
          ->  Seq Scan on public.location_tab l
                Output: l.locid, l.locname
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -356,30 +320,24 @@ select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01'
                                              Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                              Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(40 rows)
+(34 rows)
 
 :EXPLAIN
 select * from mat_m2 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_3.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-               ->  Sort
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                     Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -395,32 +353,26 @@ select * from mat_m2 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(33 rows)
+(27 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    ->  Sort
-         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Sort Key: _materialized_hypertable_3.timec DESC
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -436,32 +388,26 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(35 rows)
+(29 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    ->  Sort
-         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Sort Key: _materialized_hypertable_3.timec DESC, _materialized_hypertable_3.location NULLS FIRST
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -477,33 +423,27 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(35 rows)
+(29 rows)
 
 --plans with CTE
 :EXPLAIN
 with m1 as (
 Select * from mat_m2 where timec > '2018-10-01' order by timec desc )
 select * from m1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_3.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-               ->  Sort
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                     Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -519,37 +459,31 @@ select * from m1;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(33 rows)
+(27 rows)
 
 -- should reorder mat_m1 group by only based on mat_m1 order-by
 :EXPLAIN
 select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Hash Cond: (_materialized_hypertable_3.timec = _materialized_hypertable_2.timec)
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
-                                       Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                                       Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
+                           Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.firsth, _hyper_3_5_chunk.lasth, _hyper_3_5_chunk.maxtemp, _hyper_3_5_chunk.mintemp
+                           Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -565,22 +499,16 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
@@ -596,18 +524,18 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(70 rows)
+(58 rows)
 
 --should reorder only for mat_m1.
 :EXPLAIN
 select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
          Hash Cond: ((time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) = _materialized_hypertable_2.timec)
          ->  GroupAggregate
                Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
@@ -623,22 +551,16 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -654,7 +576,7 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(51 rows)
+(45 rows)
 
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
  locid | location |            timec             | minl | sumt | sumh 
@@ -679,29 +601,23 @@ set timescaledb.enable_cagg_reorder_groupby = false;
 set enable_hashagg = false;
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                 Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -716,7 +632,7 @@ select * from mat_m1 order by timec desc, location;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(35 rows)
+(29 rows)
 
 -----------------------------------------------------------------------
 -- Test the cagg_watermark function. The watermark gives the point
@@ -886,7 +802,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C", m1.timec DESC
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
 LIMIT 10;
  location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
 ----------+------------------------------+------+------+--------+-------+---------+---------
@@ -894,10 +810,10 @@ LIMIT 10;
  SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
  SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
  por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
-          |                              |      |      |     45 |    30 |      65 |      45
-          |                              |      |      |     45 |    45 |      65 |      55
-          |                              |      |      |     30 |    50 |      85 |      45
           |                              |      |      |     10 |       |      20 |      10
+          |                              |      |      |     30 |    50 |      85 |      45
+          |                              |      |      |     45 |    45 |      65 |      55
+          |                              |      |      |     45 |    30 |      65 |      45
           |                              |      |      |        |       |         |        
 (9 rows)
 

--- a/tsl/test/expected/cagg_query-13.out
+++ b/tsl/test/expected/cagg_query-13.out
@@ -84,31 +84,23 @@ set enable_hashagg = false;
 -- group by, we will still need a sort
 :EXPLAIN
 select * from mat_m1 order by sumh, sumt, minl, timec ;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
-   Sort Key: (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), _materialized_hypertable_2.timec
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+   Sort Key: _materialized_hypertable_2.sumh, _materialized_hypertable_2.sumt, _materialized_hypertable_2.minl, _materialized_hypertable_2.timec
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -123,7 +115,7 @@ select * from mat_m1 order by sumh, sumt, minl, timec ;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from regview order by timec desc;
@@ -153,31 +145,23 @@ select * from regview order by timec desc;
 -- This should prevent an additional sort after GroupAggregate
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -192,35 +176,27 @@ select * from mat_m1 order by timec desc, location;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec desc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -235,35 +211,27 @@ select * from mat_m1 order by location, timec desc;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec asc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -278,31 +246,24 @@ select * from mat_m1 order by location, timec asc;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Order: _materialized_hypertable_2.timec
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -318,39 +279,32 @@ select * from mat_m1 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(34 rows)
+(27 rows)
 
 -- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
 :EXPLAIN
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                 QUERY PLAN                                                                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
          Hash Cond: (l.locname = _materialized_hypertable_2.location)
          ->  Seq Scan on public.location_tab l
                Output: l.locid, l.locname
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Order: _materialized_hypertable_2.timec
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -366,31 +320,24 @@ select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01'
                                              Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                              Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(41 rows)
+(34 rows)
 
 :EXPLAIN
 select * from mat_m2 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_3.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-               ->  Sort
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Order: _materialized_hypertable_3.timec
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                     Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -406,33 +353,26 @@ select * from mat_m2 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(34 rows)
+(27 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    ->  Sort
-         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Sort Key: _materialized_hypertable_3.timec DESC
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Order: _materialized_hypertable_3.timec
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -448,33 +388,26 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(36 rows)
+(29 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    ->  Sort
-         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Sort Key: _materialized_hypertable_3.timec DESC, _materialized_hypertable_3.location NULLS FIRST
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Order: _materialized_hypertable_3.timec
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -490,34 +423,27 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(36 rows)
+(29 rows)
 
 --plans with CTE
 :EXPLAIN
 with m1 as (
 Select * from mat_m2 where timec > '2018-10-01' order by timec desc )
 select * from m1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_3.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-               ->  Sort
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Order: _materialized_hypertable_3.timec
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                     Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -533,37 +459,31 @@ select * from m1;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(34 rows)
+(27 rows)
 
 -- should reorder mat_m1 group by only based on mat_m1 order-by
 :EXPLAIN
 select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Hash Cond: (_materialized_hypertable_3.timec = _materialized_hypertable_2.timec)
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
-                                       Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                                       Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
+                           Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.firsth, _hyper_3_5_chunk.lasth, _hyper_3_5_chunk.maxtemp, _hyper_3_5_chunk.mintemp
+                           Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -579,23 +499,16 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Order: _materialized_hypertable_2.timec
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
@@ -611,18 +524,18 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(71 rows)
+(58 rows)
 
 --should reorder only for mat_m1.
 :EXPLAIN
 select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
          Hash Cond: ((time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) = _materialized_hypertable_2.timec)
          ->  GroupAggregate
                Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
@@ -638,23 +551,16 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Order: _materialized_hypertable_2.timec
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
@@ -670,7 +576,7 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(52 rows)
+(45 rows)
 
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
  locid | location |            timec             | minl | sumt | sumh 
@@ -695,31 +601,23 @@ set timescaledb.enable_cagg_reorder_groupby = false;
 set enable_hashagg = false;
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -734,7 +632,7 @@ select * from mat_m1 order by timec desc, location;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 -----------------------------------------------------------------------
 -- Test the cagg_watermark function. The watermark gives the point
@@ -904,7 +802,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C", m1.timec DESC
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
 LIMIT 10;
  location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
 ----------+------------------------------+------+------+--------+-------+---------+---------
@@ -912,10 +810,10 @@ LIMIT 10;
  SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
  SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
  por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
-          |                              |      |      |     45 |    30 |      65 |      45
-          |                              |      |      |     45 |    45 |      65 |      55
-          |                              |      |      |     30 |    50 |      85 |      45
           |                              |      |      |     10 |       |      20 |      10
+          |                              |      |      |     30 |    50 |      85 |      45
+          |                              |      |      |     45 |    45 |      65 |      55
+          |                              |      |      |     45 |    30 |      65 |      45
           |                              |      |      |        |       |         |        
 (9 rows)
 

--- a/tsl/test/expected/cagg_query-14.out
+++ b/tsl/test/expected/cagg_query-14.out
@@ -84,31 +84,23 @@ set enable_hashagg = false;
 -- group by, we will still need a sort
 :EXPLAIN
 select * from mat_m1 order by sumh, sumt, minl, timec ;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
-   Sort Key: (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), _materialized_hypertable_2.timec
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+   Sort Key: _materialized_hypertable_2.sumh, _materialized_hypertable_2.sumt, _materialized_hypertable_2.minl, _materialized_hypertable_2.timec
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -123,7 +115,7 @@ select * from mat_m1 order by sumh, sumt, minl, timec ;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from regview order by timec desc;
@@ -153,31 +145,23 @@ select * from regview order by timec desc;
 -- This should prevent an additional sort after GroupAggregate
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -192,35 +176,27 @@ select * from mat_m1 order by timec desc, location;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec desc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -235,35 +211,27 @@ select * from mat_m1 order by location, timec desc;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 order by location, timec asc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.location, _materialized_hypertable_2.timec
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -278,31 +246,24 @@ select * from mat_m1 order by location, timec asc;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 :EXPLAIN
 select * from mat_m1 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Order: _materialized_hypertable_2.timec
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -318,39 +279,32 @@ select * from mat_m1 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(34 rows)
+(27 rows)
 
 -- outer sort is used by mat_m1 for grouping. But doesn't avoid a sort after the join ---
 :EXPLAIN
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                 QUERY PLAN                                                                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+         Output: l.locid, _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
          Hash Cond: (l.locname = _materialized_hypertable_2.location)
          ->  Seq Scan on public.location_tab l
                Output: l.locid, l.locname
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Order: _materialized_hypertable_2.timec
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -366,31 +320,24 @@ select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01'
                                              Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                              Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(41 rows)
+(34 rows)
 
 :EXPLAIN
 select * from mat_m2 where timec > '2018-10-01' order by timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_3.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-               ->  Sort
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Order: _materialized_hypertable_3.timec
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                     Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -406,33 +353,26 @@ select * from mat_m2 where timec > '2018-10-01' order by timec desc;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(34 rows)
+(27 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc ) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    ->  Sort
-         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Sort Key: _materialized_hypertable_3.timec DESC
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Order: _materialized_hypertable_3.timec
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -448,33 +388,26 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(36 rows)
+(29 rows)
 
 :EXPLAIN
 select * from (select * from mat_m2 where timec > '2018-10-01' order by timec desc , location asc nulls first) as q limit 1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                              QUERY PLAN                                                                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    ->  Sort
-         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Sort Key: _materialized_hypertable_3.timec DESC, _materialized_hypertable_3.location NULLS FIRST
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Order: _materialized_hypertable_3.timec
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -490,34 +423,27 @@ select * from (select * from mat_m2 where timec > '2018-10-01' order by timec de
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                        Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(36 rows)
+(29 rows)
 
 --plans with CTE
 :EXPLAIN
 with m1 as (
 Select * from mat_m2 where timec > '2018-10-01' order by timec desc )
 select * from m1;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                           QUERY PLAN                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_3.timec DESC
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-               Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-               ->  Sort
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                     Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Order: _materialized_hypertable_3.timec
-                           Startup Exclusion: true
-                           Runtime Exclusion: false
-                           Chunks excluded during startup: 0
-                           ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                 Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                 Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+               Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                     Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                     Index Cond: ((_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_3_6_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -533,37 +459,31 @@ select * from m1;
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                  Index Cond: ((_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                  Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(34 rows)
+(27 rows)
 
 -- should reorder mat_m1 group by only based on mat_m1 order-by
 :EXPLAIN
 select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec = mat_m2.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _materialized_hypertable_3.location, _materialized_hypertable_3.timec, (_timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision)), (_timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision))
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
          Hash Cond: (_materialized_hypertable_3.timec = _materialized_hypertable_2.timec)
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _timescaledb_internal.finalize_agg('public.first(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_3_3, NULL::double precision), _timescaledb_internal.finalize_agg('public.last(pg_catalog.anyelement,pg_catalog."any")'::text, NULL::name, NULL::name, '{{pg_catalog,float8},{pg_catalog,timestamptz}}'::name[], _materialized_hypertable_3.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_5_5, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_6_6, NULL::double precision)
-                     Group Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                     ->  Sort
-                           Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                           Sort Key: _materialized_hypertable_3.timec, _materialized_hypertable_3.location
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
-                                 Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.agg_3_3, _materialized_hypertable_3.agg_4_4, _materialized_hypertable_3.agg_5_5, _materialized_hypertable_3.agg_6_6
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
-                                       Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.agg_3_3, _hyper_3_5_chunk.agg_4_4, _hyper_3_5_chunk.agg_5_5, _hyper_3_5_chunk.agg_6_6
-                                       Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
-                                       Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.agg_3_3, _hyper_3_6_chunk.agg_4_4, _hyper_3_6_chunk.agg_5_5, _hyper_3_6_chunk.agg_6_6
-                                       Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_3
+                     Output: _materialized_hypertable_3.location, _materialized_hypertable_3.timec, _materialized_hypertable_3.firsth, _materialized_hypertable_3.lasth, _materialized_hypertable_3.maxtemp, _materialized_hypertable_3.mintemp
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_3_5_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_5_chunk
+                           Output: _hyper_3_5_chunk.location, _hyper_3_5_chunk.timec, _hyper_3_5_chunk.firsth, _hyper_3_5_chunk.lasth, _hyper_3_5_chunk.maxtemp, _hyper_3_5_chunk.mintemp
+                           Index Cond: (_hyper_3_5_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
+                     ->  Index Scan using _hyper_3_6_chunk__materialized_hypertable_3_timec_idx on _timescaledb_internal._hyper_3_6_chunk
+                           Output: _hyper_3_6_chunk.location, _hyper_3_6_chunk.timec, _hyper_3_6_chunk.firsth, _hyper_3_6_chunk.lasth, _hyper_3_6_chunk.maxtemp, _hyper_3_6_chunk.mintemp
+                           Index Cond: (_hyper_3_6_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
                ->  GroupAggregate
                      Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), first(conditions.humidity, conditions.timec), last(conditions.humidity, conditions.timec), max(conditions.temperature), min(conditions.temperature)
                      Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -579,23 +499,16 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.humidity, _hyper_1_2_chunk.temperature
                                        Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone))
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Order: _materialized_hypertable_2.timec
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
@@ -611,18 +524,18 @@ select * from mat_m1, mat_m2 where mat_m1.timec > '2018-10-01' and mat_m1.timec 
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(71 rows)
+(58 rows)
 
 --should reorder only for mat_m1.
 :EXPLAIN
 select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec = regview.timec order by mat_m1.timec desc;
-                                                                                                                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
    Sort Key: _materialized_hypertable_2.timec DESC
    ->  Hash Join
-         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)), _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
+         Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh, _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), (min(_hyper_1_1_chunk.location)), (sum(_hyper_1_1_chunk.temperature)), (sum(_hyper_1_1_chunk.humidity))
          Hash Cond: ((time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)) = _materialized_hypertable_2.timec)
          ->  GroupAggregate
                Output: _hyper_1_1_chunk.location, (time_bucket('@ 1 day'::interval, _hyper_1_1_chunk.timec)), min(_hyper_1_1_chunk.location), sum(_hyper_1_1_chunk.temperature), sum(_hyper_1_1_chunk.humidity)
@@ -638,23 +551,16 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                  ->  Seq Scan on _timescaledb_internal._hyper_1_2_chunk
                                        Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
          ->  Hash
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
                ->  Append
-                     ->  GroupAggregate
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-                           Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                           ->  Sort
-                                 Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                 Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                                 ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
-                                       Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                                       Order: _materialized_hypertable_2.timec
-                                       Startup Exclusion: true
-                                       Runtime Exclusion: false
-                                       Chunks excluded during startup: 0
-                                       ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                             Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                             Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
+                     ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+                           Startup Exclusion: true
+                           Runtime Exclusion: false
+                           Chunks excluded during startup: 0
+                           ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                                 Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                                 Index Cond: ((_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_2_4_chunk.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                      ->  GroupAggregate
                            Output: conditions_1.location, (time_bucket('@ 1 day'::interval, conditions_1.timec)), min(conditions_1.location), sum(conditions_1.temperature), sum(conditions_1.humidity)
                            Group Key: (time_bucket('@ 1 day'::interval, conditions_1.timec)), conditions_1.location
@@ -670,7 +576,7 @@ select * from mat_m1, regview where mat_m1.timec > '2018-10-01' and mat_m1.timec
                                              Output: _hyper_1_2_chunk_1.location, _hyper_1_2_chunk_1.timec, _hyper_1_2_chunk_1.temperature, _hyper_1_2_chunk_1.humidity
                                              Index Cond: ((_hyper_1_2_chunk_1.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)) AND (_hyper_1_2_chunk_1.timec > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone))
                                              Filter: (time_bucket('@ 1 day'::interval, _hyper_1_2_chunk_1.timec) > 'Mon Oct 01 00:00:00 2018 PDT'::timestamp with time zone)
-(52 rows)
+(45 rows)
 
 select l.locid, mat_m1.* from mat_m1 , location_tab l where timec > '2018-10-01' and l.locname = mat_m1.location order by timec desc;
  locid | location |            timec             | minl | sumt | sumh 
@@ -695,31 +601,23 @@ set timescaledb.enable_cagg_reorder_groupby = false;
 set enable_hashagg = false;
 :EXPLAIN
 select * from mat_m1 order by timec desc, location;
-                                                                                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, (_timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision)), (_timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision))
+   Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
    Sort Key: _materialized_hypertable_2.timec DESC, _materialized_hypertable_2.location
    ->  Append
-         ->  GroupAggregate
-               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _timescaledb_internal.finalize_agg('pg_catalog.min(pg_catalog.text)'::text, 'pg_catalog'::name, 'default'::name, '{{pg_catalog,text}}'::name[], _materialized_hypertable_2.agg_3_3, NULL::text), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_4_4, NULL::double precision), _timescaledb_internal.finalize_agg('pg_catalog.sum(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_5_5, NULL::double precision)
-               Group Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-               ->  Incremental Sort
-                     Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                     Sort Key: _materialized_hypertable_2.timec, _materialized_hypertable_2.location
-                     Presorted Key: _materialized_hypertable_2.timec
-                     ->  Custom Scan (ConstraintAwareAppend)
-                           Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.agg_3_3, _materialized_hypertable_2.agg_4_4, _materialized_hypertable_2.agg_5_5
-                           Hypertable: _materialized_hypertable_2
-                           Chunks excluded during startup: 0
-                           ->  Merge Append
-                                 Sort Key: _hyper_2_3_chunk.timec
-                                 ->  Index Scan Backward using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
-                                       Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.agg_3_3, _hyper_2_3_chunk.agg_4_4, _hyper_2_3_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-                                 ->  Index Scan Backward using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
-                                       Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.agg_3_3, _hyper_2_4_chunk.agg_4_4, _hyper_2_4_chunk.agg_5_5
-                                       Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+         ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_2
+               Output: _materialized_hypertable_2.location, _materialized_hypertable_2.timec, _materialized_hypertable_2.minl, _materialized_hypertable_2.sumt, _materialized_hypertable_2.sumh
+               Startup Exclusion: true
+               Runtime Exclusion: false
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_2_3_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_3_chunk
+                     Output: _hyper_2_3_chunk.location, _hyper_2_3_chunk.timec, _hyper_2_3_chunk.minl, _hyper_2_3_chunk.sumt, _hyper_2_3_chunk.sumh
+                     Index Cond: (_hyper_2_3_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
+               ->  Index Scan using _hyper_2_4_chunk__materialized_hypertable_2_timec_idx on _timescaledb_internal._hyper_2_4_chunk
+                     Output: _hyper_2_4_chunk.location, _hyper_2_4_chunk.timec, _hyper_2_4_chunk.minl, _hyper_2_4_chunk.sumt, _hyper_2_4_chunk.sumh
+                     Index Cond: (_hyper_2_4_chunk.timec < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
          ->  GroupAggregate
                Output: conditions.location, (time_bucket('@ 1 day'::interval, conditions.timec)), min(conditions.location), sum(conditions.temperature), sum(conditions.humidity)
                Group Key: (time_bucket('@ 1 day'::interval, conditions.timec)), conditions.location
@@ -734,7 +632,7 @@ select * from mat_m1 order by timec desc, location;
                            ->  Index Scan using _hyper_1_2_chunk_conditions_timec_idx on _timescaledb_internal._hyper_1_2_chunk
                                  Output: _hyper_1_2_chunk.location, _hyper_1_2_chunk.timec, _hyper_1_2_chunk.temperature, _hyper_1_2_chunk.humidity
                                  Index Cond: (_hyper_1_2_chunk.timec >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone))
-(37 rows)
+(29 rows)
 
 -----------------------------------------------------------------------
 -- Test the cagg_watermark function. The watermark gives the point
@@ -904,7 +802,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C", m1.timec DESC
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
 LIMIT 10;
  location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
 ----------+------------------------------+------+------+--------+-------+---------+---------
@@ -912,10 +810,10 @@ LIMIT 10;
  SFO      | Mon Jan 01 16:00:00 2018 PST |   65 |   45 |     45 |    45 |      65 |      65
  SFO      | Sun Dec 31 16:00:00 2017 PST |   55 |   45 |     45 |    45 |      55 |      55
  por      | Mon Jan 01 16:00:00 2018 PST |  100 |  100 |    100 |   100 |     100 |     100
-          |                              |      |      |     45 |    30 |      65 |      45
-          |                              |      |      |     45 |    45 |      65 |      55
-          |                              |      |      |     30 |    50 |      85 |      45
           |                              |      |      |     10 |       |      20 |      10
+          |                              |      |      |     30 |    50 |      85 |      45
+          |                              |      |      |     45 |    45 |      65 |      55
+          |                              |      |      |     45 |    30 |      65 |      45
           |                              |      |      |        |       |         |        
 (9 rows)
 

--- a/tsl/test/expected/cagg_union_view-12.out
+++ b/tsl/test/expected/cagg_union_view-12.out
@@ -37,18 +37,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -68,12 +67,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_2.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,          +
+     _materialized_hypertable_2.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_2;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -91,18 +89,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -122,18 +119,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -162,12 +158,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_2.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,          +
+     _materialized_hypertable_2.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_2;
 (1 row)
 
 -- view should have results now after refresh
@@ -192,12 +187,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_3.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,          +
+     _materialized_hypertable_3.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_3;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -215,18 +209,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_3.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                              +
+     _materialized_hypertable_3.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                     +
+   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -246,12 +239,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_3.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,          +
+     _materialized_hypertable_3.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_3;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -362,26 +354,21 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=4 loops=1)
-   ->  HashAggregate (actual rows=0 loops=1)
-         Group Key: time_bucket
-         ->  Result (actual rows=0 loops=1)
-               One-Time Filter: false
-   ->  HashAggregate (actual rows=4 loops=1)
-         Group Key: time_bucket(10, boundary_test."time")
-         ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
-               Chunks excluded during startup: 0
-               ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-(17 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=4 loops=1)
+   Group Key: time_bucket(10, boundary_test."time")
+   ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
+         Chunks excluded during startup: 0
+         ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+(12 rows)
 
 -- result should have 4 rows
 SELECT * FROM boundary_view ORDER BY time_bucket;
@@ -405,16 +392,13 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- both sides of the UNION should return 2 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
-   ->  GroupAggregate (actual rows=2 loops=1)
-         Group Key: _materialized_hypertable_6.time_bucket
-         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
-               Order: _materialized_hypertable_6.time_bucket
-               Chunks excluded during startup: 0
-               ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
-                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
+         Chunks excluded during startup: 0
+         ->  Index Scan using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
+               Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: time_bucket(10, boundary_test."time")
          ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=2 loops=1)
@@ -423,7 +407,7 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-(16 rows)
+(13 rows)
 
 -- result should have 4 rows
 SELECT * FROM boundary_view ORDER BY time_bucket;
@@ -593,20 +577,16 @@ ORDER by 1;
 
 -- plan output
 :PREFIX SELECT * FROM mat_m1 ORDER BY 1;
-                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=3 loops=1)
    Sort Key: _materialized_hypertable_9.time_bucket
    Sort Method: quicksort 
    ->  Append (actual rows=3 loops=1)
-         ->  GroupAggregate (actual rows=1 loops=1)
-               Group Key: _materialized_hypertable_9.time_bucket
-               Filter: ((_timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_3, NULL::bigint) > 50) AND ((_timescaledb_internal.finalize_agg('pg_catalog.avg(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_4, NULL::numeric))::integer > 12))
-               ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
-                     Order: _materialized_hypertable_9.time_bucket
-                     Chunks excluded during startup: 0
-                     ->  Index Scan Backward using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
-                           Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
+         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
+                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
          ->  HashAggregate (actual rows=2 loops=1)
                Group Key: time_bucket(5, ht_intdata.a)
                Filter: ((sum(ht_intdata.c) > 50) AND ((avg(ht_intdata.b))::integer > 12))
@@ -623,7 +603,7 @@ ORDER by 1;
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                            Rows Removed by Filter: 2
-(28 rows)
+(24 rows)
 
 -- Test caggs with different time types
 CREATE TABLE smallint_table (time smallint, value int);

--- a/tsl/test/expected/cagg_union_view-13.out
+++ b/tsl/test/expected/cagg_union_view-13.out
@@ -37,18 +37,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -68,12 +67,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_2.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,          +
+     _materialized_hypertable_2.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_2;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -91,18 +89,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -122,18 +119,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -162,12 +158,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_2.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,          +
+     _materialized_hypertable_2.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_2;
 (1 row)
 
 -- view should have results now after refresh
@@ -192,12 +187,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_3.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,          +
+     _materialized_hypertable_3.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_3;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -215,18 +209,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_3.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                              +
+     _materialized_hypertable_3.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                     +
+   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -246,12 +239,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_3.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,          +
+     _materialized_hypertable_3.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_3;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -362,28 +354,22 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=4 loops=1)
-   ->  HashAggregate (actual rows=0 loops=1)
-         Group Key: time_bucket
-         Batches: 1 
-         ->  Result (actual rows=0 loops=1)
-               One-Time Filter: false
-   ->  HashAggregate (actual rows=4 loops=1)
-         Group Key: time_bucket(10, boundary_test."time")
-         Batches: 1 
-         ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
-               Chunks excluded during startup: 0
-               ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-(19 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=4 loops=1)
+   Group Key: time_bucket(10, boundary_test."time")
+   Batches: 1 
+   ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
+         Chunks excluded during startup: 0
+         ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+(13 rows)
 
 -- result should have 4 rows
 SELECT * FROM boundary_view ORDER BY time_bucket;
@@ -407,16 +393,13 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- both sides of the UNION should return 2 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
-   ->  GroupAggregate (actual rows=2 loops=1)
-         Group Key: _materialized_hypertable_6.time_bucket
-         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
-               Order: _materialized_hypertable_6.time_bucket
-               Chunks excluded during startup: 0
-               ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
-                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
+         Chunks excluded during startup: 0
+         ->  Index Scan using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
+               Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: time_bucket(10, boundary_test."time")
          Batches: 1 
@@ -426,7 +409,7 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-(17 rows)
+(14 rows)
 
 -- result should have 4 rows
 SELECT * FROM boundary_view ORDER BY time_bucket;
@@ -596,20 +579,16 @@ ORDER by 1;
 
 -- plan output
 :PREFIX SELECT * FROM mat_m1 ORDER BY 1;
-                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=3 loops=1)
    Sort Key: _materialized_hypertable_9.time_bucket
    Sort Method: quicksort 
    ->  Append (actual rows=3 loops=1)
-         ->  GroupAggregate (actual rows=1 loops=1)
-               Group Key: _materialized_hypertable_9.time_bucket
-               Filter: ((_timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_3, NULL::bigint) > 50) AND ((_timescaledb_internal.finalize_agg('pg_catalog.avg(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_4, NULL::numeric))::integer > 12))
-               ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
-                     Order: _materialized_hypertable_9.time_bucket
-                     Chunks excluded during startup: 0
-                     ->  Index Scan Backward using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
-                           Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
+         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
+                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
          ->  HashAggregate (actual rows=2 loops=1)
                Group Key: time_bucket(5, ht_intdata.a)
                Filter: ((sum(ht_intdata.c) > 50) AND ((avg(ht_intdata.b))::integer > 12))
@@ -627,7 +606,7 @@ ORDER by 1;
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                            Rows Removed by Filter: 2
-(29 rows)
+(25 rows)
 
 -- Test caggs with different time types
 CREATE TABLE smallint_table (time smallint, value int);

--- a/tsl/test/expected/cagg_union_view-14.out
+++ b/tsl/test/expected/cagg_union_view-14.out
@@ -37,18 +37,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -68,12 +67,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_2.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,          +
+     _materialized_hypertable_2.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_2;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -91,18 +89,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -122,18 +119,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_2.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                              +
+     _materialized_hypertable_2.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                     +
+   WHERE _materialized_hypertable_2.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(2)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -162,12 +158,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_2.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_2.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_2                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_2.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_2.time_bucket,          +
+     _materialized_hypertable_2.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_2;
 (1 row)
 
 -- view should have results now after refresh
@@ -192,12 +187,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_3.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,          +
+     _materialized_hypertable_3.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_3;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -215,18 +209,17 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                               +
-   GROUP BY _materialized_hypertable_3.time_bucket                                                                                                                                                           +
- UNION ALL                                                                                                                                                                                                   +
-  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                                                    +
-     avg(metrics.value) AS avg                                                                                                                                                                               +
-    FROM metrics                                                                                                                                                                                             +
-   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                                                      +
+                                                                                pg_get_viewdef                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                              +
+     _materialized_hypertable_3.avg                                                                                                                                           +
+    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                     +
+   WHERE _materialized_hypertable_3.time_bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)+
+ UNION ALL                                                                                                                                                                    +
+  SELECT time_bucket('@ 1 day'::interval, metrics."time") AS time_bucket,                                                                                                     +
+     avg(metrics.value) AS avg                                                                                                                                                +
+    FROM metrics                                                                                                                                                              +
+   WHERE metrics."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(3)), '-infinity'::timestamp with time zone)                       +
    GROUP BY (time_bucket('@ 1 day'::interval, metrics."time"));
 (1 row)
 
@@ -246,12 +239,11 @@ SELECT user_view_name, materialized_only FROM _timescaledb_catalog.continuous_ag
 (1 row)
 
 SELECT pg_get_viewdef('metrics_summary',true);
-                                                                                                pg_get_viewdef                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  SELECT _materialized_hypertable_3.time_bucket,                                                                                                                                                             +
-     _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_3.agg_2_2, NULL::double precision) AS avg+
-    FROM _timescaledb_internal._materialized_hypertable_3                                                                                                                                                    +
-   GROUP BY _materialized_hypertable_3.time_bucket;
+                      pg_get_viewdef                       
+-----------------------------------------------------------
+  SELECT _materialized_hypertable_3.time_bucket,          +
+     _materialized_hypertable_3.avg                       +
+    FROM _timescaledb_internal._materialized_hypertable_3;
 (1 row)
 
 SELECT time_bucket,avg FROM metrics_summary ORDER BY 1;
@@ -362,28 +354,22 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- first UNION child should have no rows because no materialization has happened yet and 2nd child should have 4 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Append (actual rows=4 loops=1)
-   ->  HashAggregate (actual rows=0 loops=1)
-         Group Key: time_bucket
-         Batches: 1 
-         ->  Result (actual rows=0 loops=1)
-               One-Time Filter: false
-   ->  HashAggregate (actual rows=4 loops=1)
-         Group Key: time_bucket(10, boundary_test."time")
-         Batches: 1 
-         ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
-               Chunks excluded during startup: 0
-               ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-               ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
-                     Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-(19 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ HashAggregate (actual rows=4 loops=1)
+   Group Key: time_bucket(10, boundary_test."time")
+   Batches: 1 
+   ->  Custom Scan (ChunkAppend) on boundary_test (actual rows=4 loops=1)
+         Chunks excluded during startup: 0
+         ->  Index Scan Backward using _hyper_5_5_chunk_boundary_test_time_idx on _hyper_5_5_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_6_chunk_boundary_test_time_idx on _hyper_5_6_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_7_chunk_boundary_test_time_idx on _hyper_5_7_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+         ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
+               Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+(13 rows)
 
 -- result should have 4 rows
 SELECT * FROM boundary_view ORDER BY time_bucket;
@@ -407,16 +393,13 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
 
 -- both sides of the UNION should return 2 rows
 :PREFIX SELECT * FROM boundary_view;
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
  Append (actual rows=4 loops=1)
-   ->  GroupAggregate (actual rows=2 loops=1)
-         Group Key: _materialized_hypertable_6.time_bucket
-         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
-               Order: _materialized_hypertable_6.time_bucket
-               Chunks excluded during startup: 0
-               ->  Index Scan Backward using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
-                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
+   ->  Custom Scan (ChunkAppend) on _materialized_hypertable_6 (actual rows=2 loops=1)
+         Chunks excluded during startup: 0
+         ->  Index Scan using _hyper_6_9_chunk__materialized_hypertable_6_time_bucket_idx on _hyper_6_9_chunk (actual rows=2 loops=1)
+               Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
    ->  HashAggregate (actual rows=2 loops=1)
          Group Key: time_bucket(10, boundary_test."time")
          Batches: 1 
@@ -426,7 +409,7 @@ SELECT _timescaledb_internal.cagg_watermark(:boundary_view_id);
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
                ->  Index Scan Backward using _hyper_5_8_chunk_boundary_test_time_idx on _hyper_5_8_chunk (actual rows=1 loops=1)
                      Index Cond: ("time" >= COALESCE((_timescaledb_internal.cagg_watermark(6))::integer, '-2147483648'::integer))
-(17 rows)
+(14 rows)
 
 -- result should have 4 rows
 SELECT * FROM boundary_view ORDER BY time_bucket;
@@ -596,20 +579,16 @@ ORDER by 1;
 
 -- plan output
 :PREFIX SELECT * FROM mat_m1 ORDER BY 1;
-                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=3 loops=1)
    Sort Key: _materialized_hypertable_9.time_bucket
    Sort Method: quicksort 
    ->  Append (actual rows=3 loops=1)
-         ->  GroupAggregate (actual rows=1 loops=1)
-               Group Key: _materialized_hypertable_9.time_bucket
-               Filter: ((_timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_3, NULL::bigint) > 50) AND ((_timescaledb_internal.finalize_agg('pg_catalog.avg(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_9.agg_0_4, NULL::numeric))::integer > 12))
-               ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
-                     Order: _materialized_hypertable_9.time_bucket
-                     Chunks excluded during startup: 0
-                     ->  Index Scan Backward using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
-                           Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
+         ->  Custom Scan (ChunkAppend) on _materialized_hypertable_9 (actual rows=1 loops=1)
+               Chunks excluded during startup: 0
+               ->  Index Scan using _hyper_9_15_chunk__materialized_hypertable_9_time_bucket_idx on _hyper_9_15_chunk (actual rows=1 loops=1)
+                     Index Cond: (time_bucket < COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
          ->  HashAggregate (actual rows=2 loops=1)
                Group Key: time_bucket(5, ht_intdata.a)
                Filter: ((sum(ht_intdata.c) > 50) AND ((avg(ht_intdata.b))::integer > 12))
@@ -627,7 +606,7 @@ ORDER by 1;
                            Index Cond: (a >= COALESCE((_timescaledb_internal.cagg_watermark(9))::integer, '-2147483648'::integer))
                            Filter: ((b < 16) AND (c > 20))
                            Rows Removed by Filter: 2
-(29 rows)
+(25 rows)
 
 -- Test caggs with different time types
 CREATE TABLE smallint_table (time smallint, value int);

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -68,7 +68,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_m1'
 \gset
 insert into :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
-select a, _timescaledb_internal.partialize_agg(count(b)),
+select a, count(b),
 time_bucket(1, a)
 from foo
 group by time_bucket(1, a) , a ;
@@ -160,7 +160,7 @@ FROM timescaledb_information.hypertables ORDER BY 1,2;
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select
- time_bucket('1day', timec), _timescaledb_internal.partialize_agg( min(location)), _timescaledb_internal.partialize_agg( sum(temperature)) , _timescaledb_internal.partialize_agg( sum(humidity))
+ time_bucket('1day', timec), min(location), sum(temperature), sum(humidity)
 from conditions
 group by time_bucket('1day', timec) ;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
@@ -234,7 +234,7 @@ WHERE user_view_name = 'mat_m1'
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select
- time_bucket('1week', timec),  _timescaledb_internal.partialize_agg( min(location)), _timescaledb_internal.partialize_agg( sum(temperature)) , _timescaledb_internal.partialize_agg( sum(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity))
+ time_bucket('1week', timec), min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 group by time_bucket('1week', timec) ;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
@@ -289,7 +289,7 @@ WHERE user_view_name = 'mat_m1'
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select
- time_bucket('1week', timec),  _timescaledb_internal.partialize_agg( min(location)), _timescaledb_internal.partialize_agg( sum(temperature)) , _timescaledb_internal.partialize_agg( sum(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity))
+ time_bucket('1week', timec), min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
 where location = 'NYC'
 group by time_bucket('1week', timec) ;
@@ -342,9 +342,10 @@ WHERE user_view_name = 'mat_m1'
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select
- time_bucket('1week', timec),  _timescaledb_internal.partialize_agg( min(location)), _timescaledb_internal.partialize_agg( sum(temperature)) , _timescaledb_internal.partialize_agg( sum(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity))
+ time_bucket('1week', timec), min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
-group by time_bucket('1week', timec) ;
+group by time_bucket('1week', timec)
+having stddev(humidity) is not null;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- should have same results --
 select * from mat_m1
@@ -397,7 +398,7 @@ select generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timest
 CREATE MATERIALIZED VIEW mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
-select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity), stddev(humidity)
+select time_bucket('1week', timec) as bucket, location as loc, sum(temperature)+sum(humidity) as sumth, stddev(humidity)
 from conditions
 group by bucket, loc
 having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
@@ -418,19 +419,16 @@ order by attnum, attname;
 --------+---------
       1 | bucket
       2 | loc
-      3 | agg_3_3
-      4 | agg_3_4
-      5 | agg_4_5
-      6 | agg_0_6
-      7 | agg_0_7
-(7 rows)
+      3 | sumth
+      4 | stddev
+(4 rows)
 
 DROP MATERIALIZED VIEW mat_naming;
 --naming with default names
 CREATE MATERIALIZED VIEW mat_naming
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
-select time_bucket('1week', timec), location, sum(temperature)+sum(humidity), stddev(humidity)
+select time_bucket('1week', timec), location, sum(temperature)+sum(humidity) as sumth, stddev(humidity)
 from conditions
 group by 1,2
 having min(location) >= 'NYC' and avg(temperature) > 20 WITH NO DATA;
@@ -451,12 +449,9 @@ order by attnum, attname;
 --------+-------------
       1 | time_bucket
       2 | location
-      3 | agg_3_3
-      4 | agg_3_4
-      5 | agg_4_5
-      6 | agg_0_6
-      7 | agg_0_7
-(7 rows)
+      3 | sumth
+      4 | stddev
+(4 rows)
 
 DROP MATERIALIZED VIEW mat_naming;
 --naming with view col names
@@ -484,12 +479,9 @@ order by attnum, attname;
 --------+---------
       1 | bucket
       2 | loc
-      3 | agg_3_3
-      4 | agg_3_4
-      5 | agg_4_5
-      6 | agg_0_6
-      7 | agg_0_7
-(7 rows)
+      3 | sum_t_h
+      4 | stdd
+(4 rows)
 
 DROP MATERIALIZED VIEW mat_naming;
 CREATE MATERIALIZED VIEW mat_m1(timec, minl, sumth, stddevh)
@@ -516,20 +508,18 @@ order by attnum, attname;
  attnum | attname 
 --------+---------
       1 | timec
-      2 | agg_2_2
-      3 | agg_3_3
-      4 | agg_3_4
-      5 | agg_4_5
-      6 | agg_0_6
-(6 rows)
+      2 | minl
+      3 | sumth
+      4 | stddevh
+(4 rows)
 
 SET ROLE :ROLE_SUPERUSER;
 insert into  :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
 select
- time_bucket('1week', timec),  _timescaledb_internal.partialize_agg( min(location)), _timescaledb_internal.partialize_agg( sum(temperature)) , _timescaledb_internal.partialize_agg( sum(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity))
-,_timescaledb_internal.partialize_agg( avg(temperature))
+ time_bucket('1week', timec), min(location), sum(temperature)+sum(humidity), stddev(humidity)
 from conditions
-group by time_bucket('1week', timec) ;
+group by time_bucket('1week', timec)
+having min(location) >= 'NYC' and avg(temperature) > 20;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 --should have same results --
 select timec, minl, sumth, stddevh
@@ -576,7 +566,7 @@ select * from :"PART_VIEW_SCHEMA".:"PART_VIEW_NAME";
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 --lets drop the view and check
 DROP MATERIALIZED VIEW mat_m1;
-NOTICE:  drop cascades to 2 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_13_24_chunk
 drop table conditions;
 CREATE TABLE conditions (
       timec       TIMESTAMPTZ       NOT NULL,
@@ -624,7 +614,7 @@ SELECT
   $$ AS "QUERY"
 \gset
 \set ECHO errors
-psql:include/cont_agg_equal.sql:8: NOTICE:  drop cascades to 2 other objects
+psql:include/cont_agg_equal.sql:8: NOTICE:  drop cascades to table _timescaledb_internal._hyper_15_34_chunk
                            ?column?                            | count 
 ---------------------------------------------------------------+-------
  Number of rows different between view and original (expect 0) |     0
@@ -894,13 +884,10 @@ FROM _timescaledb_catalog.continuous_agg ca
 INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_with_test')
 order by indexname;
-                   indexname                   |                                                                     indexdef                                                                      
------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------
- _materialized_hypertable_20_grp_5_5_timec_idx | CREATE INDEX _materialized_hypertable_20_grp_5_5_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (grp_5_5, timec DESC)
- _materialized_hypertable_20_grp_6_6_timec_idx | CREATE INDEX _materialized_hypertable_20_grp_6_6_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (grp_6_6, timec DESC)
- _materialized_hypertable_20_grp_7_7_timec_idx | CREATE INDEX _materialized_hypertable_20_grp_7_7_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (grp_7_7, timec DESC)
- _materialized_hypertable_20_timec_idx         | CREATE INDEX _materialized_hypertable_20_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (timec DESC)
-(4 rows)
+               indexname               |                                                             indexdef                                                             
+---------------------------------------+----------------------------------------------------------------------------------------------------------------------------------
+ _materialized_hypertable_20_timec_idx | CREATE INDEX _materialized_hypertable_20_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (timec DESC)
+(1 row)
 
 DROP MATERIALIZED VIEW mat_with_test;
 --no additional indexes
@@ -1020,8 +1007,8 @@ WHERE user_view_name = 'space_view'
 \gset
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
- time_bucket | agg_2_2 
--------------+---------
+ time_bucket | count 
+-------------+-------
 (0 rows)
 
 CALL refresh_continuous_aggregate('space_view', NULL, NULL);
@@ -1034,10 +1021,10 @@ SELECT * FROM space_view ORDER BY 1;
 
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
- time_bucket |      agg_2_2       
--------------+--------------------
-           0 | \x0000000000000004
-           8 | \x0000000000000004
+ time_bucket | count 
+-------------+-------
+           0 |     4
+           8 |     4
 (2 rows)
 
 INSERT INTO space_table VALUES (3, 2, 1);
@@ -1051,10 +1038,10 @@ SELECT * FROM space_view ORDER BY 1;
 
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
- time_bucket |      agg_2_2       
--------------+--------------------
-           0 | \x0000000000000005
-           8 | \x0000000000000004
+ time_bucket | count 
+-------------+-------
+           0 |     5
+           8 |     4
 (2 rows)
 
 INSERT INTO space_table VALUES (2, 3, 1);
@@ -1068,15 +1055,15 @@ SELECT * FROM space_view ORDER BY 1;
 
 SELECT * FROM :"MAT_SCHEMA_NAME".:"MAT_TABLE_NAME"
   ORDER BY time_bucket;
- time_bucket |      agg_2_2       
--------------+--------------------
-           0 | \x0000000000000006
-           8 | \x0000000000000004
+ time_bucket | count 
+-------------+-------
+           0 |     6
+           8 |     4
 (2 rows)
 
 DROP TABLE space_table CASCADE;
 NOTICE:  drop cascades to 2 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_62_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_25_60_chunk
 --
 -- TEST FINALIZEFUNC_EXTRA
 --
@@ -1135,19 +1122,19 @@ select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 1, 3, 'test
 from conditions
 group by time_bucket(100, timec);
 NOTICE:  refreshing continuous aggregate "mat_ffunc_test"
-SELECT * FROM mat_ffunc_test;
 WARNING:  type integer text
 WARNING:  type integer text
 WARNING:  type integer text
+SELECT * FROM mat_ffunc_test ORDER BY time_bucket;
  time_bucket | aggregate_to_test_ffunc_extra 
 -------------+-------------------------------
-         200 | 
            0 | 
          100 | 
+         200 | 
 (3 rows)
 
 DROP MATERIALIZED view mat_ffunc_test;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_67_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_27_65_chunk
 CREATE MATERIALIZED VIEW mat_ffunc_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
@@ -1155,20 +1142,20 @@ select time_bucket(100, timec), aggregate_to_test_ffunc_extra(timec, 4, 5, bigin
 from conditions
 group by time_bucket(100, timec);
 NOTICE:  refreshing continuous aggregate "mat_ffunc_test"
-SELECT * FROM mat_ffunc_test;
 WARNING:  type integer bigint
 WARNING:  type integer bigint
 WARNING:  type integer bigint
+SELECT * FROM mat_ffunc_test ORDER BY time_bucket;
  time_bucket | aggregate_to_test_ffunc_extra 
 -------------+-------------------------------
-         200 |                              
            0 |                              
          100 |                              
+         200 |                              
 (3 rows)
 
 --refresh mat view test when time_bucket is not projected --
 DROP MATERIALIZED VIEW mat_ffunc_test;
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_28_66_chunk
 CREATE MATERIALIZED VIEW mat_refresh_test
 WITH (timescaledb.continuous, timescaledb.materialized_only=true)
 as
@@ -1402,9 +1389,9 @@ ORDER BY water_consumption;
 
 DROP TABLE water_consumption CASCADE;
 NOTICE:  drop cascades to 6 other objects
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_35_75_chunk
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_36_76_chunk
-NOTICE:  drop cascades to table _timescaledb_internal._hyper_37_77_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_35_73_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_36_74_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_37_75_chunk
 ----
 --- github issue 2655 ---
 create table raw_data(time timestamptz, search_query text, cnt integer, cnt2 integer);
@@ -1523,22 +1510,6 @@ WHERE hypertable_name = :'MAT_TABLE_NAME';
 -[ RECORD 1 ]----------+----------------------------
 hypertable_schema      | _timescaledb_internal
 hypertable_name        | _materialized_hypertable_41
-attname                | grp_5_5
-segmentby_column_index | 1
-orderby_column_index   | 
-orderby_asc            | 
-orderby_nullsfirst     | 
--[ RECORD 2 ]----------+----------------------------
-hypertable_schema      | _timescaledb_internal
-hypertable_name        | _materialized_hypertable_41
-attname                | search_query
-segmentby_column_index | 2
-orderby_column_index   | 
-orderby_asc            | 
-orderby_nullsfirst     | 
--[ RECORD 3 ]----------+----------------------------
-hypertable_schema      | _timescaledb_internal
-hypertable_name        | _materialized_hypertable_41
 attname                | bucket
 segmentby_column_index | 
 orderby_column_index   | 1
@@ -1550,7 +1521,7 @@ SELECT compress_chunk(ch)
 FROM show_chunks('search_query_count_3') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_41_81_chunk
+ _timescaledb_internal._hyper_41_79_chunk
 (1 row)
 
 SELECT * from search_query_count_3 ORDER BY 1, 2, 3;
@@ -1573,9 +1544,9 @@ insert into raw_data select '2000-05-01 00:00+0','Q3', 0, 0;
 --this one fails now
 \set ON_ERROR_STOP 0
 CALL refresh_continuous_aggregate('search_query_count_3', NULL, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_81_chunk" as it is compressed
+ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
 CALL refresh_continuous_aggregate('search_query_count_3', '2000-05-01 00:00+0'::timestamptz, '2000-06-01 00:00+0'::timestamptz);
-ERROR:  cannot update/delete rows from chunk "_hyper_41_81_chunk" as it is compressed
+ERROR:  cannot update/delete rows from chunk "_hyper_41_79_chunk" as it is compressed
 \set ON_ERROR_STOP 1
 --insert row
 insert into raw_data select '2001-05-10 00:00+0','Q3', 100, 100;
@@ -1594,8 +1565,8 @@ WHERE hypertable_name = :'MAT_TABLE_NAME'
 ORDER BY 1;
      chunk_name     |         range_start          |          range_end           | is_compressed 
 --------------------+------------------------------+------------------------------+---------------
- _hyper_41_81_chunk | Fri Dec 24 16:00:00 1999 PST | Mon May 22 17:00:00 2000 PDT | t
- _hyper_41_85_chunk | Sun Mar 18 16:00:00 2001 PST | Wed Aug 15 17:00:00 2001 PDT | f
+ _hyper_41_79_chunk | Fri Dec 24 16:00:00 1999 PST | Mon May 22 17:00:00 2000 PDT | t
+ _hyper_41_83_chunk | Sun Mar 18 16:00:00 2001 PST | Wed Aug 15 17:00:00 2001 PDT | f
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
@@ -1625,7 +1596,7 @@ FROM _timescaledb_catalog.chunk
 WHERE hypertable_id = :'MAT_HTID' and status = 1;
              decompress_chunk             
 ------------------------------------------
- _timescaledb_internal._hyper_41_81_chunk
+ _timescaledb_internal._hyper_41_79_chunk
 (1 row)
 
 --disable compression on cagg after decompressing all chunks--
@@ -1665,7 +1636,7 @@ ALTER MATERIALIZED VIEW test_morecols_cagg SET (timescaledb.compress='true');
 SELECT compress_chunk(ch) FROM show_chunks('test_morecols_cagg') ch;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_44_91_chunk
+ _timescaledb_internal._hyper_44_89_chunk
 (1 row)
 
 SELECT * FROM test_morecols_cagg ORDER BY time_bucket;
@@ -1729,13 +1700,13 @@ SELECT
 (0 rows)
 
 -- test that option create_group_indexes is taken into account
-SET client_min_messages = ERROR;
 CREATE TABLE test_group_idx (
 time timestamptz,
 symbol int,
 value numeric
 );
 select create_hypertable('test_group_idx', 'time');
+NOTICE:  adding not-null constraint to column "time"
       create_hypertable       
 ------------------------------
  (48,public,test_group_idx,t)
@@ -1745,30 +1716,33 @@ insert into test_group_idx
 select t, round(random()*10), random()*5
 from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
 create materialized view cagg_index_true
-with (timescaledb.continuous, timescaledb.create_group_indexes = true) as 
+with (timescaledb.continuous, timescaledb.create_group_indexes=true) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol 
-from test_group_idx 
+	symbol
+from test_group_idx
 group by bucket, symbol;
+NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
-with (timescaledb.continuous, timescaledb.create_group_indexes = false) as 
+with (timescaledb.continuous, timescaledb.create_group_indexes=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol 
-from test_group_idx 
+	symbol
+from test_group_idx
 group by bucket, symbol;
+NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
-with (timescaledb.continuous) as 
+with (timescaledb.continuous) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol 
-from test_group_idx 
+	symbol
+from test_group_idx
 group by bucket, symbol;
--- see corresponding materialization_hypertables 
+NOTICE:  refreshing continuous aggregate "cagg_index_default"
+-- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
 where view_name like 'cagg_index_%';
      view_name      | materialization_hypertable_name 
@@ -1779,6 +1753,7 @@ where view_name like 'cagg_index_%';
 (3 rows)
 
 -- now make sure a group index has been created when explicitly asked for
+\x on
 select i.*
 from pg_indexes i
 join pg_class c
@@ -1787,12 +1762,301 @@ join pg_class c
 where tablename in (select materialization_hypertable_name from timescaledb_information.continuous_aggregates
 where view_name like 'cagg_index_%')
 order by tablename;
-      schemaname       |          tablename          |                   indexname                   | tablespace |                                                                     indexdef                                                                      
------------------------+-----------------------------+-----------------------------------------------+------------+---------------------------------------------------------------------------------------------------------------------------------------------------
- _timescaledb_internal | _materialized_hypertable_49 | _materialized_hypertable_49_bucket_idx        |            | CREATE INDEX _materialized_hypertable_49_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (bucket DESC)
- _timescaledb_internal | _materialized_hypertable_49 | _materialized_hypertable_49_symbol_bucket_idx |            | CREATE INDEX _materialized_hypertable_49_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (symbol, bucket DESC)
- _timescaledb_internal | _materialized_hypertable_50 | _materialized_hypertable_50_bucket_idx        |            | CREATE INDEX _materialized_hypertable_50_bucket_idx ON _timescaledb_internal._materialized_hypertable_50 USING btree (bucket DESC)
- _timescaledb_internal | _materialized_hypertable_51 | _materialized_hypertable_51_bucket_idx        |            | CREATE INDEX _materialized_hypertable_51_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (bucket DESC)
- _timescaledb_internal | _materialized_hypertable_51 | _materialized_hypertable_51_symbol_bucket_idx |            | CREATE INDEX _materialized_hypertable_51_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (symbol, bucket DESC)
+-[ RECORD 1 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_49
+indexname  | _materialized_hypertable_49_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_49_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (bucket DESC)
+-[ RECORD 2 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_49
+indexname  | _materialized_hypertable_49_symbol_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_49_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (symbol, bucket DESC)
+-[ RECORD 3 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_50
+indexname  | _materialized_hypertable_50_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_50_bucket_idx ON _timescaledb_internal._materialized_hypertable_50 USING btree (bucket DESC)
+-[ RECORD 4 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_51
+indexname  | _materialized_hypertable_51_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_51_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (bucket DESC)
+-[ RECORD 5 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_51
+indexname  | _materialized_hypertable_51_symbol_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_51_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (symbol, bucket DESC)
+
+\x off
+--
+-- TESTs for removing old CAggs restrictions
+--
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 8 other objects
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_29_67_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_30_68_chunk
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_31_69_chunk
+CREATE TABLE conditions (
+  timec       TIMESTAMPTZ       NOT NULL,
+  location    TEXT              NOT NULL,
+  temperature DOUBLE PRECISION  NULL,
+  humidity    DOUBLE PRECISION  NULL
+);
+SELECT create_hypertable('conditions', 'timec');
+    create_hypertable     
+--------------------------
+ (52,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions
+VALUES
+  ('2010-01-01 09:00:00-08', 'SFO', 55, 45),
+  ('2010-01-02 09:00:00-08', 'por', 100, 100),
+  ('2010-01-02 09:00:00-08', 'NYC', 65, 45),
+  ('2010-01-02 09:00:00-08', 'SFO', 65, 45),
+  ('2010-01-03 09:00:00-08', 'NYC', 45, 55),
+  ('2010-01-05 09:00:00-08', 'SFO', 75, 100),
+  ('2018-11-01 09:00:00-08', 'NYC', 45, 35),
+  ('2018-11-02 09:00:00-08', 'NYC', 35, 15),
+  ('2018-11-03 09:00:00-08', 'NYC', 35, 25);
+-- aggregate with DISTINCT
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1week', timec),
+  COUNT(location),
+  SUM(DISTINCT temperature)
+FROM conditions
+GROUP BY time_bucket('1week', timec), location;
+NOTICE:  refreshing continuous aggregate "mat_m1"
+SELECT * FROM mat_m1 ORDER BY 1, 2, 3;
+         time_bucket          | count | sum 
+------------------------------+-------+-----
+ Sun Dec 27 16:00:00 2009 PST |     1 | 100
+ Sun Dec 27 16:00:00 2009 PST |     2 | 110
+ Sun Dec 27 16:00:00 2009 PST |     2 | 120
+ Sun Jan 03 16:00:00 2010 PST |     1 |  75
+ Sun Oct 28 17:00:00 2018 PDT |     3 |  80
 (5 rows)
+
+-- aggregate with FILTER
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to 2 other objects
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1week', timec),
+  SUM(temperature) FILTER (WHERE humidity > 60)
+FROM conditions
+GROUP BY time_bucket('1week', timec), location;
+NOTICE:  refreshing continuous aggregate "mat_m1"
+SELECT * FROM mat_m1 ORDER BY 1, 2;
+         time_bucket          | sum 
+------------------------------+-----
+ Sun Dec 27 16:00:00 2009 PST | 100
+ Sun Dec 27 16:00:00 2009 PST |    
+ Sun Dec 27 16:00:00 2009 PST |    
+ Sun Jan 03 16:00:00 2010 PST |  75
+ Sun Oct 28 17:00:00 2018 PDT |    
+(5 rows)
+
+-- aggregate with filter in having clause
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to 2 other objects
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1week', timec),
+  MAX(temperature)
+FROM conditions
+GROUP BY time_bucket('1week', timec), location
+HAVING SUM(temperature) FILTER (WHERE humidity > 40) > 50;
+NOTICE:  refreshing continuous aggregate "mat_m1"
+SELECT * FROM mat_m1 ORDER BY 1, 2;
+         time_bucket          | max 
+------------------------------+-----
+ Sun Dec 27 16:00:00 2009 PST |  65
+ Sun Dec 27 16:00:00 2009 PST |  65
+ Sun Dec 27 16:00:00 2009 PST | 100
+ Sun Jan 03 16:00:00 2010 PST |  75
+(4 rows)
+
+-- ordered set aggr
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to table _timescaledb_internal._hyper_55_116_chunk
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1week', timec),
+  MODE() WITHIN GROUP(ORDER BY humidity)
+FROM conditions
+GROUP BY time_bucket('1week', timec);
+NOTICE:  refreshing continuous aggregate "mat_m1"
+SELECT * FROM mat_m1 ORDER BY 1;
+         time_bucket          | mode 
+------------------------------+------
+ Sun Dec 27 16:00:00 2009 PST |   45
+ Sun Jan 03 16:00:00 2010 PST |  100
+ Sun Oct 28 17:00:00 2018 PDT |   15
+(3 rows)
+
+-- hypothetical-set aggr
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to 2 other objects
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+AS
+SELECT
+  time_bucket('1week', timec),
+  RANK(60) WITHIN GROUP (ORDER BY humidity),
+  DENSE_RANK(60) WITHIN GROUP (ORDER BY humidity),
+  PERCENT_RANK(60) WITHIN GROUP (ORDER BY humidity)
+FROM conditions
+GROUP BY time_bucket('1week', timec);
+NOTICE:  refreshing continuous aggregate "mat_m1"
+SELECT * FROM mat_m1 ORDER BY 1;
+         time_bucket          | rank | dense_rank | percent_rank 
+------------------------------+------+------------+--------------
+ Sun Dec 27 16:00:00 2009 PST |    5 |          3 |          0.8
+ Sun Jan 03 16:00:00 2010 PST |    1 |          1 |            0
+ Sun Oct 28 17:00:00 2018 PDT |    4 |          4 |            1
+(3 rows)
+
+-- userdefined aggregate without combine function
+DROP MATERIALIZED VIEW mat_m1;
+NOTICE:  drop cascades to 2 other objects
+CREATE AGGREGATE newavg (
+  sfunc = int4_avg_accum,
+  basetype = int4,
+  stype = _int8,
+  finalfunc = int8_avg,
+  initcond1 = '{0,0}'
+);
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+AS
+SELECT
+  SUM(humidity),
+  round(newavg(temperature::int4))
+FROM conditions
+GROUP BY time_bucket('1week', timec), location;
+NOTICE:  refreshing continuous aggregate "mat_m1"
+SELECT * FROM mat_m1 ORDER BY 1, 2;
+ sum | round 
+-----+-------
+  75 |    38
+  90 |    60
+ 100 |    55
+ 100 |    75
+ 100 |   100
+(5 rows)
+
+--
+-- Testing the coexistence of both types of supported CAggs
+-- over the same raw hypertable.
+--
+--  . finalized = true:  without chunk_id and partials
+--  . finalized = false: with chunk_id and partials
+--
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 2 other objects
+CREATE TABLE conditions (
+  timec       TIMESTAMPTZ       NOT NULL,
+  location    TEXT              NOT NULL,
+  temperature DOUBLE PRECISION  NULL,
+  humidity    DOUBLE PRECISION  NULL
+);
+SELECT table_name FROM create_hypertable('conditions', 'timec');
+ table_name 
+------------
+ conditions
+(1 row)
+
+INSERT INTO conditions VALUES
+  ('2010-01-01 09:00:00-08', 'SFO', 55, 45),
+  ('2010-01-02 09:00:00-08', 'por', 100, 100),
+  ('2010-01-02 09:00:00-08', 'SFO', 65, 45),
+  ('2010-01-02 09:00:00-08', 'NYC', 65, 45),
+  ('2018-11-01 09:00:00-08', 'NYC', 45, 35),
+  ('2018-11-02 09:00:00-08', 'NYC', 35, 15);
+CREATE MATERIALIZED VIEW conditions_summary_new(timec, minl, sumt, sumh)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true)
+AS
+SELECT time_bucket('1day', timec), min(location), sum(temperature), sum(humidity)
+FROM conditions
+GROUP BY time_bucket('1day', timec) WITH NO DATA;
+CREATE MATERIALIZED VIEW conditions_summary_old(timec, minl, sumt, sumh)
+WITH (timescaledb.continuous, timescaledb.materialized_only=true, timescaledb.finalized=false)
+AS
+SELECT time_bucket('1day', timec), min(location), sum(temperature), sum(humidity)
+FROM conditions
+GROUP BY time_bucket('1day', timec) WITH NO DATA;
+\x ON
+SELECT *
+FROM timescaledb_information.continuous_aggregates
+WHERE view_name IN ('conditions_summary_new', 'conditions_summary_old');
+-[ RECORD 1 ]---------------------+---------------------------------------------------------------------
+hypertable_schema                 | public
+hypertable_name                   | conditions
+view_schema                       | public
+view_name                         | conditions_summary_new
+view_owner                        | default_perm_user
+materialized_only                 | t
+compression_enabled               | f
+materialization_hypertable_schema | _timescaledb_internal
+materialization_hypertable_name   | _materialized_hypertable_60
+view_definition                   |  SELECT time_bucket('@ 1 day'::interval, conditions.timec) AS timec,+
+                                  |     min(conditions.location) AS minl,                               +
+                                  |     sum(conditions.temperature) AS sumt,                            +
+                                  |     sum(conditions.humidity) AS sumh                                +
+                                  |    FROM conditions                                                  +
+                                  |   GROUP BY (time_bucket('@ 1 day'::interval, conditions.timec));
+finalized                         | t
+-[ RECORD 2 ]---------------------+---------------------------------------------------------------------
+hypertable_schema                 | public
+hypertable_name                   | conditions
+view_schema                       | public
+view_name                         | conditions_summary_old
+view_owner                        | default_perm_user
+materialized_only                 | t
+compression_enabled               | f
+materialization_hypertable_schema | _timescaledb_internal
+materialization_hypertable_name   | _materialized_hypertable_61
+view_definition                   |  SELECT time_bucket('@ 1 day'::interval, conditions.timec) AS timec,+
+                                  |     min(conditions.location) AS minl,                               +
+                                  |     sum(conditions.temperature) AS sumt,                            +
+                                  |     sum(conditions.humidity) AS sumh                                +
+                                  |    FROM conditions                                                  +
+                                  |   GROUP BY (time_bucket('@ 1 day'::interval, conditions.timec));
+finalized                         | f
+
+\x OFF
+CALL refresh_continuous_aggregate('conditions_summary_new', NULL, NULL);
+CALL refresh_continuous_aggregate('conditions_summary_old', NULL, NULL);
+-- Check and compare number of returned rows
+SELECT count(*) FROM conditions_summary_new
+UNION
+SELECT count(*) FROM conditions_summary_old;
+ count 
+-------
+     4
+(1 row)
+
+-- Should return 4 rows that is the same number of rows above
+SELECT *
+FROM conditions_summary_new
+NATURAL JOIN conditions_summary_old
+ORDER BY timec;
+            timec             | minl | sumt | sumh 
+------------------------------+------+------+------
+ Thu Dec 31 16:00:00 2009 PST | SFO  |   55 |   45
+ Fri Jan 01 16:00:00 2010 PST | NYC  |  230 |  190
+ Wed Oct 31 17:00:00 2018 PDT | NYC  |   45 |   35
+ Thu Nov 01 17:00:00 2018 PDT | NYC  |   35 |   15
+(4 rows)
 

--- a/tsl/test/expected/continuous_aggs_deprecated.out
+++ b/tsl/test/expected/continuous_aggs_deprecated.out
@@ -1742,3 +1742,246 @@ SELECT
 --
 (0 rows)
 
+-- test that option create_group_indexes is taken into account
+CREATE TABLE test_group_idx (
+time timestamptz,
+symbol int,
+value numeric
+);
+select create_hypertable('test_group_idx', 'time');
+NOTICE:  adding not-null constraint to column "time"
+      create_hypertable       
+------------------------------
+ (48,public,test_group_idx,t)
+(1 row)
+
+insert into test_group_idx
+select t, round(random()*10), random()*5
+from generate_series('2020-01-01', '2020-02-25', INTERVAL '12 hours') t;
+create materialized view cagg_index_true
+with (timescaledb.continuous, timescaledb.create_group_indexes=true, timescaledb.finalized=false) as
+select
+	time_bucket('1 day', "time") as bucket,
+	sum(value),
+	symbol
+from test_group_idx
+group by bucket, symbol;
+NOTICE:  refreshing continuous aggregate "cagg_index_true"
+create materialized view cagg_index_false
+with (timescaledb.continuous, timescaledb.create_group_indexes=false, timescaledb.finalized=false) as
+select
+	time_bucket('1 day', "time") as bucket,
+	sum(value),
+	symbol
+from test_group_idx
+group by bucket, symbol;
+NOTICE:  refreshing continuous aggregate "cagg_index_false"
+create materialized view cagg_index_default
+with (timescaledb.continuous, timescaledb.finalized=false) as
+select
+	time_bucket('1 day', "time") as bucket,
+	sum(value),
+	symbol
+from test_group_idx
+group by bucket, symbol;
+NOTICE:  refreshing continuous aggregate "cagg_index_default"
+-- see corresponding materialization_hypertables
+select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
+where view_name like 'cagg_index_%';
+     view_name      | materialization_hypertable_name 
+--------------------+---------------------------------
+ cagg_index_default | _materialized_hypertable_51
+ cagg_index_false   | _materialized_hypertable_50
+ cagg_index_true    | _materialized_hypertable_49
+(3 rows)
+
+-- now make sure a group index has been created when explicitly asked for
+\x on
+select i.*
+from pg_indexes i
+join pg_class c
+    on schemaname = relnamespace::regnamespace::text
+    and tablename = relname
+where tablename in (select materialization_hypertable_name from timescaledb_information.continuous_aggregates
+where view_name like 'cagg_index_%')
+order by tablename;
+-[ RECORD 1 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_49
+indexname  | _materialized_hypertable_49_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_49_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (bucket DESC)
+-[ RECORD 2 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_49
+indexname  | _materialized_hypertable_49_symbol_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_49_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (symbol, bucket DESC)
+-[ RECORD 3 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_50
+indexname  | _materialized_hypertable_50_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_50_bucket_idx ON _timescaledb_internal._materialized_hypertable_50 USING btree (bucket DESC)
+-[ RECORD 4 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_51
+indexname  | _materialized_hypertable_51_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_51_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (bucket DESC)
+-[ RECORD 5 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+schemaname | _timescaledb_internal
+tablename  | _materialized_hypertable_51
+indexname  | _materialized_hypertable_51_symbol_bucket_idx
+tablespace | 
+indexdef   | CREATE INDEX _materialized_hypertable_51_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (symbol, bucket DESC)
+
+\x off
+-- Test View Target Entries that contain both aggrefs and Vars in the same expression
+CREATE TABLE transactions
+(
+    "time" timestamp with time zone NOT NULL,
+    dummy1 integer,
+    dummy2 integer,
+    dummy3 integer,
+    dummy4 integer,
+    dummy5 integer,
+    amount integer,
+    fiat_value integer
+);
+SELECT create_hypertable('transactions', 'time');
+     create_hypertable      
+----------------------------
+ (52,public,transactions,t)
+(1 row)
+
+INSERT INTO transactions VALUES ( '2018-01-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:30:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:20:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-01-02 09:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 10:40:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 11:50:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 12:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-01 13:10:00-08', 0, 0, 0, 0, 0, -1, 10);
+INSERT INTO transactions VALUES ( '2018-11-02 09:20:00-08', 0, 0, 0, 0, 0, 1, 10);
+INSERT INTO transactions VALUES ( '2018-11-02 10:30:00-08', 0, 0, 0, 0, 0, -1, 10);
+CREATE materialized view cashflows(
+    bucket,
+  	amount,
+    cashflow,
+    cashflow2
+) WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only = true,
+    timescaledb.finalized = false
+) AS
+SELECT time_bucket ('1 day', time) AS bucket,
+	amount,
+  CASE
+      WHEN amount < 0 THEN (0 - sum(fiat_value))
+      ELSE sum(fiat_value)
+  END AS cashflow,
+  amount + sum(fiat_value)
+FROM transactions
+GROUP BY bucket, amount;
+NOTICE:  refreshing continuous aggregate "cashflows"
+SELECT h.table_name AS "MAT_TABLE_NAME",
+       partial_view_name AS "PART_VIEW_NAME",
+       direct_view_name AS "DIRECT_VIEW_NAME"
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON (h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'cashflows'
+\gset
+-- Show both the columns and the view definitions to see that
+-- references are correct in the view as well.
+\d+ "_timescaledb_internal".:"DIRECT_VIEW_NAME"
+                         View "_timescaledb_internal._direct_view_53"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
+    transactions.amount,
+        CASE
+            WHEN transactions.amount < 0 THEN 0 - sum(transactions.fiat_value)
+            ELSE sum(transactions.fiat_value)
+        END AS cashflow,
+    transactions.amount + sum(transactions.fiat_value) AS cashflow2
+   FROM transactions
+  GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount;
+
+\d+ "_timescaledb_internal".:"PART_VIEW_NAME"
+                         View "_timescaledb_internal._partial_view_53"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Description 
+----------+--------------------------+-----------+----------+---------+----------+-------------
+ bucket   | timestamp with time zone |           |          |         | plain    | 
+ amount   | integer                  |           |          |         | plain    | 
+ agg_3_3  | bytea                    |           |          |         | extended | 
+ agg_3_4  | bytea                    |           |          |         | extended | 
+ var_3_5  | integer                  |           |          |         | plain    | 
+ agg_4_6  | bytea                    |           |          |         | extended | 
+ chunk_id | integer                  |           |          |         | plain    | 
+View definition:
+ SELECT time_bucket('@ 1 day'::interval, transactions."time") AS bucket,
+    transactions.amount,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_3,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_3_4,
+    transactions.amount AS var_3_5,
+    _timescaledb_internal.partialize_agg(sum(transactions.fiat_value)) AS agg_4_6,
+    _timescaledb_internal.chunk_id_from_relid(transactions.tableoid) AS chunk_id
+   FROM transactions
+  GROUP BY (time_bucket('@ 1 day'::interval, transactions."time")), transactions.amount, (_timescaledb_internal.chunk_id_from_relid(transactions.tableoid));
+
+\d+ "_timescaledb_internal".:"MAT_TABLE_NAME"
+                          Table "_timescaledb_internal._materialized_hypertable_53"
+  Column  |           Type           | Collation | Nullable | Default | Storage  | Stats target | Description 
+----------+--------------------------+-----------+----------+---------+----------+--------------+-------------
+ bucket   | timestamp with time zone |           | not null |         | plain    |              | 
+ amount   | integer                  |           |          |         | plain    |              | 
+ agg_3_3  | bytea                    |           |          |         | extended |              | 
+ agg_3_4  | bytea                    |           |          |         | extended |              | 
+ var_3_5  | integer                  |           |          |         | plain    |              | 
+ agg_4_6  | bytea                    |           |          |         | extended |              | 
+ chunk_id | integer                  |           |          |         | plain    |              | 
+Indexes:
+    "_materialized_hypertable_53_amount_bucket_idx" btree (amount, bucket DESC)
+    "_materialized_hypertable_53_bucket_idx" btree (bucket DESC)
+Triggers:
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._materialized_hypertable_53 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
+Child tables: _timescaledb_internal._hyper_53_114_chunk,
+              _timescaledb_internal._hyper_53_115_chunk
+
+\d+ 'cashflows'
+                                    View "public.cashflows"
+  Column   |           Type           | Collation | Nullable | Default | Storage | Description 
+-----------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket    | timestamp with time zone |           |          |         | plain   | 
+ amount    | integer                  |           |          |         | plain   | 
+ cashflow  | bigint                   |           |          |         | plain   | 
+ cashflow2 | bigint                   |           |          |         | plain   | 
+View definition:
+ SELECT _materialized_hypertable_53.bucket,
+    _materialized_hypertable_53.amount,
+        CASE
+            WHEN _materialized_hypertable_53.var_3_5 < 0 THEN 0 - _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_53.agg_3_3, NULL::bigint)
+            ELSE _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_53.agg_3_4, NULL::bigint)
+        END AS cashflow,
+    _materialized_hypertable_53.var_3_5 + _timescaledb_internal.finalize_agg('pg_catalog.sum(integer)'::text, NULL::name, NULL::name, '{{pg_catalog,int4}}'::name[], _materialized_hypertable_53.agg_4_6, NULL::bigint) AS cashflow2
+   FROM _timescaledb_internal._materialized_hypertable_53
+  GROUP BY _materialized_hypertable_53.bucket, _materialized_hypertable_53.amount;
+
+SELECT * FROM cashflows;
+            bucket            | amount | cashflow | cashflow2 
+------------------------------+--------+----------+-----------
+ Sun Dec 31 16:00:00 2017 PST |      1 |       10 |        11
+ Mon Jan 01 16:00:00 2018 PST |     -1 |      -30 |        29
+ Wed Oct 31 17:00:00 2018 PDT |     -1 |      -20 |        19
+ Wed Oct 31 17:00:00 2018 PDT |      1 |       30 |        31
+ Thu Nov 01 17:00:00 2018 PDT |     -1 |      -10 |         9
+ Thu Nov 01 17:00:00 2018 PDT |      1 |       10 |        11
+(6 rows)
+

--- a/tsl/test/expected/jit-12.out
+++ b/tsl/test/expected/jit-12.out
@@ -183,29 +183,23 @@ ORDER BY 1;
 --
 :PREFIX
 SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, device_id LIMIT 10;
-                                                                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, (_timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision)), ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)))
+   Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
    ->  Sort
-         Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, (_timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision)), ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)))
+         Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
          Sort Key: _materialized_hypertable_4.bucket DESC, _materialized_hypertable_4.device_id
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision))
-                     Group Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
-                     Filter: ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)) = '1800'::double precision)
-                     ->  Sort
-                           Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
-                           Sort Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_4
-                                 Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan using _hyper_4_6_chunk__materialized_hypertable_4_bucket_idx on _timescaledb_internal._hyper_4_6_chunk
-                                       Output: _hyper_4_6_chunk.bucket, _hyper_4_6_chunk.device_id, _hyper_4_6_chunk.agg_3_3, _hyper_4_6_chunk.agg_4_4, _hyper_4_6_chunk.agg_4_5
-                                       Index Cond: (_hyper_4_6_chunk.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_4
+                     Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_4_6_chunk__materialized_hypertable_4_bucket_idx on _timescaledb_internal._hyper_4_6_chunk
+                           Output: _hyper_4_6_chunk.bucket, _hyper_4_6_chunk.device_id, _hyper_4_6_chunk.metric_avg, _hyper_4_6_chunk.metric_spread
+                           Index Cond: (_hyper_4_6_chunk.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
+                           Filter: (_hyper_4_6_chunk.metric_spread = '1800'::double precision)
                ->  HashAggregate
                      Output: (time_bucket('@ 1 hour'::interval, jit_test_contagg.observation_time)), jit_test_contagg.device_id, avg(jit_test_contagg.metric), (max(jit_test_contagg.metric) - min(jit_test_contagg.metric))
                      Group Key: time_bucket('@ 1 hour'::interval, jit_test_contagg.observation_time), jit_test_contagg.device_id
@@ -218,7 +212,7 @@ SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC
                            ->  Index Scan using _hyper_3_5_chunk_jit_test_contagg_observation_time_idx on _timescaledb_internal._hyper_3_5_chunk
                                  Output: _hyper_3_5_chunk.observation_time, _hyper_3_5_chunk.device_id, _hyper_3_5_chunk.metric
                                  Index Cond: (_hyper_3_5_chunk.observation_time >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
-(33 rows)
+(27 rows)
 
 -- generate the results into two different files
 \set ECHO errors

--- a/tsl/test/expected/jit-13.out
+++ b/tsl/test/expected/jit-13.out
@@ -183,31 +183,23 @@ ORDER BY 1;
 --
 :PREFIX
 SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, device_id LIMIT 10;
-                                                                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, (_timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision)), ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)))
+   Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
    ->  Sort
-         Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, (_timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision)), ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)))
+         Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
          Sort Key: _materialized_hypertable_4.bucket DESC, _materialized_hypertable_4.device_id
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision))
-                     Group Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
-                     Filter: ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)) = '1800'::double precision)
-                     ->  Incremental Sort
-                           Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
-                           Sort Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
-                           Presorted Key: _materialized_hypertable_4.bucket
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_4
-                                 Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
-                                 Order: _materialized_hypertable_4.bucket
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_4_6_chunk__materialized_hypertable_4_bucket_idx on _timescaledb_internal._hyper_4_6_chunk
-                                       Output: _hyper_4_6_chunk.bucket, _hyper_4_6_chunk.device_id, _hyper_4_6_chunk.agg_3_3, _hyper_4_6_chunk.agg_4_4, _hyper_4_6_chunk.agg_4_5
-                                       Index Cond: (_hyper_4_6_chunk.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_4
+                     Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_4_6_chunk__materialized_hypertable_4_bucket_idx on _timescaledb_internal._hyper_4_6_chunk
+                           Output: _hyper_4_6_chunk.bucket, _hyper_4_6_chunk.device_id, _hyper_4_6_chunk.metric_avg, _hyper_4_6_chunk.metric_spread
+                           Index Cond: (_hyper_4_6_chunk.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
+                           Filter: (_hyper_4_6_chunk.metric_spread = '1800'::double precision)
                ->  HashAggregate
                      Output: (time_bucket('@ 1 hour'::interval, jit_test_contagg.observation_time)), jit_test_contagg.device_id, avg(jit_test_contagg.metric), (max(jit_test_contagg.metric) - min(jit_test_contagg.metric))
                      Group Key: time_bucket('@ 1 hour'::interval, jit_test_contagg.observation_time), jit_test_contagg.device_id
@@ -220,7 +212,7 @@ SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC
                            ->  Index Scan using _hyper_3_5_chunk_jit_test_contagg_observation_time_idx on _timescaledb_internal._hyper_3_5_chunk
                                  Output: _hyper_3_5_chunk.observation_time, _hyper_3_5_chunk.device_id, _hyper_3_5_chunk.metric
                                  Index Cond: (_hyper_3_5_chunk.observation_time >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
-(35 rows)
+(27 rows)
 
 -- generate the results into two different files
 \set ECHO errors

--- a/tsl/test/expected/jit-14.out
+++ b/tsl/test/expected/jit-14.out
@@ -184,31 +184,23 @@ ORDER BY 1;
 --
 :PREFIX
 SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC, device_id LIMIT 10;
-                                                                                                                                                                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                                                                                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, (_timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision)), ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)))
+   Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
    ->  Sort
-         Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, (_timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision)), ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)))
+         Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
          Sort Key: _materialized_hypertable_4.bucket DESC, _materialized_hypertable_4.device_id
          ->  Append
-               ->  GroupAggregate
-                     Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _timescaledb_internal.finalize_agg('pg_catalog.avg(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_3_3, NULL::double precision), (_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision))
-                     Group Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
-                     Filter: ((_timescaledb_internal.finalize_agg('pg_catalog.max(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_4, NULL::double precision) - _timescaledb_internal.finalize_agg('pg_catalog.min(double precision)'::text, NULL::name, NULL::name, '{{pg_catalog,float8}}'::name[], _materialized_hypertable_4.agg_4_5, NULL::double precision)) = '1800'::double precision)
-                     ->  Incremental Sort
-                           Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
-                           Sort Key: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id
-                           Presorted Key: _materialized_hypertable_4.bucket
-                           ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_4
-                                 Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.agg_3_3, _materialized_hypertable_4.agg_4_4, _materialized_hypertable_4.agg_4_5
-                                 Order: _materialized_hypertable_4.bucket
-                                 Startup Exclusion: true
-                                 Runtime Exclusion: false
-                                 Chunks excluded during startup: 0
-                                 ->  Index Scan Backward using _hyper_4_6_chunk__materialized_hypertable_4_bucket_idx on _timescaledb_internal._hyper_4_6_chunk
-                                       Output: _hyper_4_6_chunk.bucket, _hyper_4_6_chunk.device_id, _hyper_4_6_chunk.agg_3_3, _hyper_4_6_chunk.agg_4_4, _hyper_4_6_chunk.agg_4_5
-                                       Index Cond: (_hyper_4_6_chunk.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
+               ->  Custom Scan (ChunkAppend) on _timescaledb_internal._materialized_hypertable_4
+                     Output: _materialized_hypertable_4.bucket, _materialized_hypertable_4.device_id, _materialized_hypertable_4.metric_avg, _materialized_hypertable_4.metric_spread
+                     Startup Exclusion: true
+                     Runtime Exclusion: false
+                     Chunks excluded during startup: 0
+                     ->  Index Scan using _hyper_4_6_chunk__materialized_hypertable_4_bucket_idx on _timescaledb_internal._hyper_4_6_chunk
+                           Output: _hyper_4_6_chunk.bucket, _hyper_4_6_chunk.device_id, _hyper_4_6_chunk.metric_avg, _hyper_4_6_chunk.metric_spread
+                           Index Cond: (_hyper_4_6_chunk.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
+                           Filter: (_hyper_4_6_chunk.metric_spread = '1800'::double precision)
                ->  HashAggregate
                      Output: (time_bucket('@ 1 hour'::interval, jit_test_contagg.observation_time)), jit_test_contagg.device_id, avg(jit_test_contagg.metric), (max(jit_test_contagg.metric) - min(jit_test_contagg.metric))
                      Group Key: time_bucket('@ 1 hour'::interval, jit_test_contagg.observation_time), jit_test_contagg.device_id
@@ -221,7 +213,7 @@ SELECT * FROM jit_device_summary WHERE metric_spread = 1800 ORDER BY bucket DESC
                            ->  Index Scan using _hyper_3_5_chunk_jit_test_contagg_observation_time_idx on _timescaledb_internal._hyper_3_5_chunk
                                  Output: _hyper_3_5_chunk.observation_time, _hyper_3_5_chunk.device_id, _hyper_3_5_chunk.metric
                                  Index Cond: (_hyper_3_5_chunk.observation_time >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone))
-(35 rows)
+(27 rows)
 
 -- generate the results into two different files
 \set ECHO errors

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -282,7 +282,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
      },                                             +
      "continuous_aggregates": {                     +
          "heap_size": 188416,                       +
-         "toast_size": 32768,                       +
+         "toast_size": 16384,                       +
          "compression": {                           +
              "compressed_heap_size": 0,             +
              "compressed_row_count": 0,             +
@@ -431,21 +431,21 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "num_reltuples": 697                       +
      },                                             +
      "continuous_aggregates": {                     +
-         "heap_size": 180224,                       +
-         "toast_size": 40960,                       +
+         "heap_size": 147456,                       +
+         "toast_size": 24576,                       +
          "compression": {                           +
-             "compressed_heap_size": 40960,         +
-             "compressed_row_count": 10,            +
+             "compressed_heap_size": 8192,          +
+             "compressed_row_count": 1,             +
              "num_compressed_caggs": 1,             +
              "compressed_toast_size": 8192,         +
              "num_compressed_chunks": 1,            +
              "uncompressed_heap_size": 49152,       +
              "uncompressed_row_count": 452,         +
-             "compressed_indexes_size": 16384,      +
-             "uncompressed_toast_size": 8192,       +
+             "compressed_indexes_size": 0,          +
+             "uncompressed_toast_size": 0,          +
              "uncompressed_indexes_size": 81920     +
          },                                         +
-         "indexes_size": 180224,                    +
+         "indexes_size": 163840,                    +
          "num_children": 4,                         +
          "num_relations": 2,                        +
          "num_reltuples": 452,                      +
@@ -928,21 +928,21 @@ FROM relations;
              continuous_aggregates              
 ------------------------------------------------
  {                                             +
-     "heap_size": 368640,                      +
-     "toast_size": 73728,                      +
+     "heap_size": 335872,                      +
+     "toast_size": 40960,                      +
      "compression": {                          +
-         "compressed_heap_size": 40960,        +
-         "compressed_row_count": 10,           +
+         "compressed_heap_size": 8192,         +
+         "compressed_row_count": 1,            +
          "num_compressed_caggs": 1,            +
          "compressed_toast_size": 8192,        +
          "num_compressed_chunks": 1,           +
          "uncompressed_heap_size": 49152,      +
          "uncompressed_row_count": 452,        +
-         "compressed_indexes_size": 16384,     +
-         "uncompressed_toast_size": 8192,      +
+         "compressed_indexes_size": 0,         +
+         "uncompressed_toast_size": 0,         +
          "uncompressed_indexes_size": 81920    +
      },                                        +
-     "indexes_size": 409600,                   +
+     "indexes_size": 393216,                   +
      "num_children": 8,                        +
      "num_relations": 4,                       +
      "num_reltuples": 452,                     +

--- a/tsl/test/isolation/expected/cagg_drop_chunks.out
+++ b/tsl/test/isolation/expected/cagg_drop_chunks.out
@@ -21,7 +21,7 @@ created
 t      
 (1 row)
 
-step T1_select: SELECT * FROM cond_summary;
+step T1_select: SELECT * FROM cond_summary ORDER BY bucket;
 bucket                      |avg_temp
 ----------------------------+--------
 Fri Nov 30 16:00:00 2018 PST|       0
@@ -58,13 +58,13 @@ count
 
 step T2_insert_2: <... completed>
 step T1_refresh: CALL refresh_continuous_aggregate('cond_summary', NULL, NULL);
-step T1_select: SELECT * FROM cond_summary;
+step T1_select: SELECT * FROM cond_summary ORDER BY bucket;
 bucket                      |avg_temp
 ----------------------------+--------
 Fri Nov 30 16:00:00 2018 PST|     100
 Sat Dec 01 16:00:00 2018 PST|     100
-Tue Dec 04 16:00:00 2018 PST|      10
 Sun Dec 02 16:00:00 2018 PST|      50
 Mon Dec 03 16:00:00 2018 PST|      10
+Tue Dec 04 16:00:00 2018 PST|      10
 (5 rows)
 

--- a/tsl/test/isolation/specs/cagg_drop_chunks.spec.in
+++ b/tsl/test/isolation/specs/cagg_drop_chunks.spec.in
@@ -50,7 +50,7 @@ step "L_release_chunks_locked" { SELECT debug_waitpoint_release('drop_chunks_loc
 session "T1"
 step "T1_drop_chunks"        { SELECT count(*) FROM drop_chunks('conditions', older_than => '2018-12-03 00:00'::timestamptz); }
 step "T1_refresh"            { CALL refresh_continuous_aggregate('cond_summary', NULL, NULL); }
-step "T1_select"             { SELECT * FROM cond_summary; }
+step "T1_select"             { SELECT * FROM cond_summary ORDER BY bucket; }
 
 session "T2"
 # This insert outside the dropped chunks

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_FILES_postgresql
     bgw_custom.sql
     bgw_policy.sql
     cagg_errors.sql
+    cagg_errors_deprecated.sql
     cagg_invalidation.sql
     cagg_permissions.sql
     cagg_policy.sql

--- a/tsl/test/sql/cagg_errors_deprecated.sql
+++ b/tsl/test/sql/cagg_errors_deprecated.sql
@@ -1,10 +1,13 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+
 \set ON_ERROR_STOP 0
 \set VERBOSITY default
+
 --negative tests for query validation
 create table mat_t1( a integer, b integer,c TEXT);
+
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,
@@ -14,305 +17,326 @@ CREATE TABLE conditions (
       timeinterval INTERVAL
     );
 select table_name from create_hypertable( 'conditions', 'timec');
- table_name 
-------------
- conditions
-(1 row)
 
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, timescaledb.myfill = 1)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, timescaledb.myfill = 1)
 as
 select location , min(temperature)
 from conditions
 group by time_bucket('1d', timec), location WITH NO DATA;
-ERROR:  unrecognized parameter "timescaledb.myfill"
+
 --valid PG option
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LOCAL )
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false, check_option = LOCAL )
 as
 select * from conditions , mat_t1 WITH NO DATA;
-ERROR:  unsupported combination of storage parameters
-DETAIL:  A continuous aggregate does not support standard storage parameters.
-HINT:  Use only parameters with the "timescaledb." prefix when creating a continuous aggregate.
+
 -- join multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select location, count(*) from conditions , mat_t1
 where conditions.location = mat_t1.c
 group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
+
 -- join multiple tables WITH explicit JOIN
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select location, count(*) from conditions JOIN mat_t1 ON true
 where conditions.location = mat_t1.c
 group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
+
 -- LATERAL multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select location, count(*) from conditions,
 LATERAL (Select * from mat_t1 where c = conditions.location) q
 group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
+
+
 --non-hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select a, count(*) from mat_t1
 group by a WITH NO DATA;
-ERROR:  table "mat_t1" is not a hypertable
+
+
 -- no group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select count(*) from conditions  WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
+
 -- no time_bucket in group by
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
 select count(*) from conditions group by location WITH NO DATA;
-ERROR:  continuous aggregate view must include a valid time bucket function
+
 -- with valid query in a CTE
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 with m1 as (
 Select location, count(*) from conditions
  group by time_bucket('1week', timec) , location)
 select * from m1 WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  CTEs, subqueries and set-returning functions are not supported by continuous aggregates.
+
 --with DISTINCT ON
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as
  select distinct on ( location ) count(*)  from conditions group by location, time_bucket('1week', timec)  WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  DISTINCT / DISTINCT ON queries are not supported by continuous aggregates.
+
+--aggregate with DISTINCT
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select time_bucket('1week', timec),
+ count(location) , sum(distinct temperature) from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+
+--aggregate with FILTER
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select time_bucket('1week', timec),
+ sum(temperature) filter ( where humidity > 20 ) from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+
+-- aggregate with filter in having clause
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select time_bucket('1week', timec), max(temperature)
+from conditions
+ group by time_bucket('1week', timec) , location
+ having sum(temperature) filter ( where humidity > 20 ) > 50 WITH NO DATA;
+
 -- time_bucket on non partitioning column of hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timemeasure) , location WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+
 --time_bucket on expression
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec+ '10 minutes'::interval) , location WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+
 --multiple time_bucket functions
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket('1week', timec) , time_bucket('1month', timec), location WITH NO DATA;
-ERROR:  continuous aggregate view cannot contain multiple time bucket functions
+
 --time_bucket using additional args
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( INTERVAL '5 minutes', timec, INTERVAL '-2.5 minutes') , location WITH NO DATA;
-ERROR:  continuous aggregate view must include a valid time bucket function
+
 --time_bucket using non-const for first argument
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select max(temperature)
 from conditions
  group by time_bucket( timeinterval, timec) , location WITH NO DATA;
-ERROR:  only immutable expressions allowed in time bucket function
-HINT:  Use an immutable expression as first argument to the time bucket function.
+
+-- ordered set aggr
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select mode() within group( order by humidity)
+from conditions
+ group by time_bucket('1week', timec)  WITH NO DATA;
+
 --window function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select avg(temperature) over( order by humidity)
 from conditions
  WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  Window functions are not supported by continuous aggregates.
---aggregate without combine function but stable function
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+--aggregate without combine function
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select json_agg(location)
 from conditions
  group by time_bucket('1week', timec) , location WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
 ;
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select sum(humidity), avg(temperature), array_agg(location)
+from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+;
+
+-- userdefined aggregate without combine function
+CREATE AGGREGATE newavg (
+   sfunc = int4_avg_accum, basetype = int4, stype = _int8,
+   finalfunc = int8_avg,
+   initcond1 = '{0,0}'
+);
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select sum(humidity), newavg(temperature::int4)
+from conditions
+ group by time_bucket('1week', timec) , location WITH NO DATA;
+;
+
 -- using subqueries
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from
 ( select humidity, temperature, location, timec
 from conditions ) q
  group by time_bucket('1week', timec) , location  WITH NO DATA;
-ERROR:  invalid continuous aggregate view
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 select * from
 ( Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location )  q WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-HINT:  Include at least one aggregate function and a GROUP BY clause with time bucket.
+
 --using limit /limit offset
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 limit 10  WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
-HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 offset 10 WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
-HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
+
 --using ORDER BY in view defintion
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 ORDER BY 1 WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  ORDER BY is not supported in queries defining continuous aggregates.
-HINT:  Use ORDER BY clauses in SELECTS from the continuous aggregate view instead.
+
 --using FETCH
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 fetch first 10 rows only WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  LIMIT and LIMIT OFFSET are not supported in queries defining continuous aggregates.
-HINT:  Use LIMIT and LIMIT OFFSET in SELECTS from the continuous aggregate view instead.
+
 --using locking clauses FOR clause
 --all should be disabled. we cannot guarntee locks on the hypertable
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR KEY SHARE WITH NO DATA;
-ERROR:  FOR KEY SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR SHARE WITH NO DATA;
-ERROR:  FOR SHARE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR UPDATE WITH NO DATA;
-ERROR:  FOR UPDATE is not allowed with GROUP BY clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by time_bucket('1week', timec) , location
 FOR NO KEY UPDATE WITH NO DATA;
-ERROR:  FOR NO KEY UPDATE is not allowed with GROUP BY clause
+
 --tablesample clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions tablesample bernoulli(0.2)
  group by time_bucket('1week', timec) , location
  WITH NO DATA;
-ERROR:  invalid continuous aggregate view
+
 -- ONLY in from clause
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from ONLY conditions
  group by time_bucket('1week', timec) , location  WITH NO DATA;
-ERROR:  invalid continuous aggregate view
+
 --grouping sets and variants
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
  group by grouping sets(time_bucket('1week', timec) , location )  WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by continuous aggregates
-HINT:  Define multiple continuous aggregates with different grouping levels.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), avg(temperature::int4)
 from conditions
 group by rollup(time_bucket('1week', timec) , location )  WITH NO DATA;
-ERROR:  invalid continuous aggregate query
-DETAIL:  GROUP BY GROUPING SETS, ROLLUP and CUBE are not supported by continuous aggregates
-HINT:  Define multiple continuous aggregates with different grouping levels.
+
 --NO immutable functions -- check all clauses
 CREATE FUNCTION test_stablefunc(int) RETURNS int LANGUAGE 'sql'
        STABLE AS 'SELECT $1 + 10';
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum(humidity), max(timec + INTERVAL '1h')
 from conditions
 group by time_bucket('1week', timec) , location   WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+AS
+Select sum(humidity), min(location)
+from conditions
+group by time_bucket('1week', timec)
+having  max(timec + INTERVAL '1h') > '2010-01-01 09:00:00-08' WITH NO DATA;
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum( test_stablefunc(humidity::int) ), min(location)
 from conditions
 group by time_bucket('1week', timec) WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum( temperature ), min(location)
 from conditions
 group by time_bucket('1week', timec), test_stablefunc(humidity::int) WITH NO DATA;
-ERROR:  only immutable functions supported in continuous aggregate view
-HINT:  Make sure all functions in the continuous aggregate definition have IMMUTABLE volatility. Note that functions or expressions may be IMMUTABLE for one data type, but STABLE or VOLATILE for another.
+
 -- Should use CREATE MATERIALIZED VIEW to create continuous aggregates
 CREATE VIEW continuous_aggs_errors_tbl1 WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 week', timec)
   FROM conditions
 GROUP BY time_bucket('1 week', timec);
-ERROR:  cannot create continuous aggregate with CREATE VIEW
-HINT:  Use CREATE MATERIALIZED VIEW to create a continuous aggregate.
+
 -- row security on table
 create table rowsec_tab( a bigint, b integer, c integer);
 select table_name from create_hypertable( 'rowsec_tab', 'a', chunk_time_interval=>10);
-NOTICE:  adding not-null constraint to column "a"
-DETAIL:  Time dimensions cannot have NULL values.
- table_name 
-------------
- rowsec_tab
-(1 row)
-
 CREATE OR REPLACE FUNCTION integer_now_test() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(a), 0)::bigint FROM rowsec_tab $$;
 SELECT set_integer_now_func('rowsec_tab', 'integer_now_test');
- set_integer_now_func 
-----------------------
- 
-(1 row)
-
 alter table rowsec_tab ENABLE ROW LEVEL SECURITY;
 create policy rowsec_tab_allview ON rowsec_tab FOR SELECT USING(true);
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
+
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 AS
 Select sum( b), min(c)
 from rowsec_tab
 group by time_bucket('1', a) WITH NO DATA;
-ERROR:  cannot create continuous aggregate on hypertable with row security
+
 drop table conditions cascade;
+
 --negative tests for WITH options
 CREATE TABLE conditions (
       timec       TIMESTAMPTZ       NOT NULL,
@@ -323,11 +347,8 @@ CREATE TABLE conditions (
       highp       double precision null,
       allnull     double precision null
     );
+
 select table_name from create_hypertable( 'conditions', 'timec');
- table_name 
-------------
- conditions
-(1 row)
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous)
@@ -335,6 +356,7 @@ as
 select time_bucket('1day', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket('1day', timec) WITH NO DATA;
+
 SELECT  h.schema_name AS "MAT_SCHEMA_NAME",
        h.table_name AS "MAT_TABLE_NAME",
        partial_view_name as "PART_VIEW_NAME",
@@ -343,17 +365,16 @@ FROM _timescaledb_catalog.continuous_agg ca
 INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_with_test'
 \gset
+
 \set ON_ERROR_STOP 0
 ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'false');
-ERROR:  cannot alter create_group_indexes option for continuous aggregates
 ALTER MATERIALIZED VIEW mat_with_test SET(timescaledb.create_group_indexes = 'true');
-ERROR:  cannot alter create_group_indexes option for continuous aggregates
 ALTER MATERIALIZED VIEW mat_with_test ALTER timec DROP default;
-ERROR:  cannot alter only SET options of a continuous aggregate
 \set ON_ERROR_STOP 1
 \set VERBOSITY terse
+
 DROP TABLE conditions CASCADE;
-NOTICE:  drop cascades to 3 other objects
+
 --test WITH using a hypertable with an integer time dimension
 CREATE TABLE conditions (
       timec       SMALLINT       NOT NULL,
@@ -364,18 +385,10 @@ CREATE TABLE conditions (
       highp       double precision null,
       allnull     double precision null
     );
-select table_name from create_hypertable( 'conditions', 'timec', chunk_time_interval=> 100);
- table_name 
-------------
- conditions
-(1 row)
 
+select table_name from create_hypertable( 'conditions', 'timec', chunk_time_interval=> 100);
 CREATE OR REPLACE FUNCTION integer_now_test_s() returns smallint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0)::smallint FROM conditions $$;
 SELECT set_integer_now_func('conditions', 'integer_now_test_s');
- set_integer_now_func 
-----------------------
- 
-(1 row)
 
 \set ON_ERROR_STOP 0
 create materialized view mat_with_test( timec, minl, sumt , sumh)
@@ -384,24 +397,26 @@ as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
-ERROR:  time bucket function must reference a hypertable dimension column
+
 ALTER TABLE conditions ALTER timec type int;
+
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous)
 as
 select time_bucket(100, timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by time_bucket(100, timec) WITH NO DATA;
+
 \set ON_ERROR_STOP 1
 DROP TABLE conditions cascade;
-NOTICE:  drop cascades to 3 other objects
+
 CREATE TABLE conditions (
       timec       BIGINT       NOT NULL,
       location    TEXT              NOT NULL,
@@ -411,18 +426,10 @@ CREATE TABLE conditions (
       highp       double precision null,
       allnull     double precision null
     );
-select table_name from create_hypertable( 'conditions', 'timec', chunk_time_interval=> 100);
- table_name 
-------------
- conditions
-(1 row)
 
+select table_name from create_hypertable( 'conditions', 'timec', chunk_time_interval=> 100);
 CREATE OR REPLACE FUNCTION integer_now_test_b() returns bigint LANGUAGE SQL STABLE as $$ SELECT coalesce(max(timec), 0)::bigint FROM conditions $$;
 SELECT set_integer_now_func('conditions', 'integer_now_test_b');
- set_integer_now_func 
-----------------------
- 
-(1 row)
 
 create materialized view mat_with_test( timec, minl, sumt , sumh)
 WITH (timescaledb.continuous)
@@ -430,17 +437,14 @@ as
 select time_bucket(BIGINT '100', timec), min(location), sum(temperature),sum(humidity)
 from conditions
 group by 1 WITH NO DATA;
+
 -- custom time partition functions are not supported with invalidations
 CREATE FUNCTION text_part_func(TEXT) RETURNS BIGINT
     AS $$ SELECT length($1)::BIGINT $$
     LANGUAGE SQL IMMUTABLE;
+
 CREATE TABLE text_time(time TEXT);
     SELECT create_hypertable('text_time', 'time', chunk_time_interval => 10, time_partitioning_func => 'text_part_func');
-NOTICE:  adding not-null constraint to column "time"
-   create_hypertable    
-------------------------
- (9,public,text_time,t)
-(1 row)
 
 \set VERBOSITY default
 \set ON_ERROR_STOP 0
@@ -449,8 +453,8 @@ CREATE MATERIALIZED VIEW text_view
     AS SELECT time_bucket('5', text_part_func(time)), COUNT(time)
         FROM text_time
         GROUP BY 1 WITH NO DATA;
-ERROR:  custom partitioning functions not supported with continuous aggregates
 \set ON_ERROR_STOP 1
+
 -- Check that we get an error when mixing normal materialized views
 -- and continuous aggregates.
 CREATE MATERIALIZED VIEW normal_mat_view AS
@@ -458,26 +462,25 @@ SELECT time_bucket('5', text_part_func(time)), COUNT(time)
   FROM text_time
 GROUP BY 1 WITH NO DATA;
 \set VERBOSITY terse
+
 \set ON_ERROR_STOP 0
 DROP MATERIALIZED VIEW normal_mat_view, mat_with_test;
-ERROR:  mixing continuous aggregates and other objects not allowed
 \set ON_ERROR_STOP 1
+
 DROP TABLE text_time CASCADE;
-NOTICE:  drop cascades to materialized view normal_mat_view
+
 CREATE TABLE measurements (time TIMESTAMPTZ NOT NULL, device INT, value FLOAT);
 SELECT create_hypertable('measurements', 'time');
-     create_hypertable      
-----------------------------
- (10,public,measurements,t)
-(1 row)
 
 INSERT INTO measurements VALUES ('2019-03-04 13:30', 1, 1.3);
+
 -- Add a continuous aggregate on the measurements table and a policy
 -- to be able to test error cases for the add_job function.
 CREATE MATERIALIZED VIEW measurements_summary WITH (timescaledb.continuous) AS
 SELECT time_bucket('1 day', time), COUNT(time)
   FROM measurements
 GROUP BY 1 WITH NO DATA;
+
 -- First test that add_job checks the config. It is currently possible
 -- to add non-custom jobs using the add_job function so we need to
 -- test that the function actually checks the config parameters. These
@@ -488,157 +491,105 @@ SELECT add_job(
        '_timescaledb_internal.policy_refresh_continuous_aggregate'::regproc,
        '1 hour'::interval,
        config => '{"end_offset": null, "start_offset": null}');
-ERROR:  could not find "mat_hypertable_id" in config for job
 -- ... this one because it has a bad value for start_offset
 SELECT add_job(
        '_timescaledb_internal.policy_refresh_continuous_aggregate'::regproc,
        '1 hour'::interval,
        config => '{"end_offset": null, "start_offset": "1 fortnight", "mat_hypertable_id": 11}');
-ERROR:  invalid input syntax for type interval: "1 fortnight"
 -- ... this one because it has a bad value for end_offset
 SELECT add_job(
        '_timescaledb_internal.policy_refresh_continuous_aggregate'::regproc,
        '1 hour'::interval,
        config => '{"end_offset": "chicken", "start_offset": null, "mat_hypertable_id": 11}');
-ERROR:  invalid input syntax for type interval: "chicken"
 \set ON_ERROR_STOP 1
+
 SELECT add_continuous_aggregate_policy('measurements_summary', NULL, NULL, '1 h'::interval) AS job_id
 \gset
+
 \x on
 SELECT * FROM _timescaledb_config.bgw_job WHERE id = :job_id;
--[ RECORD 1 ]-----+--------------------------------------------------------------------
-id                | 1000
-application_name  | Refresh Continuous Aggregate Policy [1000]
-schedule_interval | @ 1 hour
-max_runtime       | @ 0
-max_retries       | -1
-retry_period      | @ 1 hour
-proc_schema       | _timescaledb_internal
-proc_name         | policy_refresh_continuous_aggregate
-owner             | default_perm_user
-scheduled         | t
-hypertable_id     | 11
-config            | {"end_offset": null, "start_offset": null, "mat_hypertable_id": 11}
-
 \x off
+
 -- These are all weird values for the parameters for the continuous
 -- aggregate jobs and should generate an error. Since the config will
 -- be replaced, we will also generate error for missing arguments.
 \set ON_ERROR_STOP 0
 SELECT alter_job(:job_id, config => '{"end_offset": "1 week", "start_offset": "2 fortnights"}');
-ERROR:  could not find "mat_hypertable_id" in config for job
 SELECT alter_job(:job_id,
        config => '{"mat_hypertable_id": 11, "end_offset": "chicken", "start_offset": "1 fortnights"}');
-ERROR:  invalid input syntax for type interval: "1 fortnights"
 SELECT alter_job(:job_id,
        config => '{"mat_hypertable_id": 11, "end_offset": "chicken", "start_offset": "1 week"}');
-ERROR:  invalid input syntax for type interval: "chicken"
 \set ON_ERROR_STOP 1
+
 DROP TABLE measurements CASCADE;
-NOTICE:  drop cascades to 3 other objects
 DROP TABLE conditions CASCADE;
-NOTICE:  drop cascades to 3 other objects
+
 -- test handling of invalid mat_hypertable_id
 create table i2980(time timestamptz not null);
 select create_hypertable('i2980','time');
-  create_hypertable  
----------------------
- (12,public,i2980,t)
-(1 row)
-
 create materialized view i2980_cagg with (timescaledb.continuous) AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
-NOTICE:  continuous aggregate "i2980_cagg" is already up-to-date
 select add_continuous_aggregate_policy('i2980_cagg',NULL,NULL,'4h') AS job_id \gset
 \set ON_ERROR_STOP 0
 select alter_job(:job_id,config:='{"end_offset": null, "start_offset": null, "mat_hypertable_id": 1000}');
-ERROR:  configuration materialization hypertable id 1000 not found
+
 --test creating continuous aggregate with compression enabled --
 CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous, timescaledb.compress)
 AS SELECT time_bucket('1h',time), avg(7) FROM i2980 GROUP BY 1;
-ERROR:  cannot enable compression while creating a continuous aggregate
+
 --this one succeeds
 CREATE MATERIALIZED VIEW  i2980_cagg2 with (timescaledb.continuous)
 AS SELECT time_bucket('1h',time) as bucket, avg(7) FROM i2980 GROUP BY 1;
-NOTICE:  continuous aggregate "i2980_cagg2" is already up-to-date
+
 --now enable compression with invalid parameters
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress,
 timescaledb.compress_segmentby = 'bucket');
-ERROR:  unrecognized parameter "timescaledb.compress_segmentby"
+
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress,
 timescaledb.compress_orderby = 'bucket');
-ERROR:  unrecognized parameter "timescaledb.compress_orderby"
+
 --enable compression and test re-enabling compression
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress);
 insert into i2980 select now();
 call refresh_continuous_aggregate('i2980_cagg2', NULL, NULL);
 SELECT compress_chunk(ch) FROM show_chunks('i2980_cagg2') ch;
-             compress_chunk              
------------------------------------------
- _timescaledb_internal._hyper_14_3_chunk
-(1 row)
-
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress = 'false');
-ERROR:  cannot change configuration on already compressed chunks
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress = 'true');
-ERROR:  cannot change configuration on already compressed chunks
 ALTER MATERIALIZED VIEW i2980_cagg2 SET ( timescaledb.compress, timescaledb.compress_segmentby = 'bucket');
-ERROR:  unrecognized parameter "timescaledb.compress_segmentby"
+
 --Errors with compression policy on caggs--
 select add_continuous_aggregate_policy('i2980_cagg2', interval '10 day', interval '2 day' ,'4h') AS job_id ;
- job_id 
---------
-   1002
-(1 row)
-
 SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
-ERROR:  compression not enabled on continuous aggregate "i2980_cagg"
 ALTER MATERIALIZED VIEW i2980_cagg SET ( timescaledb.compress );
 SELECT add_compression_policy('i2980_cagg', '8 day'::interval);
-ERROR:  compress_after value for compression policy should be greater than the start of the refresh window of continuous aggregate policy for i2980_cagg
+
 SELECT add_continuous_aggregate_policy('i2980_cagg2', '10 day'::interval, '6 day'::interval);
-ERROR:  function add_continuous_aggregate_policy(unknown, interval, interval) does not exist at character 8
 SELECT add_compression_policy('i2980_cagg2', '3 day'::interval);
-ERROR:  compress_after value for compression policy should be greater than the start of the refresh window of continuous aggregate policy for i2980_cagg2
 SELECT add_compression_policy('i2980_cagg2', '1 day'::interval);
-ERROR:  compress_after value for compression policy should be greater than the start of the refresh window of continuous aggregate policy for i2980_cagg2
 SELECT add_compression_policy('i2980_cagg2', '3'::integer);
-ERROR:  unsupported compress_after argument type, expected type : interval
 SELECT add_compression_policy('i2980_cagg2', 13::integer);
-ERROR:  unsupported compress_after argument type, expected type : interval
+
 SELECT materialization_hypertable_schema || '.' || materialization_hypertable_name AS "MAT_TABLE_NAME"
 FROM timescaledb_information.continuous_aggregates
 WHERE view_name = 'i2980_cagg2'
 \gset
 SELECT add_compression_policy( :'MAT_TABLE_NAME', 13::integer);
-ERROR:  cannot add compression policy to materialized hypertable "_materialized_hypertable_14" 
+
 --TEST compressing cagg chunks without enabling compression
 SELECT count(*) FROM (select decompress_chunk(ch) FROM show_chunks('i2980_cagg2') ch ) q;
- count 
--------
-     1
-(1 row)
-
 ALTER MATERIALIZED VIEW i2980_cagg2 SET (timescaledb.compress = 'false');
 SELECT compress_chunk(ch) FROM show_chunks('i2980_cagg2') ch;
-ERROR:  compression not enabled on "i2980_cagg2"
+
 -- test error handling when trying to create cagg on internal hypertable
 CREATE TABLE comp_ht_test(time timestamptz NOT NULL);
 SELECT table_name FROM create_hypertable('comp_ht_test','time');
-  table_name  
---------------
- comp_ht_test
-(1 row)
-
 ALTER TABLE comp_ht_test SET (timescaledb.compress);
+
 SELECT
   format('%I.%I', ht.schema_name, ht.table_name) AS "INTERNALTABLE"
 FROM
   _timescaledb_catalog.hypertable ht
   INNER JOIN _timescaledb_catalog.hypertable uncompress ON (ht.id = uncompress.compressed_hypertable_id
       AND uncompress.table_name = 'comp_ht_test') \gset
+
 CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucket('1h',_ts_meta_min_1) FROM :INTERNALTABLE GROUP BY 1;
-ERROR:  hypertable is an internal compressed hypertable
---TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
---Check error handling for this case
-SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
-ERROR:  compression not enabled on "i2980"
+

--- a/tsl/test/sql/cagg_query.sql.in
+++ b/tsl/test/sql/cagg_query.sql.in
@@ -291,7 +291,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C", m1.timec DESC
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
 LIMIT 10;
 
 ROLLBACK;

--- a/tsl/test/sql/include/cagg_ddl_common.sql
+++ b/tsl/test/sql/include/cagg_ddl_common.sql
@@ -321,7 +321,7 @@ CREATE MATERIALIZED VIEW new_name_view
     timescaledb.continuous,
     timescaledb.materialized_only=true
   )
-AS SELECT time_bucket('6', time_bucket), COUNT(agg_2_2)
+AS SELECT time_bucket('6', time_bucket), COUNT("count")
     FROM new_name
     GROUP BY 1 WITH NO DATA;
 


### PR DESCRIPTION
Following work started by https://github.com/timescale/timescaledb/pull/4294 to improve performance of Continuous
Aggregates by removing the re-aggregation in the user view.

This PR get rid of `partialize_agg` and `finalize_agg` aggregate
functions and store the finalized aggregated (plain) data in the
materialization hypertable.

Because we're not storing partials anymore and removed the
re-aggregation, now is be possible to create indexes on aggregated
columns in the materialization hypertable in order to improve the
performance even more.

Also removed restrictions on types of aggregates users can perform
with Continuous Aggregates:
* aggregates with DISTINCT
* aggregates with FILTER
* aggregates with FILTER in HAVING clause
* aggregates without combine function
* ordered-set aggregates
* hypothetical-set aggregates

By default new Continuous Aggregates will be created using this new
format, but the previous version (with partials) will be supported.

Users can create the previous style by setting to `false` the storage
paramater named `timescaledb.finalized` during the creation of the
Continuous Aggregate.

Fixes #4233 