### PR TITLE
Fix flaky remote_connection test

### DIFF
--- a/tsl/test/src/remote/async.c
+++ b/tsl/test/src/remote/async.c
@@ -226,11 +226,6 @@ test_node_death()
 	async_response_report_error(response, WARNING);
 	response = async_request_set_wait_any_response_deadline(set, TS_NO_TIMEOUT);
 	TestAssertTrue(response == NULL);
-	/* No socket error */
-	TestEnsureError(remote_connection_cancel_query(conn));
-
-	set = async_request_set_create();
-	TestEnsureError(async_request_set_add_sql(set, conn, "SELECT 1"));
 
 	/* test error throwing in async_request_set_wait_any_result */
 	conn = get_connection();


### PR DESCRIPTION
Postgres changed the connection error reporting in the stable
branches of PG12, PG13 and PG14 leading to our snapshot tests
always failing. This patch removes the checks that now fail
with the upstream change.

https://github.com/postgres/postgres/commit/ae27b1ac