### PR TITLE
Use binary format in row-by-row fetcher

### DIFF
--- a/tsl/src/fdw/data_node_scan_exec.c
+++ b/tsl/src/fdw/data_node_scan_exec.c
@@ -165,6 +165,7 @@ data_node_scan_state_create(CustomScan *cscan)
 	dnss->async_state.init = create_fetcher;
 	dnss->async_state.send_fetch_request = send_fetch_request;
 	dnss->async_state.fetch_data = fetch_data;
-	dnss->fsstate.fetcher_type = intVal(list_nth(cscan->custom_private, DataNodeScanFetcherType));
+	dnss->fsstate.planned_fetcher_type =
+		intVal(list_nth(cscan->custom_private, DataNodeScanFetcherType));
 	return (Node *) dnss;
 }

--- a/tsl/src/fdw/scan_exec.h
+++ b/tsl/src/fdw/scan_exec.h
@@ -31,14 +31,20 @@ typedef struct TsFdwScanState
 	List *retrieved_attrs; /* list of retrieved attribute numbers */
 
 	/* for remote query execution */
-	struct TSConnection *conn;	/* connection for the scan */
-	struct DataFetcher *fetcher;  /* fetches tuples from data node */
-	int num_params;				  /* number of parameters passed to query */
-	FmgrInfo *param_flinfo;		  /* output conversion functions for them */
-	List *param_exprs;			  /* executable expressions for param values */
-	const char **param_values;	/* textual values of query parameters */
-	int fetch_size;				  /* number of tuples per fetch */
-	DataFetcherType fetcher_type; /* the type of data fetcher to use  */
+	struct TSConnection *conn;   /* connection for the scan */
+	struct DataFetcher *fetcher; /* fetches tuples from data node */
+	int num_params;				 /* number of parameters passed to query */
+	FmgrInfo *param_flinfo;		 /* output conversion functions for them */
+	List *param_exprs;			 /* executable expressions for param values */
+	const char **param_values;   /* textual values of query parameters */
+	int fetch_size;				 /* number of tuples per fetch */
+	/*
+	 * The type of data fetcher to use. Note that we still can revert to
+	 * cursor fetcher if row-by-row fetcher was chosen automatically, but binary
+	 * serialization turns out to be unavailable for some of the data types. We
+	 * only check this when we execute the query.
+	 */
+	DataFetcherType planned_fetcher_type;
 	int row_counter;
 } TsFdwScanState;
 

--- a/tsl/src/remote/cursor_fetcher.h
+++ b/tsl/src/remote/cursor_fetcher.h
@@ -10,11 +10,7 @@
 
 #include "data_fetcher.h"
 
-extern DataFetcher *cursor_fetcher_create_for_rel(TSConnection *conn, Relation rel,
-												  List *retrieved_attrs, const char *stmt,
-												  StmtParams *params);
-extern DataFetcher *cursor_fetcher_create_for_scan(TSConnection *conn, ScanState *ss,
-												   List *retrieved_attrs, const char *stmt,
-												   StmtParams *params);
+extern DataFetcher *cursor_fetcher_create_for_scan(TSConnection *conn, const char *stmt,
+												   StmtParams *params, TupleFactory *tf);
 
 #endif /* TIMESCALEDB_TSL_CURSOR_FETCHER_H */

--- a/tsl/src/remote/data_fetcher.c
+++ b/tsl/src/remote/data_fetcher.c
@@ -15,7 +15,7 @@
 
 void
 data_fetcher_init(DataFetcher *df, TSConnection *conn, const char *stmt, StmtParams *params,
-				  Relation rel, ScanState *ss, List *retrieved_attrs)
+				  TupleFactory *tf)
 {
 	Assert(df != NULL);
 	Assert(stmt != NULL);
@@ -25,10 +25,7 @@ data_fetcher_init(DataFetcher *df, TSConnection *conn, const char *stmt, StmtPar
 	df->conn = conn;
 	df->stmt = pstrdup(stmt);
 	df->stmt_params = params;
-	if (rel == NULL)
-		df->tf = tuplefactory_create_for_scan(ss, retrieved_attrs);
-	else
-		df->tf = tuplefactory_create_for_rel(rel, retrieved_attrs);
+	df->tf = tf;
 
 	tuplefactory_set_per_tuple_mctx_reset(df->tf, false);
 	df->batch_mctx =

--- a/tsl/src/remote/data_fetcher.h
+++ b/tsl/src/remote/data_fetcher.h
@@ -63,8 +63,7 @@ typedef struct DataFetcher
 void data_fetcher_free(DataFetcher *df);
 
 extern void data_fetcher_init(DataFetcher *df, TSConnection *conn, const char *stmt,
-							  StmtParams *params, Relation rel, ScanState *ss,
-							  List *retrieved_attrs);
+							  StmtParams *params, TupleFactory *tf);
 
 extern void data_fetcher_store_tuple(DataFetcher *df, int row, TupleTableSlot *slot);
 extern void data_fetcher_store_next_tuple(DataFetcher *df, TupleTableSlot *slot);

--- a/tsl/src/remote/row_by_row_fetcher.h
+++ b/tsl/src/remote/row_by_row_fetcher.h
@@ -10,11 +10,7 @@
 
 #include "data_fetcher.h"
 
-extern DataFetcher *row_by_row_fetcher_create_for_rel(TSConnection *conn, Relation rel,
-													  List *retrieved_attrs, const char *stmt,
-													  StmtParams *params);
-extern DataFetcher *row_by_row_fetcher_create_for_scan(TSConnection *conn, ScanState *ss,
-													   List *retrieved_attrs, const char *stmt,
-													   StmtParams *params);
+extern DataFetcher *row_by_row_fetcher_create_for_scan(TSConnection *conn, const char *stmt,
+													   StmtParams *params, TupleFactory *tf);
 
 #endif /* TIMESCALEDB_TSL_ROW_BY_ROW_FETCHER_H */

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -535,22 +535,19 @@ SELECT * FROM disttable;
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                Output: disttable_1."time", disttable_1.device, disttable_1.temp
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                Output: disttable_2."time", disttable_2.device, disttable_2.temp
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                Output: disttable_3."time", disttable_3.device, disttable_3.temp
                Data node: db_dist_hypertable_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(21 rows)
+(18 rows)
 
 SELECT * FROM disttable;
              time             | device | temp 
@@ -592,22 +589,19 @@ ORDER BY 1;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: time_bucket('@ 3 hours'::interval, disttable_1."time"), disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: time_bucket('@ 3 hours'::interval, disttable_2."time"), disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: time_bucket('@ 3 hours'::interval, disttable_3."time"), disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 -- Execute some queries on the frontend and return the results
 SELECT * FROM disttable;
@@ -695,22 +689,19 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(27 rows)
+(24 rows)
 
 SELECT max(temp)
 FROM disttable;
@@ -736,22 +727,19 @@ FROM disttable;
                  ->  Custom Scan (DataNodeScan) on public.disttable
                        Output: disttable.temp
                        Data node: db_dist_hypertable_1
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                        Output: disttable_1.temp
                        Data node: db_dist_hypertable_2
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                        Output: disttable_2.temp
                        Data node: db_dist_hypertable_3
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(25 rows)
+(22 rows)
 
 SET timescaledb.enable_async_append = ON;
 EXPLAIN (VERBOSE, COSTS FALSE)
@@ -767,22 +755,19 @@ FROM disttable;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(23 rows)
+(20 rows)
 
 SELECT min(temp), max(temp)
 FROM disttable;
@@ -810,22 +795,19 @@ ORDER BY device, temp;
                      ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                            Output: disttable_1.device, disttable_1.temp
                            Data node: db_dist_hypertable_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                            Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                            Output: disttable_2.device, disttable_2.temp
                            Data node: db_dist_hypertable_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                            Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                            Output: disttable_3.device, disttable_3.temp
                            Data node: db_dist_hypertable_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                            Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 SELECT device, temp, avg(temp) OVER (PARTITION BY device)
 FROM disttable
@@ -880,7 +862,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1."time"
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_4_chunk, _dist_hyper_1_1_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -901,7 +882,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2."time"
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_3_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -922,7 +902,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3."time"
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_6_chunk, _dist_hyper_1_2_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -940,7 +919,7 @@ FROM disttable;
                                              Output: _dist_hyper_1_2_chunk."time"
                                              Index Cond: (_dist_hyper_1_2_chunk."time" IS NOT NULL)
  
-(72 rows)
+(69 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 SELECT max(temp)
@@ -959,7 +938,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -979,7 +957,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -999,7 +976,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -1016,7 +992,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(69 rows)
+(66 rows)
 
 -- Don't remote explain if there is no VERBOSE flag
 EXPLAIN (COSTS FALSE)
@@ -2840,7 +2816,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_1
                Output: twodim_1."time", twodim_1."Color", twodim_1.temp
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_18_chunk, _dist_hyper_7_22_chunk, _dist_hyper_7_25_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12, 14]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2859,7 +2834,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_2
                Output: twodim_2."time", twodim_2."Color", twodim_2.temp
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_19_chunk, _dist_hyper_7_21_chunk, _dist_hyper_7_24_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 11, 13]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2878,7 +2852,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_3
                Output: twodim_3."time", twodim_3."Color", twodim_3.temp
                Data node: db_dist_hypertable_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_20_chunk, _dist_hyper_7_23_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2892,7 +2865,7 @@ ORDER BY time;
                    ->  Index Scan Backward using _dist_hyper_7_23_chunk_twodim_time_idx on _timescaledb_internal._dist_hyper_7_23_chunk
                          Output: _dist_hyper_7_23_chunk."time", _dist_hyper_7_23_chunk."Color", _dist_hyper_7_23_chunk.temp
  
-(59 rows)
+(56 rows)
 
 SET timescaledb.enable_remote_explain = OFF;
 -- Check results
@@ -3632,10 +3605,9 @@ SELECT * FROM dist_device;
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
-(6 rows)
+(5 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
 -- "Remote SQL" when only time partitioning is being used.
@@ -3647,7 +3619,6 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
@@ -3659,7 +3630,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
        ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
              Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(15 rows)
+(14 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 
@@ -5157,6 +5128,15 @@ SELECT count(*) FROM disttable;
     16
 (1 row)
 
+-- Binary format should lead to data incompatibility in PG 13 and earlier,
+-- because the highlow data type has different oids on data and access nodes.
+-- Use this to test the deserialization error reporting. Newer PG version
+-- ignore this oid mismatch for non-builtin types.
+SET timescaledb.enable_connection_binary_data=true;
+\set ON_ERROR_STOP 0
+SELECT * FROM disttable ORDER BY 1;
+ERROR:  wrong element type
+\set ON_ERROR_STOP 1
 -- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
 -- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
 -- different distributed hypertable as source
@@ -5346,7 +5326,7 @@ INSERT INTO disttable VALUES ('2017-08-01 06:01', 1, 35.0) RETURNING *;
          Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
          ->  Custom Scan (DataNodeCopy)  (cost=0.00..0.01 rows=1 width=28)
                Output: 'Tue Aug 01 06:01:00 2017 PDT'::timestamp with time zone, 1, '35'::double precision, NULL::double precision
-               Remote SQL: COPY public.disttable ("time", device, temp_c) FROM STDIN
+               Remote SQL: COPY public.disttable ("time", device, temp_c) FROM STDIN WITH (FORMAT binary)
                ->  Custom Scan (ChunkDispatch)  (cost=0.00..0.01 rows=1 width=28)
                      Output: 'Tue Aug 01 06:01:00 2017 PDT'::timestamp with time zone, 1, '35'::double precision, NULL::double precision
                      ->  Result  (cost=0.00..0.01 rows=1 width=28)
@@ -5508,7 +5488,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5519,7 +5498,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5531,7 +5509,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- Also test different code paths used with aggregation pushdown.
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
@@ -5550,7 +5528,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5561,7 +5538,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5573,7 +5549,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- TODO: test HAVING here and in the later now() tests as well.
 -- Change the timezone and check that the conversion is applied correctly.
@@ -5602,7 +5578,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5613,7 +5588,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5628,7 +5602,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(32 rows)
+(30 rows)
 
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
  count 
@@ -5646,7 +5620,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5657,7 +5630,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5671,7 +5643,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(31 rows)
+(29 rows)
 
 -- Conversion to timestamptz cannot be evaluated at the access node, because the
 -- argument is a column reference.
@@ -5704,7 +5676,6 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5715,7 +5686,6 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5727,7 +5697,7 @@ WHERE time > x
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- Reference value for the above test.
 WITH dummy AS (SELECT '2018-01-02 12:00:00 +00'::timestamptz::timestamp x)
@@ -5751,7 +5721,6 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5762,7 +5731,6 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5777,7 +5745,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Filter: (((_dist_hyper_31_98_chunk."time")::time without time zone > '01:00:00'::time without time zone) AND (date_trunc('month'::text, _dist_hyper_31_98_chunk."time") > '2021-01-01'::date))
  
-(32 rows)
+(30 rows)
 
 -- Check that the test function for partly overriding now() works. It's very
 -- hacky and only has effect when we estimate some costs or evaluate sTABLE

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -535,22 +535,19 @@ SELECT * FROM disttable;
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                Output: disttable_1."time", disttable_1.device, disttable_1.temp
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                Output: disttable_2."time", disttable_2.device, disttable_2.temp
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                Output: disttable_3."time", disttable_3.device, disttable_3.temp
                Data node: db_dist_hypertable_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(21 rows)
+(18 rows)
 
 SELECT * FROM disttable;
              time             | device | temp 
@@ -592,22 +589,19 @@ ORDER BY 1;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: time_bucket('@ 3 hours'::interval, disttable_1."time"), disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: time_bucket('@ 3 hours'::interval, disttable_2."time"), disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: time_bucket('@ 3 hours'::interval, disttable_3."time"), disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 -- Execute some queries on the frontend and return the results
 SELECT * FROM disttable;
@@ -695,22 +689,19 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(27 rows)
+(24 rows)
 
 SELECT max(temp)
 FROM disttable;
@@ -736,22 +727,19 @@ FROM disttable;
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                        Output: disttable_1.temp
                        Data node: db_dist_hypertable_1
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                        Output: disttable_2.temp
                        Data node: db_dist_hypertable_2
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                        Output: disttable_3.temp
                        Data node: db_dist_hypertable_3
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(25 rows)
+(22 rows)
 
 SET timescaledb.enable_async_append = ON;
 EXPLAIN (VERBOSE, COSTS FALSE)
@@ -767,22 +755,19 @@ FROM disttable;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(23 rows)
+(20 rows)
 
 SELECT min(temp), max(temp)
 FROM disttable;
@@ -809,22 +794,19 @@ ORDER BY device, temp;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 SELECT device, temp, avg(temp) OVER (PARTITION BY device)
 FROM disttable
@@ -879,7 +861,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1."time"
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_4_chunk, _dist_hyper_1_1_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -900,7 +881,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2."time"
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_3_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -921,7 +901,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3."time"
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_6_chunk, _dist_hyper_1_2_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -939,7 +918,7 @@ FROM disttable;
                                              Output: _dist_hyper_1_2_chunk."time"
                                              Index Cond: (_dist_hyper_1_2_chunk."time" IS NOT NULL)
  
-(72 rows)
+(69 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 SELECT max(temp)
@@ -958,7 +937,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -978,7 +956,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -998,7 +975,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -1015,7 +991,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(69 rows)
+(66 rows)
 
 -- Don't remote explain if there is no VERBOSE flag
 EXPLAIN (COSTS FALSE)
@@ -2839,7 +2815,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_1
                Output: twodim_1."time", twodim_1."Color", twodim_1.temp
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_18_chunk, _dist_hyper_7_22_chunk, _dist_hyper_7_25_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12, 14]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2858,7 +2833,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_2
                Output: twodim_2."time", twodim_2."Color", twodim_2.temp
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_19_chunk, _dist_hyper_7_21_chunk, _dist_hyper_7_24_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 11, 13]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2877,7 +2851,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_3
                Output: twodim_3."time", twodim_3."Color", twodim_3.temp
                Data node: db_dist_hypertable_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_20_chunk, _dist_hyper_7_23_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2891,7 +2864,7 @@ ORDER BY time;
                    ->  Index Scan Backward using _dist_hyper_7_23_chunk_twodim_time_idx on _timescaledb_internal._dist_hyper_7_23_chunk
                          Output: _dist_hyper_7_23_chunk."time", _dist_hyper_7_23_chunk."Color", _dist_hyper_7_23_chunk.temp
  
-(59 rows)
+(56 rows)
 
 SET timescaledb.enable_remote_explain = OFF;
 -- Check results
@@ -3631,10 +3604,9 @@ SELECT * FROM dist_device;
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
-(6 rows)
+(5 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
 -- "Remote SQL" when only time partitioning is being used.
@@ -3646,7 +3618,6 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
@@ -3658,7 +3629,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
        ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
              Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(15 rows)
+(14 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 
@@ -5156,6 +5127,15 @@ SELECT count(*) FROM disttable;
     16
 (1 row)
 
+-- Binary format should lead to data incompatibility in PG 13 and earlier,
+-- because the highlow data type has different oids on data and access nodes.
+-- Use this to test the deserialization error reporting. Newer PG version
+-- ignore this oid mismatch for non-builtin types.
+SET timescaledb.enable_connection_binary_data=true;
+\set ON_ERROR_STOP 0
+SELECT * FROM disttable ORDER BY 1;
+ERROR:  wrong element type
+\set ON_ERROR_STOP 1
 -- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
 -- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
 -- different distributed hypertable as source
@@ -5345,7 +5325,7 @@ INSERT INTO disttable VALUES ('2017-08-01 06:01', 1, 35.0) RETURNING *;
          Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
          ->  Custom Scan (DataNodeCopy)  (cost=0.00..0.01 rows=1 width=28)
                Output: 'Tue Aug 01 06:01:00 2017 PDT'::timestamp with time zone, 1, '35'::double precision, NULL::double precision
-               Remote SQL: COPY public.disttable ("time", device, temp_c) FROM STDIN
+               Remote SQL: COPY public.disttable ("time", device, temp_c) FROM STDIN WITH (FORMAT binary)
                ->  Custom Scan (ChunkDispatch)  (cost=0.00..0.01 rows=1 width=28)
                      Output: 'Tue Aug 01 06:01:00 2017 PDT'::timestamp with time zone, 1, '35'::double precision, NULL::double precision
                      ->  Result  (cost=0.00..0.01 rows=1 width=28)
@@ -5507,7 +5487,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5518,7 +5497,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5530,7 +5508,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- Also test different code paths used with aggregation pushdown.
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
@@ -5549,7 +5527,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5560,7 +5537,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5572,7 +5548,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- TODO: test HAVING here and in the later now() tests as well.
 -- Change the timezone and check that the conversion is applied correctly.
@@ -5601,7 +5577,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5612,7 +5587,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5627,7 +5601,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(32 rows)
+(30 rows)
 
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
  count 
@@ -5645,7 +5619,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5656,7 +5629,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5670,7 +5642,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(31 rows)
+(29 rows)
 
 -- Conversion to timestamptz cannot be evaluated at the access node, because the
 -- argument is a column reference.
@@ -5703,7 +5675,6 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5714,7 +5685,6 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5726,7 +5696,7 @@ WHERE time > x
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- Reference value for the above test.
 WITH dummy AS (SELECT '2018-01-02 12:00:00 +00'::timestamptz::timestamp x)
@@ -5750,7 +5720,6 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5761,7 +5730,6 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5776,7 +5744,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Filter: (((_dist_hyper_31_98_chunk."time")::time without time zone > '01:00:00'::time without time zone) AND (date_trunc('month'::text, _dist_hyper_31_98_chunk."time") > '2021-01-01'::date))
  
-(32 rows)
+(30 rows)
 
 -- Check that the test function for partly overriding now() works. It's very
 -- hacky and only has effect when we estimate some costs or evaluate sTABLE

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -539,22 +539,19 @@ SELECT * FROM disttable;
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                Output: disttable_1."time", disttable_1.device, disttable_1.temp
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                Output: disttable_2."time", disttable_2.device, disttable_2.temp
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
          ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                Output: disttable_3."time", disttable_3.device, disttable_3.temp
                Data node: db_dist_hypertable_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(21 rows)
+(18 rows)
 
 SELECT * FROM disttable;
              time             | device | temp 
@@ -596,22 +593,19 @@ ORDER BY 1;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: time_bucket('@ 3 hours'::interval, disttable_1."time"), disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: time_bucket('@ 3 hours'::interval, disttable_2."time"), disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: time_bucket('@ 3 hours'::interval, disttable_3."time"), disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY public.time_bucket('03:00:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 -- Execute some queries on the frontend and return the results
 SELECT * FROM disttable;
@@ -699,22 +693,19 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(27 rows)
+(24 rows)
 
 SELECT max(temp)
 FROM disttable;
@@ -740,22 +731,19 @@ FROM disttable;
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                        Output: disttable_1.temp
                        Data node: db_dist_hypertable_1
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                        Output: disttable_2.temp
                        Data node: db_dist_hypertable_2
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                  ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                        Output: disttable_3.temp
                        Data node: db_dist_hypertable_3
-                       Fetcher Type: Row by row
                        Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                        Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
-(25 rows)
+(22 rows)
 
 SET timescaledb.enable_async_append = ON;
 EXPLAIN (VERBOSE, COSTS FALSE)
@@ -771,22 +759,19 @@ FROM disttable;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2])
-(23 rows)
+(20 rows)
 
 SELECT min(temp), max(temp)
 FROM disttable;
@@ -813,22 +798,19 @@ ORDER BY device, temp;
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                      Output: disttable_1.device, disttable_1.temp
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                      Output: disttable_2.device, disttable_2.temp
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                      Output: disttable_3.device, disttable_3.temp
                      Data node: db_dist_hypertable_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                      Remote SQL: SELECT device, temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 SELECT device, temp, avg(temp) OVER (PARTITION BY device)
 FROM disttable
@@ -883,7 +865,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1."time"
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_4_chunk, _dist_hyper_1_1_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -904,7 +885,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2."time"
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_3_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -925,7 +905,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3."time"
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_6_chunk, _dist_hyper_1_2_chunk
                              Remote SQL: SELECT "time" FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[2, 1]) AND (("time" IS NOT NULL)) ORDER BY "time" DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -943,7 +922,7 @@ FROM disttable;
                                              Output: _dist_hyper_1_2_chunk."time"
                                              Index Cond: (_dist_hyper_1_2_chunk."time" IS NOT NULL)
  
-(72 rows)
+(69 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 SELECT max(temp)
@@ -962,7 +941,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_1
                              Output: disttable_1.temp
                              Data node: db_dist_hypertable_1
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -982,7 +960,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_2
                              Output: disttable_2.temp
                              Data node: db_dist_hypertable_2
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_5_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -1002,7 +979,6 @@ FROM disttable;
                        ->  Custom Scan (DataNodeScan) on public.disttable disttable_3
                              Output: disttable_3.temp
                              Data node: db_dist_hypertable_3
-                             Fetcher Type: Row by row
                              Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_6_chunk
                              Remote SQL: SELECT temp FROM public.disttable WHERE _timescaledb_internal.chunks_in(public.disttable.*, ARRAY[1, 2]) AND ((temp IS NOT NULL)) ORDER BY temp DESC NULLS FIRST LIMIT 1
                              Remote EXPLAIN: 
@@ -1019,7 +995,7 @@ FROM disttable;
                                                    Output: _dist_hyper_1_6_chunk.temp
                                                    Filter: (_dist_hyper_1_6_chunk.temp IS NOT NULL)
  
-(69 rows)
+(66 rows)
 
 -- Don't remote explain if there is no VERBOSE flag
 EXPLAIN (COSTS FALSE)
@@ -2846,7 +2822,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_1
                Output: twodim_1."time", twodim_1."Color", twodim_1.temp
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_18_chunk, _dist_hyper_7_22_chunk, _dist_hyper_7_25_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12, 14]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2865,7 +2840,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_2
                Output: twodim_2."time", twodim_2."Color", twodim_2.temp
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_19_chunk, _dist_hyper_7_21_chunk, _dist_hyper_7_24_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 11, 13]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2884,7 +2858,6 @@ ORDER BY time;
          ->  Custom Scan (DataNodeScan) on public.twodim twodim_3
                Output: twodim_3."time", twodim_3."Color", twodim_3.temp
                Data node: db_dist_hypertable_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_7_20_chunk, _dist_hyper_7_23_chunk
                Remote SQL: SELECT "time", "Color", temp FROM public.twodim WHERE _timescaledb_internal.chunks_in(public.twodim.*, ARRAY[10, 12]) ORDER BY "time" ASC NULLS LAST
                Remote EXPLAIN: 
@@ -2898,7 +2871,7 @@ ORDER BY time;
                    ->  Index Scan Backward using _dist_hyper_7_23_chunk_twodim_time_idx on _timescaledb_internal._dist_hyper_7_23_chunk
                          Output: _dist_hyper_7_23_chunk."time", _dist_hyper_7_23_chunk."Color", _dist_hyper_7_23_chunk.temp
  
-(59 rows)
+(56 rows)
 
 SET timescaledb.enable_remote_explain = OFF;
 -- Check results
@@ -3638,10 +3611,9 @@ SELECT * FROM dist_device;
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22])
-(6 rows)
+(5 rows)
 
 -- Check that datanodes use ChunkAppend plans with chunks_in function in the
 -- "Remote SQL" when only time partitioning is being used.
@@ -3653,7 +3625,6 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
  Custom Scan (DataNodeScan) on public.dist_device
    Output: dist_device."time", dist_device.dist_device, dist_device.temp
    Data node: db_dist_hypertable_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_15_37_chunk
    Remote SQL: SELECT "time", dist_device, temp FROM public.dist_device WHERE _timescaledb_internal.chunks_in(public.dist_device.*, ARRAY[22]) ORDER BY "time" ASC NULLS LAST
    Remote EXPLAIN: 
@@ -3665,7 +3636,7 @@ SELECT "time", dist_device, temp FROM public.dist_device ORDER BY "time" ASC NUL
        ->  Index Scan Backward using _dist_hyper_15_37_chunk_dist_device_time_idx on _timescaledb_internal._dist_hyper_15_37_chunk
              Output: _dist_hyper_15_37_chunk."time", _dist_hyper_15_37_chunk.dist_device, _dist_hyper_15_37_chunk.temp
  
-(15 rows)
+(14 rows)
 
 SELECT * FROM dist_device;
              time             | dist_device | temp 
@@ -5163,6 +5134,34 @@ SELECT count(*) FROM disttable;
     16
 (1 row)
 
+-- Binary format should lead to data incompatibility in PG 13 and earlier,
+-- because the highlow data type has different oids on data and access nodes.
+-- Use this to test the deserialization error reporting. Newer PG version
+-- ignore this oid mismatch for non-builtin types.
+SET timescaledb.enable_connection_binary_data=true;
+\set ON_ERROR_STOP 0
+SELECT * FROM disttable ORDER BY 1;
+ id |             time             | device |  temp_c  |  minmaxes   
+----+------------------------------+--------+----------+-------------
+  1 | Sun Jan 01 06:01:00 2017 PST |      1 |      1.2 | 
+  2 | Sun Jan 01 09:11:00 2017 PST |      3 |      4.3 | 
+  3 | Sun Jan 01 08:01:00 2017 PST |      1 |      7.3 | 
+  4 | Mon Jan 02 08:01:00 2017 PST |      2 |     0.23 | 
+  5 | Mon Jul 02 08:01:00 2018 PDT |     87 |        0 | 
+  6 | Sun Jul 01 06:01:00 2018 PDT |     13 |      3.1 | 
+  7 | Sun Jul 01 09:11:00 2018 PDT |     90 | 10303.12 | 
+  8 | Sun Jul 01 08:01:00 2018 PDT |     29 |       64 | 
+  9 | Sun Jan 01 06:01:00 2017 PST |      1 |      1.2 | {"(1,2)"}
+ 10 | Sun Jan 01 09:11:00 2017 PST |      3 |      4.3 | {"(2,3)"}
+ 11 | Sun Jan 01 08:01:00 2017 PST |      1 |      7.3 | {"(4,5)"}
+ 12 | Mon Jan 02 08:01:00 2017 PST |      2 |     0.23 | {"(6,7)"}
+ 13 | Mon Jul 02 08:01:00 2018 PDT |     87 |        0 | {"(8,9)"}
+ 14 | Sun Jul 01 06:01:00 2018 PDT |     13 |      3.1 | {"(10,11)"}
+ 15 | Sun Jul 01 09:11:00 2018 PDT |     90 | 10303.12 | {"(12,13)"}
+ 16 | Sun Jul 01 08:01:00 2018 PDT |     29 |       64 | {"(14,15)"}
+(16 rows)
+
+\set ON_ERROR_STOP 1
 -- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
 -- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
 -- different distributed hypertable as source
@@ -5352,7 +5351,7 @@ INSERT INTO disttable VALUES ('2017-08-01 06:01', 1, 35.0) RETURNING *;
          Output: disttable."time", disttable.device, disttable.temp_c, disttable.temp_f
          ->  Custom Scan (DataNodeCopy)  (cost=0.00..0.01 rows=1 width=28)
                Output: 'Tue Aug 01 06:01:00 2017 PDT'::timestamp with time zone, 1, '35'::double precision, NULL::double precision
-               Remote SQL: COPY public.disttable ("time", device, temp_c) FROM STDIN
+               Remote SQL: COPY public.disttable ("time", device, temp_c) FROM STDIN WITH (FORMAT binary)
                ->  Custom Scan (ChunkDispatch)  (cost=0.00..0.01 rows=1 width=28)
                      Output: 'Tue Aug 01 06:01:00 2017 PDT'::timestamp with time zone, 1, '35'::double precision, NULL::double precision
                      ->  Result  (cost=0.00..0.01 rows=1 width=28)
@@ -5514,7 +5513,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5525,7 +5523,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5537,7 +5534,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- Also test different code paths used with aggregation pushdown.
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
@@ -5556,7 +5553,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5567,7 +5563,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5579,7 +5574,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- TODO: test HAVING here and in the later now() tests as well.
 -- Change the timezone and check that the conversion is applied correctly.
@@ -5608,7 +5603,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5619,7 +5613,6 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5634,7 +5627,7 @@ SELECT * FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::times
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(32 rows)
+(30 rows)
 
 SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz::timestamp;
  count 
@@ -5652,7 +5645,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
          ->  Append
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                      Data node: db_dist_hypertable_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_97_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5663,7 +5655,6 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
  
                ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                      Data node: db_dist_hypertable_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                      Remote SQL: SELECT NULL FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 11:00:00'::timestamp without time zone))
                      Remote EXPLAIN: 
@@ -5677,7 +5668,7 @@ SELECT count(*) FROM test_tz WHERE time > '2018-01-02 12:00:00 +00'::timestamptz
                                ->  Index Only Scan using _dist_hyper_31_98_chunk_test_tz_time_idx on _timescaledb_internal._dist_hyper_31_98_chunk
                                      Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 11:00:00'::timestamp without time zone)
  
-(31 rows)
+(29 rows)
 
 -- Conversion to timestamptz cannot be evaluated at the access node, because the
 -- argument is a column reference.
@@ -5710,7 +5701,6 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5721,7 +5711,6 @@ WHERE time > x
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v, ('Tue Jan 02 11:00:00 2018 -01'::timestamp with time zone)::timestamp without time zone
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time" > '2018-01-02 12:00:00'::timestamp without time zone))
                Remote EXPLAIN: 
@@ -5733,7 +5722,7 @@ WHERE time > x
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Index Cond: (_dist_hyper_31_98_chunk."time" > '2018-01-02 12:00:00'::timestamp without time zone)
  
-(29 rows)
+(27 rows)
 
 -- Reference value for the above test.
 WITH dummy AS (SELECT '2018-01-02 12:00:00 +00'::timestamptz::timestamp x)
@@ -5757,7 +5746,6 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_1
                Output: test_tz_1."time", test_tz_1.v
                Data node: db_dist_hypertable_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_97_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5768,7 +5756,6 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
          ->  Custom Scan (DataNodeScan) on public.test_tz test_tz_2
                Output: test_tz_2."time", test_tz_2.v
                Data node: db_dist_hypertable_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_31_95_chunk, _dist_hyper_31_96_chunk, _dist_hyper_31_98_chunk
                Remote SQL: SELECT "time", v FROM public.test_tz WHERE _timescaledb_internal.chunks_in(public.test_tz.*, ARRAY[43, 44, 45]) AND (("time"::time without time zone > '01:00:00'::time without time zone)) AND ((date_trunc('month'::text, "time") > '2021-01-01'::date))
                Remote EXPLAIN: 
@@ -5783,7 +5770,7 @@ SELECT * FROM test_tz WHERE date_trunc('month', time) > date_in('2021-01-01')
                          Output: _dist_hyper_31_98_chunk."time", _dist_hyper_31_98_chunk.v
                          Filter: (((_dist_hyper_31_98_chunk."time")::time without time zone > '01:00:00'::time without time zone) AND (date_trunc('month'::text, _dist_hyper_31_98_chunk."time") > '2021-01-01'::date))
  
-(32 rows)
+(30 rows)
 
 -- Check that the test function for partly overriding now() works. It's very
 -- hacky and only has effect when we estimate some costs or evaluate sTABLE

--- a/tsl/test/expected/dist_partial_agg.out
+++ b/tsl/test/expected/dist_partial_agg.out
@@ -182,24 +182,21 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                Output: conditions.location, (min(conditions.allnull)), (max(conditions.temperature)), ((sum(conditions.temperature) + sum(conditions.humidity))), (avg(conditions.humidity)), (round(stddev((conditions.humidity)::integer), 5)), (bit_and(conditions.bit_int)), (bit_or(conditions.bit_int)), (bool_and(conditions.good_life)), (every((conditions.temperature > '0'::double precision))), (bool_or(conditions.good_life)), (count(*)), (count(conditions.temperature)), (count(conditions.allnull)), (round((corr(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((covar_pop(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((covar_samp(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_count(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_intercept(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_r2(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_slope(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round((regr_syy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision))::numeric, 5)), (round(stddev((conditions.temperature)::integer), 5)), (round(stddev_pop((conditions.temperature)::integer), 5)), (round(stddev_samp((conditions.temperature)::integer), 5)), (round(variance((conditions.temperature)::integer), 5)), (round(var_pop((conditions.temperature)::integer), 5)), (round(var_samp((conditions.temperature)::integer), 5)), (last(conditions.temperature, conditions.timec)), (histogram(conditions.temperature, '0'::double precision, '100'::double precision, 1)), conditions.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_1
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT location, min(allnull), max(temperature), (sum(temperature) + sum(humidity)), avg(humidity), round(stddev(humidity::integer), 5), bit_and(bit_int), bit_or(bit_int), bool_and(good_life), every((temperature > 0::double precision)), bool_or(good_life), count(*), count(temperature), count(allnull), round(corr(temperature::integer, humidity::integer)::numeric, 5), round(covar_pop(temperature::integer, humidity::integer)::numeric, 5), round(covar_samp(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgx(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgy(temperature::integer, humidity::integer)::numeric, 5), round(regr_count(temperature::integer, humidity::integer)::numeric, 5), round(regr_intercept(temperature::integer, humidity::integer)::numeric, 5), round(regr_r2(temperature::integer, humidity::integer)::numeric, 5), round(regr_slope(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxx(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxy(temperature::integer, humidity::integer)::numeric, 5), round(regr_syy(temperature::integer, humidity::integer)::numeric, 5), round(stddev(temperature::integer), 5), round(stddev_pop(temperature::integer), 5), round(stddev_samp(temperature::integer), 5), round(variance(temperature::integer), 5), round(var_pop(temperature::integer), 5), round(var_samp(temperature::integer), 5), public.last(temperature, timec), public.histogram(temperature, 0::double precision, 100::double precision, 1), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 35 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_1.location, (min(conditions_1.allnull)), (max(conditions_1.temperature)), ((sum(conditions_1.temperature) + sum(conditions_1.humidity))), (avg(conditions_1.humidity)), (round(stddev((conditions_1.humidity)::integer), 5)), (bit_and(conditions_1.bit_int)), (bit_or(conditions_1.bit_int)), (bool_and(conditions_1.good_life)), (every((conditions_1.temperature > '0'::double precision))), (bool_or(conditions_1.good_life)), (count(*)), (count(conditions_1.temperature)), (count(conditions_1.allnull)), (round((corr(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((covar_pop(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((covar_samp(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_count(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_intercept(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_r2(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_slope(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round((regr_syy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision))::numeric, 5)), (round(stddev((conditions_1.temperature)::integer), 5)), (round(stddev_pop((conditions_1.temperature)::integer), 5)), (round(stddev_samp((conditions_1.temperature)::integer), 5)), (round(variance((conditions_1.temperature)::integer), 5)), (round(var_pop((conditions_1.temperature)::integer), 5)), (round(var_samp((conditions_1.temperature)::integer), 5)), (last(conditions_1.temperature, conditions_1.timec)), (histogram(conditions_1.temperature, '0'::double precision, '100'::double precision, 1)), conditions_1.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_2
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT location, min(allnull), max(temperature), (sum(temperature) + sum(humidity)), avg(humidity), round(stddev(humidity::integer), 5), bit_and(bit_int), bit_or(bit_int), bool_and(good_life), every((temperature > 0::double precision)), bool_or(good_life), count(*), count(temperature), count(allnull), round(corr(temperature::integer, humidity::integer)::numeric, 5), round(covar_pop(temperature::integer, humidity::integer)::numeric, 5), round(covar_samp(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgx(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgy(temperature::integer, humidity::integer)::numeric, 5), round(regr_count(temperature::integer, humidity::integer)::numeric, 5), round(regr_intercept(temperature::integer, humidity::integer)::numeric, 5), round(regr_r2(temperature::integer, humidity::integer)::numeric, 5), round(regr_slope(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxx(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxy(temperature::integer, humidity::integer)::numeric, 5), round(regr_syy(temperature::integer, humidity::integer)::numeric, 5), round(stddev(temperature::integer), 5), round(stddev_pop(temperature::integer), 5), round(stddev_samp(temperature::integer), 5), round(variance(temperature::integer), 5), round(var_pop(temperature::integer), 5), round(var_samp(temperature::integer), 5), public.last(temperature, timec), public.histogram(temperature, 0::double precision, 100::double precision, 1), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 35 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_2.location, (min(conditions_2.allnull)), (max(conditions_2.temperature)), ((sum(conditions_2.temperature) + sum(conditions_2.humidity))), (avg(conditions_2.humidity)), (round(stddev((conditions_2.humidity)::integer), 5)), (bit_and(conditions_2.bit_int)), (bit_or(conditions_2.bit_int)), (bool_and(conditions_2.good_life)), (every((conditions_2.temperature > '0'::double precision))), (bool_or(conditions_2.good_life)), (count(*)), (count(conditions_2.temperature)), (count(conditions_2.allnull)), (round((corr(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((covar_pop(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((covar_samp(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_avgy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_count(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_intercept(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_r2(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_slope(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_sxy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round((regr_syy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision))::numeric, 5)), (round(stddev((conditions_2.temperature)::integer), 5)), (round(stddev_pop((conditions_2.temperature)::integer), 5)), (round(stddev_samp((conditions_2.temperature)::integer), 5)), (round(variance((conditions_2.temperature)::integer), 5)), (round(var_pop((conditions_2.temperature)::integer), 5)), (round(var_samp((conditions_2.temperature)::integer), 5)), (last(conditions_2.temperature, conditions_2.timec)), (histogram(conditions_2.temperature, '0'::double precision, '100'::double precision, 1)), conditions_2.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_3
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT location, min(allnull), max(temperature), (sum(temperature) + sum(humidity)), avg(humidity), round(stddev(humidity::integer), 5), bit_and(bit_int), bit_or(bit_int), bool_and(good_life), every((temperature > 0::double precision)), bool_or(good_life), count(*), count(temperature), count(allnull), round(corr(temperature::integer, humidity::integer)::numeric, 5), round(covar_pop(temperature::integer, humidity::integer)::numeric, 5), round(covar_samp(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgx(temperature::integer, humidity::integer)::numeric, 5), round(regr_avgy(temperature::integer, humidity::integer)::numeric, 5), round(regr_count(temperature::integer, humidity::integer)::numeric, 5), round(regr_intercept(temperature::integer, humidity::integer)::numeric, 5), round(regr_r2(temperature::integer, humidity::integer)::numeric, 5), round(regr_slope(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxx(temperature::integer, humidity::integer)::numeric, 5), round(regr_sxy(temperature::integer, humidity::integer)::numeric, 5), round(regr_syy(temperature::integer, humidity::integer)::numeric, 5), round(stddev(temperature::integer), 5), round(stddev_pop(temperature::integer), 5), round(stddev_samp(temperature::integer), 5), round(variance(temperature::integer), 5), round(var_pop(temperature::integer), 5), round(var_samp(temperature::integer), 5), public.last(temperature, timec), public.histogram(temperature, 0::double precision, 100::double precision, 1), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 35 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 -- Aggregates on custom types are not yet pushed down
 :PREFIX SELECT :GROUPING,
@@ -218,7 +215,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
          ->  Custom Scan (DataNodeScan) on public.conditions
                Output: conditions.location, conditions.timec, conditions.highlow
                Data node: data_node_1
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT timec, location, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -227,7 +223,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                Output: conditions_1.location, conditions_1.timec, conditions_1.highlow
                Data node: data_node_2
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT timec, location, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -236,10 +231,9 @@ SET timescaledb.remote_data_fetcher = 'cursor';
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                Output: conditions_2.location, conditions_2.timec, conditions_2.highlow
                Data node: data_node_3
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT timec, location, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 -- Mix of aggregates that push down and those that don't
 :PREFIX SELECT :GROUPING,
@@ -267,7 +261,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
          ->  Custom Scan (DataNodeScan) on public.conditions
                Output: conditions.location, conditions.timec, conditions.allnull, conditions.temperature, conditions.humidity, conditions.bit_int, conditions.good_life, conditions.highlow
                Data node: data_node_1
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT timec, location, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -276,7 +269,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                Output: conditions_1.location, conditions_1.timec, conditions_1.allnull, conditions_1.temperature, conditions_1.humidity, conditions_1.bit_int, conditions_1.good_life, conditions_1.highlow
                Data node: data_node_2
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT timec, location, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
    ->  GroupAggregate
@@ -285,10 +277,9 @@ SET timescaledb.remote_data_fetcher = 'cursor';
          ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                Output: conditions_2.location, conditions_2.timec, conditions_2.allnull, conditions_2.temperature, conditions_2.humidity, conditions_2.bit_int, conditions_2.good_life, conditions_2.highlow
                Data node: data_node_3
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT timec, location, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 -- Aggregates nested in expressions and no top-level aggregate #3672
 :PREFIX SELECT :GROUPING,
@@ -306,24 +297,21 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                Output: conditions.location, ((sum(conditions.temperature) + sum(conditions.humidity))), conditions.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_1
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                Remote SQL: SELECT location, (sum(temperature) + sum(humidity)), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 3 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_1.location, ((sum(conditions_1.temperature) + sum(conditions_1.humidity))), conditions_1.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_2
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                Remote SQL: SELECT location, (sum(temperature) + sum(humidity)), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 3 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: conditions_2.location, ((sum(conditions_2.temperature) + sum(conditions_2.humidity))), conditions_2.timec
                Relations: Aggregate on (public.conditions)
                Data node: data_node_3
-               Fetcher Type: Cursor
                Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                Remote SQL: SELECT location, (sum(temperature) + sum(humidity)), timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 3 ORDER BY location ASC NULLS LAST, timec ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 -- Aggregates with no aggregate reference in targetlist #3664
 :PREFIX SELECT :GROUPING
@@ -343,24 +331,21 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                      Output: conditions.location, conditions.timec
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT location, timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2 HAVING ((avg(temperature) > 20::double precision))
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.location, conditions_1.timec
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT location, timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2 HAVING ((avg(temperature) > 20::double precision))
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.location, conditions_2.timec
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT location, timec FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2 HAVING ((avg(temperature) > 20::double precision))
-(27 rows)
+(24 rows)
 
 \set GROUPING 'region, temperature'
 \ir 'include/aggregate_queries.sql'
@@ -419,24 +404,21 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                      Output: conditions.region, conditions.temperature, conditions.timec, (PARTIAL min(conditions.allnull)), (PARTIAL max(conditions.temperature)), (PARTIAL sum(conditions.temperature)), (PARTIAL sum(conditions.humidity)), (PARTIAL avg(conditions.humidity)), (PARTIAL stddev((conditions.humidity)::integer)), (PARTIAL bit_and(conditions.bit_int)), (PARTIAL bit_or(conditions.bit_int)), (PARTIAL bool_and(conditions.good_life)), (PARTIAL every((conditions.temperature > '0'::double precision))), (PARTIAL bool_or(conditions.good_life)), (PARTIAL count(*)), (PARTIAL count(conditions.temperature)), (PARTIAL count(conditions.allnull)), (PARTIAL corr(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL covar_pop(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL covar_samp(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_avgx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_avgy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_count(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_intercept(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_r2(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_slope(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_sxx(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_sxy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL regr_syy(((conditions.temperature)::integer)::double precision, ((conditions.humidity)::integer)::double precision)), (PARTIAL stddev((conditions.temperature)::integer)), (PARTIAL stddev_pop((conditions.temperature)::integer)), (PARTIAL stddev_samp((conditions.temperature)::integer)), (PARTIAL variance((conditions.temperature)::integer)), (PARTIAL var_pop((conditions.temperature)::integer)), (PARTIAL var_samp((conditions.temperature)::integer)), (PARTIAL last(conditions.temperature, conditions.timec)), (PARTIAL histogram(conditions.temperature, '0'::double precision, '100'::double precision, 1))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(min(allnull)), _timescaledb_internal.partialize_agg(max(temperature)), _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)), _timescaledb_internal.partialize_agg(avg(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity::integer)), _timescaledb_internal.partialize_agg(bit_and(bit_int)), _timescaledb_internal.partialize_agg(bit_or(bit_int)), _timescaledb_internal.partialize_agg(bool_and(good_life)), _timescaledb_internal.partialize_agg(every((temperature > 0::double precision))), _timescaledb_internal.partialize_agg(bool_or(good_life)), _timescaledb_internal.partialize_agg(count(*)), _timescaledb_internal.partialize_agg(count(temperature)), _timescaledb_internal.partialize_agg(count(allnull)), _timescaledb_internal.partialize_agg(corr(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_pop(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_samp(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_count(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_intercept(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_r2(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_slope(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_syy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(stddev(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_pop(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_samp(temperature::integer)), _timescaledb_internal.partialize_agg(variance(temperature::integer)), _timescaledb_internal.partialize_agg(var_pop(temperature::integer)), _timescaledb_internal.partialize_agg(var_samp(temperature::integer)), _timescaledb_internal.partialize_agg(public.last(temperature, timec)), _timescaledb_internal.partialize_agg(public.histogram(temperature, 0::double precision, 100::double precision, 1)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, (PARTIAL min(conditions_1.allnull)), (PARTIAL max(conditions_1.temperature)), (PARTIAL sum(conditions_1.temperature)), (PARTIAL sum(conditions_1.humidity)), (PARTIAL avg(conditions_1.humidity)), (PARTIAL stddev((conditions_1.humidity)::integer)), (PARTIAL bit_and(conditions_1.bit_int)), (PARTIAL bit_or(conditions_1.bit_int)), (PARTIAL bool_and(conditions_1.good_life)), (PARTIAL every((conditions_1.temperature > '0'::double precision))), (PARTIAL bool_or(conditions_1.good_life)), (PARTIAL count(*)), (PARTIAL count(conditions_1.temperature)), (PARTIAL count(conditions_1.allnull)), (PARTIAL corr(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL covar_pop(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL covar_samp(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_avgx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_avgy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_count(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_intercept(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_r2(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_slope(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_sxx(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_sxy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL regr_syy(((conditions_1.temperature)::integer)::double precision, ((conditions_1.humidity)::integer)::double precision)), (PARTIAL stddev((conditions_1.temperature)::integer)), (PARTIAL stddev_pop((conditions_1.temperature)::integer)), (PARTIAL stddev_samp((conditions_1.temperature)::integer)), (PARTIAL variance((conditions_1.temperature)::integer)), (PARTIAL var_pop((conditions_1.temperature)::integer)), (PARTIAL var_samp((conditions_1.temperature)::integer)), (PARTIAL last(conditions_1.temperature, conditions_1.timec)), (PARTIAL histogram(conditions_1.temperature, '0'::double precision, '100'::double precision, 1))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(min(allnull)), _timescaledb_internal.partialize_agg(max(temperature)), _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)), _timescaledb_internal.partialize_agg(avg(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity::integer)), _timescaledb_internal.partialize_agg(bit_and(bit_int)), _timescaledb_internal.partialize_agg(bit_or(bit_int)), _timescaledb_internal.partialize_agg(bool_and(good_life)), _timescaledb_internal.partialize_agg(every((temperature > 0::double precision))), _timescaledb_internal.partialize_agg(bool_or(good_life)), _timescaledb_internal.partialize_agg(count(*)), _timescaledb_internal.partialize_agg(count(temperature)), _timescaledb_internal.partialize_agg(count(allnull)), _timescaledb_internal.partialize_agg(corr(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_pop(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_samp(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_count(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_intercept(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_r2(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_slope(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_syy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(stddev(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_pop(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_samp(temperature::integer)), _timescaledb_internal.partialize_agg(variance(temperature::integer)), _timescaledb_internal.partialize_agg(var_pop(temperature::integer)), _timescaledb_internal.partialize_agg(var_samp(temperature::integer)), _timescaledb_internal.partialize_agg(public.last(temperature, timec)), _timescaledb_internal.partialize_agg(public.histogram(temperature, 0::double precision, 100::double precision, 1)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, (PARTIAL min(conditions_2.allnull)), (PARTIAL max(conditions_2.temperature)), (PARTIAL sum(conditions_2.temperature)), (PARTIAL sum(conditions_2.humidity)), (PARTIAL avg(conditions_2.humidity)), (PARTIAL stddev((conditions_2.humidity)::integer)), (PARTIAL bit_and(conditions_2.bit_int)), (PARTIAL bit_or(conditions_2.bit_int)), (PARTIAL bool_and(conditions_2.good_life)), (PARTIAL every((conditions_2.temperature > '0'::double precision))), (PARTIAL bool_or(conditions_2.good_life)), (PARTIAL count(*)), (PARTIAL count(conditions_2.temperature)), (PARTIAL count(conditions_2.allnull)), (PARTIAL corr(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL covar_pop(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL covar_samp(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_avgx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_avgy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_count(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_intercept(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_r2(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_slope(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_sxx(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_sxy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL regr_syy(((conditions_2.temperature)::integer)::double precision, ((conditions_2.humidity)::integer)::double precision)), (PARTIAL stddev((conditions_2.temperature)::integer)), (PARTIAL stddev_pop((conditions_2.temperature)::integer)), (PARTIAL stddev_samp((conditions_2.temperature)::integer)), (PARTIAL variance((conditions_2.temperature)::integer)), (PARTIAL var_pop((conditions_2.temperature)::integer)), (PARTIAL var_samp((conditions_2.temperature)::integer)), (PARTIAL last(conditions_2.temperature, conditions_2.timec)), (PARTIAL histogram(conditions_2.temperature, '0'::double precision, '100'::double precision, 1))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(min(allnull)), _timescaledb_internal.partialize_agg(max(temperature)), _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)), _timescaledb_internal.partialize_agg(avg(humidity)), _timescaledb_internal.partialize_agg(stddev(humidity::integer)), _timescaledb_internal.partialize_agg(bit_and(bit_int)), _timescaledb_internal.partialize_agg(bit_or(bit_int)), _timescaledb_internal.partialize_agg(bool_and(good_life)), _timescaledb_internal.partialize_agg(every((temperature > 0::double precision))), _timescaledb_internal.partialize_agg(bool_or(good_life)), _timescaledb_internal.partialize_agg(count(*)), _timescaledb_internal.partialize_agg(count(temperature)), _timescaledb_internal.partialize_agg(count(allnull)), _timescaledb_internal.partialize_agg(corr(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_pop(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(covar_samp(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_avgy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_count(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_intercept(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_r2(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_slope(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxx(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_sxy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(regr_syy(temperature::integer, humidity::integer)), _timescaledb_internal.partialize_agg(stddev(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_pop(temperature::integer)), _timescaledb_internal.partialize_agg(stddev_samp(temperature::integer)), _timescaledb_internal.partialize_agg(variance(temperature::integer)), _timescaledb_internal.partialize_agg(var_pop(temperature::integer)), _timescaledb_internal.partialize_agg(var_samp(temperature::integer)), _timescaledb_internal.partialize_agg(public.last(temperature, timec)), _timescaledb_internal.partialize_agg(public.histogram(temperature, 0::double precision, 100::double precision, 1)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 -- Aggregates on custom types are not yet pushed down
 :PREFIX SELECT :GROUPING,
@@ -458,7 +440,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                ->  Custom Scan (DataNodeScan) on public.conditions
                      Output: conditions.region, conditions.temperature, conditions.timec, conditions.highlow
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT timec, region, temperature, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -467,7 +448,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, conditions_1.highlow
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT timec, region, temperature, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -476,10 +456,9 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, conditions_2.highlow
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT timec, region, temperature, highlow FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(32 rows)
+(29 rows)
 
 -- Mix of aggregates that push down and those that don't
 :PREFIX SELECT :GROUPING,
@@ -510,7 +489,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                ->  Custom Scan (DataNodeScan) on public.conditions
                      Output: conditions.region, conditions.temperature, conditions.timec, conditions.allnull, conditions.humidity, conditions.bit_int, conditions.good_life, conditions.highlow
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT timec, region, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -519,7 +497,6 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_1
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, conditions_1.allnull, conditions_1.humidity, conditions_1.bit_int, conditions_1.good_life, conditions_1.highlow
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT timec, region, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -528,10 +505,9 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                ->  Custom Scan (DataNodeScan) on public.conditions conditions_2
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, conditions_2.allnull, conditions_2.humidity, conditions_2.bit_int, conditions_2.good_life, conditions_2.highlow
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT timec, region, temperature, humidity, allnull, highlow, bit_int, good_life FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(32 rows)
+(29 rows)
 
 -- Aggregates nested in expressions and no top-level aggregate #3672
 :PREFIX SELECT :GROUPING,
@@ -552,24 +528,21 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                      Output: conditions.region, conditions.temperature, conditions.timec, (PARTIAL sum(conditions.temperature)), (PARTIAL sum(conditions.humidity))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, (PARTIAL sum(conditions_1.temperature)), (PARTIAL sum(conditions_1.humidity))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, (PARTIAL sum(conditions_2.temperature)), (PARTIAL sum(conditions_2.humidity))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(sum(temperature)), _timescaledb_internal.partialize_agg(sum(humidity)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 -- Aggregates with no aggregate reference in targetlist #3664
 :PREFIX SELECT :GROUPING
@@ -591,24 +564,21 @@ SET timescaledb.remote_data_fetcher = 'cursor';
                      Output: conditions.region, conditions.temperature, conditions.timec, (PARTIAL avg(conditions.temperature))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_2_chunk, _dist_hyper_1_3_chunk, _dist_hyper_1_4_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(avg(temperature)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_1.region, conditions_1.temperature, conditions_1.timec, (PARTIAL avg(conditions_1.temperature))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_9_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_12_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(avg(temperature)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: conditions_2.region, conditions_2.temperature, conditions_2.timec, (PARTIAL avg(conditions_2.temperature))
                      Relations: Aggregate on (public.conditions)
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Chunks: _dist_hyper_1_5_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_8_chunk
                      Remote SQL: SELECT region, temperature, timec, _timescaledb_internal.partialize_agg(avg(temperature)) FROM public.conditions WHERE _timescaledb_internal.chunks_in(public.conditions.*, ARRAY[1, 2, 3, 4]) GROUP BY 1, 2, 3 ORDER BY region ASC NULLS LAST, temperature ASC NULLS LAST, timec ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 -- Full aggregate pushdown correctness check, compare location grouped query results with partionwise aggregates on and off
 \set GROUPING 'location'

--- a/tsl/test/expected/dist_query.out
+++ b/tsl/test/expected/dist_query.out
@@ -212,14 +212,12 @@ GROUP BY 1
                      Output: hyper."time", (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1."time", (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Partial GroupAggregate
@@ -228,10 +226,9 @@ GROUP BY 1
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -255,14 +252,12 @@ GROUP BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Partial GroupAggregate
@@ -271,10 +266,9 @@ GROUP BY 1
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -295,14 +289,12 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -311,10 +303,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -335,14 +326,12 @@ GROUP BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -351,10 +340,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -375,14 +363,12 @@ GROUP BY 1,2
                Output: (date_trunc('month'::text, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: (date_trunc('month'::text, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -391,10 +377,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: date_trunc('month'::text, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -416,14 +401,12 @@ HAVING device > 4
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -432,10 +415,9 @@ HAVING device > 4
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -454,24 +436,21 @@ HAVING avg(temp) > 40 AND max(temp) < 70
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision))
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision))
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision))
-(24 rows)
+(21 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -492,14 +471,12 @@ GROUP BY 1
                Output: hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1
          ->  GroupAggregate
@@ -508,10 +485,9 @@ GROUP BY 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### No push down on some functions
@@ -536,24 +512,21 @@ GROUP BY 1
                      Output: hyper_1.location, hyper_1.temp
                      Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2.location, hyper_2.temp
                      Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3.location, hyper_3.temp
                      Filter: ((hyper_3.temp * random()) >= '0'::double precision)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -576,22 +549,19 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(21 rows)
 
 
 ######### No push down on some functions
@@ -616,22 +586,19 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device, hyper_3.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### No push down on some functions
@@ -654,22 +621,19 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device, hyper_3.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(21 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -688,14 +652,12 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -704,10 +666,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
                                                                                                                                                                   QUERY PLAN                                                                                                                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -718,14 +679,12 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -734,10 +693,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -753,14 +711,12 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  GroupAggregate
@@ -769,10 +725,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -792,22 +747,19 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 10
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -828,22 +780,19 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 10
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -863,22 +812,19 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 1
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -898,22 +844,19 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) LIMIT 2000
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -933,22 +876,19 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -971,22 +911,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time", hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time", hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time", hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -1009,22 +946,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -1047,22 +981,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -1080,26 +1011,23 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(30 rows)
+(27 rows)
 
 
 ######### CTEs/Sub-queries
@@ -1136,19 +1064,16 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -1167,14 +1092,12 @@ ORDER BY 1,2
                                                          Output: hyper_4.device, (avg(hyper_4.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_1
-                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_1_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  Custom Scan (DataNodeScan)
                                                          Output: hyper_5.device, (avg(hyper_5.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_2
-                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_2_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  GroupAggregate
@@ -1183,10 +1106,9 @@ ORDER BY 1,2
                                                          ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
                                                                Output: hyper_6.device, hyper_6.temp
                                                                Data node: data_node_3
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_3_chunk
                                                                Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(66 rows)
+(60 rows)
 
 
 ######### CTEs/Sub-queries
@@ -1213,19 +1135,16 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -1233,10 +1152,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(36 rows)
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -1274,24 +1192,21 @@ ORDER BY 1
                      Output: hyper."time", (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1."time", (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2."time", (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -1316,24 +1231,21 @@ ORDER BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1355,14 +1267,12 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1371,10 +1281,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1396,14 +1305,12 @@ ORDER BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1412,10 +1319,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1437,14 +1343,12 @@ ORDER BY 1,2
                Output: (date_trunc('month'::text, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (date_trunc('month'::text, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1453,10 +1357,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: date_trunc('month'::text, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -1479,24 +1382,21 @@ ORDER BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -1516,24 +1416,21 @@ ORDER BY 1,2
                Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -1555,24 +1452,21 @@ ORDER BY 1
                Output: hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk
                Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### No push down on some functions
@@ -1597,24 +1491,21 @@ ORDER BY 1
                      Output: hyper_1.location, hyper_1.temp
                      Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2.location, hyper_2.temp
                      Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3.location, hyper_3.temp
                      Filter: ((hyper_3.temp * random()) >= '0'::double precision)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -1638,22 +1529,19 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### No push down on some functions
@@ -1681,22 +1569,19 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -1720,22 +1605,19 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device, hyper_3.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -1755,14 +1637,12 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1771,10 +1651,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
                                                                                                                                                                          QUERY PLAN                                                                                                                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1786,14 +1665,12 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1802,10 +1679,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -1822,14 +1698,12 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -1838,10 +1712,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -1862,22 +1735,19 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -1899,22 +1769,19 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -1935,22 +1802,19 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -1971,22 +1835,19 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -2007,22 +1868,19 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -2048,22 +1906,19 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -2086,22 +1941,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -2124,22 +1976,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -2157,26 +2006,23 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(30 rows)
+(27 rows)
 
 
 ######### CTEs/Sub-queries
@@ -2213,19 +2059,16 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -2244,14 +2087,12 @@ ORDER BY 1,2
                                                          Output: hyper_4.device, (avg(hyper_4.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_1
-                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_1_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  Custom Scan (DataNodeScan)
                                                          Output: hyper_5.device, (avg(hyper_5.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_2
-                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_2_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  GroupAggregate
@@ -2260,10 +2101,9 @@ ORDER BY 1,2
                                                          ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
                                                                Output: hyper_6.device, hyper_6.temp
                                                                Data node: data_node_3
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_3_chunk
                                                                Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(66 rows)
+(60 rows)
 
 
 ######### CTEs/Sub-queries
@@ -2290,19 +2130,16 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -2310,10 +2147,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(36 rows)
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -2344,10 +2180,9 @@ ORDER BY 1
    Output: hyper."time", (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
-(7 rows)
+(6 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -2365,10 +2200,9 @@ ORDER BY 1
    Output: (time_bucket('@ 2 days'::interval, hyper."time")), (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(7 rows)
+(6 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2386,10 +2220,9 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(7 rows)
+(6 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2407,10 +2240,9 @@ ORDER BY 1,2
    Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(7 rows)
+(6 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2428,10 +2260,9 @@ ORDER BY 1,2
    Output: (date_trunc('month'::text, hyper."time")), hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT date_trunc('month'::text, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST
-(7 rows)
+(6 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -2471,10 +2302,9 @@ ORDER BY 1,2
    Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(7 rows)
+(6 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -2492,10 +2322,9 @@ ORDER BY 1
    Output: hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1
-(7 rows)
+(6 rows)
 
 
 ######### No push down on some functions
@@ -2516,10 +2345,9 @@ ORDER BY 1
          Output: hyper.location, hyper.temp
          Filter: ((hyper.temp * random()) >= '0'::double precision)
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY location ASC NULLS LAST
-(10 rows)
+(9 rows)
 
 
 ######### No push down on some functions
@@ -2539,10 +2367,9 @@ ORDER BY 1,2
    ->  Custom Scan (DataNodeScan) on public.hyper
          Output: time_bucket('@ 2 days'::interval, hyper."time"), hyper.device, hyper.temp
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(9 rows)
+(8 rows)
 
 
 ######### No push down on some functions
@@ -2564,10 +2391,9 @@ ORDER BY 1,2
    ->  Custom Scan (DataNodeScan) on public.hyper
          Output: hyper."time", hyper.device, hyper.temp
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY "time" ASC NULLS LAST
-(10 rows)
+(9 rows)
 
 
 ######### No push down on some functions
@@ -2587,10 +2413,9 @@ ORDER BY 1,2
    ->  Custom Scan (DataNodeScan) on public.hyper
          Output: hyper."time", hyper.device, hyper.temp
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_1_1_chunk
          Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY "time" ASC NULLS LAST
-(9 rows)
+(8 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -2606,10 +2431,9 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(7 rows)
+(6 rows)
 
                                                                                                                                                                  QUERY PLAN                                                                                                                                                                 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -2617,10 +2441,9 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(7 rows)
+(6 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -2633,10 +2456,9 @@ ORDER BY 1,2
    Output: hyper."time", hyper.device, (avg(hyper.temp))
    Relations: Aggregate on (public.hyper)
    Data node: data_node_1
-   Fetcher Type: Row by row
    Chunks: _dist_hyper_1_1_chunk
    Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST
-(7 rows)
+(6 rows)
 
 
 ######### LIMIT push down cases
@@ -2657,22 +2479,19 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -2694,22 +2513,19 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -2730,22 +2546,19 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -2766,22 +2579,19 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -2802,22 +2612,19 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -2843,22 +2650,19 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -2881,22 +2685,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -2919,22 +2720,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -2952,26 +2750,23 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(30 rows)
+(27 rows)
 
 
 ######### CTEs/Sub-queries
@@ -3000,7 +2795,6 @@ ORDER BY 1,2
          ->  Custom Scan (DataNodeScan) on public.hyper
                Output: hyper."time", hyper.device, hyper.temp, time_bucket('@ 1 min'::interval, hyper."time")
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk
                Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST
          ->  Materialize
@@ -3014,10 +2808,9 @@ ORDER BY 1,2
                                  Output: hyper_1.device, (avg(hyper_1.temp))
                                  Relations: Aggregate on (public.hyper)
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device = 1)) GROUP BY 1 ORDER BY avg(temp) DESC NULLS FIRST
-(25 rows)
+(23 rows)
 
 
 ######### CTEs/Sub-queries
@@ -3044,19 +2837,16 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -3064,10 +2854,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(36 rows)
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -3106,22 +2895,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -3147,22 +2933,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3188,22 +2971,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3229,22 +3009,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3270,22 +3047,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: date_trunc('month'::text, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: date_trunc('month'::text, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: date_trunc('month'::text, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -3312,22 +3086,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) AND ((device > 4)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -3349,24 +3120,21 @@ LIMIT 10
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 HAVING ((avg(temp) > 40::double precision)) AND ((max(temp) < 70::double precision)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -3392,22 +3160,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### No push down on some functions
@@ -3434,24 +3199,21 @@ LIMIT 10
                            Output: hyper_1.location, hyper_1.temp
                            Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.location, hyper_2.temp
                            Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.location, hyper_3.temp
                            Filter: ((hyper_3.temp * random()) >= '0'::double precision)
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(30 rows)
+(27 rows)
 
 
 ######### No push down on some functions
@@ -3477,22 +3239,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: time_bucket('@ 2 days'::interval, hyper_3."time"), hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### No push down on some functions
@@ -3520,22 +3279,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -3561,22 +3317,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -3600,22 +3353,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
                                                                                                                                                                      QUERY PLAN                                                                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -3631,22 +3381,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -3667,22 +3414,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1."time", hyper_1.device, hyper_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2."time", hyper_2.device, hyper_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3."time", hyper_3.device, hyper_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 
 ######### LIMIT push down cases
@@ -3703,22 +3447,19 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -3740,22 +3481,19 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -3776,22 +3514,19 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -3812,22 +3547,19 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -3848,22 +3580,19 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -3889,22 +3618,19 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -3927,22 +3653,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -3965,22 +3688,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -3998,26 +3718,23 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(30 rows)
+(27 rows)
 
 
 ######### CTEs/Sub-queries
@@ -4054,19 +3771,16 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -4085,14 +3799,12 @@ ORDER BY 1,2
                                                          Output: hyper_4.device, (avg(hyper_4.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_1
-                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_1_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  Custom Scan (DataNodeScan)
                                                          Output: hyper_5.device, (avg(hyper_5.temp))
                                                          Relations: Aggregate on (public.hyper)
                                                          Data node: data_node_2
-                                                         Fetcher Type: Row by row
                                                          Chunks: _dist_hyper_1_2_chunk
                                                          Remote SQL: SELECT device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                    ->  GroupAggregate
@@ -4101,10 +3813,9 @@ ORDER BY 1,2
                                                          ->  Custom Scan (DataNodeScan) on public.hyper hyper_6
                                                                Output: hyper_6.device, hyper_6.temp
                                                                Data node: data_node_3
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_3_chunk
                                                                Remote SQL: SELECT device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY device ASC NULLS LAST
-(66 rows)
+(60 rows)
 
 
 ######### CTEs/Sub-queries
@@ -4131,19 +3842,16 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -4151,10 +3859,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(36 rows)
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper
@@ -4191,24 +3898,21 @@ GROUP BY 1
                      Output: hyper."time", (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1."time", (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2."time", (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -4232,24 +3936,21 @@ GROUP BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4271,24 +3972,21 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4313,24 +4011,21 @@ ORDER BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4355,24 +4050,21 @@ ORDER BY 1,2
                      Output: (date_trunc('month'::text, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY date_trunc('month'::text, "time") ASC NULLS LAST, device ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -4398,24 +4090,21 @@ ORDER BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -4439,24 +4128,21 @@ ORDER BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper."time")), hyper.device, (PARTIAL avg(hyper.temp)), (PARTIAL max(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_1."time")), hyper_1.device, (PARTIAL avg(hyper_1.temp)), (PARTIAL max(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper_2."time")), hyper_2.device, (PARTIAL avg(hyper_2.temp)), (PARTIAL max(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -4480,24 +4166,21 @@ GROUP BY 1
                      Output: hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1
-(27 rows)
+(24 rows)
 
 
 ######### No push down on some functions
@@ -4525,7 +4208,6 @@ GROUP BY 1
                            Output: hyper.location, hyper.temp
                            Filter: ((hyper.temp * random()) >= '0'::double precision)
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -4535,7 +4217,6 @@ GROUP BY 1
                            Output: hyper_1.location, hyper_1.temp
                            Filter: ((hyper_1.temp * random()) >= '0'::double precision)
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -4545,10 +4226,9 @@ GROUP BY 1
                            Output: hyper_2.location, hyper_2.temp
                            Filter: ((hyper_2.temp * random()) >= '0'::double precision)
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(37 rows)
+(34 rows)
 
 
 ######### No push down on some functions
@@ -4573,7 +4253,6 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper
                      Output: time_bucket('@ 2 days'::interval, hyper."time"), hyper.device, hyper.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -4582,7 +4261,6 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: time_bucket('@ 2 days'::interval, hyper_1."time"), hyper_1.device, hyper_1.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -4591,10 +4269,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: time_bucket('@ 2 days'::interval, hyper_2."time"), hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(29 rows)
 
 
 ######### No push down on some functions
@@ -4620,7 +4297,6 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper
                      Output: hyper."time", hyper.device, hyper.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4630,7 +4306,6 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4640,10 +4315,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(34 rows)
+(31 rows)
 
 
 ######### No push down on some functions
@@ -4667,7 +4341,6 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper
                      Output: hyper."time", hyper.device, hyper.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4676,7 +4349,6 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device, hyper_1.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -4685,10 +4357,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device, hyper_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(31 rows)
+(28 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -4708,24 +4379,21 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
                                                                                                                                                QUERY PLAN                                                                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4737,24 +4405,21 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -4771,24 +4436,21 @@ ORDER BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2 ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### LIMIT push down cases
@@ -4809,22 +4471,19 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -4846,22 +4505,19 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 10
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -4882,22 +4538,19 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 1
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -4918,22 +4571,19 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST LIMIT 2000
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -4954,22 +4604,19 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                      Output: hyper_1."time", hyper_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                      Output: hyper_2."time", hyper_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                      Output: hyper_3."time", hyper_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -4995,22 +4642,19 @@ LIMIT 10
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1.device, hyper_1."time", hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2.device, hyper_2."time", hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3.device, hyper_3."time", hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST
-(29 rows)
+(26 rows)
 
 
 ######### LIMIT push down cases
@@ -5033,22 +4677,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -5071,22 +4712,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                            Output: hyper_1.device, hyper_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                            Output: hyper_2.device, hyper_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                            Output: hyper_3.device, hyper_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -5104,26 +4742,23 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7])
                      ->  Custom Scan (DataNodeScan) on public.hyper t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(30 rows)
+(27 rows)
 
 
 ######### CTEs/Sub-queries
@@ -5160,19 +4795,16 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_1
                                  Output: hyper_1."time", hyper_1.device, hyper_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_2
                                  Output: hyper_2."time", hyper_2.device, hyper_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper hyper_3
                                  Output: hyper_3."time", hyper_3.device, hyper_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -5195,24 +4827,21 @@ ORDER BY 1,2
                                                                Output: hyper_4.device, (PARTIAL avg(hyper_4.temp))
                                                                Relations: Aggregate on (public.hyper)
                                                                Data node: data_node_1
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper_5.device, (PARTIAL avg(hyper_5.temp))
                                                                Relations: Aggregate on (public.hyper)
                                                                Data node: data_node_2
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper_6.device, (PARTIAL avg(hyper_6.temp))
                                                                Relations: Aggregate on (public.hyper)
                                                                Data node: data_node_3
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(68 rows)
+(62 rows)
 
 
 ######### CTEs/Sub-queries
@@ -5239,19 +4868,16 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -5259,10 +4885,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(36 rows)
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: hyper1d
@@ -5297,24 +4922,21 @@ ORDER BY 1
                Output: hyper1d."time", (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY "time" ASC NULLS LAST
-(25 rows)
+(22 rows)
 
 
 ######### Grouping on time only (partial aggregation)
@@ -5339,24 +4961,21 @@ ORDER BY 1
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -5377,24 +4996,21 @@ GROUP BY 1,2
                Output: hyper."time", hyper.device, (avg(hyper.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_1."time", hyper_1.device, (avg(hyper_1.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper_2."time", hyper_2.device, (avg(hyper_2.temp))
                Relations: Aggregate on (public.hyper)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(24 rows)
+(21 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -5418,24 +5034,21 @@ GROUP BY 1,2
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -5459,24 +5072,21 @@ GROUP BY 1,2
                      Output: (date_trunc('month'::text, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (date_trunc('month'::text, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT date_trunc('month'::text, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(27 rows)
+(24 rows)
 
 
 ######### Grouping on time and device (full aggregation)
@@ -5501,24 +5111,21 @@ HAVING device > 4
                      Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
                ->  Custom Scan (DataNodeScan)
                      Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp))
                      Relations: Aggregate on (public.hyper1d)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND ((device > 4)) GROUP BY 1, 2
-(27 rows)
+(24 rows)
 
 EXPLAIN (verbose, costs off)
 SELECT time_bucket('2 days', time) AS time, device, avg(temp)
@@ -5544,24 +5151,21 @@ HAVING avg(temp) > 40 AND max(temp) < 70
                            Output: (time_bucket('@ 2 days'::interval, hyper1d."time")), hyper1d.device, (PARTIAL avg(hyper1d.temp)), (PARTIAL max(hyper1d.temp))
                            Relations: Aggregate on (public.hyper1d)
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                      ->  Custom Scan (DataNodeScan)
                            Output: (time_bucket('@ 2 days'::interval, hyper1d_1."time")), hyper1d_1.device, (PARTIAL avg(hyper1d_1.temp)), (PARTIAL max(hyper1d_1.temp))
                            Relations: Aggregate on (public.hyper1d)
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
                      ->  Custom Scan (DataNodeScan)
                            Output: (time_bucket('@ 2 days'::interval, hyper1d_2."time")), hyper1d_2.device, (PARTIAL avg(hyper1d_2.temp)), (PARTIAL max(hyper1d_2.temp))
                            Relations: Aggregate on (public.hyper1d)
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT public.time_bucket('@ 2 days'::interval, "time"), device, _timescaledb_internal.partialize_agg(avg(temp)), _timescaledb_internal.partialize_agg(max(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(31 rows)
+(28 rows)
 
 
 ######### Grouping on device only (full aggregation)
@@ -5586,24 +5190,21 @@ ORDER BY 1
                      Output: hyper.device, (PARTIAL avg(hyper.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_1_chunk, _dist_hyper_1_4_chunk, _dist_hyper_1_8_chunk, _dist_hyper_1_12_chunk, _dist_hyper_1_13_chunk, _dist_hyper_1_15_chunk, _dist_hyper_1_17_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_1.device, (PARTIAL avg(hyper_1.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_2_chunk, _dist_hyper_1_5_chunk, _dist_hyper_1_7_chunk, _dist_hyper_1_9_chunk, _dist_hyper_1_11_chunk, _dist_hyper_1_14_chunk, _dist_hyper_1_18_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4, 5, 6, 7]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                ->  Custom Scan (DataNodeScan)
                      Output: hyper_2.device, (PARTIAL avg(hyper_2.temp))
                      Relations: Aggregate on (public.hyper)
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_1_3_chunk, _dist_hyper_1_6_chunk, _dist_hyper_1_10_chunk, _dist_hyper_1_16_chunk
                      Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1, 2, 3, 4]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(28 rows)
+(25 rows)
 
 
 ######### No push down on some functions
@@ -5631,7 +5232,6 @@ ORDER BY 1
                            Output: hyper1d.location, hyper1d.temp
                            Filter: ((hyper1d.temp * random()) >= '0'::double precision)
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -5641,7 +5241,6 @@ ORDER BY 1
                            Output: hyper1d_1.location, hyper1d_1.temp
                            Filter: ((hyper1d_1.temp * random()) >= '0'::double precision)
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
                ->  Partial GroupAggregate
@@ -5651,10 +5250,9 @@ ORDER BY 1
                            Output: hyper1d_2.location, hyper1d_2.temp
                            Filter: ((hyper1d_2.temp * random()) >= '0'::double precision)
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT location, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY location ASC NULLS LAST
-(37 rows)
+(34 rows)
 
 
 ######### No push down on some functions
@@ -5679,7 +5277,6 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: time_bucket('@ 2 days'::interval, hyper1d."time"), hyper1d.device, hyper1d.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -5688,7 +5285,6 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: time_bucket('@ 2 days'::interval, hyper1d_1."time"), hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Partial GroupAggregate
@@ -5697,10 +5293,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: time_bucket('@ 2 days'::interval, hyper1d_2."time"), hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('2 days'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(32 rows)
+(29 rows)
 
 
 ######### No push down on some functions
@@ -5725,7 +5320,6 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: hyper1d."time", hyper1d.device, hyper1d.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5735,7 +5329,6 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5745,10 +5338,9 @@ HAVING avg(temp) * custom_sum(device) > 0.8
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(33 rows)
+(30 rows)
 
 
 ######### No push down on some functions
@@ -5771,7 +5363,6 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d
                      Output: hyper1d."time", hyper1d.device, hyper1d.temp
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5780,7 +5371,6 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
          ->  GroupAggregate
@@ -5789,10 +5379,9 @@ GROUP BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY "time" ASC NULLS LAST, device ASC NULLS LAST
-(30 rows)
+(27 rows)
 
 
 ######### Constification and runtime push down of time-related functions
@@ -5811,24 +5400,21 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(24 rows)
+(21 rows)
 
                                                                                                              QUERY PLAN                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -5839,24 +5425,21 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(24 rows)
+(21 rows)
 
  tsl_override_current_timestamptz 
 ----------------------------------
@@ -5872,24 +5455,21 @@ GROUP BY 1,2
                Output: hyper1d."time", hyper1d.device, (avg(hyper1d.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_20_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_1."time", hyper1d_1.device, (avg(hyper1d_1.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_2
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_21_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
          ->  Custom Scan (DataNodeScan)
                Output: hyper1d_2."time", hyper1d_2.device, (avg(hyper1d_2.temp))
                Relations: Aggregate on (public.hyper1d)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_2_19_chunk
                Remote SQL: SELECT "time", device, avg(temp) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1, 2
-(24 rows)
+(21 rows)
 
 
 ######### LIMIT push down cases
@@ -5909,22 +5489,19 @@ LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 10
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -5945,22 +5522,19 @@ OFFSET 5
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 10
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 10
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -5980,22 +5554,19 @@ LIMIT 0
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 1
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 1
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -6015,22 +5586,19 @@ LIMIT extract(year from date '2000-01-01')
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) LIMIT 2000
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) LIMIT 2000
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -6050,22 +5618,19 @@ LIMIT greatest(random(), 10.0)
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                      Output: hyper1d_1."time", hyper1d_1.device
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_20_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                      Output: hyper1d_2."time", hyper1d_2.device
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_21_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                      Output: hyper1d_3."time", hyper1d_3.device
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5])
-(23 rows)
+(20 rows)
 
 
 ######### LIMIT push down cases
@@ -6088,22 +5653,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time", hyper1d_1.temp
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time", hyper1d_2.temp
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time", hyper1d_3.temp
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -6126,22 +5688,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT DISTINCT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -6164,22 +5723,19 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                            Output: hyper1d_1.device, hyper1d_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                            Output: hyper1d_2.device, hyper1d_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) ORDER BY device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                            Output: hyper1d_3.device, hyper1d_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT DISTINCT ON (device) "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) ORDER BY device ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 
 ######### LIMIT push down cases
@@ -6197,26 +5753,23 @@ LIMIT 10
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_1
                            Output: t_1."time", t_1.device
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_20_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_2
                            Output: t_2."time", t_2.device
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_21_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8])
                      ->  Custom Scan (DataNodeScan) on public.hyper1d t_3
                            Output: t_3."time", t_3.device
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_2_19_chunk
                            Remote SQL: SELECT "time", device FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5])
          ->  Materialize
                Output: join_test.device
                ->  Seq Scan on public.join_test
                      Output: join_test.device
-(30 rows)
+(27 rows)
 
 
 ######### CTEs/Sub-queries
@@ -6253,19 +5806,16 @@ ORDER BY 1,2
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_1
                                  Output: hyper1d_1."time", hyper1d_1.device, hyper1d_1.temp
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_2_20_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_2
                                  Output: hyper1d_2."time", hyper1d_2.device, hyper1d_2.temp
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_2_21_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                            ->  Custom Scan (DataNodeScan) on public.hyper1d hyper1d_3
                                  Output: hyper1d_3."time", hyper1d_3.device, hyper1d_3.temp
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_2_19_chunk
                                  Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                ->  Hash
@@ -6287,24 +5837,21 @@ ORDER BY 1,2
                                                                Output: hyper1d_4.device, (PARTIAL avg(hyper1d_4.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_1
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_2_20_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper1d_5.device, (PARTIAL avg(hyper1d_5.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_2
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_2_21_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[8]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
                                                          ->  Custom Scan (DataNodeScan)
                                                                Output: hyper1d_6.device, (PARTIAL avg(hyper1d_6.temp))
                                                                Relations: Aggregate on (public.hyper1d)
                                                                Data node: data_node_3
-                                                               Fetcher Type: Row by row
                                                                Chunks: _dist_hyper_2_19_chunk
                                                                Remote SQL: SELECT device, _timescaledb_internal.partialize_agg(avg(temp)) FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) GROUP BY 1 ORDER BY device ASC NULLS LAST
-(67 rows)
+(61 rows)
 
 
 ######### CTEs/Sub-queries
@@ -6331,19 +5878,16 @@ ORDER BY 1,2
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_1
                            Output: h1_1."time", h1_1.device, h1_1.temp, time_bucket('@ 1 min'::interval, h1_1."time")
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_1_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_2
                            Output: h1_2."time", h1_2.device, h1_2.temp, time_bucket('@ 1 min'::interval, h1_2."time")
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_2_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.hyper h1_3
                            Output: h1_3."time", h1_3.device, h1_3.temp, time_bucket('@ 1 min'::interval, h1_3."time")
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_1_3_chunk
                            Remote SQL: SELECT "time", device, temp FROM public.hyper WHERE _timescaledb_internal.chunks_in(public.hyper.*, ARRAY[1]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
          ->  Materialize
@@ -6351,10 +5895,9 @@ ORDER BY 1,2
                ->  Custom Scan (DataNodeScan) on public.hyper1d h2
                      Output: h2.temp, h2."time", h2.device, time_bucket('@ 1 min'::interval, h2."time")
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_2_19_chunk
                      Remote SQL: SELECT "time", device, temp FROM public.hyper1d WHERE _timescaledb_internal.chunks_in(public.hyper1d.*, ARRAY[5]) AND (("time" >= '2019-01-01 00:00:00-08'::timestamp with time zone)) AND (("time" <= '2019-01-01 15:00:00-08'::timestamp with time zone)) ORDER BY public.time_bucket('00:01:00'::interval, "time") ASC NULLS LAST, device ASC NULLS LAST
-(36 rows)
+(32 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: reference

--- a/tsl/test/shared/expected/dist_distinct.out
+++ b/tsl/test/shared/expected/dist_distinct.out
@@ -39,22 +39,19 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 RESET enable_hashagg;
 SET timescaledb.enable_per_data_node_queries = true;
@@ -77,22 +74,19 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: (metrics_dist_1.device_id * metrics_dist_1.v1)
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: (metrics_dist_2.device_id * metrics_dist_2.v1)
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: (metrics_dist_3.device_id * metrics_dist_3.v1)
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT device_id, v1 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY (device_id * v1) ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 SET timescaledb.enable_remote_explain = ON;
 SELECT DISTINCT on column with index uses SkipScan
@@ -114,7 +108,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -141,7 +134,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -168,7 +160,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -192,7 +183,7 @@ LIMIT 10;
                                                  Output: _dist_hyper_X_X_chunk.device_id
                                                  Index Cond: (_dist_hyper_X_X_chunk.device_id > NULL::integer)
  
-(89 rows)
+(86 rows)
 
 SELECT DISTINCT with constants and NULLs in targetlist uses SkipScan
 EXPLAIN (verbose, costs off)
@@ -213,7 +204,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, NULL::text, 'const1'::text
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -240,7 +230,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, NULL::text, 'const1'::text
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -267,7 +256,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, NULL::text, 'const1'::text
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -291,7 +279,7 @@ LIMIT 10;
                                                  Output: _dist_hyper_X_X_chunk.device_id
                                                  Index Cond: (_dist_hyper_X_X_chunk.device_id > NULL::integer)
  
-(89 rows)
+(86 rows)
 
 SELECT DISTINCT only sends columns to the data nodes
 EXPLAIN (verbose, costs off)
@@ -312,7 +300,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1."time", NULL::text, 'const1'::text
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -332,7 +319,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2."time", NULL::text, 'const1'::text
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -353,7 +339,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3."time", NULL::text, 'const1'::text
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -370,7 +355,7 @@ LIMIT 10;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(69 rows)
+(66 rows)
 
 SELECT DISTINCE is pushed down in attribute attno order
 EXPLAIN (verbose, costs off)
@@ -391,7 +376,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -411,7 +395,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -432,7 +415,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -449,7 +431,7 @@ LIMIT 10;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(69 rows)
+(66 rows)
 
 SELECT DISTINCT ON multiple columns is pushed to data nodes
 EXPLAIN (verbose, costs off)
@@ -470,7 +452,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -490,7 +471,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -510,7 +490,6 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id, "time") "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                            Remote EXPLAIN: 
@@ -527,7 +506,7 @@ LIMIT 10;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(68 rows)
+(65 rows)
 
 SELECT DISTINCT within a sub-select
 EXPLAIN (verbose, costs off)
@@ -550,7 +529,6 @@ LIMIT 10) a;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                                  Output: metrics_dist_1.device_id, metrics_dist_1."time"
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                                  Remote EXPLAIN: 
@@ -570,7 +548,6 @@ LIMIT 10) a;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                                  Output: metrics_dist_2.device_id, metrics_dist_2."time"
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                                  Remote EXPLAIN: 
@@ -590,7 +567,6 @@ LIMIT 10) a;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                                  Output: metrics_dist_3.device_id, metrics_dist_3."time"
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                                  Remote EXPLAIN: 
@@ -607,7 +583,7 @@ LIMIT 10) a;
                                                  ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                        Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.device_id
  
-(70 rows)
+(67 rows)
 
 SET timescaledb.enable_per_data_node_queries = false;
 SELECT DISTINCT works with enable_per_data_node_queries disabled
@@ -627,7 +603,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -641,7 +616,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -655,7 +629,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -669,7 +642,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -683,7 +655,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -697,7 +668,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -711,7 +681,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_1
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -725,7 +694,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_2
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -739,7 +707,6 @@ LIMIT 10;
                ->  Foreign Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                      Output: _dist_hyper_X_X_chunk.device_id
                      Data node: data_node_3
-                     Fetcher Type: Cursor
                      Remote SQL: SELECT DISTINCT device_id FROM _timescaledb_internal._dist_hyper_X_X_chunk ORDER BY device_id ASC NULLS LAST
                      Remote EXPLAIN: 
                        Unique
@@ -750,7 +717,7 @@ LIMIT 10;
                                      Output: device_id
                                      Index Cond: (_dist_hyper_X_X_chunk.device_id > NULL::integer)
  
-(132 rows)
+(123 rows)
 
 SET timescaledb.enable_per_data_node_queries = true;
 SET timescaledb.enable_remote_explain = OFF;
@@ -773,22 +740,19 @@ ORDER BY 1;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1.device_id, metrics_dist_1.device_id
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2.device_id, metrics_dist_2.device_id
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3.device_id, metrics_dist_3.device_id
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT device_id FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST
-(27 rows)
+(24 rows)
 
 SELECT DISTINCT handles whole row correctly
 EXPLAIN (verbose, costs off)
@@ -809,22 +773,19 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1."time", metrics_dist_1.device_id, metrics_dist_1.v0, metrics_dist_1.v1, metrics_dist_1.v2, metrics_dist_1.v3
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2."time", metrics_dist_2.device_id, metrics_dist_2.v0, metrics_dist_2.v1, metrics_dist_2.v2, metrics_dist_2.v3
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3."time", metrics_dist_3.device_id, metrics_dist_3.v0, metrics_dist_3.v1, metrics_dist_3.v2, metrics_dist_3.v3
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY "time" ASC NULLS LAST, device_id ASC NULLS LAST, v0 ASC NULLS LAST, v1 ASC NULLS LAST, v2 ASC NULLS LAST, v3 ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 SELECT DISTINCT ON (expr) handles whole row correctly
 EXPLAIN (verbose, costs off)
@@ -845,22 +806,19 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: metrics_dist_1."time", metrics_dist_1.device_id, metrics_dist_1.v0, metrics_dist_1.v1, metrics_dist_1.v2, metrics_dist_1.v3
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: metrics_dist_2."time", metrics_dist_2.device_id, metrics_dist_2.v0, metrics_dist_2.v1, metrics_dist_2.v2, metrics_dist_2.v3
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: metrics_dist_3."time", metrics_dist_3.device_id, metrics_dist_3.v0, metrics_dist_3.v1, metrics_dist_3.v2, metrics_dist_3.v3
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT DISTINCT ON (device_id) "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY device_id ASC NULLS LAST, "time" ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 SELECT DISTINCT RECORD works correctly
 SET enable_hashagg TO false;
@@ -884,22 +842,19 @@ LIMIT 10;
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                                  Output: metrics_dist_1.*
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                                  Output: metrics_dist_2.*
                                  Data node: data_node_2
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                            ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                                  Output: metrics_dist_3.*
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT DISTINCT "time", device_id, v0, v1, v2, v3 FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
-(28 rows)
+(25 rows)
 
 RESET enable_hashagg;
 SELECT DISTINCT FUNCTION_EXPR not pushed down currently
@@ -921,22 +876,19 @@ LIMIT 10;
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                            Output: time_bucket('@ 1 hour'::interval, metrics_dist_1."time")
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                            Output: time_bucket('@ 1 hour'::interval, metrics_dist_2."time")
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
                      ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                            Output: time_bucket('@ 1 hour'::interval, metrics_dist_3."time")
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time" FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3]) ORDER BY public.time_bucket('01:00:00'::interval, "time") ASC NULLS LAST
-(26 rows)
+(23 rows)
 
 SELECT DISTINCT without any var references is handled correctly
 EXPLAIN (verbose, costs off)
@@ -952,22 +904,19 @@ FROM metrics_dist;
                ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_1
                      Output: 1, 'constx'::text
                      Data node: data_node_1
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                      Remote SQL: SELECT NULL FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_2
                      Output: 1, 'constx'::text
                      Data node: data_node_2
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                      Remote SQL: SELECT NULL FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
                ->  Custom Scan (DataNodeScan) on public.metrics_dist metrics_dist_3
                      Output: 1, 'constx'::text
                      Data node: data_node_3
-                     Fetcher Type: Row by row
                      Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                      Remote SQL: SELECT NULL FROM public.metrics_dist WHERE _timescaledb_internal.chunks_in(public.metrics_dist.*, ARRAY[1, 2, 3])
-(23 rows)
+(20 rows)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% RUNNING TESTS on table: metrics

--- a/tsl/test/shared/expected/dist_distinct_pushdown.out
+++ b/tsl/test/shared/expected/dist_distinct_pushdown.out
@@ -43,10 +43,9 @@ select distinct on (id) ts, id from distinct_on_distributed order by id, ts desc
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(8 rows)
+(7 rows)
 
 -- A case where we have a filter on the DISTINCT ON column.
 select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1') order by id, ts desc;
@@ -65,10 +64,9 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = ANY ('{0,1}'::integer[]))) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(8 rows)
+(7 rows)
 
 -- A somewhat dumb case where the DISTINCT ON column is deduced to be constant
 -- and not added to pathkeys.
@@ -90,10 +88,9 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0') or
          ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
                Output: distinct_on_distributed.ts, distinct_on_distributed.id
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = 0))
-(11 rows)
+(10 rows)
 
 -- All above but with disabled local sort, to try to force more interesting plans where the sort
 -- is pushed down.
@@ -113,10 +110,9 @@ select ts, id from distinct_on_distributed order by id, ts desc limit 1;
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST LIMIT 1
-(8 rows)
+(7 rows)
 
 select distinct on (id) ts, id from distinct_on_distributed order by id, ts desc;
             ts            | id 
@@ -136,10 +132,9 @@ select distinct on (id) ts, id from distinct_on_distributed order by id, ts desc
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(8 rows)
+(7 rows)
 
 select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1') order by id, ts desc;
             ts            | id 
@@ -157,10 +152,9 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0', '1
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT DISTINCT ON (id) ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = ANY ('{0,1}'::integer[]))) ORDER BY id ASC NULLS LAST, ts DESC NULLS FIRST
-(8 rows)
+(7 rows)
 
 select distinct on (id) ts, id from distinct_on_distributed where id in ('0') order by id, ts desc;
             ts            | id 
@@ -177,9 +171,8 @@ select distinct on (id) ts, id from distinct_on_distributed where id in ('0') or
    ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed
          Output: distinct_on_distributed.ts, distinct_on_distributed.id
          Data node: data_node_1
-         Fetcher Type: Row by row
          Chunks: _dist_hyper_X_X_chunk
          Remote SQL: SELECT ts, id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) AND ((id = 0)) ORDER BY ts DESC NULLS FIRST
-(8 rows)
+(7 rows)
 
 reset enable_sort;

--- a/tsl/test/shared/expected/dist_fetcher_type.out
+++ b/tsl/test/shared/expected/dist_fetcher_type.out
@@ -12,6 +12,29 @@ limit 1;
  1
 (1 row)
 
+-- This query should choose row-by-row fetcher.
+select 1 x from distinct_on_distributed t1
+limit 1;
+ x 
+---
+ 1
+(1 row)
+
+explain (analyze, verbose, costs off, timing off, summary off)
+select 1 x from distinct_on_distributed t1
+limit 1;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=1 loops=1)
+   Output: 1
+   ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1 (actual rows=1 loops=1)
+         Output: 1
+         Data node: data_node_1
+         Fetcher Type: Row by row
+         Chunks: _dist_hyper_X_X_chunk
+         Remote SQL: SELECT NULL FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27]) LIMIT 1
+(8 rows)
+
 set timescaledb.remote_data_fetcher = 'cursor';
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
 where t1.id = t2.id + 1
@@ -21,65 +44,40 @@ limit 1;
  1
 (1 row)
 
-explain (verbose, costs off)
+explain (analyze, verbose, costs off, timing off, summary off)
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
 where t1.id = t2.id + 1
 limit 1;
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit
+ Limit (actual rows=1 loops=1)
    Output: 1
-   ->  Nested Loop
+   ->  Nested Loop (actual rows=1 loops=1)
          Output: 1
          Join Filter: (t1.id = (t2.id + 1))
-         ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1
+         Rows Removed by Join Filter: 4
+         ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1 (actual rows=1 loops=1)
                Output: t1.id
                Data node: data_node_1
                Fetcher Type: Cursor
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
-         ->  Materialize
+         ->  Materialize (actual rows=5 loops=1)
                Output: t2.id
-               ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t2
+               ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t2 (actual rows=5 loops=1)
                      Output: t2.id
                      Data node: data_node_1
                      Fetcher Type: Cursor
                      Chunks: _dist_hyper_X_X_chunk
                      Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
-(19 rows)
+(20 rows)
 
+-- This query can't work with rowbyrow fetcher.
 set timescaledb.remote_data_fetcher = 'rowbyrow';
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
 where t1.id = t2.id + 1
 limit 1;
 ERROR:  could not set single-row mode on connection to "data_node_1"
-explain (verbose, costs off)
-select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
-where t1.id = t2.id + 1
-limit 1;
-                                                                            QUERY PLAN                                                                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit
-   Output: 1
-   ->  Nested Loop
-         Output: 1
-         Join Filter: (t1.id = (t2.id + 1))
-         ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t1
-               Output: t1.id
-               Data node: data_node_1
-               Fetcher Type: Row by row
-               Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
-         ->  Materialize
-               Output: t2.id
-               ->  Custom Scan (DataNodeScan) on public.distinct_on_distributed t2
-                     Output: t2.id
-                     Data node: data_node_1
-                     Fetcher Type: Row by row
-                     Chunks: _dist_hyper_X_X_chunk
-                     Remote SQL: SELECT id FROM public.distinct_on_distributed WHERE _timescaledb_internal.chunks_in(public.distinct_on_distributed.*, ARRAY[27])
-(19 rows)
-
 -- Check once again that 'auto' is used after 'rowbyrow'.
 set timescaledb.remote_data_fetcher = 'auto';
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
@@ -119,3 +117,24 @@ ORDER BY 1,2;
 (0 rows)
 
 RESET jit;
+-- Row by row fetcher should fail on a custom type that has no binary
+-- serialization.
+set timescaledb.remote_data_fetcher = 'rowbyrow';
+explain (analyze, verbose, costs off, timing off, summary off)
+select time, txn_id, val, substring(info for 20) from disttable_with_ct;
+ERROR:  cannot use row-by-row fetcher because some of the column types do not have binary serialization
+-- Cursor fetcher should be chosen automatically if we have a data type with no
+-- binary serialization.
+set timescaledb.remote_data_fetcher = 'auto';
+explain (analyze, verbose, costs off, timing off, summary off)
+select * from disttable_with_ct;
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (DataNodeScan) on public.disttable_with_ct (actual rows=2 loops=1)
+   Output: disttable_with_ct."time", disttable_with_ct.txn_id, disttable_with_ct.val, disttable_with_ct.info
+   Data node: data_node_1
+   Fetcher Type: Cursor
+   Chunks: _dist_hyper_X_X_chunk
+   Remote SQL: SELECT "time", txn_id, val, info FROM public.disttable_with_ct WHERE _timescaledb_internal.chunks_in(public.disttable_with_ct.*, ARRAY[33])
+(6 rows)
+

--- a/tsl/test/shared/expected/dist_gapfill_pushdown-12.out
+++ b/tsl/test/shared/expected/dist_gapfill_pushdown-12.out
@@ -20,7 +20,6 @@ GROUP BY 1,2;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill.name, (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 1, 2
                Remote EXPLAIN: 
@@ -41,7 +40,6 @@ GROUP BY 1,2;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.name, (first(test_gapfill_1.value, test_gapfill_1."time")), (avg(test_gapfill_1.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 1, 2
                Remote EXPLAIN: 
@@ -63,7 +61,7 @@ GROUP BY 1,2;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(50 rows)
+(48 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
        name,
@@ -80,7 +78,6 @@ GROUP BY 2,1;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill.name, (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 2, 1
                Remote EXPLAIN: 
@@ -101,7 +98,6 @@ GROUP BY 2,1;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.name, (first(test_gapfill_1.value, test_gapfill_1."time")), (avg(test_gapfill_1.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 2, 1
                Remote EXPLAIN: 
@@ -123,7 +119,7 @@ GROUP BY 2,1;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(50 rows)
+(48 rows)
 
 -- Check for multiple gapfill calls
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
@@ -158,7 +154,6 @@ GROUP BY 1;
                            ->  Custom Scan (DataNodeScan) on public.test_gapfill
                                  Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill.value, test_gapfill."time"
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
                                  Remote EXPLAIN: 
@@ -171,7 +166,6 @@ GROUP BY 1;
                            ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
                                  Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
                                  Remote EXPLAIN: 
@@ -183,7 +177,7 @@ GROUP BY 1;
                                      ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                            Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
  
-(40 rows)
+(38 rows)
 
 -- Window functions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT
@@ -210,7 +204,6 @@ GROUP BY 1;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill."time"
                                        Data node: data_node_1
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
                                        Remote EXPLAIN: 
@@ -223,7 +216,6 @@ GROUP BY 1;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
                                        Data node: data_node_3
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
                                        Remote EXPLAIN: 
@@ -235,7 +227,7 @@ GROUP BY 1;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time"
  
-(42 rows)
+(40 rows)
 
 -- Data nodes are overlapping
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2018-01-01 06:00', '2018-01-01 18:00'),
@@ -265,7 +257,6 @@ GROUP BY 1,2;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap.name, test_gapfill_overlap.value, test_gapfill_overlap."time"
                                        Data node: data_node_1
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[29, 30, 31, 32])
                                        Remote EXPLAIN: 
@@ -288,7 +279,6 @@ GROUP BY 1,2;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
                                        Data node: data_node_2
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[20])
                                        Remote EXPLAIN: 
@@ -304,7 +294,6 @@ GROUP BY 1,2;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
                                        Data node: data_node_3
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[26, 27, 28, 29, 30])
                                        Remote EXPLAIN: 
@@ -320,7 +309,7 @@ GROUP BY 1,2;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(74 rows)
+(71 rows)
 
 SET timescaledb.enable_remote_explain = false;
 DROP TABLE test_gapfill;

--- a/tsl/test/shared/expected/dist_gapfill_pushdown-13.out
+++ b/tsl/test/shared/expected/dist_gapfill_pushdown-13.out
@@ -20,7 +20,6 @@ GROUP BY 1,2;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill.name, (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 1, 2
                Remote EXPLAIN: 
@@ -41,7 +40,6 @@ GROUP BY 1,2;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.name, (first(test_gapfill_1.value, test_gapfill_1."time")), (avg(test_gapfill_1.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 1, 2
                Remote EXPLAIN: 
@@ -63,7 +61,7 @@ GROUP BY 1,2;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(50 rows)
+(48 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
        name,
@@ -80,7 +78,6 @@ GROUP BY 2,1;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill.name, (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 2, 1
                Remote EXPLAIN: 
@@ -101,7 +98,6 @@ GROUP BY 2,1;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.name, (first(test_gapfill_1.value, test_gapfill_1."time")), (avg(test_gapfill_1.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 2, 1
                Remote EXPLAIN: 
@@ -123,7 +119,7 @@ GROUP BY 2,1;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(50 rows)
+(48 rows)
 
 -- Check for multiple gapfill calls
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
@@ -158,7 +154,6 @@ GROUP BY 1;
                            ->  Custom Scan (DataNodeScan) on public.test_gapfill
                                  Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill.value, test_gapfill."time"
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
                                  Remote EXPLAIN: 
@@ -171,7 +166,6 @@ GROUP BY 1;
                            ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
                                  Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
                                  Remote EXPLAIN: 
@@ -183,7 +177,7 @@ GROUP BY 1;
                                      ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                            Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
  
-(40 rows)
+(38 rows)
 
 -- Window functions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT
@@ -210,7 +204,6 @@ GROUP BY 1;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill."time"
                                        Data node: data_node_1
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
                                        Remote EXPLAIN: 
@@ -223,7 +216,6 @@ GROUP BY 1;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
                                        Data node: data_node_3
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
                                        Remote EXPLAIN: 
@@ -235,7 +227,7 @@ GROUP BY 1;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time"
  
-(42 rows)
+(40 rows)
 
 -- Data nodes are overlapping
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2018-01-01 06:00', '2018-01-01 18:00'),
@@ -258,7 +250,6 @@ GROUP BY 1,2;
                      ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
                            Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[29, 30, 31, 32])
                            Remote EXPLAIN: 
@@ -275,7 +266,6 @@ GROUP BY 1,2;
                      ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
                            Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[20])
                            Remote EXPLAIN: 
@@ -285,7 +275,6 @@ GROUP BY 1,2;
                      ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_3
                            Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_3."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_3.name, test_gapfill_overlap_3.value, test_gapfill_overlap_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[26, 27, 28, 29, 30])
                            Remote EXPLAIN: 
@@ -301,7 +290,7 @@ GROUP BY 1,2;
                                ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                      Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(55 rows)
+(52 rows)
 
 SET timescaledb.enable_remote_explain = false;
 DROP TABLE test_gapfill;

--- a/tsl/test/shared/expected/dist_gapfill_pushdown-14.out
+++ b/tsl/test/shared/expected/dist_gapfill_pushdown-14.out
@@ -20,7 +20,6 @@ GROUP BY 1,2;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill.name, (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 1, 2
                Remote EXPLAIN: 
@@ -41,7 +40,6 @@ GROUP BY 1,2;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.name, (first(test_gapfill_1.value, test_gapfill_1."time")), (avg(test_gapfill_1.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 1, 2
                Remote EXPLAIN: 
@@ -63,7 +61,7 @@ GROUP BY 1,2;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(50 rows)
+(48 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
        name,
@@ -80,7 +78,6 @@ GROUP BY 2,1;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill.name, (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 2, 1
                Remote EXPLAIN: 
@@ -101,7 +98,6 @@ GROUP BY 2,1;
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.name, (first(test_gapfill_1.value, test_gapfill_1."time")), (avg(test_gapfill_1.value))
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
-               Fetcher Type: Row by row
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 2, 1
                Remote EXPLAIN: 
@@ -123,7 +119,7 @@ GROUP BY 2,1;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(50 rows)
+(48 rows)
 
 -- Check for multiple gapfill calls
 SELECT time_bucket_gapfill('3 hours', time, '2017-01-01 06:00', '2017-01-01 18:00'),
@@ -158,7 +154,6 @@ GROUP BY 1;
                            ->  Custom Scan (DataNodeScan) on public.test_gapfill
                                  Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill.value, test_gapfill."time"
                                  Data node: data_node_1
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
                                  Remote EXPLAIN: 
@@ -171,7 +166,6 @@ GROUP BY 1;
                            ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
                                  Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
                                  Data node: data_node_3
-                                 Fetcher Type: Row by row
                                  Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                  Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
                                  Remote EXPLAIN: 
@@ -183,7 +177,7 @@ GROUP BY 1;
                                      ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                            Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
  
-(40 rows)
+(38 rows)
 
 -- Window functions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT
@@ -210,7 +204,6 @@ GROUP BY 1;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill."time"
                                        Data node: data_node_1
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
                                        Remote EXPLAIN: 
@@ -223,7 +216,6 @@ GROUP BY 1;
                                  ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
                                        Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
                                        Data node: data_node_3
-                                       Fetcher Type: Row by row
                                        Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                                        Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
                                        Remote EXPLAIN: 
@@ -235,7 +227,7 @@ GROUP BY 1;
                                            ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                                  Output: _dist_hyper_X_X_chunk."time"
  
-(42 rows)
+(40 rows)
 
 -- Data nodes are overlapping
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2018-01-01 06:00', '2018-01-01 18:00'),
@@ -258,7 +250,6 @@ GROUP BY 1,2;
                      ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
                            Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
                            Data node: data_node_1
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[29, 30, 31, 32])
                            Remote EXPLAIN: 
@@ -275,7 +266,6 @@ GROUP BY 1,2;
                      ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
                            Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
                            Data node: data_node_2
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[20])
                            Remote EXPLAIN: 
@@ -285,7 +275,6 @@ GROUP BY 1,2;
                      ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_3
                            Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_3."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_3.name, test_gapfill_overlap_3.value, test_gapfill_overlap_3."time"
                            Data node: data_node_3
-                           Fetcher Type: Row by row
                            Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
                            Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[26, 27, 28, 29, 30])
                            Remote EXPLAIN: 
@@ -301,7 +290,7 @@ GROUP BY 1,2;
                                ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                      Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(55 rows)
+(52 rows)
 
 SET timescaledb.enable_remote_explain = false;
 DROP TABLE test_gapfill;

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -289,3 +289,12 @@ INSERT INTO test_gapfill_overlap VALUES
 ('2020-07-06 06:01', 'forty-six', 3.1),
 ('2020-07-07 09:11', 'eleven', 10303.12),
 ('2020-07-08 08:01', 'ten', 64);
+
+-- Distributed table with custom type that has no binary output
+CREATE TABLE disttable_with_ct(time timestamptz, txn_id rxid, val float, info text);
+SELECT * FROM create_hypertable('disttable_with_ct', 'time', replication_factor => 2);
+
+-- Insert data with custom type
+INSERT INTO disttable_with_ct VALUES
+    ('2019-01-01 01:01', 'ts-1-10-20-30', 1.1, 'a'),
+    ('2019-01-01 01:02', 'ts-1-11-20-30', 2.0, repeat('abc', 1000000)); -- TOAST

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -1664,6 +1664,15 @@ SET timescaledb.enable_connection_binary_data=false;
 SELECT * FROM disttable ORDER BY 1;
 SELECT count(*) FROM disttable;
 
+-- Binary format should lead to data incompatibility in PG 13 and earlier,
+-- because the highlow data type has different oids on data and access nodes.
+-- Use this to test the deserialization error reporting. Newer PG version
+-- ignore this oid mismatch for non-builtin types.
+SET timescaledb.enable_connection_binary_data=true;
+\set ON_ERROR_STOP 0
+SELECT * FROM disttable ORDER BY 1;
+\set ON_ERROR_STOP 1
+
 -- Show that DataNodeCopy is NOT used when source hypertable and target hypertable
 -- of the SELECT are both distributed. Try subselects with LIMIT, RETURNING and
 -- different distributed hypertable as source


### PR DESCRIPTION
This gives some minor speedup and prepares for use of COPY protocol in
row-by-row-fetcher. We can only use the binary format if all the data
types support binary serialization. This is checked at execution time
when creating a TupleFactory. The fetcher interface is refactored to
allow for external creation of TupleFactory.

When a data type doesn't have binary serialization, we revert to using Cursor fetcher.

Part of #4188