### PR TITLE
Use one connection per data node for distributed copy insert

### DIFF
--- a/tsl/src/remote/dist_copy.c
+++ b/tsl/src/remote/dist_copy.c
@@ -254,6 +254,9 @@ create_connection_list_for_chunk(CopyConnectionState *state, int32 chunk_id,
 
 		if (lc2 == NULL)
 		{
+			/*
+			 * Did not find a cached connection, create a new one and cache it.
+			 */
 			connection = remote_dist_txn_get_connection(required_id, REMOTE_TXN_NO_PREP_STMT);
 
 			DataNodeConnection *entry = palloc(sizeof(DataNodeConnection));

--- a/tsl/src/remote/dist_copy.c
+++ b/tsl/src/remote/dist_copy.c
@@ -56,8 +56,21 @@ typedef struct DataNodeConnection
  */
 typedef struct CopyConnectionState
 {
+	/*
+	 * Cached connections to data nodes.
+	 * Why do we need another layer of caching, when there is dist_txn layer
+	 * already? The API it provides is one function that "does everything
+	 * automatically", namely it's going to stop the COPY each time we request
+	 * the connection. This is not something we want to do for each row when
+	 * we're trying to do bulk copy.
+	 */
 	List *data_node_connections;
+
+	/*
+	 * Connections to which we have written something and have to finalize them.
+	 */
 	List *connections_in_use;
+
 	bool using_binary;
 	const char *outgoing_copy_cmd;
 } CopyConnectionState;


### PR DESCRIPTION
Currently we use one connection per chunk, and they all run the same
query `COPY destination_hypertable FROM STDIN`. Not sure what's the
point.

Part of https://github.com/timescale/timescaledb/pull/4285