### PR TITLE
Fix unqualified type reference in time_bucket

### DIFF
--- a/sql/time_bucket.sql
+++ b/sql/time_bucket.sql
@@ -55,6 +55,6 @@ $BODY$;
 CREATE OR REPLACE FUNCTION @extschema@.time_bucket(bucket_width INTERVAL, ts DATE, "offset" INTERVAL)
     RETURNS DATE LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT AS
 $BODY$
-    SELECT (@extschema@.time_bucket(bucket_width, ts OPERATOR(pg_catalog.-) "offset") OPERATOR(pg_catalog.+) "offset")::date;
+    SELECT (@extschema@.time_bucket(bucket_width, ts OPERATOR(pg_catalog.-) "offset") OPERATOR(pg_catalog.+) "offset")::pg_catalog.date;
 $BODY$;
 


### PR DESCRIPTION
This was not caught earlier and is not currently caught by CI
because the check for unqualified casts is currently only in main
branch of pgspot and not yet in the tagged version we use as
part of PR checks.