### PR TITLE
Ignore flaky "dist_gapfill_pushdown" test

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -68,7 +68,7 @@ jobs:
           cp build_abi/install_lib/* `pg_config --pkglibdir`
           chown -R postgres /mnt
           set -o pipefail
-          sudo -u postgres make -C build_abi -k regresscheck regresscheck-t regresscheck-shared IGNORES="memoize" | tee installcheck.log
+          sudo -u postgres make -C build_abi -k regresscheck regresscheck-t regresscheck-shared IGNORES="memoize dist_gapfill_pushdown-12 dist_gapfill_pushdown-13 dist_gapfill_pushdown-14" | tee installcheck.log
         EOF
 
     - name: Show regression diffs

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -23,13 +23,13 @@ jobs:
         build_type: [ Debug ]
         include:
           - pg: "12.10"
-            ignores: append-12 debug_notice transparent_decompression-12 transparent_decompress_chunk-12 plan_skip_scan-12 pg_dump
+            ignores: append-12 debug_notice transparent_decompression-12 transparent_decompress_chunk-12 plan_skip_scan-12 pg_dump dist_gapfill_pushdown-12
             pg_major: 12
           - pg: "13.6"
-            ignores: append-13 debug_notice transparent_decompression-13 transparent_decompress_chunk-13 pg_dump
+            ignores: append-13 debug_notice transparent_decompression-13 transparent_decompress_chunk-13 pg_dump dist_gapfill_pushdown-13
             pg_major: 13
           - pg: "14.2"
-            ignores: append-14 debug_notice transparent_decompression-14 transparent_decompress_chunk-14 pg_dump
+            ignores: append-14 debug_notice transparent_decompression-14 transparent_decompress_chunk-14 pg_dump dist_gapfill_pushdown-14
             pg_major: 14
 
     steps:

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -48,7 +48,7 @@ def build_debug_config(overrides):
     "build_type": "Debug",
     "pg_build_args": "--enable-debug --enable-cassert",
     "tsdb_build_args": "-DCODECOVERAGE=ON -DWARNINGS_AS_ERRORS=ON",
-    "installcheck_args": "IGNORES='bgw_db_scheduler'",
+    "installcheck_args": "IGNORES='bgw_db_scheduler dist_gapfill_pushdown-12 dist_gapfill_pushdown-13 dist_gapfill_pushdown-14'",
     "coverage": True,
     "extra_packages": "clang-9 llvm-9 llvm-9-dev llvm-9-tools",
     "llvm_config": "llvm-config-9",
@@ -111,7 +111,7 @@ def macos_config(overrides):
     "tsdb_build_args": "-DASSERTIONS=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl",
     "llvm_config": "/usr/local/opt/llvm/bin/llvm-config",
     "coverage": False,
-    "installcheck_args": "IGNORES='bgw_db_scheduler bgw_launcher pg_dump remote_connection compressed_collation'",
+    "installcheck_args": "IGNORES='bgw_db_scheduler bgw_launcher pg_dump remote_connection compressed_collation dist_gapfill_pushdown-12 dist_gapfill_pushdown-13 dist_gapfill_pushdown-14'",
     "extra_packages": "",
   })
   base_config.update(overrides)


### PR DESCRIPTION
This is a *temporary* change to our workflows to ignore the test
because it is flaky and requires many jobs to be restarted before a
commit can be merged.  Does not address the issue that causes the
flakiness, which needs to be investigated.