### PR TITLE
Append pg_temp to search_path

### DIFF
--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: 'timescale/pgspot'
-        ref: '0.1.1'
+        ref: '0.2.0'
         submodules: true
         path: 'pgspot'
 
@@ -64,5 +64,8 @@ jobs:
         python pgspot/pgspot ${{ env.PGSPOT_OPTS }} -a build/sql/timescaledb--${version}.sql build/sql/timescaledb--${downgrade_to}--${version}.sql
         # The next pgspot execution tests the downgrade script to the previous version
         # we prepend the installation script here so pgspot can correctly keep track of created objects
-        python pgspot/pgspot ${{ env.PGSPOT_OPTS }} -a build/sql/timescaledb--${version}.sql build/sql/timescaledb--${version}--${downgrade_to}.sql
+        # skip this check for 2.6.1 since the search_path in 2.6.1 is not considered safe by pgspot
+        if [ "${downgrade_to}" != "2.6.1" ]; then
+          python pgspot/pgspot ${{ env.PGSPOT_OPTS }} -a build/sql/timescaledb--${version}.sql build/sql/timescaledb--${version}--${downgrade_to}.sql
+        fi
 

--- a/sql/chunk_constraint.sql
+++ b/sql/chunk_constraint.sql
@@ -63,11 +63,11 @@ BEGIN
     IF def IS NOT NULL THEN
         -- to allow for custom types with operators outside of pg_catalog
         -- we set search_path to @extschema@
-        SET LOCAL search_path TO @extschema@;
+        SET LOCAL search_path TO @extschema@, pg_temp;
         EXECUTE pg_catalog.format(
             $$ ALTER TABLE %I.%I ADD CONSTRAINT %I %s $$,
             chunk_row.schema_name, chunk_row.table_name, chunk_constraint_row.constraint_name, def
         );
     END IF;
 END
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -49,4 +49,4 @@ BEGIN
     END LOOP;
     RAISE 'subscription sync wait timedout';
 END
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;

--- a/sql/hypertable_constraint.sql
+++ b/sql/hypertable_constraint.sql
@@ -30,7 +30,7 @@ BEGIN
     IF def IS NOT NULL THEN
         -- to allow for custom types with operators outside of pg_catalog
         -- we set search_path to @extschema@
-        SET LOCAL search_path TO @extschema@;
+        SET LOCAL search_path TO @extschema@, pg_temp;
         EXECUTE pg_catalog.format(
             $$ ALTER TABLE %I.%I ADD CONSTRAINT %I %s $$,
             compressed_ht_row.schema_name, compressed_ht_row.table_name, user_ht_constraint_name, def
@@ -38,4 +38,4 @@ BEGIN
     END IF;
 
 END
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;

--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -49,7 +49,7 @@ BEGIN
 
     -- procedures with SET clause cannot execute transaction
     -- control so we adjust search_path in procedure body
-    SET LOCAL search_path TO pg_catalog;
+    SET LOCAL search_path TO pg_catalog, pg_temp;
 
     status := _timescaledb_internal.chunk_status(chunk);
 
@@ -73,7 +73,7 @@ BEGIN
         -- While we could use SET at the start of the function we do not
         -- want to bleed out search_path to caller, so we do SET LOCAL
         -- again after COMMIT
-        SET LOCAL search_path TO pg_catalog;
+        SET LOCAL search_path TO pg_catalog, pg_temp;
     END CASE;
     PERFORM @extschema@.compress_chunk(chunk, if_not_compressed);
 END

--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -35,7 +35,7 @@ BEGIN
 
   -- procedures with SET clause cannot execute transaction
   -- control so we adjust search_path in procedure body
-  SET LOCAL search_path TO pg_catalog;
+  SET LOCAL search_path TO pg_catalog, pg_temp;
 
   SELECT format('%I.%I', schema_name, table_name) INTO htoid
   FROM _timescaledb_catalog.hypertable
@@ -75,7 +75,7 @@ BEGIN
     -- While we could use SET at the start of the function we do not
     -- want to bleed out search_path to caller, so we do SET LOCAL
     -- again after COMMIT
-    SET LOCAL search_path TO pg_catalog;
+    SET LOCAL search_path TO pg_catalog, pg_temp;
     IF verbose_log THEN
        RAISE LOG 'job % completed processing chunk %.%', job_id, chunk_rec.schema_name, chunk_rec.table_name;
     END IF;
@@ -106,7 +106,7 @@ BEGIN
 
   -- procedures with SET clause cannot execute transaction
   -- control so we adjust search_path in procedure body
-  SET LOCAL search_path TO pg_catalog;
+  SET LOCAL search_path TO pg_catalog, pg_temp;
 
   IF config IS NULL THEN
     RAISE EXCEPTION 'job % has null config', job_id;

--- a/sql/pre_install/schemas.sql
+++ b/sql/pre_install/schemas.sql
@@ -2,7 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
-SET LOCAL search_path TO pg_catalog;
+SET LOCAL search_path TO pg_catalog, pg_temp;
 
 CREATE SCHEMA _timescaledb_catalog;
 CREATE SCHEMA _timescaledb_internal;

--- a/sql/restoring.sql
+++ b/sql/restoring.sql
@@ -16,7 +16,7 @@ BEGIN
     RETURN true;
 END
 $BODY$
-LANGUAGE PLPGSQL SET search_path TO pg_catalog;
+LANGUAGE PLPGSQL SET search_path TO pg_catalog, pg_temp;
 
 
 CREATE OR REPLACE FUNCTION @extschema@.timescaledb_post_restore() RETURNS BOOL AS
@@ -38,4 +38,4 @@ BEGIN
     RETURN true;
 END
 $BODY$
-LANGUAGE PLPGSQL SET search_path TO pg_catalog;
+LANGUAGE PLPGSQL SET search_path TO pg_catalog, pg_temp;

--- a/sql/schema_info.sql
+++ b/sql/schema_info.sql
@@ -17,7 +17,7 @@ $BODY$
     FROM pg_class c
     INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
     WHERE c.OID = table_oid;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Check if given table is a hypertable's main table
 CREATE OR REPLACE FUNCTION _timescaledb_internal.is_main_table(
@@ -31,7 +31,7 @@ $BODY$
          WHERE h.schema_name = is_main_table.schema_name AND 
                h.table_name = is_main_table.table_name
      );
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Get a hypertable given its main table OID
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hypertable_from_main_table(
@@ -44,7 +44,7 @@ $BODY$
     INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
     INNER JOIN _timescaledb_catalog.hypertable h ON (h.table_name = c.relname AND h.schema_name = n.nspname)
     WHERE c.OID = table_oid;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.main_table_from_hypertable(
     hypertable_id int
@@ -54,5 +54,5 @@ $BODY$
     SELECT format('%I.%I',h.schema_name, h.table_name)::regclass
     FROM _timescaledb_catalog.hypertable h
     WHERE id = hypertable_id;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -153,7 +153,7 @@ $BODY$
 		(SELECT * FROM _hypertable_sizes
          UNION ALL
          SELECT * FROM _chunk_sizes) AS sizes;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.hypertable_remote_size(
     schema_name_in name,
@@ -186,7 +186,7 @@ $BODY$
     LEFT OUTER JOIN LATERAL _timescaledb_internal.data_node_hypertable_info(
         srv.node_name, schema_name_in, table_name_in) entry ON TRUE
     GROUP BY srv.node_name;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Get relation size of hypertable
 -- like pg_relation_size(hypertable)
@@ -237,7 +237,7 @@ BEGIN
 			FROM _timescaledb_internal.hypertable_local_size(schema_name, table_name);
         END CASE;
 END;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 --- returns total-bytes for a hypertable (includes table + index)
 CREATE OR REPLACE FUNCTION @extschema@.hypertable_size(
@@ -249,7 +249,7 @@ $BODY$
    -- hypertable), so sum them up:
    SELECT sum(total_bytes)::bigint
    FROM @extschema@.hypertable_detailed_size(hypertable);
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunks_local_size(
     schema_name_in name,
@@ -277,7 +277,7 @@ $BODY$
    WHERE
       ch.hypertable_schema = schema_name_in
       AND ch.hypertable_name = table_name_in;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 ---should return same information as chunks_local_size--
 CREATE OR REPLACE FUNCTION _timescaledb_internal.chunks_remote_size(
@@ -318,7 +318,7 @@ $BODY$
         srv.node_name, schema_name_in, table_name_in) entry ON TRUE
 	WHERE
 	    entry.chunk_name IS NOT NULL;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Get relation size of the chunks of an hypertable
 -- hypertable - hypertable to get size of
@@ -371,7 +371,7 @@ BEGIN
             FROM _timescaledb_internal.chunks_local_size(schema_name, table_name) chl;
         END CASE;
 END;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 ---------- end of detailed size functions ------
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.range_value_to_pretty(
@@ -400,7 +400,7 @@ BEGIN
         RETURN time_value;
     END CASE;
 END
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Convenience function to return approximate row count
 --
@@ -424,7 +424,7 @@ $BODY$
   SELECT COALESCE((SUM(reltuples) FILTER (WHERE reltuples > 0 AND relkind <> 'p')), 0)::BIGINT
   FROM inherited_id
   JOIN pg_class USING (oid);
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -------- stats related to compression ------
 CREATE OR REPLACE VIEW _timescaledb_internal.compressed_chunk_stats AS
@@ -505,7 +505,7 @@ $BODY$
     WHERE
         ch.hypertable_schema = schema_name_in
         AND ch.hypertable_name = table_name_in;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.compressed_chunk_remote_stats (schema_name_in name, table_name_in name)
     RETURNS TABLE (
@@ -541,7 +541,7 @@ $BODY$
     LEFT OUTER JOIN LATERAL _timescaledb_internal.data_node_compressed_chunk_stats (
         srv.node_name, schema_name_in, table_name_in) ch ON TRUE
 	WHERE ch.chunk_name IS NOT NULL;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Get per chunk compression statistics for a hypertable that has
 -- compression enabled
@@ -602,7 +602,7 @@ BEGIN
             _timescaledb_internal.compressed_chunk_local_stats (schema_name, table_name);
     END CASE;
 END;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Get compression statistics for a hypertable that has
 -- compression enabled
@@ -639,7 +639,7 @@ $BODY$
 	    @extschema@.chunk_compression_stats(hypertable) ch
     GROUP BY
         ch.node_name;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -------------Get index size for hypertables -------
 --schema_name      - schema_name for hypertable index
@@ -681,7 +681,7 @@ $BODY$
 		 AND c.oid = i.indrelid
 		 AND h.schema_name = schema_name_in
 		 AND h.table_name = c.relname;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.data_node_index_size (node_name name, schema_name_in name, index_name_in name)
 RETURNS TABLE ( hypertable_id INTEGER, total_bytes BIGINT)
@@ -710,7 +710,7 @@ $BODY$
          ) AS srv
     JOIN LATERAL _timescaledb_internal.data_node_index_size(
         srv.node_name, schema_name_in, index_name_in) entry ON TRUE;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Get sizes of indexes on a hypertable
 --
@@ -761,6 +761,6 @@ BEGIN
 
    RETURN index_bytes;
 END;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -------------End index size for hypertables -------

--- a/sql/updates/README.md
+++ b/sql/updates/README.md
@@ -1,11 +1,11 @@
 ## General principles for statements in update/downgrade scripts
 
 1. The `search_path` for these scripts will be locked down to
-  `pg_catalog`. Locking down `search_path` happens in `pre-update.sql`.
-  Therefore all object references need to be fully qualified unless
-  they reference objects from `pg_catalog`. Use `@extschema@` to refer
-  to the target schema of the installation (resolves to `public` by
-  default).
+  `pg_catalog, pg_temp`. Locking down `search_path` happens in
+  `pre-update.sql`. Therefore all object references need to be fully
+  qualified unless they reference objects from `pg_catalog`.
+  Use `@extschema@` to refer to the target schema of the installation
+  (resolves to `public` by default).
 2. Creating objects must not use IF NOT EXISTS as this will
   introduce privilege escalation vulnerabilities.
 3. All functions should have explicit `search_path`. Setting explicit

--- a/sql/updates/pre-update.sql
+++ b/sql/updates/pre-update.sql
@@ -3,7 +3,7 @@
 -- LICENSE-APACHE for a copy of the license.
 
 -- This file is always prepended to all upgrade and downgrade scripts.
-SET LOCAL search_path TO pg_catalog;
+SET LOCAL search_path TO pg_catalog, pg_temp;
 
 -- Disable parallel execution for the duration of the update process.
 -- This avoids version mismatch errors that would have beeen triggered by the

--- a/sql/util_internal_table_ddl.sql
+++ b/sql/util_internal_table_ddl.sql
@@ -12,7 +12,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.dimension_is_finite(
 $BODY$
     --end values of bigint reserved for infinite
     SELECT val > (-9223372036854775808)::bigint AND val < 9223372036854775807::bigint
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.dimension_slice_get_constraint_sql(
@@ -90,7 +90,7 @@ BEGIN
         return array_to_string(parts, 'AND');
     END IF;
 END
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 -- Outputs the create_hypertable command to recreate the given hypertable.
 --
@@ -156,4 +156,4 @@ BEGIN
 
     RETURN ret;
 END
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;

--- a/sql/util_time.sql
+++ b/sql/util_time.sql
@@ -56,7 +56,7 @@ BEGIN
          RETURN ret;
     END CASE;
 END
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.interval_to_usec(
        chunk_interval INTERVAL
@@ -64,7 +64,7 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.interval_to_usec(
 RETURNS BIGINT LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
 $BODY$
     SELECT (int_sec * 1000000)::bigint from extract(epoch from chunk_interval) as int_sec;
-$BODY$ SET search_path TO pg_catalog;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.time_to_internal(time_val ANYELEMENT)
 RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_time_to_internal' LANGUAGE C VOLATILE STRICT;


### PR DESCRIPTION
Postgres will prepend pg_temp to the effective search_path if it
is not present in the search_path. While pg_temp will never be
used to look up functions or operators unless explicitly requested
pg_temp will be used to look up relations. Putting pg_temp in
search_path makes sure objects in pg_temp will be considered last
and pg_temp cannot be used to mask existing objects.