### PR TITLE
Support moving compressed chunks between data nodes

### DIFF
--- a/sql/maintenance_utils.sql
+++ b/sql/maintenance_utils.sql
@@ -19,6 +19,19 @@ CREATE OR REPLACE FUNCTION @extschema@.move_chunk(
     verbose BOOLEAN=FALSE
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_move_chunk' LANGUAGE C VOLATILE;
 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.create_compressed_chunk(
+    chunk REGCLASS,
+    chunk_table REGCLASS,
+    uncompressed_heap_size BIGINT,
+    uncompressed_toast_size BIGINT,
+    uncompressed_index_size BIGINT,
+    compressed_heap_size BIGINT,
+    compressed_toast_size BIGINT,
+    compressed_index_size BIGINT,
+    numrows_pre_compression BIGINT,
+    numrows_post_compression BIGINT
+) RETURNS REGCLASS AS '@MODULE_PATHNAME@', 'ts_create_compressed_chunk' LANGUAGE C STRICT VOLATILE;
+
 CREATE OR REPLACE FUNCTION @extschema@.compress_chunk(
     uncompressed_chunk REGCLASS,
     if_not_compressed BOOLEAN = false

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -410,6 +410,7 @@ CREATE TABLE _timescaledb_catalog.chunk_copy_operation (
   completed_stage name NOT NULL, -- the completed stage/step
   time_start timestamptz NOT NULL DEFAULT NOW(), -- start time of the activity
   chunk_id integer NOT NULL REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE,
+  compress_chunk_name name NOT NULL,
   source_node_name name NOT NULL,
   dest_node_name name NOT NULL,
   delete_on_source_node bool NOT NULL -- is a move or copy activity

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -88,9 +88,84 @@ ALTER TABLE _timescaledb_catalog.continuous_agg
   ALTER COLUMN finalized SET DEFAULT TRUE;
 
 DROP PROCEDURE IF EXISTS timescaledb_experimental.move_chunk(REGCLASS, NAME, NAME);
-
 DROP PROCEDURE IF EXISTS timescaledb_experimental.copy_chunk(REGCLASS, NAME, NAME);
 
 CREATE OR REPLACE FUNCTION timescaledb_experimental.subscription_exec(
     subscription_command TEXT
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_subscription_exec' LANGUAGE C VOLATILE;
+
+-- Recreate chunk_copy_operation table with newly added `compress_chunk_name` column
+--
+
+CREATE TABLE _timescaledb_catalog._tmp_chunk_copy_operation (
+  operation_id name NOT NULL,
+  backend_pid integer NOT NULL,
+  completed_stage name NOT NULL,
+  time_start timestamptz NOT NULL DEFAULT NOW(),
+  chunk_id integer NOT NULL,
+  compress_chunk_name name NOT NULL, -- new column
+  source_node_name name NOT NULL,
+  dest_node_name name NOT NULL,
+  delete_on_source_node bool NOT NULL
+);
+
+INSERT INTO _timescaledb_catalog._tmp_chunk_copy_operation
+    SELECT
+        operation_id,
+        backend_pid,
+        completed_stage,
+        time_start,
+        chunk_id,
+        '', -- compress_chunk_name
+        source_node_name,
+        dest_node_name,
+        delete_on_source_node
+    FROM
+        _timescaledb_catalog.chunk_copy_operation
+    ORDER BY
+        operation_id;
+
+ALTER EXTENSION timescaledb
+    DROP TABLE _timescaledb_catalog.chunk_copy_operation;
+
+DROP TABLE _timescaledb_catalog.chunk_copy_operation;
+
+-- Create a new table to void doing rename operation on the tmp table
+--
+CREATE TABLE _timescaledb_catalog.chunk_copy_operation (
+  operation_id name NOT NULL,
+  backend_pid integer NOT NULL,
+  completed_stage name NOT NULL,
+  time_start timestamptz NOT NULL DEFAULT NOW(),
+  chunk_id integer NOT NULL,
+  compress_chunk_name name NOT NULL,
+  source_node_name name NOT NULL,
+  dest_node_name name NOT NULL,
+  delete_on_source_node bool NOT NULL
+);
+
+INSERT INTO _timescaledb_catalog.chunk_copy_operation
+    SELECT
+        operation_id,
+        backend_pid,
+        completed_stage,
+        time_start,
+        chunk_id,
+        compress_chunk_name,
+        source_node_name,
+        dest_node_name,
+        delete_on_source_node
+    FROM
+        _timescaledb_catalog._tmp_chunk_copy_operation
+    ORDER BY
+        operation_id;
+
+DROP TABLE _timescaledb_catalog._tmp_chunk_copy_operation;
+
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation
+    ADD CONSTRAINT chunk_copy_operation_pkey PRIMARY KEY (operation_id),
+    ADD CONSTRAINT chunk_copy_operation_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+
+GRANT SELECT ON TABLE _timescaledb_catalog.chunk_copy_operation TO PUBLIC;
+
+ANALYZE _timescaledb_catalog.chunk_copy_operation;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -105,4 +105,83 @@ ANALYZE _timescaledb_catalog.continuous_agg;
 
 DROP PROCEDURE timescaledb_experimental.move_chunk(REGCLASS, NAME, NAME, NAME);
 DROP PROCEDURE timescaledb_experimental.copy_chunk(REGCLASS, NAME, NAME, NAME);
+
 DROP FUNCTION IF EXISTS timescaledb_experimental.subscription_exec(TEXT);
+
+DROP FUNCTION _timescaledb_internal.create_compressed_chunk(REGCLASS, REGCLASS,
+	BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT);
+
+--
+-- Rebuild the catalog table `_timescaledb_catalog.chunk_copy_operation`
+--
+-- We need to recreate the catalog from scratch because when we drop a column
+-- Postgres mark the `pg_attribute.attisdropped=TRUE` instead of removing it from
+-- the `pg_catalog.pg_attribute` table.
+--
+-- If we downgrade and upgrade the extension without rebuild the catalog table it
+-- will mess with `pg_attribute.attnum` and we will end up with issues when trying
+-- to update data in those catalog tables.
+
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation
+	DROP COLUMN compress_chunk_name;
+
+CREATE TABLE _timescaledb_catalog._tmp_chunk_copy_operation (
+    LIKE _timescaledb_catalog.chunk_copy_operation
+    INCLUDING ALL
+    EXCLUDING INDEXES
+    EXCLUDING CONSTRAINTS
+);
+
+INSERT INTO _timescaledb_catalog._tmp_chunk_copy_operation
+    SELECT
+        operation_id,
+        backend_pid,
+        completed_stage,
+        time_start,
+        chunk_id,
+        source_node_name,
+        dest_node_name,
+        delete_on_source_node
+    FROM
+        _timescaledb_catalog.chunk_copy_operation
+    ORDER BY
+        operation_id;
+
+ALTER EXTENSION timescaledb
+    DROP TABLE _timescaledb_catalog.chunk_copy_operation;
+
+DROP TABLE _timescaledb_catalog.chunk_copy_operation;
+
+CREATE TABLE _timescaledb_catalog.chunk_copy_operation (
+    LIKE _timescaledb_catalog._tmp_chunk_copy_operation
+    INCLUDING ALL
+    EXCLUDING INDEXES
+    EXCLUDING CONSTRAINTS
+);
+
+-- Create a new table to void doing rename operation on the tmp table
+--
+INSERT INTO _timescaledb_catalog.chunk_copy_operation
+    SELECT
+        operation_id,
+        backend_pid,
+        completed_stage,
+        time_start,
+        chunk_id,
+        source_node_name,
+        dest_node_name,
+        delete_on_source_node
+    FROM
+        _timescaledb_catalog._tmp_chunk_copy_operation
+    ORDER BY
+        operation_id;
+
+DROP TABLE _timescaledb_catalog._tmp_chunk_copy_operation;
+
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation
+    ADD CONSTRAINT chunk_copy_operation_pkey PRIMARY KEY (operation_id),
+    ADD CONSTRAINT chunk_copy_operation_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+
+GRANT SELECT ON TABLE _timescaledb_catalog.chunk_copy_operation TO PUBLIC;
+
+ANALYZE _timescaledb_catalog.chunk_copy_operation;

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -11,6 +11,7 @@
 #include "export.h"
 #include "cross_module_fn.h"
 #include "guc.h"
+#include "license_guc.h"
 #include "bgw/job.h"
 #ifdef USE_TELEMETRY
 #include "telemetry/telemetry.h"
@@ -69,6 +70,7 @@ CROSSMODULE_WRAPPER(dictionary_compressor_append);
 CROSSMODULE_WRAPPER(dictionary_compressor_finish);
 CROSSMODULE_WRAPPER(array_compressor_append);
 CROSSMODULE_WRAPPER(array_compressor_finish);
+CROSSMODULE_WRAPPER(create_compressed_chunk);
 CROSSMODULE_WRAPPER(compress_chunk);
 CROSSMODULE_WRAPPER(decompress_chunk);
 
@@ -194,6 +196,28 @@ error_no_default_fn_pg_community(PG_FUNCTION_ARGS)
 					get_func_name(fcinfo->flinfo->fn_oid),
 					ts_guc_license),
 			 errhint("Upgrade your license to 'timescale' to use this free community feature.")));
+
+	pg_unreachable();
+}
+
+static Datum
+process_compressed_data_in(PG_FUNCTION_ARGS)
+{
+	/*
+	 * TSL library is not loaded by the replication worker for some reason,
+	 * so a call to `compressed_data_in` function would produce a misleading
+	 * error saying that your license is "timescale" and you should upgrade to
+	 * "timescale" license, even if you have already upgraded.
+	 *
+	 * As a workaround, we try to load the TSL module it in this function. It will still
+	 * error out in the "apache" version
+	 */
+	ts_license_enable_module_loading();
+
+	if (ts_cm_functions->compressed_data_in != process_compressed_data_in)
+		return ts_cm_functions->compressed_data_in(fcinfo);
+
+	error_no_default_fn_pg_community(fcinfo);
 	pg_unreachable();
 }
 
@@ -400,9 +424,10 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	/* compression */
 	.compressed_data_send = error_no_default_fn_pg_community,
 	.compressed_data_recv = error_no_default_fn_pg_community,
-	.compressed_data_in = error_no_default_fn_pg_community,
+	.compressed_data_in = process_compressed_data_in,
 	.compressed_data_out = error_no_default_fn_pg_community,
 	.process_compress_table = process_compress_table_default,
+	.create_compressed_chunk = error_no_default_fn_pg_community,
 	.compress_chunk = error_no_default_fn_pg_community,
 	.decompress_chunk = error_no_default_fn_pg_community,
 	.compressed_data_decompress_forward = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -123,6 +123,7 @@ typedef struct CrossModuleFunctions
 								   WithClauseResult *with_clause_options);
 	void (*process_altertable_cmd)(Hypertable *ht, const AlterTableCmd *cmd);
 	void (*process_rename_cmd)(Oid relid, Cache *hcache, const RenameStmt *stmt);
+	PGFunction create_compressed_chunk;
 	PGFunction compress_chunk;
 	PGFunction decompress_chunk;
 	/* The compression functions below are not installed in SQL as part of create extension;

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1238,6 +1238,7 @@ enum Anum_chunk_copy_operation
 	Anum_chunk_copy_operation_completed_stage,
 	Anum_chunk_copy_operation_time_start,
 	Anum_chunk_copy_operation_chunk_id,
+	Anum_chunk_copy_operation_compressed_chunk_name,
 	Anum_chunk_copy_operation_source_node_name,
 	Anum_chunk_copy_operation_dest_node_name,
 	Anum_chunk_copy_operation_delete_on_src_node,
@@ -1253,6 +1254,7 @@ typedef struct FormData_chunk_copy_operation
 	NameData completed_stage;
 	TimestampTz time_start;
 	int32 chunk_id;
+	NameData compressed_chunk_name;
 	NameData source_node_name;
 	NameData dest_node_name;
 	bool delete_on_src_node;

--- a/tsl/src/chunk_copy.c
+++ b/tsl/src/chunk_copy.c
@@ -27,6 +27,7 @@
 #include <miscadmin.h>
 #include <fmgr.h>
 #include <executor/spi.h>
+#include <replication/slot.h>
 
 #ifdef USE_ASSERT_CHECKING
 #include <funcapi.h>
@@ -49,6 +50,7 @@
 
 #define CCS_INIT "init"
 #define CCS_CREATE_EMPTY_CHUNK "create_empty_chunk"
+#define CCS_CREATE_EMPTY_COMPRESSED_CHUNK "create_empty_compressed_chunk"
 #define CCS_CREATE_PUBLICATION "create_publication"
 #define CCS_CREATE_REPLICATION_SLOT "create_replication_slot"
 #define CCS_CREATE_SUBSCRIPTION "create_subscription"
@@ -57,6 +59,7 @@
 #define CCS_DROP_PUBLICATION "drop_publication"
 #define CCS_DROP_SUBSCRIPTION "drop_subscription"
 #define CCS_ATTACH_CHUNK "attach_chunk"
+#define CCS_ATTACH_COMPRESSED_CHUNK "attach_compressed_chunk"
 #define CCS_DELETE_CHUNK "delete_chunk"
 
 typedef struct ChunkCopyStage ChunkCopyStage;
@@ -76,6 +79,7 @@ struct ChunkCopy
 {
 	/* catalog data */
 	FormData_chunk_copy_operation fd;
+	FormData_compression_chunk_size fd_ccs;
 	/* current stage being executed */
 	const ChunkCopyStage *stage;
 	/* chunk to copy */
@@ -90,7 +94,7 @@ struct ChunkCopy
 static HeapTuple
 chunk_copy_operation_make_tuple(const FormData_chunk_copy_operation *fd, TupleDesc desc)
 {
-	Datum values[Natts_chunk_copy_operation];
+	Datum values[Natts_chunk_copy_operation] = { 0 };
 	bool nulls[Natts_chunk_copy_operation] = { false };
 	memset(values, 0, sizeof(values));
 	values[AttrNumberGetAttrOffset(Anum_chunk_copy_operation_operation_id)] =
@@ -103,6 +107,8 @@ chunk_copy_operation_make_tuple(const FormData_chunk_copy_operation *fd, TupleDe
 		TimestampTzGetDatum(fd->time_start);
 	values[AttrNumberGetAttrOffset(Anum_chunk_copy_operation_chunk_id)] =
 		Int32GetDatum(fd->chunk_id);
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_operation_compressed_chunk_name)] =
+		NameGetDatum(&fd->compressed_chunk_name);
 	values[AttrNumberGetAttrOffset(Anum_chunk_copy_operation_source_node_name)] =
 		NameGetDatum(&fd->source_node_name);
 	values[AttrNumberGetAttrOffset(Anum_chunk_copy_operation_dest_node_name)] =
@@ -152,11 +158,12 @@ chunk_copy_operation_tuple_update(TupleInfo *ti, void *data)
 
 	heap_deform_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls);
 
-	/* We only update the "completed_stage" field */
+	/* We only update the "completed_stage" and "compressed_chunk_name" fields */
 	Assert(NULL != cc->stage);
 	values[AttrNumberGetAttrOffset(Anum_chunk_copy_operation_completed_stage)] =
 		DirectFunctionCall1(namein, CStringGetDatum((cc->stage->name)));
-
+	values[AttrNumberGetAttrOffset(Anum_chunk_copy_operation_compressed_chunk_name)] =
+		NameGetDatum(&cc->fd.compressed_chunk_name);
 	new_tuple = heap_form_tuple(ts_scanner_get_tupledesc(ti), values, nulls);
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_update_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti), new_tuple);
@@ -288,14 +295,6 @@ chunk_copy_setup(ChunkCopy *cc, Oid chunk_relid, const char *src_node, const cha
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("\"%s\" is not a valid remote chunk", get_rel_name(chunk_relid))));
 
-	/* It has to be an uncompressed chunk, we query the status field on the AN for this */
-	if (ts_chunk_is_compressed(cc->chunk))
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("\"%s\" is a compressed remote chunk. Chunk copy/move not supported"
-						" currently on compressed chunks",
-						get_rel_name(chunk_relid))));
-
 	ht = ts_hypertable_cache_get_cache_and_entry(cc->chunk->hypertable_relid,
 												 CACHE_FLAG_NONE,
 												 &hcache);
@@ -341,12 +340,14 @@ chunk_copy_setup(ChunkCopy *cc, Oid chunk_relid, const char *src_node, const cha
 	 *
 	 * The operation_id will be populated in the chunk_copy_stage_init function.
 	 */
+	memset(&cc->fd_ccs, 0, sizeof(cc->fd_ccs));
 	cc->fd.backend_pid = MyProcPid;
 	namestrcpy(&cc->fd.completed_stage, CCS_INIT);
 	cc->fd.time_start = GetCurrentTimestamp();
 	cc->fd.chunk_id = cc->chunk->fd.id;
 	namestrcpy(&cc->fd.source_node_name, src_node);
 	namestrcpy(&cc->fd.dest_node_name, dst_node);
+	memset(cc->fd.compressed_chunk_name.data, 0, NAMEDATALEN);
 	cc->fd.delete_on_src_node = delete_on_src_node;
 
 	ts_cache_release(hcache);
@@ -427,15 +428,171 @@ chunk_copy_stage_create_empty_chunk_cleanup(ChunkCopy *cc)
 }
 
 static void
-chunk_copy_stage_create_publication(ChunkCopy *cc)
+chunk_copy_get_source_compressed_chunk_name(ChunkCopy *cc)
+{
+	char *cmd;
+	DistCmdResult *dist_res;
+	PGresult *res;
+
+	/* Get compressed chunk name on the source data node */
+	cmd = psprintf("SELECT c2.table_name "
+				   "FROM _timescaledb_catalog.chunk c1 "
+				   "JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id) "
+				   "WHERE c1.schema_name = %s and c1.table_name = %s",
+				   quote_literal_cstr(NameStr(cc->chunk->fd.schema_name)),
+				   quote_literal_cstr(NameStr(cc->chunk->fd.table_name)));
+	dist_res =
+		ts_dist_cmd_invoke_on_data_nodes(cmd, list_make1(NameStr(cc->fd.source_node_name)), true);
+	res = ts_dist_cmd_get_result_by_node_name(dist_res, NameStr(cc->fd.source_node_name));
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_EXCEPTION), errmsg("%s", PQresultErrorMessage(res))));
+
+	/* Set compressed chunk name of the source data node */
+	if (PQntuples(res) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("failed to get corresponding compressed chunk name from the source data "
+						"node")));
+
+	snprintf(cc->fd.compressed_chunk_name.data,
+			 sizeof(cc->fd.compressed_chunk_name.data),
+			 "%s",
+			 PQgetvalue(res, 0, 0));
+
+	ts_dist_cmd_close_response(dist_res);
+}
+
+static void
+chunk_copy_get_source_compressed_chunk_stats(ChunkCopy *cc)
+{
+	char *cmd;
+	DistCmdResult *dist_res;
+	PGresult *res;
+
+	/* Get compressed chunk statistics from the source data node */
+	cmd = psprintf("SELECT cs.uncompressed_heap_size, cs.uncompressed_toast_size, "
+				   "cs.uncompressed_index_size, cs.compressed_heap_size, "
+				   "cs.compressed_toast_size, cs.compressed_index_size, "
+				   "cs.numrows_pre_compression, cs.numrows_post_compression "
+				   "FROM _timescaledb_catalog.compression_chunk_size cs "
+				   "JOIN _timescaledb_catalog.chunk c ON (cs.chunk_id = c.id) "
+				   "WHERE c.schema_name = %s and c.table_name = %s",
+				   quote_literal_cstr(NameStr(cc->chunk->fd.schema_name)),
+				   quote_literal_cstr(NameStr(cc->chunk->fd.table_name)));
+	dist_res =
+		ts_dist_cmd_invoke_on_data_nodes(cmd, list_make1(NameStr(cc->fd.source_node_name)), true);
+	res = ts_dist_cmd_get_result_by_node_name(dist_res, NameStr(cc->fd.source_node_name));
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_EXCEPTION), errmsg("%s", PQresultErrorMessage(res))));
+
+	if (PQntuples(res) != 1)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("failed to get corresponding compressed chunk stats from the source data "
+						"node")));
+
+	cc->fd_ccs.uncompressed_heap_size = atoll(PQgetvalue(res, 0, 0));
+	cc->fd_ccs.uncompressed_toast_size = atoll(PQgetvalue(res, 0, 1));
+	cc->fd_ccs.uncompressed_index_size = atoll(PQgetvalue(res, 0, 2));
+	cc->fd_ccs.compressed_heap_size = atoll(PQgetvalue(res, 0, 3));
+	cc->fd_ccs.compressed_toast_size = atoll(PQgetvalue(res, 0, 4));
+	cc->fd_ccs.compressed_index_size = atoll(PQgetvalue(res, 0, 5));
+	cc->fd_ccs.numrows_pre_compression = atoll(PQgetvalue(res, 0, 6));
+	cc->fd_ccs.numrows_post_compression = atoll(PQgetvalue(res, 0, 7));
+
+	ts_dist_cmd_close_response(dist_res);
+}
+
+static void
+chunk_copy_create_dest_empty_compressed_chunk(ChunkCopy *cc)
+{
+	char *cmd;
+	DistCmdResult *dist_res;
+	PGresult *res;
+	Cache *hcache;
+	Hypertable *ht;
+
+	/* Create empty compressed chunk table in the compressed hypertable of the
+	 * source chunk on the destination data node */
+	ht = ts_hypertable_cache_get_cache_and_entry(cc->chunk->hypertable_relid,
+												 CACHE_FLAG_NONE,
+												 &hcache);
+	cmd =
+		psprintf("SELECT %s.create_chunk_table(h2.schema_name || '.' || h2.table_name, "
+				 "'{}'::jsonb, %s, %s) "
+				 "FROM _timescaledb_catalog.hypertable h1 "
+				 "JOIN _timescaledb_catalog.hypertable h2 ON (h1.compressed_hypertable_id = h2.id) "
+				 "WHERE h1.table_name = %s",
+				 INTERNAL_SCHEMA_NAME,
+				 quote_literal_cstr(INTERNAL_SCHEMA_NAME),
+				 quote_literal_cstr(NameStr(cc->fd.compressed_chunk_name)),
+				 quote_literal_cstr(NameStr(ht->fd.table_name)));
+	ts_cache_release(hcache);
+
+	dist_res =
+		ts_dist_cmd_invoke_on_data_nodes(cmd, list_make1(NameStr(cc->fd.dest_node_name)), true);
+	res = ts_dist_cmd_get_result_by_node_name(dist_res, NameStr(cc->fd.dest_node_name));
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_EXCEPTION), errmsg("%s", PQresultErrorMessage(res))));
+	ts_dist_cmd_close_response(dist_res);
+}
+
+static void
+chunk_copy_stage_create_empty_compressed_chunk(ChunkCopy *cc)
+{
+	if (!ts_chunk_is_compressed(cc->chunk))
+		return;
+
+	/* Get compressed chunk name from the source data node */
+	chunk_copy_get_source_compressed_chunk_name(cc);
+
+	/* Get compressed chunk stats from the source data node */
+	chunk_copy_get_source_compressed_chunk_stats(cc);
+
+	/* Create empty compressed chunk table in the compressed hypertable of the
+	 * source chunk on the destination data node */
+	chunk_copy_create_dest_empty_compressed_chunk(cc);
+}
+
+static void
+chunk_copy_stage_create_empty_compressed_chunk_cleanup(ChunkCopy *cc)
 {
 	const char *cmd;
 
-	/* Create publication on the source data node */
+	if (!*NameStr(cc->fd.compressed_chunk_name))
+		return;
+
+	cmd = psprintf("DROP TABLE IF EXISTS %s.%s",
+				   INTERNAL_SCHEMA_NAME,
+				   NameStr(cc->fd.compressed_chunk_name));
+	ts_dist_cmd_run_on_data_nodes(cmd, list_make1(NameStr(cc->fd.dest_node_name)), true);
+	cc->fd.compressed_chunk_name.data[0] = 0;
+}
+
+static void
+chunk_copy_stage_create_publication(ChunkCopy *cc)
+{
+	const char *table_list;
+	const char *cmd;
+
+	/* Create publication on the source data node, include compressed
+	 * chunk if necessary */
+	if (ts_chunk_is_compressed(cc->chunk))
+		table_list = psprintf("%s, %s ",
+							  quote_qualified_identifier(NameStr(cc->chunk->fd.schema_name),
+														 NameStr(cc->chunk->fd.table_name)),
+							  quote_qualified_identifier(INTERNAL_SCHEMA_NAME,
+														 NameStr(cc->fd.compressed_chunk_name)));
+	else
+		table_list = psprintf("%s ",
+							  quote_qualified_identifier(NameStr(cc->chunk->fd.schema_name),
+														 NameStr(cc->chunk->fd.table_name)));
 	cmd = psprintf("CREATE PUBLICATION %s FOR TABLE %s",
 				   quote_identifier(NameStr(cc->fd.operation_id)),
-				   quote_qualified_identifier(NameStr(cc->chunk->fd.schema_name),
-											  NameStr(cc->chunk->fd.table_name)));
+				   table_list);
 
 	/* Create the publication */
 	ts_dist_cmd_run_on_data_nodes(cmd, list_make1(NameStr(cc->fd.source_node_name)), true);
@@ -658,6 +815,17 @@ chunk_copy_stage_sync(ChunkCopy *cc)
 
 	ts_dist_cmd_run_on_data_nodes(cmd, list_make1(NameStr(cc->fd.dest_node_name)), true);
 	pfree(cmd);
+
+	/* Wait until compressed chunk being copied */
+	if (ts_chunk_is_compressed(cc->chunk))
+	{
+		cmd = psprintf("CALL _timescaledb_internal.wait_subscription_sync(%s, %s)",
+					   quote_literal_cstr(INTERNAL_SCHEMA_NAME),
+					   quote_literal_cstr(NameStr(cc->fd.compressed_chunk_name)));
+
+		ts_dist_cmd_run_on_data_nodes(cmd, list_make1(NameStr(cc->fd.dest_node_name)), true);
+		pfree(cmd);
+	}
 }
 
 static void
@@ -733,6 +901,50 @@ chunk_copy_stage_attach_chunk(ChunkCopy *cc)
 }
 
 static void
+chunk_copy_stage_attach_compressed_chunk(ChunkCopy *cc)
+{
+	char *cmd;
+	const char *chunk_name;
+	const char *compressed_chunk_name;
+	PGresult *res;
+	DistCmdResult *dist_res;
+
+	if (!ts_chunk_is_compressed(cc->chunk))
+		return;
+
+	chunk_name = psprintf("%s.%s",
+						  quote_identifier(cc->chunk->fd.schema_name.data),
+						  quote_identifier(cc->chunk->fd.table_name.data));
+
+	compressed_chunk_name = psprintf("%s.%s",
+									 quote_identifier(INTERNAL_SCHEMA_NAME),
+									 quote_identifier(NameStr(cc->fd.compressed_chunk_name)));
+
+	cmd = psprintf("SELECT %s.create_compressed_chunk(%s, %s, " INT64_FORMAT ", " INT64_FORMAT
+				   ", " INT64_FORMAT ", " INT64_FORMAT ", " INT64_FORMAT ", " INT64_FORMAT
+				   ", " INT64_FORMAT ", " INT64_FORMAT ")",
+				   INTERNAL_SCHEMA_NAME,
+				   quote_literal_cstr(chunk_name),
+				   quote_literal_cstr(compressed_chunk_name),
+				   cc->fd_ccs.uncompressed_heap_size,
+				   cc->fd_ccs.uncompressed_toast_size,
+				   cc->fd_ccs.uncompressed_index_size,
+				   cc->fd_ccs.compressed_heap_size,
+				   cc->fd_ccs.compressed_toast_size,
+				   cc->fd_ccs.compressed_index_size,
+				   cc->fd_ccs.numrows_pre_compression,
+				   cc->fd_ccs.numrows_post_compression);
+	dist_res =
+		ts_dist_cmd_invoke_on_data_nodes(cmd, list_make1(NameStr(cc->fd.dest_node_name)), true);
+	res = ts_dist_cmd_get_result_by_node_name(dist_res, NameStr(cc->fd.dest_node_name));
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_EXCEPTION), errmsg("%s", PQresultErrorMessage(res))));
+
+	ts_dist_cmd_close_response(dist_res);
+}
+
+static void
 chunk_copy_stage_delete_chunk(ChunkCopy *cc)
 {
 	if (!cc->fd.delete_on_src_node)
@@ -754,6 +966,15 @@ static const ChunkCopyStage chunk_copy_stages[] = {
 	{ CCS_CREATE_EMPTY_CHUNK,
 	  chunk_copy_stage_create_empty_chunk,
 	  chunk_copy_stage_create_empty_chunk_cleanup },
+
+	/*
+	 * Create compressed empty chunk table on the dst node.
+	 * The corresponding cleanup function should just delete this empty chunk, if
+	 * the compressed_chunk_name column was set in the operation metadata.
+	 */
+	{ CCS_CREATE_EMPTY_COMPRESSED_CHUNK,
+	  chunk_copy_stage_create_empty_compressed_chunk,
+	  chunk_copy_stage_create_empty_compressed_chunk_cleanup },
 
 	/*
 	 * Setup logical replication between nodes.
@@ -791,6 +1012,11 @@ static const ChunkCopyStage chunk_copy_stages[] = {
 	 * No cleanup required here.
 	 */
 	{ CCS_ATTACH_CHUNK, chunk_copy_stage_attach_chunk, NULL },
+
+	/*
+	 * Attach compressed chunk to the hypertable on the dst_node.
+	 */
+	{ CCS_ATTACH_COMPRESSED_CHUNK, chunk_copy_stage_attach_compressed_chunk, NULL },
 
 	/*
 	 * Maybe delete chunk from the src_node (move operation).
@@ -838,9 +1064,21 @@ chunk_copy(Oid chunk_relid, const char *src_node, const char *dst_node, const ch
 
 	/* Populate copy structure. First set up the operation id if it's provided */
 	if (op_id)
+	{
+		/* Validate operation id as beign compatible to be used as a replication slot name */
+		if (!ReplicationSlotValidateName(op_id, DEBUG2))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_NAME),
+					 errmsg("operation_id name \"%s\" is not valid", op_id),
+					 errhint("operation_id names may only contain lower case letters, numbers, and "
+							 "the underscore character.")));
+
 		snprintf(cc.fd.operation_id.data, sizeof(cc.fd.operation_id.data), "%s", op_id);
+	}
 	else
+	{
 		cc.fd.operation_id.data[0] = '\0';
+	}
 
 	chunk_copy_setup(&cc, chunk_relid, src_node, dst_node, delete_on_src_node);
 

--- a/tsl/src/compression/compress_utils.h
+++ b/tsl/src/compression/compress_utils.h
@@ -9,6 +9,7 @@
 #include <postgres.h>
 #include <fmgr.h>
 
+extern Datum tsl_create_compressed_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_recompress_chunk(PG_FUNCTION_ARGS);

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -581,11 +581,15 @@ create_compression_table(Oid owner, CompressColInfo *compress_cols)
 }
 
 /*
+ * Create compress chunk for specific table.
+ *
+ * If table_id is InvalidOid, create a new table.
+ *
  * Constraints and triggers are not created on the PG chunk table.
  * Caller is expected to do this explicitly.
  */
 Chunk *
-create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
+create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id)
 {
 	Hyperspace *hs = compress_ht->space;
 	Catalog *catalog = ts_catalog_get();
@@ -608,19 +612,30 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 	compress_chunk->constraints = ts_chunk_constraints_alloc(1, CurrentMemoryContext);
 	namestrcpy(&compress_chunk->fd.schema_name, INTERNAL_SCHEMA_NAME);
 
-	/* Fail if we overflow the name limit */
-	namelen = snprintf(NameStr(compress_chunk->fd.table_name),
-					   NAMEDATALEN,
-					   "compress%s_%d_chunk",
-					   NameStr(compress_ht->fd.associated_table_prefix),
-					   compress_chunk->fd.id);
+	if (OidIsValid(table_id))
+	{
+		Relation table_rel = table_open(table_id, AccessShareLock);
+		strncpy(NameStr(compress_chunk->fd.table_name),
+				RelationGetRelationName(table_rel),
+				NAMEDATALEN);
+		table_close(table_rel, AccessShareLock);
+	}
+	else
+	{
+		/* Fail if we overflow the name limit */
+		namelen = snprintf(NameStr(compress_chunk->fd.table_name),
+						   NAMEDATALEN,
+						   "compress%s_%d_chunk",
+						   NameStr(compress_ht->fd.associated_table_prefix),
+						   compress_chunk->fd.id);
 
-	if (namelen >= NAMEDATALEN)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("invalid name \"%s\" for compressed chunk",
-						NameStr(compress_chunk->fd.table_name)),
-				 errdetail("The associated table prefix is too long.")));
+		if (namelen >= NAMEDATALEN)
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("invalid name \"%s\" for compressed chunk",
+							NameStr(compress_chunk->fd.table_name)),
+					 errdetail("The associated table prefix is too long.")));
+	}
 
 	/* Insert chunk */
 	ts_chunk_insert_lock(compress_chunk, RowExclusiveLock);
@@ -640,7 +655,11 @@ create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk)
 	 */
 	tablespace_oid = get_rel_tablespace(src_chunk->table_id);
 	tablespace = get_tablespace_name(tablespace_oid);
-	compress_chunk->table_id = ts_chunk_create_table(compress_chunk, compress_ht, tablespace);
+
+	if (OidIsValid(table_id))
+		compress_chunk->table_id = table_id;
+	else
+		compress_chunk->table_id = ts_chunk_create_table(compress_chunk, compress_ht, tablespace);
 
 	if (!OidIsValid(compress_chunk->table_id))
 		elog(ERROR, "could not create compressed chunk table");

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -20,8 +20,8 @@ bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 								WithClauseResult *with_clause_options);
 void tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def);
 void tsl_process_compress_table_drop_column(Hypertable *ht, char *name);
-Chunk *create_compress_chunk_table(Hypertable *compress_ht, Chunk *src_chunk);
 void tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt);
+Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_oid);
 
 char *compression_column_segment_min_name(const FormData_hypertable_compression *fd);
 char *compression_column_segment_max_name(const FormData_hypertable_compression *fd);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -181,6 +181,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.data_node_block_new_chunks = data_node_block_new_chunks,
 	.chunk_set_default_data_node = chunk_set_default_data_node,
 	.show_chunk = chunk_show,
+	.create_compressed_chunk = tsl_create_compressed_chunk,
 	.create_chunk = chunk_create,
 	.create_chunk_on_data_nodes = chunk_api_create_on_data_nodes,
 	.chunk_drop_replica = chunk_drop_replica,

--- a/tsl/test/expected/dist_move_chunk.out
+++ b/tsl/test/expected/dist_move_chunk.out
@@ -169,20 +169,6 @@ ERROR:  "_hyper_2_5_chunk" is not a valid remote chunk
 CALL timescaledb_experimental.copy_chunk(chunk=>'_timescaledb_internal._hyper_2_5_chunk', source_node=> 'data_node_1', destination_node => 'data_node_2');
 ERROR:  "_hyper_2_5_chunk" is not a valid remote chunk
 \set ON_ERROR_STOP 1
--- ensure that distributed chunk is not compressed
-ALTER TABLE dist_test SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
-SELECT compress_chunk('_timescaledb_internal._dist_hyper_1_4_chunk');
-               compress_chunk                
----------------------------------------------
- _timescaledb_internal._dist_hyper_1_4_chunk
-(1 row)
-
-\set ON_ERROR_STOP 0
-CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_4_chunk', source_node=> 'data_node_1', destination_node => 'data_node_2');
-ERROR:  "_dist_hyper_1_4_chunk" is a compressed remote chunk. Chunk copy/move not supported currently on compressed chunks
-CALL timescaledb_experimental.copy_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_4_chunk', source_node=> 'data_node_1', destination_node => 'data_node_2');
-ERROR:  "_dist_hyper_1_4_chunk" is a compressed remote chunk. Chunk copy/move not supported currently on compressed chunks
-\set ON_ERROR_STOP 1
 -- ensure that chunk exists on a source data node
 \set ON_ERROR_STOP 0
 CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_2_chunk', source_node=> 'data_node_1', destination_node => 'data_node_2');
@@ -335,6 +321,300 @@ FROM timescaledb_experimental.chunk_replication_status;
 
 DROP PROCEDURE copy_wrapper;
 DROP PROCEDURE move_wrapper;
+DROP TABLE dist_test;
+-- Test copy/move compressed chunk
+--
+-- Create a compressed hypertable
+CREATE TABLE dist_test(time timestamp NOT NULL, device int, temp float);
+SELECT create_distributed_hypertable('dist_test', 'time', 'device', 3);
+ create_distributed_hypertable 
+-------------------------------
+ (3,public,dist_test,t)
+(1 row)
+
+INSERT INTO dist_test SELECT t, (abs(timestamp_hash(t::timestamp)) % 10) + 1, 0.10 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-08 1:00', '1 hour') t;
+ALTER TABLE dist_test SET (timescaledb.compress, timescaledb.compress_segmentby='device', timescaledb.compress_orderby = 'time DESC');
+-- Integrity check (see below)
+SELECT sum(device) FROM dist_test;
+ sum 
+-----
+ 846
+(1 row)
+
+-- Get a list of chunks
+SELECT * from show_chunks('dist_test');
+                 show_chunks                  
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_3_9_chunk
+ _timescaledb_internal._dist_hyper_3_10_chunk
+ _timescaledb_internal._dist_hyper_3_11_chunk
+ _timescaledb_internal._dist_hyper_3_12_chunk
+(4 rows)
+
+SELECT * FROM test.remote_exec(NULL, $$ SELECT * from show_chunks('dist_test'); $$);
+NOTICE:  [data_node_1]:  SELECT * from show_chunks('dist_test')
+NOTICE:  [data_node_1]:
+show_chunks                                 
+--------------------------------------------
+_timescaledb_internal._dist_hyper_3_9_chunk 
+_timescaledb_internal._dist_hyper_3_12_chunk
+(2 rows)
+
+
+NOTICE:  [data_node_2]:  SELECT * from show_chunks('dist_test')
+NOTICE:  [data_node_2]:
+show_chunks                                 
+--------------------------------------------
+_timescaledb_internal._dist_hyper_3_10_chunk
+(1 row)
+
+
+NOTICE:  [data_node_3]:  SELECT * from show_chunks('dist_test')
+NOTICE:  [data_node_3]:
+show_chunks                                 
+--------------------------------------------
+_timescaledb_internal._dist_hyper_3_11_chunk
+(1 row)
+
+
+ remote_exec 
+-------------
+ 
+(1 row)
+
+SELECT chunk_schema || '.' ||  chunk_name, data_nodes
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'dist_test';
+                   ?column?                   |  data_nodes   
+----------------------------------------------+---------------
+ _timescaledb_internal._dist_hyper_3_9_chunk  | {data_node_1}
+ _timescaledb_internal._dist_hyper_3_10_chunk | {data_node_2}
+ _timescaledb_internal._dist_hyper_3_11_chunk | {data_node_3}
+ _timescaledb_internal._dist_hyper_3_12_chunk | {data_node_1}
+(4 rows)
+
+-- Compress a chunk
+SELECT compress_chunk('_timescaledb_internal._dist_hyper_3_12_chunk');
+                compress_chunk                
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_3_12_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
+           time           | device | temp 
+--------------------------+--------+------
+ Thu Mar 08 00:00:00 2018 |     10 |  0.1
+ Thu Mar 08 01:00:00 2018 |      1 |  0.1
+(2 rows)
+
+-- Get compressed chunk name on the source data node and show its content
+\c :DN_DBNAME_1 :ROLE_CLUSTER_SUPERUSER;
+SELECT c2.table_name
+FROM _timescaledb_catalog.chunk c1
+JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
+WHERE c1.table_name = '_dist_hyper_3_12_chunk';
+        table_name        
+--------------------------
+ compress_hyper_3_6_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk;
+                           time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
+----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
+ BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
+ BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    20 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
+(2 rows)
+
+SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
+           time           | device | temp 
+--------------------------+--------+------
+ Thu Mar 08 00:00:00 2018 |     10 |  0.1
+ Thu Mar 08 01:00:00 2018 |      1 |  0.1
+(2 rows)
+
+-- Get compressed chunk stat
+SELECT * FROM _timescaledb_internal.compressed_chunk_stats WHERE  chunk_name = '_dist_hyper_3_12_chunk';
+ hypertable_schema | hypertable_name |     chunk_schema      |       chunk_name       | compression_status | uncompressed_heap_size | uncompressed_index_size | uncompressed_toast_size | uncompressed_total_size | compressed_heap_size | compressed_index_size | compressed_toast_size | compressed_total_size 
+-------------------+-----------------+-----------------------+------------------------+--------------------+------------------------+-------------------------+-------------------------+-------------------------+----------------------+-----------------------+-----------------------+-----------------------
+ public            | dist_test       | _timescaledb_internal | _dist_hyper_3_12_chunk | Compressed         |                   8192 |                   32768 |                       0 |                   40960 |                 8192 |                 16384 |                  8192 |                 32768
+(1 row)
+
+-- Move compressed chunk from data node 1 to data node 2
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_3_12_chunk', source_node=> 'data_node_1', destination_node => 'data_node_2');
+SELECT count(*) FROM  _timescaledb_catalog.chunk_copy_operation;
+ count 
+-------
+     5
+(1 row)
+
+-- Make sure same compressed chunk hash been created on the destination data node
+\c :DN_DBNAME_2 :ROLE_CLUSTER_SUPERUSER;
+-- Chunk created on data node has different id but the same name, make sure
+-- compressed_chunk_id is correctly set
+SELECT c2.table_name
+FROM _timescaledb_catalog.chunk c1
+JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
+WHERE c1.table_name = '_dist_hyper_3_12_chunk';
+        table_name        
+--------------------------
+ compress_hyper_3_6_chunk
+(1 row)
+
+-- Try to query hypertable member with compressed chunk
+SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk;
+                           time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
+----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
+ BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
+ BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    20 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
+(2 rows)
+
+SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
+           time           | device | temp 
+--------------------------+--------+------
+ Thu Mar 08 00:00:00 2018 |     10 |  0.1
+ Thu Mar 08 01:00:00 2018 |      1 |  0.1
+(2 rows)
+
+-- Ensure that compressed chunk stats match stats from the source data node
+SELECT * FROM _timescaledb_internal.compressed_chunk_stats WHERE chunk_name = '_dist_hyper_3_12_chunk';
+ hypertable_schema | hypertable_name |     chunk_schema      |       chunk_name       | compression_status | uncompressed_heap_size | uncompressed_index_size | uncompressed_toast_size | uncompressed_total_size | compressed_heap_size | compressed_index_size | compressed_toast_size | compressed_total_size 
+-------------------+-----------------+-----------------------+------------------------+--------------------+------------------------+-------------------------+-------------------------+-------------------------+----------------------+-----------------------+-----------------------+-----------------------
+ public            | dist_test       | _timescaledb_internal | _dist_hyper_3_12_chunk | Compressed         |                   8192 |                   32768 |                       0 |                   40960 |                 8192 |                 16384 |                  8192 |                 32768
+(1 row)
+
+-- Ensure moved chunks are no longer present on the source data node
+\c :DN_DBNAME_1 :ROLE_CLUSTER_SUPERUSER;
+SELECT c2.table_name
+FROM _timescaledb_catalog.chunk c1
+JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
+WHERE c1.table_name = '_dist_hyper_3_12_chunk';
+ table_name 
+------------
+(0 rows)
+
+\set ON_ERROR_STOP 0
+SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk;
+ERROR:  relation "_timescaledb_internal.compress_hyper_3_6_chunk" does not exist at character 15
+SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
+ERROR:  relation "_timescaledb_internal._dist_hyper_3_12_chunk" does not exist at character 15
+\set ON_ERROR_STOP 1
+-- Make sure chunk has been properly moved from AN
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SELECT * FROM show_chunks('dist_test');
+                 show_chunks                  
+----------------------------------------------
+ _timescaledb_internal._dist_hyper_3_9_chunk
+ _timescaledb_internal._dist_hyper_3_10_chunk
+ _timescaledb_internal._dist_hyper_3_11_chunk
+ _timescaledb_internal._dist_hyper_3_12_chunk
+(4 rows)
+
+SELECT * FROM test.remote_exec(NULL, $$ SELECT * from show_chunks('dist_test'); $$);
+NOTICE:  [data_node_1]:  SELECT * from show_chunks('dist_test')
+NOTICE:  [data_node_1]:
+show_chunks                                
+-------------------------------------------
+_timescaledb_internal._dist_hyper_3_9_chunk
+(1 row)
+
+
+NOTICE:  [data_node_2]:  SELECT * from show_chunks('dist_test')
+NOTICE:  [data_node_2]:
+show_chunks                                 
+--------------------------------------------
+_timescaledb_internal._dist_hyper_3_10_chunk
+_timescaledb_internal._dist_hyper_3_12_chunk
+(2 rows)
+
+
+NOTICE:  [data_node_3]:  SELECT * from show_chunks('dist_test')
+NOTICE:  [data_node_3]:
+show_chunks                                 
+--------------------------------------------
+_timescaledb_internal._dist_hyper_3_11_chunk
+(1 row)
+
+
+ remote_exec 
+-------------
+ 
+(1 row)
+
+SELECT chunk_schema || '.' ||  chunk_name, data_nodes
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'dist_test';
+                   ?column?                   |  data_nodes   
+----------------------------------------------+---------------
+ _timescaledb_internal._dist_hyper_3_9_chunk  | {data_node_1}
+ _timescaledb_internal._dist_hyper_3_10_chunk | {data_node_2}
+ _timescaledb_internal._dist_hyper_3_11_chunk | {data_node_3}
+ _timescaledb_internal._dist_hyper_3_12_chunk | {data_node_2}
+(4 rows)
+
+-- Query distributed hypertable again to query newly moved chunk, make
+-- sure result has not changed
+SELECT sum(device) FROM dist_test;
+ sum 
+-----
+ 846
+(1 row)
+
+-- Test operation_id name validation
+\set ON_ERROR_STOP 0
+CALL timescaledb_experimental.move_chunk(operation_id => ' move chunk id ', chunk=>'_timescaledb_internal._dist_hyper_3_12_chunk', source_node=> 'data_node_2', destination_node => 'data_node_3');
+ERROR:  operation_id name " move chunk id " is not valid
+CALL timescaledb_experimental.move_chunk(operation_id => 'ChUnK_MoVe_Op', chunk=>'_timescaledb_internal._dist_hyper_3_12_chunk', source_node=> 'data_node_2', destination_node => 'data_node_3');
+ERROR:  operation_id name "ChUnK_MoVe_Op" is not valid
+CALL timescaledb_experimental.move_chunk(operation_id => '_ID123', chunk=>'_timescaledb_internal._dist_hyper_3_12_chunk', source_node=> 'data_node_2', destination_node => 'data_node_3');
+ERROR:  operation_id name "_ID123" is not valid
+\set ON_ERROR_STOP 1
+-- Now copy chunk from data node 2 to data node 3
+CALL timescaledb_experimental.move_chunk(operation_id => 'id123', chunk=>'_timescaledb_internal._dist_hyper_3_12_chunk', source_node=> 'data_node_2', destination_node => 'data_node_3');
+\c :DN_DBNAME_3 :ROLE_CLUSTER_SUPERUSER;
+-- Validate chunk on data node 3
+SELECT c2.table_name
+FROM _timescaledb_catalog.chunk c1
+JOIN _timescaledb_catalog.chunk c2 ON (c1.compressed_chunk_id = c2.id)
+WHERE c1.table_name = '_dist_hyper_3_12_chunk';
+        table_name        
+--------------------------
+ compress_hyper_3_6_chunk
+(1 row)
+
+SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk;
+                           time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
+----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
+ BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
+ BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    20 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
+(2 rows)
+
+SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
+           time           | device | temp 
+--------------------------+--------+------
+ Thu Mar 08 00:00:00 2018 |     10 |  0.1
+ Thu Mar 08 01:00:00 2018 |      1 |  0.1
+(2 rows)
+
+SELECT * FROM _timescaledb_internal.compressed_chunk_stats WHERE chunk_name = '_dist_hyper_3_12_chunk';
+ hypertable_schema | hypertable_name |     chunk_schema      |       chunk_name       | compression_status | uncompressed_heap_size | uncompressed_index_size | uncompressed_toast_size | uncompressed_total_size | compressed_heap_size | compressed_index_size | compressed_toast_size | compressed_total_size 
+-------------------+-----------------+-----------------------+------------------------+--------------------+------------------------+-------------------------+-------------------------+-------------------------+----------------------+-----------------------+-----------------------+-----------------------
+ public            | dist_test       | _timescaledb_internal | _dist_hyper_3_12_chunk | Compressed         |                   8192 |                   32768 |                       0 |                   40960 |                 8192 |                 16384 |                  8192 |                 32768
+(1 row)
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+-- _dist_hyper_3_12_chunk should be moved in data node 3 now
+SELECT chunk_schema || '.' ||  chunk_name, data_nodes
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'dist_test';
+                   ?column?                   |  data_nodes   
+----------------------------------------------+---------------
+ _timescaledb_internal._dist_hyper_3_9_chunk  | {data_node_1}
+ _timescaledb_internal._dist_hyper_3_10_chunk | {data_node_2}
+ _timescaledb_internal._dist_hyper_3_11_chunk | {data_node_3}
+ _timescaledb_internal._dist_hyper_3_12_chunk | {data_node_3}
+(4 rows)
+
 RESET ROLE;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -43,6 +43,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_internal.create_chunk(regclass,jsonb,name,name,regclass)
  _timescaledb_internal.create_chunk_replica_table(regclass,name)
  _timescaledb_internal.create_chunk_table(regclass,jsonb,name,name)
+ _timescaledb_internal.create_compressed_chunk(regclass,regclass,bigint,bigint,bigint,bigint,bigint,bigint,bigint,bigint)
  _timescaledb_internal.data_node_chunk_info(name,name,name)
  _timescaledb_internal.data_node_compressed_chunk_stats(name,name,name)
  _timescaledb_internal.data_node_hypertable_info(name,name,name)


### PR DESCRIPTION
This change allows to copy or move compressed chunks between data nodes by including compressed chunk into the chunk copy command stages.