### PR TITLE
Make the test remote_copy stable by adding ORDER BYs

### DIFF
--- a/tsl/test/expected/remote_copy-12.out
+++ b/tsl/test/expected/remote_copy-12.out
@@ -76,30 +76,30 @@ cOpy public."+ri(k33_')" (thYme, "pH", "))_", "flavor") FrOm
 StDiN wiTH dElImITeR ','
 ;
 COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
-     315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
+       1 |                   11 | strawberry             |   2.3 | stuff
       10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
+     208 |                   40 | mint                   |  0.01 | 
+     315 |                   37 | mint                   |    10 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
-   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
-       1 |                   11 | strawberry             |   2.3 | stuff
-     208 |                   40 | mint                   |  0.01 | 
     3420 |                 4324 | "empties"              |    40 | \N
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (18 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
  id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status 
 ----+---------------+-----------------------+------------------------+---------------------+---------+--------
   1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0
@@ -120,13 +120,13 @@ SELECT * FROM _timescaledb_catalog.chunk;
  19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0
 (16 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk_data_node;
+SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
  chunk_id | node_chunk_id |  node_name  
 ----------+---------------+-------------
-        1 |             1 | data_node_3
         1 |             1 | data_node_1
-        2 |             2 | data_node_3
+        1 |             1 | data_node_3
         2 |             2 | data_node_1
+        2 |             2 | data_node_3
         3 |             3 | data_node_1
         3 |             1 | data_node_2
         4 |             4 | data_node_1
@@ -153,11 +153,11 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
        17 |            13 | data_node_2
        18 |            17 | data_node_1
        18 |            14 | data_node_2
-       19 |             6 | data_node_3
        19 |            18 | data_node_1
+       19 |             6 | data_node_3
 (32 rows)
 
-SELECT * FROM _timescaledb_catalog.hypertable_data_node;
+SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
  hypertable_id | node_hypertable_id |  node_name  | block_chunks 
 ---------------+--------------------+-------------+--------------
              1 |                  1 | data_node_1 | f
@@ -165,7 +165,7 @@ SELECT * FROM _timescaledb_catalog.hypertable_data_node;
              1 |                  1 | data_node_3 | f
 (3 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
@@ -187,30 +187,30 @@ select * from show_chunks('"+ri(k33_'')"');
 (16 rows)
 
 \c :DN_DBNAME_1
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
        1 |                   11 | strawberry             |   2.3 | stuff
+      10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
+     203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
-      10 |                   11 | strawberry             |  12.3 | stuff
-     203 |              3.21321 | something like lemon   |     1 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
-   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
     3420 |                 4324 | "empties"              |    40 | \N
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (18 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
@@ -232,27 +232,27 @@ select * from show_chunks('"+ri(k33_'')"');
 (16 rows)
 
 \c :DN_DBNAME_2
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
-     315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
       10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
+     315 |                   37 | mint                   |    10 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (15 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_3_chunk
@@ -271,7 +271,7 @@ select * from show_chunks('"+ri(k33_'')"');
 (13 rows)
 
 \c :DN_DBNAME_3
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
  thyme | ))_  |   flavor   |  pH  | optional 
 -------+------+------------+------+----------
      1 |   11 | strawberry |  2.3 | stuff
@@ -279,7 +279,7 @@ SELECT * FROM "+ri(k33_')";
   3420 | 4324 | "empties"  |   40 | \N
 (3 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk

--- a/tsl/test/expected/remote_copy-13.out
+++ b/tsl/test/expected/remote_copy-13.out
@@ -76,30 +76,30 @@ cOpy public."+ri(k33_')" (thYme, "pH", "))_", "flavor") FrOm
 StDiN wiTH dElImITeR ','
 ;
 COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
-     315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
+       1 |                   11 | strawberry             |   2.3 | stuff
       10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
+     208 |                   40 | mint                   |  0.01 | 
+     315 |                   37 | mint                   |    10 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
-   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
-       1 |                   11 | strawberry             |   2.3 | stuff
-     208 |                   40 | mint                   |  0.01 | 
     3420 |                 4324 | "empties"              |    40 | \N
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (18 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
  id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status 
 ----+---------------+-----------------------+------------------------+---------------------+---------+--------
   1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0
@@ -120,13 +120,13 @@ SELECT * FROM _timescaledb_catalog.chunk;
  19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0
 (16 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk_data_node;
+SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
  chunk_id | node_chunk_id |  node_name  
 ----------+---------------+-------------
-        1 |             1 | data_node_3
         1 |             1 | data_node_1
-        2 |             2 | data_node_3
+        1 |             1 | data_node_3
         2 |             2 | data_node_1
+        2 |             2 | data_node_3
         3 |             3 | data_node_1
         3 |             1 | data_node_2
         4 |             4 | data_node_1
@@ -153,11 +153,11 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
        17 |            13 | data_node_2
        18 |            17 | data_node_1
        18 |            14 | data_node_2
-       19 |             6 | data_node_3
        19 |            18 | data_node_1
+       19 |             6 | data_node_3
 (32 rows)
 
-SELECT * FROM _timescaledb_catalog.hypertable_data_node;
+SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
  hypertable_id | node_hypertable_id |  node_name  | block_chunks 
 ---------------+--------------------+-------------+--------------
              1 |                  1 | data_node_1 | f
@@ -165,7 +165,7 @@ SELECT * FROM _timescaledb_catalog.hypertable_data_node;
              1 |                  1 | data_node_3 | f
 (3 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
@@ -187,30 +187,30 @@ select * from show_chunks('"+ri(k33_'')"');
 (16 rows)
 
 \c :DN_DBNAME_1
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
        1 |                   11 | strawberry             |   2.3 | stuff
+      10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
+     203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
-      10 |                   11 | strawberry             |  12.3 | stuff
-     203 |              3.21321 | something like lemon   |     1 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
-   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
     3420 |                 4324 | "empties"              |    40 | \N
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (18 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
@@ -232,27 +232,27 @@ select * from show_chunks('"+ri(k33_'')"');
 (16 rows)
 
 \c :DN_DBNAME_2
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
-     315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
       10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
+     315 |                   37 | mint                   |    10 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (15 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_3_chunk
@@ -271,7 +271,7 @@ select * from show_chunks('"+ri(k33_'')"');
 (13 rows)
 
 \c :DN_DBNAME_3
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
  thyme | ))_  |   flavor   |  pH  | optional 
 -------+------+------------+------+----------
      1 |   11 | strawberry |  2.3 | stuff
@@ -279,7 +279,7 @@ SELECT * FROM "+ri(k33_')";
   3420 | 4324 | "empties"  |   40 | \N
 (3 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk

--- a/tsl/test/expected/remote_copy-14.out
+++ b/tsl/test/expected/remote_copy-14.out
@@ -76,30 +76,30 @@ cOpy public."+ri(k33_')" (thYme, "pH", "))_", "flavor") FrOm
 StDiN wiTH dElImITeR ','
 ;
 COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
-     315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
+       1 |                   11 | strawberry             |   2.3 | stuff
       10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
+     208 |                   40 | mint                   |  0.01 | 
+     315 |                   37 | mint                   |    10 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
-   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
-       1 |                   11 | strawberry             |   2.3 | stuff
-     208 |                   40 | mint                   |  0.01 | 
     3420 |                 4324 | "empties"              |    40 | \N
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (18 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk;
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
  id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status 
 ----+---------------+-----------------------+------------------------+---------------------+---------+--------
   1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0
@@ -120,13 +120,13 @@ SELECT * FROM _timescaledb_catalog.chunk;
  19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0
 (16 rows)
 
-SELECT * FROM _timescaledb_catalog.chunk_data_node;
+SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
  chunk_id | node_chunk_id |  node_name  
 ----------+---------------+-------------
-        1 |             1 | data_node_3
         1 |             1 | data_node_1
-        2 |             2 | data_node_3
+        1 |             1 | data_node_3
         2 |             2 | data_node_1
+        2 |             2 | data_node_3
         3 |             3 | data_node_1
         3 |             1 | data_node_2
         4 |             4 | data_node_1
@@ -153,11 +153,11 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
        17 |            13 | data_node_2
        18 |            17 | data_node_1
        18 |            14 | data_node_2
-       19 |             6 | data_node_3
        19 |            18 | data_node_1
+       19 |             6 | data_node_3
 (32 rows)
 
-SELECT * FROM _timescaledb_catalog.hypertable_data_node;
+SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
  hypertable_id | node_hypertable_id |  node_name  | block_chunks 
 ---------------+--------------------+-------------+--------------
              1 |                  1 | data_node_1 | f
@@ -165,7 +165,7 @@ SELECT * FROM _timescaledb_catalog.hypertable_data_node;
              1 |                  1 | data_node_3 | f
 (3 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
@@ -187,30 +187,30 @@ select * from show_chunks('"+ri(k33_'')"');
 (16 rows)
 
 \c :DN_DBNAME_1
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
        1 |                   11 | strawberry             |   2.3 | stuff
+      10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
+     203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
-      10 |                   11 | strawberry             |  12.3 | stuff
-     203 |              3.21321 | something like lemon   |     1 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
-   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
     3420 |                 4324 | "empties"              |    40 | \N
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+   42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (18 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
@@ -232,27 +232,27 @@ select * from show_chunks('"+ri(k33_'')"');
 (16 rows)
 
 \c :DN_DBNAME_2
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
   thyme  |         ))_          |         flavor         |  pH   | optional 
 ---------+----------------------+------------------------+-------+----------
-     315 |                   37 | mint                   |    10 | 
-      15 |                  403 |                        |     1 | 
       10 |                   11 | strawberry             |  12.3 | stuff
+      15 |                  403 |                        |     1 | 
+     150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
+     315 |                   37 | mint                   |    10 | 
      333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
-  120321 |     4.43244243242544 |                        |     0 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
-     150 |                  403 |                        |    10 | 
-    2030 |              3.21321 | something like lemon   |    10 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
- 1203210 |     4.43244243242544 |                        |     0 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | 
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
+  120321 |     4.43244243242544 |                        |     0 | 
+ 1203210 |     4.43244243242544 |                        |     0 | 
 (15 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_3_chunk
@@ -271,7 +271,7 @@ select * from show_chunks('"+ri(k33_'')"');
 (13 rows)
 
 \c :DN_DBNAME_3
-SELECT * FROM "+ri(k33_')";
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
  thyme | ))_  |   flavor   |  pH  | optional 
 -------+------+------------+------+----------
      1 |   11 | strawberry |  2.3 | stuff
@@ -279,7 +279,7 @@ SELECT * FROM "+ri(k33_')";
   3420 | 4324 | "empties"  |   40 | \N
 (3 rows)
 
-select * from show_chunks('"+ri(k33_'')"');
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
                  show_chunks                  
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk

--- a/tsl/test/sql/remote_copy.sql.in
+++ b/tsl/test/sql/remote_copy.sql.in
@@ -113,20 +113,20 @@ COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FOR
 3420,4324,"empties",40,\N
 \.
 
-SELECT * FROM "+ri(k33_')";
-SELECT * FROM _timescaledb_catalog.chunk;
-SELECT * FROM _timescaledb_catalog.chunk_data_node;
-SELECT * FROM _timescaledb_catalog.hypertable_data_node;
-select * from show_chunks('"+ri(k33_'')"');
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
+SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
+SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
+SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 \c :DN_DBNAME_1
-SELECT * FROM "+ri(k33_')";
-select * from show_chunks('"+ri(k33_'')"');
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 \c :DN_DBNAME_2
-SELECT * FROM "+ri(k33_')";
-select * from show_chunks('"+ri(k33_'')"');
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 \c :DN_DBNAME_3
-SELECT * FROM "+ri(k33_')";
-select * from show_chunks('"+ri(k33_'')"');
+SELECT * FROM "+ri(k33_')" ORDER BY 1;
+select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 SET ROLE :ROLE_1;
 


### PR DESCRIPTION
Currently it depends on the (unspecified) order in which the original
rows were inserted.

Part of #4285