### PR TITLE
Multi-buffer copy optimization backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If you use compression with a non-default collation on a segmentby-column you mi
 * #4120 Add logging for retention policy
 * #4169 Add support for chunk exclusion on DELETE to PG14
 * #4209 Add support for chunk exclusion on UPDATE to PG14
+* #4301 Add support for bulk inserts in COPY operator
 
 **Bugfixes**
 * #3899 Fix segfault in Continuous Aggregates

--- a/src/nodes/chunk_insert_state.h
+++ b/src/nodes/chunk_insert_state.h
@@ -31,6 +31,8 @@ typedef struct CompressChunkInsertState
 	int cagg_trig_nargs;
 } CompressChunkInsertState;
 
+typedef struct TSCopyMultiInsertBuffer TSCopyMultiInsertBuffer;
+
 typedef struct ChunkInsertState
 {
 	Relation rel;
@@ -73,6 +75,9 @@ typedef struct ChunkInsertState
 
 	/* for tracking compressed chunks */
 	CompressChunkInsertState *compress_info;
+
+	/* for use by copy.c when performing multi-inserts */
+	struct TSCopyMultiInsertBuffer *copy_multi_insert_buffer;
 } ChunkInsertState;
 
 typedef struct ChunkDispatch ChunkDispatch;

--- a/test/expected/copy-12.out
+++ b/test/expected/copy-12.out
@@ -167,3 +167,544 @@ NOTICE:  hypertable data are in the chunks, no data will be copied
 COPY (SELECT * FROM hyper) TO STDOUT DELIMITER ',';
 1,1,1
 1,2,1
+----------------------------------------------------------------
+-- Testing multi-buffer optimization.
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+    create_hypertable    
+-------------------------
+ (6,public,hyper_copy,t)
+(1 row)
+
+-- First copy call with default client_min_messages, to get rid of the 
+-- building index "_hyper_XXX_chunk_hyper_copy_time_idx" on table "_hyper_XXX_chunk" serially
+-- messages
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+    50
+(1 row)
+
+-- Limit number of open chunks
+SET timescaledb.max_open_chunks_per_insert = 1;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+    75
+(1 row)
+
+-- Before trigger disable the multi-buffer optimization
+CREATE OR REPLACE FUNCTION empty_test_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   100
+(1 row)
+
+-- Suppress 'DEBUG:  EventTriggerInvoke XXXX' messages
+RESET client_min_messages;
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy;
+SET client_min_messages TO DEBUG1;
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   125
+(1 row)
+
+RESET client_min_messages;
+RESET timescaledb.max_open_chunks_per_insert;
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (no index on destination hypertable).
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy_noindex" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('hyper_copy_noindex', 'time', chunk_time_interval => 10, create_default_indexes => false);
+        create_hypertable        
+---------------------------------
+ (7,public,hyper_copy_noindex,t)
+(1 row)
+
+-- No trigger
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+    50
+(1 row)
+
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+   100
+(1 row)
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy_noindex;
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+   150
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (more chunks than MAX_PARTITION_BUFFERS).
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy_large" (
+    "time" timestamp NOT NULL,
+    "value" double precision NOT NULL
+);
+-- Genate data that will create more than 32 (MAX_PARTITION_BUFFERS)
+-- chunks on the 10 second chunk_time_interval partitioned hypertable.
+INSERT INTO hyper_copy_large
+SELECT time,
+random() AS value
+FROM
+generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 day',
+  INTERVAL '1 hour') AS g1(time)
+ORDER BY time;
+SELECT COUNT(*) FROM hyper_copy_large;
+ count 
+-------
+   697
+(1 row)
+
+-- Migrate data to chunks by using copy
+SELECT create_hypertable('hyper_copy_large', 'time',
+   chunk_time_interval => INTERVAL '1 hour', migrate_data => 'true');
+NOTICE:  migrating data to chunks
+       create_hypertable       
+-------------------------------
+ (8,public,hyper_copy_large,t)
+(1 row)
+
+SELECT COUNT(*) FROM hyper_copy_large;
+ count 
+-------
+   697
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (triggers on chunks).
+----------------------------------------------------------------
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+-- This trigger counts the already inserted tuples in
+-- the table table_with_chunk_trigger.
+CREATE OR REPLACE FUNCTION count_test_chunk_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+    cnt INTEGER;
+BEGIN
+    SELECT count(*) FROM table_with_chunk_trigger INTO cnt;
+    RAISE WARNING 'Trigger counted % tuples in table table_with_chunk_trigger', cnt;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1);
+           create_hypertable           
+---------------------------------------
+ (9,public,table_with_chunk_trigger,t)
+(1 row)
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    25
+(1 row)
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+-- Create before trigger on the 4th chunk
+CREATE TRIGGER table_with_chunk_trigger_before_trigger
+    BEFORE INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+-- Insert data
+-- 25 tuples are already imported. The trigger is executed before tuples 
+-- are copied into the 4th chunk. So, the trigger should report 25+3 = 28
+-- This test requires that the multi-insert buffers of the other chunks 
+-- are flushed before the trigger is executed. 
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+WARNING:  Trigger counted 28 tuples in table table_with_chunk_trigger
+RESET client_min_messages;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    50
+(1 row)
+
+DROP TRIGGER table_with_chunk_trigger_before_trigger ON :chunk_schema.:chunk_name;
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+-- Insert data
+-- 50 tuples are already imported. The trigger is executed after all 
+-- tuples are imported. So, the trigger should report 50+25 = 75
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+WARNING:  Trigger counted 75 tuples in table table_with_chunk_trigger
+RESET client_min_messages;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    75
+(1 row)
+
+-- Hypertable with after row trigger and no index
+DROP TABLE table_with_chunk_trigger;
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1, create_default_indexes => false);
+           create_hypertable            
+----------------------------------------
+ (10,public,table_with_chunk_trigger,t)
+(1 row)
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    25
+(1 row)
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+WARNING:  Trigger counted 50 tuples in table table_with_chunk_trigger
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    50
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Hypertable without before insert trigger)
+----------------------------------------------------------------
+CREATE TABLE "table_without_bf_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('table_without_bf_trigger', 'time', chunk_time_interval => 1);
+           create_hypertable            
+----------------------------------------
+ (11,public,table_without_bf_trigger,t)
+(1 row)
+
+-- Drop the default insert block trigger
+DROP TRIGGER ts_insert_blocker ON table_without_bf_trigger;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM table_without_bf_trigger;
+ count 
+-------
+    50
+(1 row)
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON table_without_bf_trigger
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger();
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM table_without_bf_trigger;
+ count 
+-------
+    75
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Chunks with different layouts)
+----------------------------------------------------------------
+-- Time is not the first attribute of the hypertable
+CREATE TABLE "table_with_layout_change" (
+    "value1" real NOT NULL DEFAULT 1,
+    "value2" smallint DEFAULT NULL,
+    "value3" bigint DEFAULT NULL,
+    "time" bigint NOT NULL,
+    "value4" double precision NOT NULL DEFAULT 4,
+    "value5" double precision NOT NULL DEFAULT 5
+);
+SELECT create_hypertable('table_with_layout_change', 'time', chunk_time_interval => 1);
+           create_hypertable            
+----------------------------------------
+ (12,public,table_with_layout_change,t)
+(1 row)
+
+-- Chunk 1 (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change;
+ value1 | value2 | value3 | time | value4 | value5 
+--------+--------+--------+------+--------+--------
+    100 |    200 |    300 |    1 |    400 |    500
+(1 row)
+
+-- Drop the first attribute
+ALTER TABLE table_with_layout_change DROP COLUMN value1;
+SELECT * FROM table_with_layout_change;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+(1 row)
+
+-- COPY into existing chunk (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+-- Create new chunk (time = 2)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+    201 |    301 |    1 |    401 |    501
+    202 |    302 |    2 |    402 |    502
+(3 rows)
+
+-- Create new chunk (time = 2), insert in different order
+COPY table_with_layout_change (time, value5, value4, value3, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+COPY table_with_layout_change (value5, value4, value3, value2, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+COPY table_with_layout_change (value5, value4, value3, time, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+    201 |    301 |    1 |    401 |    501
+    202 |    302 |    2 |    402 |    502
+    203 |    303 |    2 |    403 |    503
+    204 |    304 |    2 |    404 |    504
+    205 |    305 |    2 |    405 |    505
+(6 rows)
+
+-- Drop the last attribute and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value5;
+ALTER TABLE table_with_layout_change ADD COLUMN value6 double precision NOT NULL default 600;
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+ value2 | value3 | time | value4 | value6 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    600
+    201 |    301 |    1 |    401 |    600
+    202 |    302 |    2 |    402 |    600
+    203 |    303 |    2 |    403 |    600
+    204 |    304 |    2 |    404 |    600
+    205 |    305 |    2 |    405 |    600
+(6 rows)
+
+-- COPY in first chunk (time = 1)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in second chunk (time = 2)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in new chunk (time = 3)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in all chunks, different attribute order
+COPY table_with_layout_change (value3, value4, time, value6, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+ value2 | value3 | time | value4 | value6 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    600
+    201 |    301 |    1 |    401 |    600
+    206 |    306 |    1 |    406 |    606
+    211 |    311 |    1 |    411 |    611
+    202 |    302 |    2 |    402 |    600
+    203 |    303 |    2 |    403 |    600
+    204 |    304 |    2 |    404 |    600
+    205 |    305 |    2 |    405 |    600
+    207 |    307 |    2 |    407 |    607
+    210 |    310 |    2 |    410 |    610
+    208 |    308 |    3 |    408 |    608
+    209 |    309 |    3 |    409 |    609
+(12 rows)
+
+-- Drop first column
+ALTER TABLE table_with_layout_change DROP COLUMN value2;
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+ value3 | time | value4 | value6 
+--------+------+--------+--------
+    300 |    1 |    400 |    600
+    301 |    1 |    401 |    600
+    306 |    1 |    406 |    606
+    311 |    1 |    411 |    611
+    302 |    2 |    402 |    600
+    303 |    2 |    403 |    600
+    304 |    2 |    404 |    600
+    305 |    2 |    405 |    600
+    307 |    2 |    407 |    607
+    310 |    2 |    410 |    610
+    308 |    3 |    408 |    608
+    309 |    3 |    409 |    609
+(12 rows)
+
+-- COPY in all exiting chunks and create a new one (time 4)
+COPY table_with_layout_change (value3, value4, time, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+ value3 | time | value4 | value6 
+--------+------+--------+--------
+    300 |    1 |    400 |    600
+    301 |    1 |    401 |    600
+    306 |    1 |    406 |    606
+    311 |    1 |    411 |    611
+    315 |    1 |    415 |    615
+    302 |    2 |    402 |    600
+    303 |    2 |    403 |    600
+    304 |    2 |    404 |    600
+    305 |    2 |    405 |    600
+    307 |    2 |    407 |    607
+    310 |    2 |    410 |    610
+    313 |    2 |    413 |    613
+    308 |    3 |    408 |    608
+    309 |    3 |    409 |    609
+    312 |    3 |    412 |    612
+    314 |    4 |    414 |    614
+(16 rows)
+
+-- Drop the last two columns
+ALTER TABLE table_with_layout_change DROP COLUMN value4;
+ALTER TABLE table_with_layout_change DROP COLUMN value6;
+-- COPY in all exiting chunks and create a new one (time 5)
+COPY table_with_layout_change (value3, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value3;
+ value3 | time 
+--------+------
+    300 |    1
+    301 |    1
+    306 |    1
+    311 |    1
+    315 |    1
+    317 |    1
+    302 |    2
+    303 |    2
+    304 |    2
+    305 |    2
+    307 |    2
+    310 |    2
+    313 |    2
+    316 |    2
+    308 |    3
+    309 |    3
+    312 |    3
+    318 |    3
+    314 |    4
+    320 |    4
+    319 |    5
+(21 rows)
+
+-- Drop the last of the initial attributes and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value3;
+ALTER TABLE table_with_layout_change ADD COLUMN value7 double precision NOT NULL default 700;
+-- COPY in all exiting chunks and create a new one (time 6)
+COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value7;
+ time | value7 
+------+--------
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    722
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    721
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    723
+    4 |    700
+    4 |    700
+    4 |    726
+    5 |    700
+    5 |    724
+    6 |    725
+(27 rows)
+

--- a/test/expected/copy-13.out
+++ b/test/expected/copy-13.out
@@ -167,3 +167,544 @@ NOTICE:  hypertable data are in the chunks, no data will be copied
 COPY (SELECT * FROM hyper) TO STDOUT DELIMITER ',';
 1,1,1
 1,2,1
+----------------------------------------------------------------
+-- Testing multi-buffer optimization.
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+    create_hypertable    
+-------------------------
+ (6,public,hyper_copy,t)
+(1 row)
+
+-- First copy call with default client_min_messages, to get rid of the 
+-- building index "_hyper_XXX_chunk_hyper_copy_time_idx" on table "_hyper_XXX_chunk" serially
+-- messages
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+    50
+(1 row)
+
+-- Limit number of open chunks
+SET timescaledb.max_open_chunks_per_insert = 1;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+    75
+(1 row)
+
+-- Before trigger disable the multi-buffer optimization
+CREATE OR REPLACE FUNCTION empty_test_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   100
+(1 row)
+
+-- Suppress 'DEBUG:  EventTriggerInvoke XXXX' messages
+RESET client_min_messages;
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy;
+SET client_min_messages TO DEBUG1;
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   125
+(1 row)
+
+RESET client_min_messages;
+RESET timescaledb.max_open_chunks_per_insert;
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (no index on destination hypertable).
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy_noindex" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('hyper_copy_noindex', 'time', chunk_time_interval => 10, create_default_indexes => false);
+        create_hypertable        
+---------------------------------
+ (7,public,hyper_copy_noindex,t)
+(1 row)
+
+-- No trigger
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+    50
+(1 row)
+
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+   100
+(1 row)
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy_noindex;
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+   150
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (more chunks than MAX_PARTITION_BUFFERS).
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy_large" (
+    "time" timestamp NOT NULL,
+    "value" double precision NOT NULL
+);
+-- Genate data that will create more than 32 (MAX_PARTITION_BUFFERS)
+-- chunks on the 10 second chunk_time_interval partitioned hypertable.
+INSERT INTO hyper_copy_large
+SELECT time,
+random() AS value
+FROM
+generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 day',
+  INTERVAL '1 hour') AS g1(time)
+ORDER BY time;
+SELECT COUNT(*) FROM hyper_copy_large;
+ count 
+-------
+   697
+(1 row)
+
+-- Migrate data to chunks by using copy
+SELECT create_hypertable('hyper_copy_large', 'time',
+   chunk_time_interval => INTERVAL '1 hour', migrate_data => 'true');
+NOTICE:  migrating data to chunks
+       create_hypertable       
+-------------------------------
+ (8,public,hyper_copy_large,t)
+(1 row)
+
+SELECT COUNT(*) FROM hyper_copy_large;
+ count 
+-------
+   697
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (triggers on chunks).
+----------------------------------------------------------------
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+-- This trigger counts the already inserted tuples in
+-- the table table_with_chunk_trigger.
+CREATE OR REPLACE FUNCTION count_test_chunk_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+    cnt INTEGER;
+BEGIN
+    SELECT count(*) FROM table_with_chunk_trigger INTO cnt;
+    RAISE WARNING 'Trigger counted % tuples in table table_with_chunk_trigger', cnt;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1);
+           create_hypertable           
+---------------------------------------
+ (9,public,table_with_chunk_trigger,t)
+(1 row)
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    25
+(1 row)
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+-- Create before trigger on the 4th chunk
+CREATE TRIGGER table_with_chunk_trigger_before_trigger
+    BEFORE INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+-- Insert data
+-- 25 tuples are already imported. The trigger is executed before tuples 
+-- are copied into the 4th chunk. So, the trigger should report 25+3 = 28
+-- This test requires that the multi-insert buffers of the other chunks 
+-- are flushed before the trigger is executed. 
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+WARNING:  Trigger counted 28 tuples in table table_with_chunk_trigger
+RESET client_min_messages;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    50
+(1 row)
+
+DROP TRIGGER table_with_chunk_trigger_before_trigger ON :chunk_schema.:chunk_name;
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+-- Insert data
+-- 50 tuples are already imported. The trigger is executed after all 
+-- tuples are imported. So, the trigger should report 50+25 = 75
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+WARNING:  Trigger counted 75 tuples in table table_with_chunk_trigger
+RESET client_min_messages;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    75
+(1 row)
+
+-- Hypertable with after row trigger and no index
+DROP TABLE table_with_chunk_trigger;
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1, create_default_indexes => false);
+           create_hypertable            
+----------------------------------------
+ (10,public,table_with_chunk_trigger,t)
+(1 row)
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    25
+(1 row)
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+WARNING:  Trigger counted 50 tuples in table table_with_chunk_trigger
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    50
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Hypertable without before insert trigger)
+----------------------------------------------------------------
+CREATE TABLE "table_without_bf_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('table_without_bf_trigger', 'time', chunk_time_interval => 1);
+           create_hypertable            
+----------------------------------------
+ (11,public,table_without_bf_trigger,t)
+(1 row)
+
+-- Drop the default insert block trigger
+DROP TRIGGER ts_insert_blocker ON table_without_bf_trigger;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM table_without_bf_trigger;
+ count 
+-------
+    50
+(1 row)
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON table_without_bf_trigger
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger();
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM table_without_bf_trigger;
+ count 
+-------
+    75
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Chunks with different layouts)
+----------------------------------------------------------------
+-- Time is not the first attribute of the hypertable
+CREATE TABLE "table_with_layout_change" (
+    "value1" real NOT NULL DEFAULT 1,
+    "value2" smallint DEFAULT NULL,
+    "value3" bigint DEFAULT NULL,
+    "time" bigint NOT NULL,
+    "value4" double precision NOT NULL DEFAULT 4,
+    "value5" double precision NOT NULL DEFAULT 5
+);
+SELECT create_hypertable('table_with_layout_change', 'time', chunk_time_interval => 1);
+           create_hypertable            
+----------------------------------------
+ (12,public,table_with_layout_change,t)
+(1 row)
+
+-- Chunk 1 (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change;
+ value1 | value2 | value3 | time | value4 | value5 
+--------+--------+--------+------+--------+--------
+    100 |    200 |    300 |    1 |    400 |    500
+(1 row)
+
+-- Drop the first attribute
+ALTER TABLE table_with_layout_change DROP COLUMN value1;
+SELECT * FROM table_with_layout_change;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+(1 row)
+
+-- COPY into existing chunk (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+-- Create new chunk (time = 2)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+    201 |    301 |    1 |    401 |    501
+    202 |    302 |    2 |    402 |    502
+(3 rows)
+
+-- Create new chunk (time = 2), insert in different order
+COPY table_with_layout_change (time, value5, value4, value3, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+COPY table_with_layout_change (value5, value4, value3, value2, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+COPY table_with_layout_change (value5, value4, value3, time, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+    201 |    301 |    1 |    401 |    501
+    202 |    302 |    2 |    402 |    502
+    203 |    303 |    2 |    403 |    503
+    204 |    304 |    2 |    404 |    504
+    205 |    305 |    2 |    405 |    505
+(6 rows)
+
+-- Drop the last attribute and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value5;
+ALTER TABLE table_with_layout_change ADD COLUMN value6 double precision NOT NULL default 600;
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+ value2 | value3 | time | value4 | value6 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    600
+    201 |    301 |    1 |    401 |    600
+    202 |    302 |    2 |    402 |    600
+    203 |    303 |    2 |    403 |    600
+    204 |    304 |    2 |    404 |    600
+    205 |    305 |    2 |    405 |    600
+(6 rows)
+
+-- COPY in first chunk (time = 1)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in second chunk (time = 2)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in new chunk (time = 3)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in all chunks, different attribute order
+COPY table_with_layout_change (value3, value4, time, value6, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+ value2 | value3 | time | value4 | value6 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    600
+    201 |    301 |    1 |    401 |    600
+    206 |    306 |    1 |    406 |    606
+    211 |    311 |    1 |    411 |    611
+    202 |    302 |    2 |    402 |    600
+    203 |    303 |    2 |    403 |    600
+    204 |    304 |    2 |    404 |    600
+    205 |    305 |    2 |    405 |    600
+    207 |    307 |    2 |    407 |    607
+    210 |    310 |    2 |    410 |    610
+    208 |    308 |    3 |    408 |    608
+    209 |    309 |    3 |    409 |    609
+(12 rows)
+
+-- Drop first column
+ALTER TABLE table_with_layout_change DROP COLUMN value2;
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+ value3 | time | value4 | value6 
+--------+------+--------+--------
+    300 |    1 |    400 |    600
+    301 |    1 |    401 |    600
+    306 |    1 |    406 |    606
+    311 |    1 |    411 |    611
+    302 |    2 |    402 |    600
+    303 |    2 |    403 |    600
+    304 |    2 |    404 |    600
+    305 |    2 |    405 |    600
+    307 |    2 |    407 |    607
+    310 |    2 |    410 |    610
+    308 |    3 |    408 |    608
+    309 |    3 |    409 |    609
+(12 rows)
+
+-- COPY in all exiting chunks and create a new one (time 4)
+COPY table_with_layout_change (value3, value4, time, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+ value3 | time | value4 | value6 
+--------+------+--------+--------
+    300 |    1 |    400 |    600
+    301 |    1 |    401 |    600
+    306 |    1 |    406 |    606
+    311 |    1 |    411 |    611
+    315 |    1 |    415 |    615
+    302 |    2 |    402 |    600
+    303 |    2 |    403 |    600
+    304 |    2 |    404 |    600
+    305 |    2 |    405 |    600
+    307 |    2 |    407 |    607
+    310 |    2 |    410 |    610
+    313 |    2 |    413 |    613
+    308 |    3 |    408 |    608
+    309 |    3 |    409 |    609
+    312 |    3 |    412 |    612
+    314 |    4 |    414 |    614
+(16 rows)
+
+-- Drop the last two columns
+ALTER TABLE table_with_layout_change DROP COLUMN value4;
+ALTER TABLE table_with_layout_change DROP COLUMN value6;
+-- COPY in all exiting chunks and create a new one (time 5)
+COPY table_with_layout_change (value3, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value3;
+ value3 | time 
+--------+------
+    300 |    1
+    301 |    1
+    306 |    1
+    311 |    1
+    315 |    1
+    317 |    1
+    302 |    2
+    303 |    2
+    304 |    2
+    305 |    2
+    307 |    2
+    310 |    2
+    313 |    2
+    316 |    2
+    308 |    3
+    309 |    3
+    312 |    3
+    318 |    3
+    314 |    4
+    320 |    4
+    319 |    5
+(21 rows)
+
+-- Drop the last of the initial attributes and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value3;
+ALTER TABLE table_with_layout_change ADD COLUMN value7 double precision NOT NULL default 700;
+-- COPY in all exiting chunks and create a new one (time 6)
+COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value7;
+ time | value7 
+------+--------
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    722
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    721
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    723
+    4 |    700
+    4 |    700
+    4 |    726
+    5 |    700
+    5 |    724
+    6 |    725
+(27 rows)
+

--- a/test/expected/copy-14.out
+++ b/test/expected/copy-14.out
@@ -167,3 +167,544 @@ NOTICE:  hypertable data are in the chunks, no data will be copied
 COPY (SELECT * FROM hyper) TO STDOUT DELIMITER ',';
 1,1,1
 1,2,1
+----------------------------------------------------------------
+-- Testing multi-buffer optimization.
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+    create_hypertable    
+-------------------------
+ (6,public,hyper_copy,t)
+(1 row)
+
+-- First copy call with default client_min_messages, to get rid of the 
+-- building index "_hyper_XXX_chunk_hyper_copy_time_idx" on table "_hyper_XXX_chunk" serially
+-- messages
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+    50
+(1 row)
+
+-- Limit number of open chunks
+SET timescaledb.max_open_chunks_per_insert = 1;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+    75
+(1 row)
+
+-- Before trigger disable the multi-buffer optimization
+CREATE OR REPLACE FUNCTION empty_test_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   100
+(1 row)
+
+-- Suppress 'DEBUG:  EventTriggerInvoke XXXX' messages
+RESET client_min_messages;
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy;
+SET client_min_messages TO DEBUG1;
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   125
+(1 row)
+
+RESET client_min_messages;
+RESET timescaledb.max_open_chunks_per_insert;
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (no index on destination hypertable).
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy_noindex" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('hyper_copy_noindex', 'time', chunk_time_interval => 10, create_default_indexes => false);
+        create_hypertable        
+---------------------------------
+ (7,public,hyper_copy_noindex,t)
+(1 row)
+
+-- No trigger
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+    50
+(1 row)
+
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using normal unbuffered copy operation (CIM_SINGLE) because triggers are defined on the destination table.
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+   100
+(1 row)
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy_noindex;
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM hyper_copy_noindex;
+ count 
+-------
+   150
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (more chunks than MAX_PARTITION_BUFFERS).
+----------------------------------------------------------------
+CREATE TABLE "hyper_copy_large" (
+    "time" timestamp NOT NULL,
+    "value" double precision NOT NULL
+);
+-- Genate data that will create more than 32 (MAX_PARTITION_BUFFERS)
+-- chunks on the 10 second chunk_time_interval partitioned hypertable.
+INSERT INTO hyper_copy_large
+SELECT time,
+random() AS value
+FROM
+generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 day',
+  INTERVAL '1 hour') AS g1(time)
+ORDER BY time;
+SELECT COUNT(*) FROM hyper_copy_large;
+ count 
+-------
+   697
+(1 row)
+
+-- Migrate data to chunks by using copy
+SELECT create_hypertable('hyper_copy_large', 'time',
+   chunk_time_interval => INTERVAL '1 hour', migrate_data => 'true');
+NOTICE:  migrating data to chunks
+       create_hypertable       
+-------------------------------
+ (8,public,hyper_copy_large,t)
+(1 row)
+
+SELECT COUNT(*) FROM hyper_copy_large;
+ count 
+-------
+   697
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (triggers on chunks).
+----------------------------------------------------------------
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+-- This trigger counts the already inserted tuples in
+-- the table table_with_chunk_trigger.
+CREATE OR REPLACE FUNCTION count_test_chunk_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+    cnt INTEGER;
+BEGIN
+    SELECT count(*) FROM table_with_chunk_trigger INTO cnt;
+    RAISE WARNING 'Trigger counted % tuples in table table_with_chunk_trigger', cnt;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1);
+           create_hypertable           
+---------------------------------------
+ (9,public,table_with_chunk_trigger,t)
+(1 row)
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    25
+(1 row)
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+-- Create before trigger on the 4th chunk
+CREATE TRIGGER table_with_chunk_trigger_before_trigger
+    BEFORE INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+-- Insert data
+-- 25 tuples are already imported. The trigger is executed before tuples 
+-- are copied into the 4th chunk. So, the trigger should report 25+3 = 28
+-- This test requires that the multi-insert buffers of the other chunks 
+-- are flushed before the trigger is executed. 
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+WARNING:  Trigger counted 28 tuples in table table_with_chunk_trigger
+RESET client_min_messages;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    50
+(1 row)
+
+DROP TRIGGER table_with_chunk_trigger_before_trigger ON :chunk_schema.:chunk_name;
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+-- Insert data
+-- 50 tuples are already imported. The trigger is executed after all 
+-- tuples are imported. So, the trigger should report 50+25 = 75
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+WARNING:  Trigger counted 75 tuples in table table_with_chunk_trigger
+RESET client_min_messages;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    75
+(1 row)
+
+-- Hypertable with after row trigger and no index
+DROP TABLE table_with_chunk_trigger;
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1, create_default_indexes => false);
+           create_hypertable            
+----------------------------------------
+ (10,public,table_with_chunk_trigger,t)
+(1 row)
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    25
+(1 row)
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+WARNING:  Trigger counted 50 tuples in table table_with_chunk_trigger
+SELECT count(*) FROM table_with_chunk_trigger;
+ count 
+-------
+    50
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Hypertable without before insert trigger)
+----------------------------------------------------------------
+CREATE TABLE "table_without_bf_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+SELECT create_hypertable('table_without_bf_trigger', 'time', chunk_time_interval => 1);
+           create_hypertable            
+----------------------------------------
+ (11,public,table_without_bf_trigger,t)
+(1 row)
+
+-- Drop the default insert block trigger
+DROP TRIGGER ts_insert_blocker ON table_without_bf_trigger;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM table_without_bf_trigger;
+ count 
+-------
+    50
+(1 row)
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON table_without_bf_trigger
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger();
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+RESET client_min_messages;
+SELECT count(*) FROM table_without_bf_trigger;
+ count 
+-------
+    75
+(1 row)
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Chunks with different layouts)
+----------------------------------------------------------------
+-- Time is not the first attribute of the hypertable
+CREATE TABLE "table_with_layout_change" (
+    "value1" real NOT NULL DEFAULT 1,
+    "value2" smallint DEFAULT NULL,
+    "value3" bigint DEFAULT NULL,
+    "time" bigint NOT NULL,
+    "value4" double precision NOT NULL DEFAULT 4,
+    "value5" double precision NOT NULL DEFAULT 5
+);
+SELECT create_hypertable('table_with_layout_change', 'time', chunk_time_interval => 1);
+           create_hypertable            
+----------------------------------------
+ (12,public,table_with_layout_change,t)
+(1 row)
+
+-- Chunk 1 (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change;
+ value1 | value2 | value3 | time | value4 | value5 
+--------+--------+--------+------+--------+--------
+    100 |    200 |    300 |    1 |    400 |    500
+(1 row)
+
+-- Drop the first attribute
+ALTER TABLE table_with_layout_change DROP COLUMN value1;
+SELECT * FROM table_with_layout_change;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+(1 row)
+
+-- COPY into existing chunk (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+-- Create new chunk (time = 2)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+    201 |    301 |    1 |    401 |    501
+    202 |    302 |    2 |    402 |    502
+(3 rows)
+
+-- Create new chunk (time = 2), insert in different order
+COPY table_with_layout_change (time, value5, value4, value3, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+COPY table_with_layout_change (value5, value4, value3, value2, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+COPY table_with_layout_change (value5, value4, value3, time, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+ value2 | value3 | time | value4 | value5 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    500
+    201 |    301 |    1 |    401 |    501
+    202 |    302 |    2 |    402 |    502
+    203 |    303 |    2 |    403 |    503
+    204 |    304 |    2 |    404 |    504
+    205 |    305 |    2 |    405 |    505
+(6 rows)
+
+-- Drop the last attribute and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value5;
+ALTER TABLE table_with_layout_change ADD COLUMN value6 double precision NOT NULL default 600;
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+ value2 | value3 | time | value4 | value6 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    600
+    201 |    301 |    1 |    401 |    600
+    202 |    302 |    2 |    402 |    600
+    203 |    303 |    2 |    403 |    600
+    204 |    304 |    2 |    404 |    600
+    205 |    305 |    2 |    405 |    600
+(6 rows)
+
+-- COPY in first chunk (time = 1)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in second chunk (time = 2)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in new chunk (time = 3)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+-- COPY in all chunks, different attribute order
+COPY table_with_layout_change (value3, value4, time, value6, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+ value2 | value3 | time | value4 | value6 
+--------+--------+------+--------+--------
+    200 |    300 |    1 |    400 |    600
+    201 |    301 |    1 |    401 |    600
+    206 |    306 |    1 |    406 |    606
+    211 |    311 |    1 |    411 |    611
+    202 |    302 |    2 |    402 |    600
+    203 |    303 |    2 |    403 |    600
+    204 |    304 |    2 |    404 |    600
+    205 |    305 |    2 |    405 |    600
+    207 |    307 |    2 |    407 |    607
+    210 |    310 |    2 |    410 |    610
+    208 |    308 |    3 |    408 |    608
+    209 |    309 |    3 |    409 |    609
+(12 rows)
+
+-- Drop first column
+ALTER TABLE table_with_layout_change DROP COLUMN value2;
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+ value3 | time | value4 | value6 
+--------+------+--------+--------
+    300 |    1 |    400 |    600
+    301 |    1 |    401 |    600
+    306 |    1 |    406 |    606
+    311 |    1 |    411 |    611
+    302 |    2 |    402 |    600
+    303 |    2 |    403 |    600
+    304 |    2 |    404 |    600
+    305 |    2 |    405 |    600
+    307 |    2 |    407 |    607
+    310 |    2 |    410 |    610
+    308 |    3 |    408 |    608
+    309 |    3 |    409 |    609
+(12 rows)
+
+-- COPY in all exiting chunks and create a new one (time 4)
+COPY table_with_layout_change (value3, value4, time, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+ value3 | time | value4 | value6 
+--------+------+--------+--------
+    300 |    1 |    400 |    600
+    301 |    1 |    401 |    600
+    306 |    1 |    406 |    606
+    311 |    1 |    411 |    611
+    315 |    1 |    415 |    615
+    302 |    2 |    402 |    600
+    303 |    2 |    403 |    600
+    304 |    2 |    404 |    600
+    305 |    2 |    405 |    600
+    307 |    2 |    407 |    607
+    310 |    2 |    410 |    610
+    313 |    2 |    413 |    613
+    308 |    3 |    408 |    608
+    309 |    3 |    409 |    609
+    312 |    3 |    412 |    612
+    314 |    4 |    414 |    614
+(16 rows)
+
+-- Drop the last two columns
+ALTER TABLE table_with_layout_change DROP COLUMN value4;
+ALTER TABLE table_with_layout_change DROP COLUMN value6;
+-- COPY in all exiting chunks and create a new one (time 5)
+COPY table_with_layout_change (value3, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value3;
+ value3 | time 
+--------+------
+    300 |    1
+    301 |    1
+    306 |    1
+    311 |    1
+    315 |    1
+    317 |    1
+    302 |    2
+    303 |    2
+    304 |    2
+    305 |    2
+    307 |    2
+    310 |    2
+    313 |    2
+    316 |    2
+    308 |    3
+    309 |    3
+    312 |    3
+    318 |    3
+    314 |    4
+    320 |    4
+    319 |    5
+(21 rows)
+
+-- Drop the last of the initial attributes and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value3;
+ALTER TABLE table_with_layout_change ADD COLUMN value7 double precision NOT NULL default 700;
+-- COPY in all exiting chunks and create a new one (time 6)
+COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+SELECT * FROM table_with_layout_change ORDER BY time, value7;
+ time | value7 
+------+--------
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    700
+    1 |    722
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    700
+    2 |    721
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    700
+    3 |    723
+    4 |    700
+    4 |    700
+    4 |    726
+    5 |    700
+    5 |    724
+    6 |    725
+(27 rows)
+

--- a/test/sql/copy.sql.in
+++ b/test/sql/copy.sql.in
@@ -111,3 +111,403 @@ COPY hyper TO STDOUT DELIMITER ',';
 -- notice.
 COPY (SELECT * FROM hyper) TO STDOUT DELIMITER ',';
 
+----------------------------------------------------------------
+-- Testing multi-buffer optimization.
+----------------------------------------------------------------
+
+CREATE TABLE "hyper_copy" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+
+-- First copy call with default client_min_messages, to get rid of the 
+-- building index "_hyper_XXX_chunk_hyper_copy_time_idx" on table "_hyper_XXX_chunk" serially
+-- messages
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+
+SELECT count(*) FROM hyper_copy;
+
+-- Limit number of open chunks
+
+SET timescaledb.max_open_chunks_per_insert = 1;
+
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+
+SELECT count(*) FROM hyper_copy;
+
+-- Before trigger disable the multi-buffer optimization
+
+CREATE OR REPLACE FUNCTION empty_test_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+
+SELECT count(*) FROM hyper_copy;
+
+-- Suppress 'DEBUG:  EventTriggerInvoke XXXX' messages
+RESET client_min_messages;
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy;
+SET client_min_messages TO DEBUG1;
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+
+\copy hyper_copy FROM data/copy_data.csv WITH csv header;
+
+SELECT count(*) FROM hyper_copy;
+
+RESET client_min_messages;
+RESET timescaledb.max_open_chunks_per_insert;
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (no index on destination hypertable).
+----------------------------------------------------------------
+
+CREATE TABLE "hyper_copy_noindex" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+
+SELECT create_hypertable('hyper_copy_noindex', 'time', chunk_time_interval => 10, create_default_indexes => false);
+
+-- No trigger
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+RESET client_min_messages;
+
+SELECT count(*) FROM hyper_copy_noindex;
+
+-- Before trigger (CIM_SINGLE should be used)
+CREATE TRIGGER hyper_copy_trigger_insert_before
+    BEFORE INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+RESET client_min_messages;
+
+SELECT count(*) FROM hyper_copy_noindex;
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+DROP TRIGGER hyper_copy_trigger_insert_before ON hyper_copy_noindex;
+CREATE TRIGGER hyper_copy_trigger_insert_after
+    AFTER INSERT ON hyper_copy_noindex
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+
+SET client_min_messages TO DEBUG1;
+\copy hyper_copy_noindex FROM data/copy_data.csv WITH csv header;
+RESET client_min_messages;
+
+SELECT count(*) FROM hyper_copy_noindex;
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (more chunks than MAX_PARTITION_BUFFERS).
+----------------------------------------------------------------
+
+CREATE TABLE "hyper_copy_large" (
+    "time" timestamp NOT NULL,
+    "value" double precision NOT NULL
+);
+
+-- Genate data that will create more than 32 (MAX_PARTITION_BUFFERS)
+-- chunks on the 10 second chunk_time_interval partitioned hypertable.
+INSERT INTO hyper_copy_large
+SELECT time,
+random() AS value
+FROM
+generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 day',
+  INTERVAL '1 hour') AS g1(time)
+ORDER BY time;
+
+SELECT COUNT(*) FROM hyper_copy_large;
+
+-- Migrate data to chunks by using copy
+SELECT create_hypertable('hyper_copy_large', 'time',
+   chunk_time_interval => INTERVAL '1 hour', migrate_data => 'true');
+
+SELECT COUNT(*) FROM hyper_copy_large;
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (triggers on chunks).
+----------------------------------------------------------------
+
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+
+-- This trigger counts the already inserted tuples in
+-- the table table_with_chunk_trigger.
+CREATE OR REPLACE FUNCTION count_test_chunk_trigger()
+    RETURNS TRIGGER LANGUAGE PLPGSQL AS
+$BODY$
+DECLARE
+    cnt INTEGER;
+BEGIN
+    SELECT count(*) FROM table_with_chunk_trigger INTO cnt;
+    RAISE WARNING 'Trigger counted % tuples in table table_with_chunk_trigger', cnt;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END
+$BODY$;
+
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1);
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+
+-- Create before trigger on the 4th chunk
+CREATE TRIGGER table_with_chunk_trigger_before_trigger
+    BEFORE INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+
+-- Insert data
+-- 25 tuples are already imported. The trigger is executed before tuples 
+-- are copied into the 4th chunk. So, the trigger should report 25+3 = 28
+-- This test requires that the multi-insert buffers of the other chunks 
+-- are flushed before the trigger is executed. 
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+RESET client_min_messages;
+
+SELECT count(*) FROM table_with_chunk_trigger;
+DROP TRIGGER table_with_chunk_trigger_before_trigger ON :chunk_schema.:chunk_name;
+
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+
+-- Insert data
+-- 50 tuples are already imported. The trigger is executed after all 
+-- tuples are imported. So, the trigger should report 50+25 = 75
+SET client_min_messages TO DEBUG1;
+\copy table_with_chunk_trigger FROM data/copy_data.csv WITH csv header;
+RESET client_min_messages;
+
+SELECT count(*) FROM table_with_chunk_trigger;
+
+-- Hypertable with after row trigger and no index
+DROP TABLE table_with_chunk_trigger;
+CREATE TABLE "table_with_chunk_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+
+-- Create hypertable and chunks
+SELECT create_hypertable('table_with_chunk_trigger', 'time', chunk_time_interval => 1, create_default_indexes => false);
+
+-- Insert data to create all missing chunks
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+
+-- Chunk 1: 1-2, Chunk 2: 2-3, Chunk 3: 3-4, Chunk 4: 4-5
+SELECT chunk_schema, chunk_name FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'table_with_chunk_trigger' AND range_end_integer=5 \gset
+
+-- Create after trigger
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON :chunk_schema.:chunk_name
+    FOR EACH ROW EXECUTE FUNCTION count_test_chunk_trigger();
+
+\copy table_with_chunk_trigger from data/copy_data.csv with csv header;
+SELECT count(*) FROM table_with_chunk_trigger;
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Hypertable without before insert trigger)
+----------------------------------------------------------------
+CREATE TABLE "table_without_bf_trigger" (
+    "time" bigint NOT NULL,
+    "value" double precision NOT NULL
+);
+
+SELECT create_hypertable('table_without_bf_trigger', 'time', chunk_time_interval => 1);
+
+-- Drop the default insert block trigger
+DROP TRIGGER ts_insert_blocker ON table_without_bf_trigger;
+
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+RESET client_min_messages;
+
+SELECT count(*) FROM table_without_bf_trigger;
+
+-- After trigger (CIM_MULTI_CONDITIONAL should be used)
+CREATE TRIGGER table_with_chunk_trigger_after_trigger
+    AFTER INSERT ON table_without_bf_trigger
+    FOR EACH ROW EXECUTE FUNCTION empty_test_trigger();
+
+SET client_min_messages TO DEBUG1;
+\copy table_without_bf_trigger from data/copy_data.csv with csv header;
+RESET client_min_messages;
+
+SELECT count(*) FROM table_without_bf_trigger;
+
+----------------------------------------------------------------
+-- Testing multi-buffer optimization
+-- (Chunks with different layouts)
+----------------------------------------------------------------
+-- Time is not the first attribute of the hypertable
+
+CREATE TABLE "table_with_layout_change" (
+    "value1" real NOT NULL DEFAULT 1,
+    "value2" smallint DEFAULT NULL,
+    "value3" bigint DEFAULT NULL,
+    "time" bigint NOT NULL,
+    "value4" double precision NOT NULL DEFAULT 4,
+    "value5" double precision NOT NULL DEFAULT 5
+);
+
+SELECT create_hypertable('table_with_layout_change', 'time', chunk_time_interval => 1);
+
+-- Chunk 1 (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+100,200,300,1,400,500
+\.
+
+SELECT * FROM table_with_layout_change;
+
+-- Drop the first attribute
+ALTER TABLE table_with_layout_change DROP COLUMN value1;
+SELECT * FROM table_with_layout_change;
+
+-- COPY into existing chunk (time = 1)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+201,301,1,401,501
+\.
+
+-- Create new chunk (time = 2)
+COPY table_with_layout_change FROM STDIN DELIMITER ',' NULL AS 'null';
+202,302,2,402,502
+\.
+
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+
+-- Create new chunk (time = 2), insert in different order
+COPY table_with_layout_change (time, value5, value4, value3, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+2,503,403,303,203
+\.
+
+COPY table_with_layout_change (value5, value4, value3, value2, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+504,404,304,204,2
+\.
+
+COPY table_with_layout_change (value5, value4, value3, time, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+505,405,305,2,205
+\.
+
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value5;
+
+-- Drop the last attribute and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value5;
+ALTER TABLE table_with_layout_change ADD COLUMN value6 double precision NOT NULL default 600;
+
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+
+-- COPY in first chunk (time = 1)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+1,206,306,406,606 
+\.
+
+-- COPY in second chunk (time = 2)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+2,207,307,407,607
+\.
+
+-- COPY in new chunk (time = 3)
+COPY table_with_layout_change (time, value2, value3, value4, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+3,208,308,408,608
+\.
+
+-- COPY in all chunks, different attribute order
+COPY table_with_layout_change (value3, value4, time, value6, value2) FROM STDIN DELIMITER ',' NULL AS 'null';
+309,409,3,609,209
+310,410,2,610,210
+311,411,1,611,211
+\.
+
+SELECT * FROM table_with_layout_change ORDER BY time, value2, value3, value4, value6;
+
+-- Drop first column
+ALTER TABLE table_with_layout_change DROP COLUMN value2;
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+
+-- COPY in all exiting chunks and create a new one (time 4)
+COPY table_with_layout_change (value3, value4, time, value6) FROM STDIN DELIMITER ',' NULL AS 'null';
+312,412,3,612
+313,413,2,613
+314,414,4,614
+315,415,1,615
+\.
+
+SELECT * FROM table_with_layout_change ORDER BY time, value3, value4, value6;
+
+-- Drop the last two columns
+ALTER TABLE table_with_layout_change DROP COLUMN value4;
+ALTER TABLE table_with_layout_change DROP COLUMN value6;
+
+-- COPY in all exiting chunks and create a new one (time 5)
+COPY table_with_layout_change (value3, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+316,2
+317,1
+318,3
+319,5
+320,4
+\.
+
+SELECT * FROM table_with_layout_change ORDER BY time, value3;
+
+-- Drop the last of the initial attributes and add a new one
+ALTER TABLE table_with_layout_change DROP COLUMN value3;
+ALTER TABLE table_with_layout_change ADD COLUMN value7 double precision NOT NULL default 700;
+
+-- COPY in all exiting chunks and create a new one (time 6)
+COPY table_with_layout_change (value7, time) FROM STDIN DELIMITER ',' NULL AS 'null';
+721,2
+722,1
+723,3
+724,5
+725,6
+726,4
+\.
+
+SELECT * FROM table_with_layout_change ORDER BY time, value7;
+


### PR DESCRIPTION
This commit backports the Postgres upstream multi-buffer / bulk insert
optimization into the timescale copy operator. If the target chunk
allows it (e.g., if no triggers are defined on the hypertable or the
chunk is not compressed), the data is stored in in-memory buffers
first and then flushed to the chunks in bulk operations.

The `CopyMulti*` functions are based on the [PG 14 source code](https://github.com/postgres/postgres/blob/REL_14_STABLE/src/backend/commands/copyfrom.c)
and adapted to work with hypertables and chunks.

Implements: #4080

For posterity, the benchmarks are here: https://docs.google.com/document/d/1qi44rQOcagirCBTWorB5ht1useZpzdgvhBVECkOQUPg/edit //akuzm