### PR TITLE
Support non-superuser move chunk operations

### DIFF
--- a/sql/ddl_experimental.sql
+++ b/sql/ddl_experimental.sql
@@ -35,6 +35,10 @@ CREATE OR REPLACE PROCEDURE timescaledb_experimental.copy_chunk(
     operation_id NAME = NULL)
 AS '@MODULE_PATHNAME@', 'ts_copy_chunk_proc' LANGUAGE C;
 
+CREATE OR REPLACE FUNCTION timescaledb_experimental.subscription_exec(
+    subscription_command TEXT
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_subscription_exec' LANGUAGE C VOLATILE;
+
 -- A copy_chunk or move_chunk procedure call involves multiple nodes and
 -- depending on the data size can take a long time. Failures are possible
 -- when this long running activity is ongoing. We need to be able to recover

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -90,3 +90,7 @@ ALTER TABLE _timescaledb_catalog.continuous_agg
 DROP PROCEDURE IF EXISTS timescaledb_experimental.move_chunk(REGCLASS, NAME, NAME);
 
 DROP PROCEDURE IF EXISTS timescaledb_experimental.copy_chunk(REGCLASS, NAME, NAME);
+
+CREATE OR REPLACE FUNCTION timescaledb_experimental.subscription_exec(
+    subscription_command TEXT
+) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_subscription_exec' LANGUAGE C VOLATILE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -105,3 +105,4 @@ ANALYZE _timescaledb_catalog.continuous_agg;
 
 DROP PROCEDURE timescaledb_experimental.move_chunk(REGCLASS, NAME, NAME, NAME);
 DROP PROCEDURE timescaledb_experimental.copy_chunk(REGCLASS, NAME, NAME, NAME);
+DROP FUNCTION IF EXISTS timescaledb_experimental.subscription_exec(TEXT);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -47,6 +47,7 @@ CROSSMODULE_WRAPPER(move_chunk);
 CROSSMODULE_WRAPPER(move_chunk_proc);
 CROSSMODULE_WRAPPER(copy_chunk_proc);
 CROSSMODULE_WRAPPER(copy_chunk_cleanup_proc);
+CROSSMODULE_WRAPPER(subscription_exec);
 
 /* partialize/finalize aggregate */
 CROSSMODULE_WRAPPER(partialize_agg);
@@ -374,6 +375,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.move_chunk_proc = error_no_default_fn_pg_community,
 	.copy_chunk_proc = error_no_default_fn_pg_community,
 	.copy_chunk_cleanup_proc = error_no_default_fn_pg_community,
+	.subscription_exec = error_no_default_fn_pg_community,
 	.reorder_chunk = error_no_default_fn_pg_community,
 
 	.partialize_agg = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -81,6 +81,7 @@ typedef struct CrossModuleFunctions
 	PGFunction move_chunk;
 	PGFunction move_chunk_proc;
 	PGFunction copy_chunk_proc;
+	PGFunction subscription_exec;
 	PGFunction copy_chunk_cleanup_proc;
 	void (*ddl_command_start)(ProcessUtilityArgs *args);
 	void (*ddl_command_end)(EventTriggerData *command);

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -127,6 +127,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.move_chunk_proc = tsl_move_chunk_proc,
 	.copy_chunk_proc = tsl_copy_chunk_proc,
 	.copy_chunk_cleanup_proc = tsl_copy_chunk_cleanup_proc,
+	.subscription_exec = tsl_subscription_exec,
 
 	/* Continuous Aggregates */
 	.partialize_agg = tsl_partialize_agg,

--- a/tsl/src/reorder.h
+++ b/tsl/src/reorder.h
@@ -14,6 +14,7 @@ extern Datum tsl_move_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_move_chunk_proc(PG_FUNCTION_ARGS);
 extern Datum tsl_copy_chunk_proc(PG_FUNCTION_ARGS);
 extern Datum tsl_copy_chunk_cleanup_proc(PG_FUNCTION_ARGS);
+extern Datum tsl_subscription_exec(PG_FUNCTION_ARGS);
 extern void reorder_chunk(Oid chunk_id, Oid index_id, bool verbose, Oid wait_id,
 						  Oid destination_tablespace, Oid index_tablespace);
 

--- a/tsl/test/expected/dist_move_chunk.out
+++ b/tsl/test/expected/dist_move_chunk.out
@@ -133,7 +133,7 @@ ROLLBACK;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_1_chunk', source_node=> 'data_node_1', destination_node => 'data_node_2');
-ERROR:  must be superuser to copy/move chunk to data node
+ERROR:  must be superuser or replication role to copy/move chunk to data node
 \set ON_ERROR_STOP 1
 SET ROLE :ROLE_1;
 -- can't run copy/move chunk on a data node

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -209,6 +209,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  timescaledb_experimental.cleanup_copy_chunk_operation(name)
  timescaledb_experimental.copy_chunk(regclass,name,name,name)
  timescaledb_experimental.move_chunk(regclass,name,name,name)
+ timescaledb_experimental.subscription_exec(text)
  timescaledb_experimental.time_bucket_ng(interval,date)
  timescaledb_experimental.time_bucket_ng(interval,date,date)
  timescaledb_experimental.time_bucket_ng(interval,timestamp with time zone)

--- a/tsl/test/t/002_chunk_copy_move.pl
+++ b/tsl/test/t/002_chunk_copy_move.pl
@@ -8,7 +8,7 @@ use warnings;
 use AccessNode;
 use DataNode;
 use TestLib;
-use Test::More tests => 272;
+use Test::More tests => 274;
 
 #Initialize all the multi-node instances
 my $an  = AccessNode->create('an');
@@ -83,9 +83,45 @@ while ($curr_index < $arrSize)
 	$curr_index++;
 }
 
+for my $node ($an, $dn1, $dn2)
+{
+	$node->safe_psql('postgres', "CREATE ROLE testrole LOGIN");
+}
+
+#Error out the move if user doesn't have superuser nor replication perms
+($ret, $stdout, $stderr) = $an->psql('postgres',
+	"SET ROLE testrole; CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_1_chunk', source_node=> 'dn1', destination_node => 'dn2')"
+);
+
+like(
+	$stderr,
+	qr/must be superuser or replication role to copy\/move chunk to data node/,
+	'Expected failure due to no credentials');
+
+#Provide REPLICATION creds to this user now
+for my $node ($an, $dn1, $dn2)
+{
+	$node->safe_psql('postgres', "ALTER ROLE testrole REPLICATION;");
+}
+
+#Check that function errors out if any non SUBSCRIPTON command is passed to it
+($ret, $stdout, $stderr) = $an->psql('postgres',
+	"SET ROLE testrole; SELECT timescaledb_experimental.subscription_exec('DROP ROLE testrole')"
+);
+
+like(
+	$stderr,
+	qr/this function only accepts SUBSCRIPTION commands/,
+	'Expected failure due to wrong command to function');
+
+#Also grant it ownership of the table and related permissions
+$an->safe_psql('postgres',
+	"ALTER TABLE test OWNER TO testrole; GRANT ALL PRIVILEGES ON DATABASE postgres TO testrole; GRANT USAGE, SELECT ON SEQUENCE _timescaledb_catalog.chunk_copy_operation_id_seq TO testrole; GRANT USAGE ON FOREIGN SERVER dn1, dn2 TO testrole;"
+);
+
 #Move chunk _timescaledb_internal._dist_hyper_1_1_chunk to DN2 from AN
 $an->safe_psql('postgres',
-	"CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_1_chunk', source_node=> 'dn1', destination_node => 'dn2')"
+	"SET ROLE testrole; CALL timescaledb_experimental.move_chunk(chunk=>'_timescaledb_internal._dist_hyper_1_1_chunk', source_node=> 'dn1', destination_node => 'dn2')"
 );
 
 #Query datanode1 after the above move


### PR DESCRIPTION
The non-superuser needs to have REPLICATION privileges atleast. A
new function "subscription_cmd" has been added to allow running
subscription related commands on datanodes. This function implicitly
upgrades to the bootstrapped superuser and then performs subscription
creation/alteration/deletion commands. It only accepts subscriptions
related commands and errors out otherwise.