### PR TITLE
Update dump_meta_data.sql

### DIFF
--- a/scripts/dump_meta_data.sql
+++ b/scripts/dump_meta_data.sql
@@ -56,6 +56,7 @@ SELECT hypertable,
               AND pns.oid = pgc.relnamespace
               AND pns.nspname = h.schema_name
               AND relkind = 'r'
+              AND c.dropped is false
               GROUP BY pgc.oid
               ) sub1
        ) sub2;
@@ -102,6 +103,7 @@ SELECT *,
              AND c.id = cc.chunk_id
              AND cc.dimension_slice_id = ds.id
              AND ds.dimension_id = d.id
+             AND c.dropped is false
        GROUP BY c.id, pgc.reltoastrelid, pgc.oid ORDER BY c.id
        ) sub1
 ) sub2;

--- a/test/expected/dump_meta.out
+++ b/test/expected/dump_meta.out
@@ -130,6 +130,7 @@ SELECT hypertable,
               AND pns.oid = pgc.relnamespace
               AND pns.nspname = h.schema_name
               AND relkind = 'r'
+              AND c.dropped is false
               GROUP BY pgc.oid
               ) sub1
        ) sub2;
@@ -181,6 +182,7 @@ SELECT *,
              AND c.id = cc.chunk_id
              AND cc.dimension_slice_id = ds.id
              AND ds.dimension_id = d.id
+             AND c.dropped is false
        GROUP BY c.id, pgc.reltoastrelid, pgc.oid ORDER BY c.id
        ) sub1
 ) sub2;


### PR DESCRIPTION
Added `c.dropped is false ` for table _timescaledb_catalog.chunk to skip dropped chunks in the size calculation.