### PR TITLE
Telemetry Stats for CAggs finals form

### DIFF
--- a/src/telemetry/stats.c
+++ b/src/telemetry/stats.c
@@ -266,6 +266,9 @@ process_continuous_agg(CaggStats *cs, Form_pg_class class, const ContinuousAgg *
 
 	if (!cagg->data.materialized_only)
 		cs->uses_real_time_aggregation_count++;
+
+	if (ContinuousAggIsFinalized(cagg))
+		cs->finalized++;
 }
 
 static void

--- a/src/telemetry/stats.h
+++ b/src/telemetry/stats.h
@@ -75,6 +75,7 @@ typedef struct CaggStats
 	HyperStats hyp; /* "hyper" as field name leads to name conflict on Windows compiler */
 	int64 on_distributed_hypertable_count;
 	int64 uses_real_time_aggregation_count;
+	int64 finalized;
 } CaggStats;
 
 typedef struct TelemetryStats

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -306,6 +306,7 @@ format_iso8601(Datum value)
 
 #define REQ_RELKIND_CAGG_ON_DISTRIBUTED_HYPERTABLE_COUNT "num_caggs_on_distributed_hypertables"
 #define REQ_RELKIND_CAGG_USES_REAL_TIME_AGGREGATION_COUNT "num_caggs_using_real_time_aggregation"
+#define REQ_RELKIND_CAGG_FINALIZED "num_caggs_finalized"
 
 static JsonbValue *
 add_compression_stats_object(JsonbParseState *parse_state, StatsRelType reltype,
@@ -398,6 +399,7 @@ add_relkind_stats_object(JsonbParseState *parse_state, const char *relkindname,
 		ts_jsonb_add_int64(parse_state,
 						   REQ_RELKIND_CAGG_USES_REAL_TIME_AGGREGATION_COUNT,
 						   cs->uses_real_time_aggregation_count);
+		ts_jsonb_add_int64(parse_state, REQ_RELKIND_CAGG_FINALIZED, cs->finalized);
 	}
 
 	return pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -92,6 +92,12 @@ typedef struct ContinuousAgg
 	Oid partition_type;
 } ContinuousAgg;
 
+static inline bool
+ContinuousAggIsFinalized(const ContinuousAgg *cagg)
+{
+	return (cagg->data.finalized == true);
+}
+
 typedef enum ContinuousAggHypertableStatus
 {
 	HypertableIsNotContinuousAgg = 0,

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -2363,7 +2363,7 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 		final_query = destroy_union_query(final_query);
 	}
 
-	if (agg->data.finalized)
+	if (ContinuousAggIsFinalized(agg))
 	{ /* This continuous aggregate does not have partials, do not check for defects. */
 		relation_close(user_view_rel, NoLock);
 		elog(INFO,

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -485,7 +485,7 @@ continuous_agg_refresh_with_window(const ContinuousAgg *cagg,
 	 * hypertable is responsible for check if the `chunk_id` is valid
 	 * and then use it or not during the refresh.
 	 */
-	if (cagg->data.finalized)
+	if (ContinuousAggIsFinalized(cagg))
 		chunk_id = INVALID_CHUNK_ID;
 
 	if (do_merged_refresh)

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -68,6 +68,16 @@ FROM
   hyper
 GROUP BY hour, device;
 NOTICE:  continuous aggregate "contagg" is already up-to-date
+CREATE MATERIALIZED VIEW contagg_old
+WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+SELECT
+  time_bucket('1 hour', time) AS hour,
+  device,
+  min(time)
+FROM
+  hyper
+GROUP BY hour, device;
+NOTICE:  continuous aggregate "contagg_old" is already up-to-date
 -- Create another view (already have the "relations" view)
 CREATE VIEW devices AS
 SELECT DISTINCT ON (device) device
@@ -139,10 +149,11 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          },                                         +
          "indexes_size": 0,                         +
          "num_children": 0,                         +
-         "num_relations": 1,                        +
+         "num_relations": 2,                        +
          "num_reltuples": 0,                        +
+         "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
-         "num_caggs_using_real_time_aggregation": 1 +
+         "num_caggs_using_real_time_aggregation": 2 +
      },                                             +
      "distributed_hypertables_data_node": {         +
          "heap_size": 0,                            +
@@ -198,6 +209,7 @@ SELECT * FROM normal;
 INSERT INTO part
 SELECT * FROM normal;
 CALL refresh_continuous_aggregate('contagg', NULL, NULL);
+CALL refresh_continuous_aggregate('contagg_old', NULL, NULL);
 -- ANALYZE to get updated reltuples stats
 ANALYZE normal, hyper, part;
 SELECT count(c) FROM show_chunks('hyper') c;
@@ -207,6 +219,12 @@ SELECT count(c) FROM show_chunks('hyper') c;
 (1 row)
 
 SELECT count(c) FROM show_chunks('contagg') c;
+ count 
+-------
+     2
+(1 row)
+
+SELECT count(c) FROM show_chunks('contagg_old') c;
  count 
 -------
      2
@@ -263,8 +281,8 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "num_reltuples": 697                       +
      },                                             +
      "continuous_aggregates": {                     +
-         "heap_size": 90112,                        +
-         "toast_size": 16384,                       +
+         "heap_size": 188416,                       +
+         "toast_size": 32768,                       +
          "compression": {                           +
              "compressed_heap_size": 0,             +
              "compressed_row_count": 0,             +
@@ -277,12 +295,13 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
              "uncompressed_toast_size": 0,          +
              "uncompressed_indexes_size": 0         +
          },                                         +
-         "indexes_size": 114688,                    +
-         "num_children": 2,                         +
-         "num_relations": 1,                        +
+         "indexes_size": 229376,                    +
+         "num_children": 4,                         +
+         "num_relations": 2,                        +
          "num_reltuples": 0,                        +
+         "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
-         "num_caggs_using_real_time_aggregation": 1 +
+         "num_caggs_using_real_time_aggregation": 2 +
      },                                             +
      "distributed_hypertables_data_node": {         +
          "heap_size": 0,                            +
@@ -341,7 +360,7 @@ SELECT (SELECT count(*) FROM normal) num_inserted_rows,
 
 -- Add compression
 ALTER TABLE hyper SET (timescaledb.compress);
-SELECT compress_chunk(c) 
+SELECT compress_chunk(c)
 FROM show_chunks('hyper') c ORDER BY c LIMIT 4;
              compress_chunk             
 ----------------------------------------
@@ -352,7 +371,7 @@ FROM show_chunks('hyper') c ORDER BY c LIMIT 4;
 (4 rows)
 
 ALTER MATERIALIZED VIEW contagg SET (timescaledb.compress);
-SELECT compress_chunk(c) 
+SELECT compress_chunk(c)
 FROM show_chunks('contagg') c ORDER BY c LIMIT 1;
              compress_chunk              
 -----------------------------------------
@@ -412,8 +431,8 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "num_reltuples": 697                       +
      },                                             +
      "continuous_aggregates": {                     +
-         "heap_size": 81920,                        +
-         "toast_size": 24576,                       +
+         "heap_size": 180224,                       +
+         "toast_size": 40960,                       +
          "compression": {                           +
              "compressed_heap_size": 40960,         +
              "compressed_row_count": 10,            +
@@ -426,12 +445,13 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
              "uncompressed_toast_size": 8192,       +
              "uncompressed_indexes_size": 81920     +
          },                                         +
-         "indexes_size": 65536,                     +
-         "num_children": 2,                         +
-         "num_relations": 1,                        +
+         "indexes_size": 180224,                    +
+         "num_children": 4,                         +
+         "num_relations": 2,                        +
          "num_reltuples": 452,                      +
+         "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
-         "num_caggs_using_real_time_aggregation": 0 +
+         "num_caggs_using_real_time_aggregation": 1 +
      },                                             +
      "distributed_hypertables_data_node": {         +
          "heap_size": 0,                            +
@@ -554,7 +574,7 @@ CREATE TABLE disthyper (LIKE normal);
 SELECT create_distributed_hypertable('disthyper', 'time', 'device');
  create_distributed_hypertable 
 -------------------------------
- (5,public,disthyper,t)
+ (6,public,disthyper,t)
 (1 row)
 
 -- Show distributed hypertables stats with no data
@@ -727,14 +747,14 @@ distributed_hypertables_dn
 
 -- Add compression
 ALTER TABLE disthyper SET (timescaledb.compress);
-SELECT compress_chunk(c) 
+SELECT compress_chunk(c)
 FROM show_chunks('disthyper') c ORDER BY c LIMIT 4;
                 compress_chunk                
 ----------------------------------------------
- _timescaledb_internal._dist_hyper_5_17_chunk
- _timescaledb_internal._dist_hyper_5_18_chunk
- _timescaledb_internal._dist_hyper_5_19_chunk
- _timescaledb_internal._dist_hyper_5_20_chunk
+ _timescaledb_internal._dist_hyper_6_19_chunk
+ _timescaledb_internal._dist_hyper_6_20_chunk
+ _timescaledb_internal._dist_hyper_6_21_chunk
+ _timescaledb_internal._dist_hyper_6_22_chunk
 (4 rows)
 
 ANALYZE disthyper;
@@ -845,7 +865,7 @@ CREATE TABLE disthyper_repl (LIKE normal);
 SELECT create_distributed_hypertable('disthyper_repl', 'time', 'device', replication_factor => 2);
  create_distributed_hypertable 
 -------------------------------
- (6,public,disthyper_repl,t)
+ (7,public,disthyper_repl,t)
 (1 row)
 
 INSERT INTO disthyper_repl
@@ -891,6 +911,16 @@ FROM
   disthyper
 GROUP BY hour, device;
 NOTICE:  refreshing continuous aggregate "distcontagg"
+CREATE MATERIALIZED VIEW distcontagg_old
+WITH (timescaledb.continuous, timescaledb.finalized=false) AS
+SELECT
+  time_bucket('1 hour', time) AS hour,
+  device,
+  min(time)
+FROM
+  disthyper
+GROUP BY hour, device;
+NOTICE:  refreshing continuous aggregate "distcontagg_old"
 REFRESH MATERIALIZED VIEW telemetry_report;
 SELECT
 	jsonb_pretty(rels -> 'continuous_aggregates') AS continuous_aggregates
@@ -898,8 +928,8 @@ FROM relations;
              continuous_aggregates              
 ------------------------------------------------
  {                                             +
-     "heap_size": 172032,                      +
-     "toast_size": 40960,                      +
+     "heap_size": 368640,                      +
+     "toast_size": 73728,                      +
      "compression": {                          +
          "compressed_heap_size": 40960,        +
          "compressed_row_count": 10,           +
@@ -912,12 +942,13 @@ FROM relations;
          "uncompressed_toast_size": 8192,      +
          "uncompressed_indexes_size": 81920    +
      },                                        +
-     "indexes_size": 180224,                   +
-     "num_children": 4,                        +
-     "num_relations": 2,                       +
+     "indexes_size": 409600,                   +
+     "num_children": 8,                        +
+     "num_relations": 4,                       +
      "num_reltuples": 452,                     +
-     "num_caggs_on_distributed_hypertables": 1,+
-     "num_caggs_using_real_time_aggregation": 1+
+     "num_caggs_finalized": 2,                 +
+     "num_caggs_on_distributed_hypertables": 2,+
+     "num_caggs_using_real_time_aggregation": 3+
  }
 (1 row)
 


### PR DESCRIPTION
Introduced by #4294 and #4269 PRs the default implementation of
Continuous Aggregates get rid of `chunk_id` in the materialization
hypertable and `partialize_agg`/`finalize_agg` aggregate functions.

A new counter named `num_caggs_finalized` was added to telemetry report
in this PR to count the number of Continuos Aggregates created in this
new format.