### PR TITLE
Fix gapfill pushdown issue

### DIFF
--- a/tsl/src/fdw/scan_plan.c
+++ b/tsl/src/fdw/scan_plan.c
@@ -926,23 +926,6 @@ add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel, RelOptInfo 
 	fpinfo->startup_cost = startup_cost;
 	fpinfo->total_cost = total_cost;
 
-	if (ifpinfo->pushdown_gapfill)
-	{
-		/*
-		 * If pushdown of gapfill is possible then also check if it would
-		 * be beneficial to actually push it down. Since, it can create
-		 * more tuples and they need to be transferred to the data node.
-		 * However, still pushing of gapfill to the data nodes could make
-		 * sense because aggregating over it could be then done at the data
-		 * nodes itself, hence ignore pushing down gapfill to data nodes
-		 * when it produces a "really" larger amount of tuples.
-		 */
-		if (10 * ifpinfo->rows > fpinfo->rows)
-		{
-			fpinfo->pushdown_gapfill = false;
-			ifpinfo->pushdown_gapfill = false;
-		}
-	}
 	/* Create and add path to the grouping relation. */
 	grouppath = (Path *) create_path(root,
 									 grouped_rel,

--- a/tsl/test/shared/expected/dist_gapfill_pushdown-12.out
+++ b/tsl/test/shared/expected/dist_gapfill_pushdown-12.out
@@ -1,6 +1,53 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Table with non-overlapping data across data-nodes to test gapfill pushdown to data nodes
+DROP TABLE IF EXISTS test_gapfill CASCADE;
+CREATE TABLE test_gapfill(time timestamp, name text, value numeric);
+SELECT table_name from create_distributed_hypertable('test_gapfill', 'time', partitioning_column => 'name');
+NOTICE:  adding not-null constraint to column "time"
+  table_name  
+--------------
+ test_gapfill
+(1 row)
+
+INSERT INTO test_gapfill VALUES
+    ('2018-01-01 06:01', 'one', 1.2),
+    ('2018-01-02 09:11', 'two', 4.3),
+    ('2018-01-03 08:01', 'three', 7.3),
+    ('2018-01-04 08:01', 'one', 0.23),
+    ('2018-07-05 08:01', 'five', 0.0),
+    ('2018-07-06 06:01', 'forty', 3.1),
+    ('2018-07-07 09:11', 'eleven', 10303.12),
+    ('2018-07-08 08:01', 'ten', 64);
+ANALYZE test_gapfill;
+-- Make table with data nodes overlapping
+DROP TABLE IF EXISTS test_gapfill_overlap CASCADE;
+CREATE TABLE test_gapfill_overlap(time timestamp, name text, value numeric);
+SELECT table_name from create_distributed_hypertable('test_gapfill_overlap', 'time', partitioning_column => 'name');
+NOTICE:  adding not-null constraint to column "time"
+      table_name      
+----------------------
+ test_gapfill_overlap
+(1 row)
+
+INSERT INTO test_gapfill_overlap SELECT  * FROM test_gapfill;
+SELECT set_number_partitions('test_gapfill_overlap', 4);
+ set_number_partitions 
+-----------------------
+ 
+(1 row)
+
+INSERT INTO test_gapfill_overlap VALUES
+('2020-01-01 06:01', 'eleven', 1.2),
+('2020-01-02 09:11', 'twenty-two', 4.3),
+('2020-01-03 08:01', 'three', 7.3),
+('2020-01-04 08:01', 'one', 0.23),
+('2020-07-05 08:01', 'five', 0.0),
+('2020-07-06 06:01', 'forty-six', 3.1),
+('2020-07-07 09:11', 'eleven', 10303.12),
+('2020-07-08 08:01', 'ten', 64);
+ANALYZE test_gapfill_overlap;
 \set ON_ERROR_STOP 0
 SET enable_partitionwise_aggregate = 'on';
 SET timescaledb.enable_remote_explain = true;
@@ -11,8 +58,8 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-0
        avg(value)
 FROM test_gapfill
 GROUP BY 1,2;
-                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (AsyncAppend)
    Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), name, (first(value, "time")), (avg(value))
    ->  Append
@@ -21,7 +68,7 @@ GROUP BY 1,2;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 1, 2
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34]) GROUP BY 1, 2
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
@@ -41,7 +88,7 @@ GROUP BY 1,2;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 1, 2
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33]) GROUP BY 1, 2
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
@@ -79,16 +126,16 @@ GROUP BY 2,1;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 2, 1
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34]) GROUP BY 2, 1
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
-                   ->  Sort
-                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, (public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time")), (avg(_dist_hyper_X_X_chunk.value))
-                         Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
-                         ->  HashAggregate
-                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
-                               Group Key: _dist_hyper_X_X_chunk.name, public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)
+                   ->  GroupAggregate
+                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
+                         Group Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
+                         ->  Sort
+                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
+                               Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
                                ->  Result
                                      Output: public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
                                      ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
@@ -99,16 +146,16 @@ GROUP BY 2,1;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 2, 1
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33]) GROUP BY 2, 1
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
-                   ->  Sort
-                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, (public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time")), (avg(_dist_hyper_X_X_chunk.value))
-                         Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
-                         ->  HashAggregate
-                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
-                               Group Key: _dist_hyper_X_X_chunk.name, public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)
+                   ->  GroupAggregate
+                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
+                         Group Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
+                         ->  Sort
+                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
+                               Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
                                ->  Result
                                      Output: public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
                                      ->  Append
@@ -137,47 +184,41 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-0
        avg(value)
 FROM test_gapfill
 GROUP BY 1;
-                                                                                                                                                       QUERY PLAN                                                                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (first(value, "time")), (avg(value))
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), first(test_gapfill.value, test_gapfill."time"), avg(test_gapfill.value)
          Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
          ->  Sort
-               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (PARTIAL first(test_gapfill.value, test_gapfill."time")), (PARTIAL avg(test_gapfill.value))
+               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), test_gapfill.value, test_gapfill."time"
                Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
                ->  Append
-                     ->  Partial HashAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), PARTIAL first(test_gapfill.value, test_gapfill."time"), PARTIAL avg(test_gapfill.value)
-                           Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)
-                           ->  Custom Scan (DataNodeScan) on public.test_gapfill
-                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill.value, test_gapfill."time"
-                                 Data node: data_node_1
-                                 Chunks: _dist_hyper_X_X_chunk
-                                 Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
-                                 Remote EXPLAIN: 
-                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                     ->  Custom Scan (DataNodeScan) on public.test_gapfill
+                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill.value, test_gapfill."time"
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_X_X_chunk
+                           Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34])
+                           Remote EXPLAIN: 
+                             Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                               Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+ 
+                     ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
+                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                           Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33])
+                           Remote EXPLAIN: 
+                             Append
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                      Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
  
-                     ->  Partial HashAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), PARTIAL first(test_gapfill_1.value, test_gapfill_1."time"), PARTIAL avg(test_gapfill_1.value)
-                           Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)
-                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
-                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
-                                 Data node: data_node_3
-                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                 Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
-                                 Remote EXPLAIN: 
-                                   Append
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
- 
-(38 rows)
+(32 rows)
 
 -- Window functions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT
@@ -185,49 +226,43 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT
   lag(min(time)) OVER ()
 FROM test_gapfill
 GROUP BY 1;
-                                                                                                                            QUERY PLAN                                                                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  WindowAgg
    Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), lag((min("time"))) OVER (?)
    ->  Custom Scan (GapFill)
          Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (min("time"))
-         ->  Finalize GroupAggregate
+         ->  GroupAggregate
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), min(test_gapfill."time")
                Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
                ->  Sort
-                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (PARTIAL min(test_gapfill."time"))
+                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill."time"
                      Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
                      ->  Append
-                           ->  Partial HashAggregate
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), PARTIAL min(test_gapfill."time")
-                                 Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill."time"
-                                       Data node: data_node_1
-                                       Chunks: _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
-                                       Remote EXPLAIN: 
-                                         Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill."time"
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34])
+                                 Remote EXPLAIN: 
+                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time"
+ 
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time"
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time"
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                            Output: _dist_hyper_X_X_chunk."time"
  
-                           ->  Partial HashAggregate
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), PARTIAL min(test_gapfill_1."time")
-                                 Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
-                                       Data node: data_node_3
-                                       Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
-                                       Remote EXPLAIN: 
-                                         Append
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
- 
-(40 rows)
+(34 rows)
 
 -- Data nodes are overlapping
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2018-01-01 06:00', '2018-01-01 18:00'),
@@ -236,80 +271,64 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2018-0
        avg(value)
 FROM test_gapfill_overlap
 GROUP BY 1,2;
-                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                  QUERY PLAN                                                                                                                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
    Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), name, (first(value, "time")), (avg(value))
    ->  Sort
          Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name, (first(test_gapfill_overlap.value, test_gapfill_overlap."time")), (avg(test_gapfill_overlap.value))
          Sort Key: test_gapfill_overlap.name, (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone))
-         ->  Finalize GroupAggregate
+         ->  GroupAggregate
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name, first(test_gapfill_overlap.value, test_gapfill_overlap."time"), avg(test_gapfill_overlap.value)
                Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name
-               ->  Merge Append
+               ->  Sort
+                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name, test_gapfill_overlap.value, test_gapfill_overlap."time"
                      Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name
-                     ->  Partial GroupAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name, PARTIAL first(test_gapfill_overlap.value, test_gapfill_overlap."time"), PARTIAL avg(test_gapfill_overlap.value)
-                           Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name
-                           ->  Sort
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name, test_gapfill_overlap.value, test_gapfill_overlap."time"
-                                 Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap.name
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap.name, test_gapfill_overlap.value, test_gapfill_overlap."time"
-                                       Data node: data_node_1
-                                       Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[29, 30, 31, 32])
-                                       Remote EXPLAIN: 
-                                         Append
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
- 
-                     ->  Partial GroupAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, PARTIAL first(test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"), PARTIAL avg(test_gapfill_overlap_1.value)
-                           Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name
-                           ->  Sort
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
-                                 Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
-                                       Data node: data_node_2
-                                       Chunks: _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[20])
-                                       Remote EXPLAIN: 
-                                         Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap.name, test_gapfill_overlap.value, test_gapfill_overlap."time"
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[35, 36, 37, 38])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                            Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-                     ->  Partial GroupAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_2.name, PARTIAL first(test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"), PARTIAL avg(test_gapfill_overlap_2.value)
-                           Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_2.name
-                           ->  Sort
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
-                                 Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_2.name
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
-                                       Data node: data_node_3
-                                       Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[26, 27, 28, 29, 30])
-                                       Remote EXPLAIN: 
-                                         Append
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[22])
+                                 Remote EXPLAIN: 
+                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-(71 rows)
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[34, 35, 36, 37, 38])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+ 
+(55 rows)
 
 SET timescaledb.enable_remote_explain = false;
 DROP TABLE test_gapfill;

--- a/tsl/test/shared/expected/dist_gapfill_pushdown-13.out
+++ b/tsl/test/shared/expected/dist_gapfill_pushdown-13.out
@@ -1,6 +1,53 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Table with non-overlapping data across data-nodes to test gapfill pushdown to data nodes
+DROP TABLE IF EXISTS test_gapfill CASCADE;
+CREATE TABLE test_gapfill(time timestamp, name text, value numeric);
+SELECT table_name from create_distributed_hypertable('test_gapfill', 'time', partitioning_column => 'name');
+NOTICE:  adding not-null constraint to column "time"
+  table_name  
+--------------
+ test_gapfill
+(1 row)
+
+INSERT INTO test_gapfill VALUES
+    ('2018-01-01 06:01', 'one', 1.2),
+    ('2018-01-02 09:11', 'two', 4.3),
+    ('2018-01-03 08:01', 'three', 7.3),
+    ('2018-01-04 08:01', 'one', 0.23),
+    ('2018-07-05 08:01', 'five', 0.0),
+    ('2018-07-06 06:01', 'forty', 3.1),
+    ('2018-07-07 09:11', 'eleven', 10303.12),
+    ('2018-07-08 08:01', 'ten', 64);
+ANALYZE test_gapfill;
+-- Make table with data nodes overlapping
+DROP TABLE IF EXISTS test_gapfill_overlap CASCADE;
+CREATE TABLE test_gapfill_overlap(time timestamp, name text, value numeric);
+SELECT table_name from create_distributed_hypertable('test_gapfill_overlap', 'time', partitioning_column => 'name');
+NOTICE:  adding not-null constraint to column "time"
+      table_name      
+----------------------
+ test_gapfill_overlap
+(1 row)
+
+INSERT INTO test_gapfill_overlap SELECT  * FROM test_gapfill;
+SELECT set_number_partitions('test_gapfill_overlap', 4);
+ set_number_partitions 
+-----------------------
+ 
+(1 row)
+
+INSERT INTO test_gapfill_overlap VALUES
+('2020-01-01 06:01', 'eleven', 1.2),
+('2020-01-02 09:11', 'twenty-two', 4.3),
+('2020-01-03 08:01', 'three', 7.3),
+('2020-01-04 08:01', 'one', 0.23),
+('2020-07-05 08:01', 'five', 0.0),
+('2020-07-06 06:01', 'forty-six', 3.1),
+('2020-07-07 09:11', 'eleven', 10303.12),
+('2020-07-08 08:01', 'ten', 64);
+ANALYZE test_gapfill_overlap;
 \set ON_ERROR_STOP 0
 SET enable_partitionwise_aggregate = 'on';
 SET timescaledb.enable_remote_explain = true;
@@ -11,8 +58,8 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-0
        avg(value)
 FROM test_gapfill
 GROUP BY 1,2;
-                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (AsyncAppend)
    Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), name, (first(value, "time")), (avg(value))
    ->  Append
@@ -21,7 +68,7 @@ GROUP BY 1,2;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 1, 2
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34]) GROUP BY 1, 2
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
@@ -41,7 +88,7 @@ GROUP BY 1,2;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 1, 2
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33]) GROUP BY 1, 2
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, test_gapfill."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), test_gapfill.name, (public.first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
@@ -79,16 +126,16 @@ GROUP BY 2,1;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 2, 1
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34]) GROUP BY 2, 1
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
-                   ->  Sort
-                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, (public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time")), (avg(_dist_hyper_X_X_chunk.value))
-                         Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
-                         ->  HashAggregate
-                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
-                               Group Key: _dist_hyper_X_X_chunk.name, public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)
+                   ->  GroupAggregate
+                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
+                         Group Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
+                         ->  Sort
+                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
+                               Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
                                ->  Result
                                      Output: public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
                                      ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
@@ -99,16 +146,16 @@ GROUP BY 2,1;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 2, 1
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33]) GROUP BY 2, 1
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, test_gapfill."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), test_gapfill.name, (public.first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
-                   ->  Sort
-                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, (public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time")), (avg(_dist_hyper_X_X_chunk.value))
-                         Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
-                         ->  HashAggregate
-                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
-                               Group Key: _dist_hyper_X_X_chunk.name, public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)
+                   ->  GroupAggregate
+                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
+                         Group Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
+                         ->  Sort
+                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
+                               Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
                                ->  Result
                                      Output: public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
                                      ->  Append
@@ -137,47 +184,41 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-0
        avg(value)
 FROM test_gapfill
 GROUP BY 1;
-                                                                                                                                                       QUERY PLAN                                                                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
-   Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (first(value, "time")), (avg(value))
-   ->  Finalize GroupAggregate
-         Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), first(test_gapfill.value, test_gapfill."time"), avg(test_gapfill.value)
-         Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
+   Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
+   ->  GroupAggregate
+         Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), first(test_gapfill_1.value, test_gapfill_1."time"), avg(test_gapfill_1.value)
+         Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
          ->  Sort
-               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (PARTIAL first(test_gapfill.value, test_gapfill."time")), (PARTIAL avg(test_gapfill.value))
-               Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
+               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.value, test_gapfill_1."time"
+               Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
                ->  Append
-                     ->  Partial HashAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), PARTIAL first(test_gapfill.value, test_gapfill."time"), PARTIAL avg(test_gapfill.value)
-                           Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)
-                           ->  Custom Scan (DataNodeScan) on public.test_gapfill
-                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill.value, test_gapfill."time"
-                                 Data node: data_node_1
-                                 Chunks: _dist_hyper_X_X_chunk
-                                 Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
-                                 Remote EXPLAIN: 
-                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                     ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
+                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_X_X_chunk
+                           Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34])
+                           Remote EXPLAIN: 
+                             Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                               Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+ 
+                     ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_2
+                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_2."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_2.value, test_gapfill_2."time"
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                           Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33])
+                           Remote EXPLAIN: 
+                             Append
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                      Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
  
-                     ->  Partial HashAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), PARTIAL first(test_gapfill_1.value, test_gapfill_1."time"), PARTIAL avg(test_gapfill_1.value)
-                           Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)
-                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
-                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
-                                 Data node: data_node_3
-                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                 Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
-                                 Remote EXPLAIN: 
-                                   Append
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
- 
-(38 rows)
+(32 rows)
 
 -- Window functions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT
@@ -185,49 +226,43 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT
   lag(min(time)) OVER ()
 FROM test_gapfill
 GROUP BY 1;
-                                                                                                                            QUERY PLAN                                                                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  WindowAgg
-   Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), lag((min("time"))) OVER (?)
+   Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), lag((min(test_gapfill."time"))) OVER (?)
    ->  Custom Scan (GapFill)
-         Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (min("time"))
-         ->  Finalize GroupAggregate
-               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), min(test_gapfill."time")
-               Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
+         Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (min(test_gapfill."time"))
+         ->  GroupAggregate
+               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), min(test_gapfill_1."time")
+               Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
                ->  Sort
-                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (PARTIAL min(test_gapfill."time"))
-                     Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
+                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1."time"
+                     Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
                      ->  Append
-                           ->  Partial HashAggregate
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), PARTIAL min(test_gapfill."time")
-                                 Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill."time"
-                                       Data node: data_node_1
-                                       Chunks: _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
-                                       Remote EXPLAIN: 
-                                         Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34])
+                                 Remote EXPLAIN: 
+                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time"
+ 
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_2
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_2."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_2."time"
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time"
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time"
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                            Output: _dist_hyper_X_X_chunk."time"
  
-                           ->  Partial HashAggregate
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), PARTIAL min(test_gapfill_1."time")
-                                 Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
-                                       Data node: data_node_3
-                                       Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
-                                       Remote EXPLAIN: 
-                                         Append
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
- 
-(40 rows)
+(34 rows)
 
 -- Data nodes are overlapping
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2018-01-01 06:00', '2018-01-01 18:00'),
@@ -243,54 +278,57 @@ GROUP BY 1,2;
    ->  Sort
          Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, (first(test_gapfill_overlap_1.value, test_gapfill_overlap_1."time")), (avg(test_gapfill_overlap_1.value))
          Sort Key: test_gapfill_overlap_1.name, (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone))
-         ->  HashAggregate
+         ->  GroupAggregate
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, first(test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"), avg(test_gapfill_overlap_1.value)
                Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name
-               ->  Append
-                     ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
-                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
-                           Data node: data_node_1
-                           Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                           Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[29, 30, 31, 32])
-                           Remote EXPLAIN: 
-                             Append
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+               ->  Sort
+                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
+                     Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[35, 36, 37, 38])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+ 
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[22])
+                                 Remote EXPLAIN: 
+                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                      Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-                     ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
-                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
-                           Data node: data_node_2
-                           Chunks: _dist_hyper_X_X_chunk
-                           Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[20])
-                           Remote EXPLAIN: 
-                             Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                               Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_3
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_3."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_3.name, test_gapfill_overlap_3.value, test_gapfill_overlap_3."time"
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[34, 35, 36, 37, 38])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-                     ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_3
-                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_3."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_3.name, test_gapfill_overlap_3.value, test_gapfill_overlap_3."time"
-                           Data node: data_node_3
-                           Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                           Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[26, 27, 28, 29, 30])
-                           Remote EXPLAIN: 
-                             Append
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
- 
-(52 rows)
+(55 rows)
 
 SET timescaledb.enable_remote_explain = false;
 DROP TABLE test_gapfill;

--- a/tsl/test/shared/expected/dist_gapfill_pushdown-14.out
+++ b/tsl/test/shared/expected/dist_gapfill_pushdown-14.out
@@ -1,6 +1,53 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+-- Table with non-overlapping data across data-nodes to test gapfill pushdown to data nodes
+DROP TABLE IF EXISTS test_gapfill CASCADE;
+CREATE TABLE test_gapfill(time timestamp, name text, value numeric);
+SELECT table_name from create_distributed_hypertable('test_gapfill', 'time', partitioning_column => 'name');
+NOTICE:  adding not-null constraint to column "time"
+  table_name  
+--------------
+ test_gapfill
+(1 row)
+
+INSERT INTO test_gapfill VALUES
+    ('2018-01-01 06:01', 'one', 1.2),
+    ('2018-01-02 09:11', 'two', 4.3),
+    ('2018-01-03 08:01', 'three', 7.3),
+    ('2018-01-04 08:01', 'one', 0.23),
+    ('2018-07-05 08:01', 'five', 0.0),
+    ('2018-07-06 06:01', 'forty', 3.1),
+    ('2018-07-07 09:11', 'eleven', 10303.12),
+    ('2018-07-08 08:01', 'ten', 64);
+ANALYZE test_gapfill;
+-- Make table with data nodes overlapping
+DROP TABLE IF EXISTS test_gapfill_overlap CASCADE;
+CREATE TABLE test_gapfill_overlap(time timestamp, name text, value numeric);
+SELECT table_name from create_distributed_hypertable('test_gapfill_overlap', 'time', partitioning_column => 'name');
+NOTICE:  adding not-null constraint to column "time"
+      table_name      
+----------------------
+ test_gapfill_overlap
+(1 row)
+
+INSERT INTO test_gapfill_overlap SELECT  * FROM test_gapfill;
+SELECT set_number_partitions('test_gapfill_overlap', 4);
+ set_number_partitions 
+-----------------------
+ 
+(1 row)
+
+INSERT INTO test_gapfill_overlap VALUES
+('2020-01-01 06:01', 'eleven', 1.2),
+('2020-01-02 09:11', 'twenty-two', 4.3),
+('2020-01-03 08:01', 'three', 7.3),
+('2020-01-04 08:01', 'one', 0.23),
+('2020-07-05 08:01', 'five', 0.0),
+('2020-07-06 06:01', 'forty-six', 3.1),
+('2020-07-07 09:11', 'eleven', 10303.12),
+('2020-07-08 08:01', 'ten', 64);
+ANALYZE test_gapfill_overlap;
 \set ON_ERROR_STOP 0
 SET enable_partitionwise_aggregate = 'on';
 SET timescaledb.enable_remote_explain = true;
@@ -11,8 +58,8 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-0
        avg(value)
 FROM test_gapfill
 GROUP BY 1,2;
-                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (AsyncAppend)
    Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), name, (first(value, "time")), (avg(value))
    ->  Append
@@ -21,7 +68,7 @@ GROUP BY 1,2;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 1, 2
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34]) GROUP BY 1, 2
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
@@ -41,7 +88,7 @@ GROUP BY 1,2;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 1, 2
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33]) GROUP BY 1, 2
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, test_gapfill."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), test_gapfill.name, (public.first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
@@ -79,16 +126,16 @@ GROUP BY 2,1;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_1
                Chunks: _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28]) GROUP BY 2, 1
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34]) GROUP BY 2, 1
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, "time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), name, (public.first(value, "time")), (avg(value))
-                   ->  Sort
-                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, (public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time")), (avg(_dist_hyper_X_X_chunk.value))
-                         Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
-                         ->  HashAggregate
-                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
-                               Group Key: _dist_hyper_X_X_chunk.name, public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)
+                   ->  GroupAggregate
+                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
+                         Group Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
+                         ->  Sort
+                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
+                               Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
                                ->  Result
                                      Output: public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
                                      ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
@@ -99,16 +146,16 @@ GROUP BY 2,1;
                Relations: Aggregate on (public.test_gapfill)
                Data node: data_node_3
                Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25]) GROUP BY 2, 1
+               Remote SQL: SELECT public.time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), name, public.first(value, "time"), avg(value) FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33]) GROUP BY 2, 1
                Remote EXPLAIN: 
                  Custom Scan (GapFill)
                    Output: (public.time_bucket_gapfill('03:00:00'::interval, test_gapfill."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), test_gapfill.name, (public.first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
-                   ->  Sort
-                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, (public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time")), (avg(_dist_hyper_X_X_chunk.value))
-                         Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
-                         ->  HashAggregate
-                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
-                               Group Key: _dist_hyper_X_X_chunk.name, public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)
+                   ->  GroupAggregate
+                         Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, public.first(_dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"), avg(_dist_hyper_X_X_chunk.value)
+                         Group Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
+                         ->  Sort
+                               Output: (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone)), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
+                               Sort Key: _dist_hyper_X_X_chunk.name, (public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone))
                                ->  Result
                                      Output: public.time_bucket_gapfill('03:00:00'::interval, _dist_hyper_X_X_chunk."time", '2017-01-01 06:00:00'::timestamp without time zone, '2017-01-01 18:00:00'::timestamp without time zone), _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value, _dist_hyper_X_X_chunk."time"
                                      ->  Append
@@ -137,47 +184,41 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2017-0
        avg(value)
 FROM test_gapfill
 GROUP BY 1;
-                                                                                                                                                       QUERY PLAN                                                                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                      QUERY PLAN                                                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (GapFill)
-   Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (first(value, "time")), (avg(value))
-   ->  Finalize GroupAggregate
-         Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), first(test_gapfill.value, test_gapfill."time"), avg(test_gapfill.value)
-         Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
+   Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (first(test_gapfill.value, test_gapfill."time")), (avg(test_gapfill.value))
+   ->  GroupAggregate
+         Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), first(test_gapfill_1.value, test_gapfill_1."time"), avg(test_gapfill_1.value)
+         Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
          ->  Sort
-               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), (PARTIAL first(test_gapfill.value, test_gapfill."time")), (PARTIAL avg(test_gapfill.value))
-               Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
+               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), test_gapfill_1.value, test_gapfill_1."time"
+               Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone))
                ->  Append
-                     ->  Partial HashAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), PARTIAL first(test_gapfill.value, test_gapfill."time"), PARTIAL avg(test_gapfill.value)
-                           Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)
-                           ->  Custom Scan (DataNodeScan) on public.test_gapfill
-                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill.value, test_gapfill."time"
-                                 Data node: data_node_1
-                                 Chunks: _dist_hyper_X_X_chunk
-                                 Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
-                                 Remote EXPLAIN: 
-                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                     ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
+                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
+                           Data node: data_node_1
+                           Chunks: _dist_hyper_X_X_chunk
+                           Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34])
+                           Remote EXPLAIN: 
+                             Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                               Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+ 
+                     ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_2
+                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_2."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_2.value, test_gapfill_2."time"
+                           Data node: data_node_3
+                           Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                           Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33])
+                           Remote EXPLAIN: 
+                             Append
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
+                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                      Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
  
-                     ->  Partial HashAggregate
-                           Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)), PARTIAL first(test_gapfill_1.value, test_gapfill_1."time"), PARTIAL avg(test_gapfill_1.value)
-                           Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone)
-                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
-                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Mon Jan 02 18:00:00 2017'::timestamp without time zone), test_gapfill_1.value, test_gapfill_1."time"
-                                 Data node: data_node_3
-                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                 Remote SQL: SELECT "time", value FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
-                                 Remote EXPLAIN: 
-                                   Append
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
-                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.value
- 
-(38 rows)
+(32 rows)
 
 -- Window functions
 EXPLAIN (VERBOSE, COSTS OFF) SELECT
@@ -185,49 +226,43 @@ EXPLAIN (VERBOSE, COSTS OFF) SELECT
   lag(min(time)) OVER ()
 FROM test_gapfill
 GROUP BY 1;
-                                                                                                                            QUERY PLAN                                                                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                     QUERY PLAN                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  WindowAgg
-   Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), lag((min("time"))) OVER (?)
+   Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), lag((min(test_gapfill."time"))) OVER (?)
    ->  Custom Scan (GapFill)
-         Output: (time_bucket_gapfill('@ 3 hours'::interval, "time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (min("time"))
-         ->  Finalize GroupAggregate
-               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), min(test_gapfill."time")
-               Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
+         Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (min(test_gapfill."time"))
+         ->  GroupAggregate
+               Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), min(test_gapfill_1."time")
+               Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
                ->  Sort
-                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), (PARTIAL min(test_gapfill."time"))
-                     Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
+                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), test_gapfill_1."time"
+                     Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone))
                      ->  Append
-                           ->  Partial HashAggregate
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), PARTIAL min(test_gapfill."time")
-                                 Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill."time"
-                                       Data node: data_node_1
-                                       Chunks: _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[28])
-                                       Remote EXPLAIN: 
-                                         Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[34])
+                                 Remote EXPLAIN: 
+                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                     Output: _dist_hyper_X_X_chunk."time"
+ 
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_2
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_2."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_2."time"
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[31, 32, 33])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time"
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time"
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                            Output: _dist_hyper_X_X_chunk."time"
  
-                           ->  Partial HashAggregate
-                                 Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)), PARTIAL min(test_gapfill_1."time")
-                                 Group Key: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone)
-                                 ->  Custom Scan (DataNodeScan) on public.test_gapfill test_gapfill_1
-                                       Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_1."time", 'Sun Jan 01 06:00:00 2017'::timestamp without time zone, 'Sun Jan 01 18:00:00 2017'::timestamp without time zone), test_gapfill_1."time"
-                                       Data node: data_node_3
-                                       Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                                       Remote SQL: SELECT "time" FROM public.test_gapfill WHERE _timescaledb_internal.chunks_in(public.test_gapfill.*, ARRAY[23, 24, 25])
-                                       Remote EXPLAIN: 
-                                         Append
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
-                                           ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                                 Output: _dist_hyper_X_X_chunk."time"
- 
-(40 rows)
+(34 rows)
 
 -- Data nodes are overlapping
 EXPLAIN (VERBOSE, COSTS OFF) SELECT time_bucket_gapfill('3 hours', time, '2018-01-01 06:00', '2018-01-01 18:00'),
@@ -243,54 +278,57 @@ GROUP BY 1,2;
    ->  Sort
          Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, (first(test_gapfill_overlap_1.value, test_gapfill_overlap_1."time")), (avg(test_gapfill_overlap_1.value))
          Sort Key: test_gapfill_overlap_1.name, (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone))
-         ->  HashAggregate
+         ->  GroupAggregate
                Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, first(test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"), avg(test_gapfill_overlap_1.value)
                Group Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name
-               ->  Append
-                     ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
-                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
-                           Data node: data_node_1
-                           Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                           Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[29, 30, 31, 32])
-                           Remote EXPLAIN: 
-                             Append
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+               ->  Sort
+                     Output: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
+                     Sort Key: (time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone)), test_gapfill_overlap_1.name
+                     ->  Append
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_1
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_1."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_1.name, test_gapfill_overlap_1.value, test_gapfill_overlap_1."time"
+                                 Data node: data_node_1
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[35, 36, 37, 38])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+ 
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
+                                 Data node: data_node_2
+                                 Chunks: _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[22])
+                                 Remote EXPLAIN: 
+                                   Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
                                      Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-                     ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_2
-                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_2."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_2.name, test_gapfill_overlap_2.value, test_gapfill_overlap_2."time"
-                           Data node: data_node_2
-                           Chunks: _dist_hyper_X_X_chunk
-                           Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[20])
-                           Remote EXPLAIN: 
-                             Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                               Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                           ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_3
+                                 Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_3."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_3.name, test_gapfill_overlap_3.value, test_gapfill_overlap_3."time"
+                                 Data node: data_node_3
+                                 Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
+                                 Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[34, 35, 36, 37, 38])
+                                 Remote EXPLAIN: 
+                                   Append
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
+                                     ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
+                                           Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
  
-                     ->  Custom Scan (DataNodeScan) on public.test_gapfill_overlap test_gapfill_overlap_3
-                           Output: time_bucket_gapfill('@ 3 hours'::interval, test_gapfill_overlap_3."time", 'Mon Jan 01 06:00:00 2018'::timestamp without time zone, 'Mon Jan 01 18:00:00 2018'::timestamp without time zone), test_gapfill_overlap_3.name, test_gapfill_overlap_3.value, test_gapfill_overlap_3."time"
-                           Data node: data_node_3
-                           Chunks: _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk, _dist_hyper_X_X_chunk
-                           Remote SQL: SELECT "time", name, value FROM public.test_gapfill_overlap WHERE _timescaledb_internal.chunks_in(public.test_gapfill_overlap.*, ARRAY[26, 27, 28, 29, 30])
-                           Remote EXPLAIN: 
-                             Append
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
-                               ->  Seq Scan on _timescaledb_internal._dist_hyper_X_X_chunk
-                                     Output: _dist_hyper_X_X_chunk."time", _dist_hyper_X_X_chunk.name, _dist_hyper_X_X_chunk.value
- 
-(52 rows)
+(55 rows)
 
 SET timescaledb.enable_remote_explain = false;
 DROP TABLE test_gapfill;

--- a/tsl/test/shared/sql/dist_gapfill_pushdown.sql.in
+++ b/tsl/test/shared/sql/dist_gapfill_pushdown.sql.in
@@ -2,6 +2,46 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+-- Table with non-overlapping data across data-nodes to test gapfill pushdown to data nodes
+DROP TABLE IF EXISTS test_gapfill CASCADE;
+CREATE TABLE test_gapfill(time timestamp, name text, value numeric);
+
+SELECT table_name from create_distributed_hypertable('test_gapfill', 'time', partitioning_column => 'name');
+
+INSERT INTO test_gapfill VALUES
+    ('2018-01-01 06:01', 'one', 1.2),
+    ('2018-01-02 09:11', 'two', 4.3),
+    ('2018-01-03 08:01', 'three', 7.3),
+    ('2018-01-04 08:01', 'one', 0.23),
+    ('2018-07-05 08:01', 'five', 0.0),
+    ('2018-07-06 06:01', 'forty', 3.1),
+    ('2018-07-07 09:11', 'eleven', 10303.12),
+    ('2018-07-08 08:01', 'ten', 64);
+
+ANALYZE test_gapfill;
+
+-- Make table with data nodes overlapping
+DROP TABLE IF EXISTS test_gapfill_overlap CASCADE;
+CREATE TABLE test_gapfill_overlap(time timestamp, name text, value numeric);
+
+SELECT table_name from create_distributed_hypertable('test_gapfill_overlap', 'time', partitioning_column => 'name');
+
+INSERT INTO test_gapfill_overlap SELECT  * FROM test_gapfill;
+
+SELECT set_number_partitions('test_gapfill_overlap', 4);
+
+INSERT INTO test_gapfill_overlap VALUES
+('2020-01-01 06:01', 'eleven', 1.2),
+('2020-01-02 09:11', 'twenty-two', 4.3),
+('2020-01-03 08:01', 'three', 7.3),
+('2020-01-04 08:01', 'one', 0.23),
+('2020-07-05 08:01', 'five', 0.0),
+('2020-07-06 06:01', 'forty-six', 3.1),
+('2020-07-07 09:11', 'eleven', 10303.12),
+('2020-07-08 08:01', 'ten', 64);
+
+ANALYZE test_gapfill_overlap;
+
 \set ON_ERROR_STOP 0
 
 SET enable_partitionwise_aggregate = 'on';


### PR DESCRIPTION
Previously, after cost estimating of the push down plans, Gapfill
is set to false if the tuples returning from data nodes are
estimated to be *too much*, this leads to inconsistency between
data nodes and access nodes, which resulted in absence of Gapfill
node in the plan altogether.
This part of code is now removed. So, now once plan is marked safe to
push down Gapfill, it will always execute Gapfill at data nodes.

Fixes  #4271