### PR TITLE
Remove _PG_fini functions

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -61,7 +61,6 @@ extern void _conn_mock_fini();
 extern void _chunk_append_init();
 
 extern void TSDLLEXPORT _PG_init(void);
-extern void TSDLLEXPORT _PG_fini(void);
 
 TS_FUNCTION_INFO_V1(ts_post_load_init);
 
@@ -120,12 +119,6 @@ _PG_init(void)
 
 	/* Register a cleanup function to be called when the backend exits */
 	on_proc_exit(cleanup_on_pg_proc_exit, 0);
-}
-
-void
-_PG_fini(void)
-{
-	cleanup_on_pg_proc_exit(0, 0);
 }
 
 TSDLLEXPORT Datum

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -96,7 +96,6 @@ PG_MODULE_MAGIC;
 #define CalledInParallelWorker()                                                                   \
 	(MyBgworkerEntry != NULL && (MyBgworkerEntry->bgw_flags & BGWORKER_CLASS_PARALLEL) != 0)
 extern void TSDLLEXPORT _PG_init(void);
-extern void TSDLLEXPORT _PG_fini(void);
 
 /* was the versioned-extension loaded*/
 static bool loader_present = true;
@@ -661,16 +660,6 @@ _PG_init(void)
 	/* register utility hook to handle a distributed database drop */
 	prev_ProcessUtility_hook = ProcessUtility_hook;
 	ProcessUtility_hook = loader_process_utility_hook;
-}
-
-void
-_PG_fini(void)
-{
-	post_parse_analyze_hook = prev_post_parse_analyze_hook;
-	shmem_startup_hook = prev_shmem_startup_hook;
-
-	ProcessUtility_hook = prev_ProcessUtility_hook;
-	/* No way to unregister relcache callback */
 }
 
 static void inline do_load()

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -27,7 +27,6 @@ PG_MODULE_MAGIC;
 #endif
 
 extern void PGDLLEXPORT _PG_init(void);
-extern void PGDLLEXPORT _PG_fini(void);
 
 static post_parse_analyze_hook_type prev_post_parse_analyze_hook;
 
@@ -86,13 +85,6 @@ _PG_init(void)
 #endif
 	post_parse_analyze_hook = post_analyze_hook;
 	CacheRegisterRelcacheCallback(cache_invalidate_callback, PointerGetDatum(NULL));
-}
-
-void
-_PG_fini(void)
-{
-	post_parse_analyze_hook = prev_post_parse_analyze_hook;
-	/* No way to unregister relcache callback */
 }
 
 /* mock for extension.c */

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -66,7 +66,6 @@ PG_MODULE_MAGIC;
 #endif
 
 extern void PGDLLEXPORT _PG_init(void);
-extern void PGDLLEXPORT _PG_fini(void);
 
 static void
 cache_syscache_invalidate(Datum arg, int cacheid, uint32 hashvalue)
@@ -266,10 +265,4 @@ _PG_init(void)
 	ts_license_enable_module_loading();
 
 	_remote_connection_init();
-}
-
-PGDLLEXPORT void
-_PG_fini(void)
-{
-	ts_module_cleanup_on_pg_exit(0, 0);
 }


### PR DESCRIPTION
_PG_fini is meant to be the hook to run code on module unload but
this code is not working and has not been working for over 12 years
because upstream does not support it.

https://github.com/postgres/postgres/commit/ab02d702ef08343fba30d90fdf7df5950063e8c9