### PR TITLE
Remove printouts from signal handlers

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -805,15 +805,6 @@ ts_bgw_job_timeout_at(BgwJob *job, TimestampTz start_time)
 												   IntervalPGetDatum(&job->fd.max_runtime)));
 }
 
-static void handle_sigterm(SIGNAL_ARGS)
-{
-	/* Do not use anything that calls malloc() inside a signal handler since
-	 * malloc() is not signal-safe. This includes ereport() */
-	write_stderr("terminating TimescaleDB background job \"%s\" due to administrator command\n",
-				 MyBgworkerEntry->bgw_name);
-	die(postgres_signal_arg);
-}
-
 TS_FUNCTION_INFO_V1(ts_bgw_job_entrypoint);
 
 static void
@@ -850,7 +841,7 @@ ts_bgw_job_entrypoint(PG_FUNCTION_ARGS)
 	 * do not use the default `bgworker_die` sigterm handler because it does
 	 * not respect critical sections
 	 */
-	pqsignal(SIGTERM, handle_sigterm);
+	pqsignal(SIGTERM, die);
 	BackgroundWorkerUnblockSignals();
 
 	elog(DEBUG1, "started background job %d", job_id);

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -836,14 +836,6 @@ ts_bgw_scheduler_setup_mctx()
 	MemoryContextSwitchTo(scratch_mctx);
 }
 
-static void handle_sigterm(SIGNAL_ARGS)
-{
-	/* Do not use anything that calls malloc() inside a signal handler since
-	 * malloc() is not signal-safe. This includes ereport() */
-	write_stderr("terminating TimescaleDB job scheduler due to administrator command\n");
-	die(postgres_signal_arg);
-}
-
 static void handle_sighup(SIGNAL_ARGS)
 {
 	/* based on av_sighup_handler */
@@ -867,7 +859,7 @@ ts_bgw_scheduler_register_signal_handlers(void)
 	 * do not use the default `bgworker_die` sigterm handler because it does
 	 * not respect critical sections
 	 */
-	pqsignal(SIGTERM, handle_sigterm);
+	pqsignal(SIGTERM, die);
 	pqsignal(SIGHUP, handle_sighup);
 
 	/* Some SIGHUPS may already have been dropped, so we must load the file here */


### PR DESCRIPTION
In #4199 existing calls of `ereport` were replaced with calls of
`write_stderr` to eliminate the use of signal-unsafe calls, in
particular calls to `malloc`. Unfortunately, `write_stderr` contains a
call to `vfprintf`, which allocates memory as well, occationally
causing servers that are shutting down to become unresponsive.

Since the existing signal handlers just called `die` after printing out
a useful message, this commit fixes this by using `die` as a signal
handler.

Fixes #4200