### PR TITLE
Refactor upgrade/downgrade setup sql test scripts

### DIFF
--- a/test/sql/updates/setup.continuous_aggs.sql
+++ b/test/sql/updates/setup.continuous_aggs.sql
@@ -2,6 +2,15 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+-- Collect information about different features so that we can pick
+-- the right usage. Some of these are changed in the same version, but
+-- we keep them separate anyway so that we can do additional checking
+-- if necessary.
+SELECT
+	extversion < '2.0.0' AS has_refresh_mat_view
+  FROM pg_extension
+ WHERE extname = 'timescaledb' \gset
+
 CREATE TYPE custom_type AS (high int, low int);
 
 CREATE TABLE conditions_before (
@@ -26,22 +35,21 @@ SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-31 00:00'::timest
 INSERT INTO conditions_before
 SELECT generate_series('2018-11-01 00:00'::timestamp, '2018-12-15 00:00'::timestamp, '1 day'), 'LA', 73, 55, NULL, 28, NULL, NULL, 8, true;
 
-DO LANGUAGE PLPGSQL $$
-DECLARE
-  ts_version TEXT;
-BEGIN
-  SELECT extversion INTO ts_version FROM pg_extension WHERE extname = 'timescaledb';
-  IF ts_version < '2.0.0' THEN
+\if has_refresh_mat_view
     CREATE VIEW mat_before
     WITH ( timescaledb.continuous, timescaledb.refresh_lag='-30 day', timescaledb.max_interval_per_job ='1000 day')
+\else
+    CREATE MATERIALIZED VIEW IF NOT EXISTS mat_before
+	WITH ( timescaledb.continuous)
+\endif
     AS
       SELECT time_bucket('1week', timec) as bucket,
 	location,
-	min(allnull) as min_allnull,
-	max(temperature) as max_temp,
-	sum(temperature)+sum(humidity) as agg_sum_expr,
-	avg(humidity) AS avg_humidity,
-	stddev(humidity),
+	round(min(allnull)) as min_allnull,
+	round(max(temperature)) as max_temp,
+	round(sum(temperature)+sum(humidity)) as agg_sum_expr,
+	round(avg(humidity)) AS avg_humidity,
+	round(stddev(humidity)) as stddev_humidity,
 	bit_and(bit_int),
 	bit_or(bit_int),
 	bool_and(good_life),
@@ -50,21 +58,21 @@ BEGIN
 	count(*) as count_rows,
 	count(temperature) as count_temp,
 	count(allnull) as count_zero,
-	corr(temperature, humidity),
-	covar_pop(temperature, humidity),
-	covar_samp(temperature, humidity),
-	regr_avgx(temperature, humidity),
-	regr_avgy(temperature, humidity),
-	regr_count(temperature, humidity),
-	regr_intercept(temperature, humidity),
-	regr_r2(temperature, humidity),
-	regr_slope(temperature, humidity),
-	regr_sxx(temperature, humidity),
-	regr_sxy(temperature, humidity),
+	round(corr(temperature, humidity)) as corr,
+	round(covar_pop(temperature, humidity)) as covar_pop,
+	round(covar_samp(temperature, humidity)) as covar_samp,
+	round(regr_avgx(temperature, humidity)) as regr_avgx,
+	round(regr_avgy(temperature, humidity)) as regr_avgy,
+	round(regr_count(temperature, humidity)) as regr_count,
+	round(regr_intercept(temperature, humidity)) as regr_intercept,
+	round(regr_r2(temperature, humidity)) as regr_r2,
+	round(regr_slope(temperature, humidity)) as regr_slope,
+	round(regr_sxx(temperature, humidity)) as regr_sxx,
+	round(regr_sxy(temperature, humidity)) as regr_sxy,
 	round(regr_syy(temperature, humidity)) as regr_syy,
-	stddev(temperature) as stddev_temp,
+	round(stddev(temperature)) as stddev_temp,
 	round(stddev_pop(temperature)) as stddev_pop,
-	stddev_samp(temperature),
+	round(stddev_samp(temperature)) as stddev_samp,
 	round(variance(temperature)) as variance,
 	round(var_pop(temperature)) as var_pop,
 	round(var_samp(temperature)) as var_samp,
@@ -73,67 +81,21 @@ BEGIN
 	first(highlow, timec) as first_hl,
 	histogram(temperature, 0, 100, 5)
       FROM conditions_before
+\if :has_refresh_mat_view
       GROUP BY bucket, location
       HAVING min(location) >= 'NYC' and avg(temperature) > 2;
-  ELSE
-    CREATE MATERIALIZED VIEW IF NOT EXISTS mat_before
-    WITH ( timescaledb.continuous)
-    AS
-      SELECT time_bucket('1week', timec) as bucket,
-	location,
-	min(allnull) as min_allnull,
-	max(temperature) as max_temp,
-	sum(temperature)+sum(humidity) as agg_sum_expr,
-	avg(humidity) AS avg_humidity,
-	stddev(humidity),
-	bit_and(bit_int),
-	bit_or(bit_int),
-	bool_and(good_life),
-	every(temperature > 0),
-	bool_or(good_life),
-	count(*) as count_rows,
-	count(temperature) as count_temp,
-	count(allnull) as count_zero,
-	corr(temperature, humidity),
-	covar_pop(temperature, humidity),
-	covar_samp(temperature, humidity),
-	regr_avgx(temperature, humidity),
-	regr_avgy(temperature, humidity),
-	regr_count(temperature, humidity),
-	regr_intercept(temperature, humidity),
-	regr_r2(temperature, humidity),
-	regr_slope(temperature, humidity),
-	regr_sxx(temperature, humidity),
-	regr_sxy(temperature, humidity),
-	round(regr_syy(temperature, humidity)) as regr_syy,
-	stddev(temperature) as stddev_temp,
-	round(stddev_pop(temperature)) as stddev_pop,
-	stddev_samp(temperature),
-	round(variance(temperature)) as variance,
-	round(var_pop(temperature)) as var_pop,
-	round(var_samp(temperature)) as var_samp,
-	last(temperature, timec) as last_temp,
-	last(highlow, timec) as last_hl,
-	first(highlow, timec) as first_hl,
-	histogram(temperature, 0, 100, 5)
-      FROM conditions_before
+
+    ALTER VIEW mat_before SET (timescaledb.materialized_only=true);
+\else
       GROUP BY bucket, location
       HAVING min(location) >= 'NYC' and avg(temperature) > 2 WITH NO DATA;
-    PERFORM add_continuous_aggregate_policy('mat_before', NULL, '-30 days'::interval, '336 h');
-
-  END IF;
-
-  IF ts_version >= '2.0.0' THEN
+	SELECT add_continuous_aggregate_policy('mat_before', NULL, '-30 days'::interval, '336 h');
     ALTER MATERIALIZED VIEW mat_before SET (timescaledb.materialized_only=true);
-  ELSIF ts_version >= '1.7.0' THEN
-    ALTER VIEW mat_before SET (timescaledb.materialized_only=true);
-  END IF;
-END $$;
+\endif
 
 GRANT SELECT ON mat_before TO cagg_user WITH GRANT OPTION;
 
 -- have to use psql conditional here because the procedure call can't be in transaction
-SELECT extversion < '2.0.0' AS has_refresh_mat_view from pg_extension WHERE extname = 'timescaledb' \gset
 \if :has_refresh_mat_view
 REFRESH MATERIALIZED VIEW mat_before;
 \else


### PR DESCRIPTION
The setup scripts for upgrade/downgrade tests of Continuous Aggregates
has too many duplicated code for pre-2.0 tests. Refactor it a bit
removing the duplicated code by using `\if \else \endif` psql
meta-commands.

Also added a properly `round` function to all functions that returns
`float8` in SQL scripts  because in rare cases it lead to flaky tests.

This is part of #4269.