### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DREQUIRE_ALL_TESTS=ON -DLINTER_STRICT=ON
+        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DREQUIRE_ALL_TESTS=ON -DLINTER_STRICT=ON -DLINTER=ON -DCMAKE_VERBOSE_MAKEFILE=ON
         make -j $MAKE_JOBS -C build
         make -C build install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,7 +527,7 @@ if(LINTER)
     message(STATUS "Linter support (clang-tidy) enabled")
     if(LINTER_STRICT)
       set(CMAKE_C_CLANG_TIDY
-          "${CLANG_TIDY};--warnings-as-errors=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*"
+          "${CLANG_TIDY};--checks=cppcoreguidelines-init-variables,clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*;--warnings-as-errors=*"
       )
     else()
       set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")

--- a/src/agg_bookend.c
+++ b/src/agg_bookend.c
@@ -390,12 +390,11 @@ bookend_combinefunc(MemoryContext aggcontext, InternalCmpAggStore *state1,
 	{
 		PG_RETURN_POINTER(state1);
 	}
-	else if (state1->cmp.is_null != state2->cmp.is_null)
+	if (state1->cmp.is_null != state2->cmp.is_null)
 	{
 		if (state1->cmp.is_null)
 			PG_RETURN_POINTER(state2);
-		else
-			PG_RETURN_POINTER(state1);
+		PG_RETURN_POINTER(state1);
 	}
 
 	cmpproc_init(fcinfo, &cache->cmp_proc, state1->cmp.type_oid, opname);

--- a/src/agg_bookend.c
+++ b/src/agg_bookend.c
@@ -277,7 +277,8 @@ typeinfocache_polydatumcopy(TypeInfoCache *tic, PolyDatum input, PolyDatum *outp
 inline static void
 cmpproc_init(FunctionCallInfo fcinfo, FmgrInfo *cmp_proc, Oid type_oid, char *opname)
 {
-	Oid cmp_op, cmp_regproc;
+	Oid cmp_op;
+	Oid cmp_regproc;
 
 	if (!OidIsValid(type_oid))
 		elog(ERROR, "could not determine the type of the comparison_element");

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -56,14 +56,14 @@ typedef enum JobLockLifetime
 } JobLockLifetime;
 
 BackgroundWorkerHandle *
-ts_bgw_job_start(BgwJob *job, Oid user_uid)
+ts_bgw_job_start(BgwJob *job, Oid user_oid)
 {
 	int32 job_id = Int32GetDatum(job->fd.id);
 	StringInfo si = makeStringInfo();
 	BackgroundWorkerHandle *bgw_handle;
 
 	/* Changing this requires changes to ts_bgw_job_entrypoint */
-	appendStringInfo(si, "%u %d", user_uid, job_id);
+	appendStringInfo(si, "%u %d", user_oid, job_id);
 
 	bgw_handle = ts_bgw_start_worker(job_entrypoint_function_name,
 									 NameStr(job->fd.application_name),

--- a/src/bgw_policy/chunk_stats.h
+++ b/src/bgw_policy/chunk_stats.h
@@ -15,7 +15,7 @@ typedef struct BgwPolicyChunkStats
 	FormData_bgw_policy_chunk_stats fd;
 } BgwPolicyChunkStats;
 
-extern TSDLLEXPORT void ts_bgw_policy_chunk_stats_insert(BgwPolicyChunkStats *stat);
+extern TSDLLEXPORT void ts_bgw_policy_chunk_stats_insert(BgwPolicyChunkStats *chunk_stats);
 extern BgwPolicyChunkStats *ts_bgw_policy_chunk_stats_find(int32 job_id, int32 chunk_id);
 extern void ts_bgw_policy_chunk_stats_delete_row_only_by_job_id(int32 job_id);
 extern void ts_bgw_policy_chunk_stats_delete_by_chunk_id(int32 chunk_id);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -388,7 +388,8 @@ calculate_and_set_new_chunk_interval(const Hypertable *ht, const Point *p)
 	Hyperspace *hs = ht->space;
 	Dimension *dim = NULL;
 	Datum datum;
-	int64 chunk_interval, coord;
+	int64 chunk_interval;
+	int64 coord;
 	int i;
 
 	if (!OidIsValid(ht->chunk_sizing_func) || ht->fd.chunk_target_size <= 0)
@@ -737,7 +738,8 @@ copy_hypertable_acl_to_relid(const Hypertable *ht, Oid owner_id, Oid relid)
 	acl_datum = SysCacheGetAttr(RELOID, ht_tuple, Anum_pg_class_relacl, &is_null);
 	if (!is_null)
 	{
-		HeapTuple chunk_tuple, newtuple;
+		HeapTuple chunk_tuple;
+		HeapTuple newtuple;
 		Datum new_val[Natts_pg_class] = { 0 };
 		bool new_null[Natts_pg_class] = { false };
 		bool new_repl[Natts_pg_class] = { false };
@@ -834,7 +836,8 @@ ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tabl
 								 get_am_name_for_rel(chunk->hypertable_relid) :
 								 NULL,
 	};
-	Oid uid, saved_uid;
+	Oid uid;
+	Oid saved_uid;
 
 	Assert(chunk->hypertable_relid == ht->main_table_relid);
 
@@ -2409,7 +2412,8 @@ Chunk *
 ts_chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name,
 										 MemoryContext mctx, bool fail_if_not_found)
 {
-	NameData schema, table;
+	NameData schema;
+	NameData table;
 	ScanKeyData scankey[2];
 	static const DisplayKeyData displaykey[2] = {
 		[0] = { .name = "schema_name", .as_string = DatumGetNameString },
@@ -3703,7 +3707,8 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 	uint64 num_chunks = 0;
 	Chunk *chunks;
 	List *dropped_chunk_names = NIL;
-	const char *schema_name, *table_name;
+	const char *schema_name;
+	const char *table_name;
 	const int32 hypertable_id = ht->fd.id;
 	bool has_continuous_aggs;
 	List *data_nodes = NIL;

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -469,7 +469,8 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 		Chunk *chunk = lfirst(lc);
 		const DimensionSlice *slice =
 			ts_hypercube_get_slice_by_dimension_id(chunk->cube, dimension_id);
-		int64 chunk_size, slice_interval;
+		int64 chunk_size;
+		int64 slice_interval;
 		Datum minmax[2];
 		AttrNumber attno =
 			chunk_get_attno(ht->main_table_relid, chunk->table_id, dim->column_attno);
@@ -485,7 +486,8 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 		{
 			int64 min = ts_time_value_to_internal(minmax[0], dim->fd.column_type);
 			int64 max = ts_time_value_to_internal(minmax[1], dim->fd.column_type);
-			double interval_fillfactor, size_fillfactor;
+			double interval_fillfactor;
+			double size_fillfactor;
 			int64 extrapolated_chunk_size;
 
 			/*

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -847,7 +847,8 @@ chunk_constraint_rename_hypertable_from_tuple(TupleInfo *ti, const char *newname
 	bool nulls[Natts_chunk_constraint];
 	Datum values[Natts_chunk_constraint];
 	bool repl[Natts_chunk_constraint] = { false };
-	HeapTuple tuple, new_tuple;
+	HeapTuple tuple;
+	HeapTuple new_tuple;
 	TupleDesc tupdesc = ts_scanner_get_tupledesc(ti);
 	NameData new_hypertable_constraint_name;
 	NameData new_chunk_constraint_name;

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -36,9 +36,9 @@ typedef struct Hypercube Hypercube;
 typedef struct ChunkScanCtx ChunkScanCtx;
 
 extern TSDLLEXPORT ChunkConstraints *ts_chunk_constraints_alloc(int size_hint, MemoryContext mctx);
-extern ChunkConstraints *ts_chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint,
-															  MemoryContext mctx);
-extern ChunkConstraints *ts_chunk_constraints_copy(ChunkConstraints *constraints);
+extern ChunkConstraints *
+ts_chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size num_constraints_hint, MemoryContext mctx);
+extern ChunkConstraints *ts_chunk_constraints_copy(ChunkConstraints *ccs);
 extern int ts_chunk_constraint_scan_by_dimension_slice(const DimensionSlice *slice,
 													   ChunkScanCtx *ctx, MemoryContext mctx);
 extern int ts_chunk_constraint_scan_by_dimension_slice_to_list(const DimensionSlice *slice,

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -199,8 +199,7 @@ ts_chunk_index_get_tablespace(int32 hypertable_id, Relation template_indexrel, R
 	 */
 	if (OidIsValid(template_indexrel->rd_rel->reltablespace))
 		return template_indexrel->rd_rel->reltablespace;
-	else
-		return chunk_index_select_tablespace(hypertable_id, chunkrel);
+	return chunk_index_select_tablespace(hypertable_id, chunkrel);
 }
 
 /*

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -45,7 +45,7 @@ extern int ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char 
 extern int ts_chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid,
 										const char *newname);
 extern int ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name,
-									  const char *old_name, const char *new_name);
+									  const char *oldname, const char *newname);
 extern int ts_chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid,
 										 const char *tablespace);
 extern void ts_chunk_index_create_from_constraint(int32 hypertable_id, Oid hypertable_constraint,

--- a/src/compression_with_clause.c
+++ b/src/compression_with_clause.c
@@ -259,8 +259,7 @@ ts_compress_hypertable_parse_segment_by(WithClauseResult *parsed_options, Hypert
 		Datum textarg = parsed_options[CompressSegmentBy].parsed;
 		return parse_segment_collist(TextDatumGetCString(textarg), hypertable);
 	}
-	else
-		return NIL;
+	return NIL;
 }
 
 /* returns List of CompressedParsedCol
@@ -274,6 +273,5 @@ ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options, Hypertab
 		Datum textarg = parsed_options[CompressOrderBy].parsed;
 		return parse_order_collist(TextDatumGetCString(textarg), hypertable);
 	}
-	else
-		return NIL;
+	return NIL;
 }

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -398,17 +398,15 @@ ts_dimension_get_open_slice_ordinal(const Dimension *dim, const DimensionSlice *
 
 	if (i >= 0)
 		return i;
-	else
-	{
-		/*
-		 * Returns the number of slices if the slice not found, i.e., i = -1.
-		 * Dimension slice might not exist if a chunk table is created without
-		 * modifying metadata. It happens only during copy/move chunk for distributed
-		 * hypertable, thus this code, which is used when no space dimension exists,
-		 * is unlikely to be used.
-		 */
-		return vec->num_slices;
-	}
+
+	/*
+	 * Returns the number of slices if the slice not found, i.e., i = -1.
+	 * Dimension slice might not exist if a chunk table is created without
+	 * modifying metadata. It happens only during copy/move chunk for distributed
+	 * hypertable, thus this code, which is used when no space dimension exists,
+	 * is unlikely to be used.
+	 */
+	return vec->num_slices;
 }
 
 /*
@@ -462,8 +460,7 @@ ts_dimension_get_closed_slice_ordinal(const Dimension *dim, const DimensionSlice
 	 * doesn't affect the correctness of the following check. */
 	if (target_overlap_with_candidate_slice >= target_slice_size / 2)
 		return candidate_slice_ordinal;
-	else
-		return candidate_slice_ordinal + 1;
+	return candidate_slice_ordinal + 1;
 }
 
 /*

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -244,7 +244,8 @@ create_range_datum(FunctionCallInfo fcinfo, DimensionSlice *slice)
 static DimensionSlice *
 calculate_open_range_default(const Dimension *dim, int64 value)
 {
-	int64 range_start, range_end;
+	int64 range_start;
+	int64 range_end;
 	Oid dimtype = ts_dimension_get_partition_type(dim);
 
 	if (value < 0)
@@ -306,7 +307,8 @@ calculate_closed_range_interval(const Dimension *dim)
 static DimensionSlice *
 calculate_closed_range_default(const Dimension *dim, int64 value)
 {
-	int64 range_start, range_end;
+	int64 range_start;
+	int64 range_end;
 
 	/* The interval that divides the dimension into N equal sized slices */
 	int64 interval = calculate_closed_range_interval(dim);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -138,7 +138,7 @@ extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_closed(Oid table_reli
 
 extern void ts_dimension_info_validate(DimensionInfo *info);
 extern int32 ts_dimension_add_from_info(DimensionInfo *info);
-extern void ts_dimensions_rename_schema_name(const char *oldname, const char *newname);
+extern void ts_dimensions_rename_schema_name(const char *old_name, const char *new_name);
 extern TSDLLEXPORT void ts_dimension_update(const Hypertable *ht, const NameData *dimname,
 											DimensionType dimtype, Datum *interval,
 											Oid *intervaltype, int16 *num_slices,

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -812,7 +812,7 @@ ts_dimension_slice_cut(DimensionSlice *to_cut, const DimensionSlice *other, int6
 
 		return true;
 	}
-	else if (other->fd.range_start > coord && other->fd.range_start < to_cut->fd.range_end)
+	if (other->fd.range_start > coord && other->fd.range_start < to_cut->fd.range_end)
 	{
 		/* Cut "after" the coordinate */
 		to_cut->fd.range_end = other->fd.range_start;

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -876,7 +876,8 @@ ts_dimension_slice_insert_multi(DimensionSlice **slices, Size num_slices)
 {
 	Catalog *catalog = ts_catalog_get();
 	Relation rel;
-	Size i, n = 0;
+	Size i;
+	Size n = 0;
 
 	rel = table_open(catalog_get_table_id(catalog, DIMENSION_SLICE), RowExclusiveLock);
 

--- a/src/estimate.c
+++ b/src/estimate.c
@@ -32,8 +32,10 @@ estimate_max_spread_var(PlannerInfo *root, Var *var)
 {
 	VariableStatData vardata;
 	Oid ltop;
-	Datum max_datum, min_datum;
-	volatile int64 max, min;
+	Datum max_datum;
+	Datum min_datum;
+	volatile int64 max;
+	volatile int64 min;
 	volatile bool valid;
 
 	examine_variable(root, (Node *) var, 0, &vardata);

--- a/src/guc.c
+++ b/src/guc.c
@@ -396,8 +396,8 @@ _guc_init(void)
 #endif
 
 	DefineCustomStringVariable(/* name= */ "timescaledb.license",
-							   /* short_dec= */ "TimescaleDB license type",
-							   /* long_dec= */ "Determines which features are enabled",
+							   /* short_desc= */ "TimescaleDB license type",
+							   /* long_desc= */ "Determines which features are enabled",
 							   /* valueAddr= */ &ts_guc_license,
 							   /* bootValue= */ TS_LICENSE_DEFAULT,
 							   /* context= */ PGC_SUSET,
@@ -407,8 +407,8 @@ _guc_init(void)
 							   /* show_hook= */ NULL);
 
 	DefineCustomStringVariable(/* name= */ "timescaledb.last_tuned",
-							   /* short_dec= */ "last tune run",
-							   /* long_dec= */ "records last time timescaledb-tune ran",
+							   /* short_desc= */ "last tune run",
+							   /* long_desc= */ "records last time timescaledb-tune ran",
 							   /* valueAddr= */ &ts_last_tune_time,
 							   /* bootValue= */ NULL,
 							   /* context= */ PGC_SIGHUP,
@@ -418,8 +418,8 @@ _guc_init(void)
 							   /* show_hook= */ NULL);
 
 	DefineCustomStringVariable(/* name= */ "timescaledb.last_tuned_version",
-							   /* short_dec= */ "version of timescaledb-tune",
-							   /* long_dec= */ "version of timescaledb-tune used to tune",
+							   /* short_desc= */ "version of timescaledb-tune",
+							   /* long_desc= */ "version of timescaledb-tune used to tune",
 							   /* valueAddr= */ &ts_last_tune_version,
 							   /* bootValue= */ NULL,
 							   /* context= */ PGC_SIGHUP,
@@ -430,8 +430,8 @@ _guc_init(void)
 
 #ifdef USE_TELEMETRY
 	DefineCustomStringVariable(/* name= */ "timescaledb_telemetry.cloud",
-							   /* short_dec= */ "cloud provider",
-							   /* long_dec= */ "cloud provider used for this instance",
+							   /* short_desc= */ "cloud provider",
+							   /* long_desc= */ "cloud provider used for this instance",
 							   /* valueAddr= */ &ts_telemetry_cloud,
 							   /* bootValue= */ NULL,
 							   /* context= */ PGC_SIGHUP,
@@ -443,8 +443,8 @@ _guc_init(void)
 
 #ifdef TS_DEBUG
 	DefineCustomBoolVariable(/* name= */ "timescaledb.shutdown_bgw_scheduler",
-							 /* short_dec= */ "immediately shutdown the bgw scheduler",
-							 /* long_dec= */ "this is for debugging purposes",
+							 /* short_desc= */ "immediately shutdown the bgw scheduler",
+							 /* long_desc= */ "this is for debugging purposes",
 							 /* valueAddr= */ &ts_shutdown_bgw,
 							 /* bootValue= */ false,
 							 /* context= */ PGC_SIGHUP,
@@ -454,8 +454,8 @@ _guc_init(void)
 							 /* show_hook= */ NULL);
 
 	DefineCustomStringVariable(/* name= */ "timescaledb.current_timestamp_mock",
-							   /* short_dec= */ "set the current timestamp",
-							   /* long_dec= */ "this is for debugging purposes",
+							   /* short_desc= */ "set the current timestamp",
+							   /* long_desc= */ "this is for debugging purposes",
 							   /* valueAddr= */ &ts_current_timestamp_mock,
 							   /* bootValue= */ NULL,
 							   /* context= */ PGC_USERSET,

--- a/src/histogram.c
+++ b/src/histogram.c
@@ -35,7 +35,7 @@ TS_FUNCTION_INFO_V1(ts_hist_serializefunc);
 TS_FUNCTION_INFO_V1(ts_hist_deserializefunc);
 TS_FUNCTION_INFO_V1(ts_hist_finalfunc);
 
-#define HISTOGRAM_SIZE(state, nbuckets) (sizeof(*state) + nbuckets * sizeof(*state->buckets))
+#define HISTOGRAM_SIZE(state, nbuckets) (sizeof(*(state)) + (nbuckets) * sizeof(*(state)->buckets))
 
 typedef struct Histogram
 {

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1913,7 +1913,9 @@ ts_hypertable_create_from_info(Oid table_relid, int32 hypertable_id, uint32 flag
 	Oid user_oid = GetUserId();
 	Oid tspc_oid = get_rel_tablespace(table_relid);
 	bool table_has_data;
-	NameData schema_name, table_name, default_associated_schema_name;
+	NameData schema_name;
+	NameData table_name;
+	NameData default_associated_schema_name;
 	Relation rel;
 	bool if_not_exists = (flags & HYPERTABLE_CREATE_IF_NOT_EXISTS) != 0;
 
@@ -2395,7 +2397,9 @@ ts_hypertable_create_compressed(Oid table_relid, int32 hypertable_id)
 {
 	Oid user_oid = GetUserId();
 	Oid tspc_oid = get_rel_tablespace(table_relid);
-	NameData schema_name, table_name, associated_schema_name;
+	NameData schema_name;
+	NameData table_name;
+	NameData associated_schema_name;
 	ChunkSizingInfo *chunk_sizing_info;
 	Relation rel;
 
@@ -2506,7 +2510,8 @@ ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cub
 	List *chunk_data_nodes = NIL;
 	List *available_nodes = ts_hypertable_get_available_data_nodes(ht, true);
 	int num_assigned = MIN(ht->fd.replication_factor, list_length(available_nodes));
-	int n, i;
+	int n;
+	int i;
 
 	n = hypertable_get_chunk_round_robin_index(ht, cube);
 

--- a/src/hypertable_cache.c
+++ b/src/hypertable_cache.c
@@ -163,8 +163,7 @@ ts_hypertable_cache_get_entry(Cache *const cache, const Oid relid, const unsigne
 	{
 		if (flags & CACHE_FLAG_MISSING_OK)
 			return NULL;
-		else
-			ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("invalid Oid")));
+		ereport(ERROR, (errcode(ERRCODE_UNDEFINED_OBJECT), errmsg("invalid Oid")));
 	}
 
 	return ts_hypertable_cache_get_entry_with_table(cache, relid, NULL, NULL, flags);

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -281,7 +281,9 @@ static bool
 hypertable_restrict_info_add_expr(HypertableRestrictInfo *hri, PlannerInfo *root, List *expr_args,
 								  Oid op_oid, get_dimension_values func_get_dim_values, bool use_or)
 {
-	Expr *leftop, *rightop, *expr;
+	Expr *leftop;
+	Expr *rightop;
+	Expr *expr;
 	DimensionRestrictInfo *dri;
 	Var *v;
 	Const *c;
@@ -289,7 +291,8 @@ hypertable_restrict_info_add_expr(HypertableRestrictInfo *hri, PlannerInfo *root
 	Oid columntype;
 	TypeCacheEntry *tce;
 	int strategy;
-	Oid lefttype, righttype;
+	Oid lefttype;
+	Oid righttype;
 	DimensionValues *dimvalues;
 
 	if (list_length(expr_args) != 2)

--- a/src/import/planner.c
+++ b/src/import/planner.c
@@ -601,7 +601,9 @@ PathKey *
 ts_make_pathkey_from_sortop(PlannerInfo *root, Expr *expr, Relids nullable_relids, Oid ordering_op,
 							bool nulls_first, Index sortref, bool create_it)
 {
-	Oid opfamily, opcintype, collation;
+	Oid opfamily;
+	Oid opcintype;
+	Oid collation;
 	int16 strategy;
 
 	/* Find the operator in pg_amop --- failure shouldn't happen */

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -237,7 +237,8 @@ indexing_create_and_verify_hypertable_indexes(const Hypertable *ht, bool create_
 		/* Check for existence of "default" indexes */
 		if (create_default && NULL != time_dim)
 		{
-			Form_pg_attribute idxattr_time, idxattr_space;
+			Form_pg_attribute idxattr_time;
+			Form_pg_attribute idxattr_space;
 
 			switch (idxrel->rd_att->natts)
 			{

--- a/src/jsonb_utils.h
+++ b/src/jsonb_utils.h
@@ -17,7 +17,7 @@ extern TSDLLEXPORT void ts_jsonb_add_bool(JsonbParseState *state, const char *ke
 extern TSDLLEXPORT void ts_jsonb_add_str(JsonbParseState *state, const char *key,
 										 const char *value);
 extern TSDLLEXPORT void ts_jsonb_add_interval(JsonbParseState *state, const char *key,
-											  Interval *value);
+											  Interval *interval);
 extern TSDLLEXPORT void ts_jsonb_add_int32(JsonbParseState *state, const char *key,
 										   const int32 value);
 extern TSDLLEXPORT void ts_jsonb_add_int64(JsonbParseState *state, const char *key,

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -215,7 +215,6 @@ wait_for_background_worker_startup(BackgroundWorkerHandle *handle, pid_t *pidp)
 		bgw_on_postmaster_death();
 
 	Assert(status == BGWH_STOPPED || status == BGWH_STARTED);
-	return;
 }
 
 static void
@@ -233,7 +232,6 @@ wait_for_background_worker_shutdown(BackgroundWorkerHandle *handle)
 		bgw_on_postmaster_death();
 
 	Assert(status == BGWH_STOPPED);
-	return;
 }
 
 static void

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -241,8 +241,7 @@ terminate_background_worker(BackgroundWorkerHandle *handle)
 {
 	if (handle == NULL)
 		return;
-	else
-		TerminateBackgroundWorker(handle);
+	TerminateBackgroundWorker(handle);
 }
 
 extern void

--- a/src/loader/bgw_message_queue.c
+++ b/src/loader/bgw_message_queue.c
@@ -236,7 +236,7 @@ ts_shm_mq_wait_for_attach(MessageQueue *queue, shm_mq_handle *ack_queue_handle)
 		reader_proc = shm_mq_get_sender(shm_mq_get_queue(ack_queue_handle));
 		if (reader_proc != NULL)
 			return SHM_MQ_SUCCESS;
-		else if (queue_get_reader(queue) == InvalidPid)
+		if (queue_get_reader(queue) == InvalidPid)
 			return SHM_MQ_DETACHED; /* Reader died after we enqueued our
 									 * message */
 		WaitLatch(MyLatch,

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -346,7 +346,6 @@ stop_workers_on_db_drop(DropdbStmt *drop_db_statement)
 						dropped_db_oid)));
 		ts_bgw_message_send_and_wait(STOP, dropped_db_oid);
 	}
-	return;
 }
 
 static void

--- a/src/net/conn_plain.c
+++ b/src/net/conn_plain.c
@@ -42,7 +42,8 @@ int
 ts_plain_connect(Connection *conn, const char *host, const char *servname, int port)
 {
 	char strport[6];
-	struct addrinfo *ainfo, hints = {
+	struct addrinfo *ainfo;
+	struct addrinfo hints = {
 		.ai_family = AF_UNSPEC,
 		.ai_socktype = SOCK_STREAM,
 	};

--- a/src/net/conn_ssl.c
+++ b/src/net/conn_ssl.c
@@ -203,14 +203,13 @@ ssl_errmsg(Connection *conn)
 				{
 					if (err == 0)
 						return "EOF in SSL operation";
-					else if (IS_SOCKET_ERROR(err))
+					if (IS_SOCKET_ERROR(err))
 					{
 						/* reset error for plan_errmsg() */
 						conn->err = err;
 						return ts_plain_errmsg(conn);
 					}
-					else
-						return "unknown SSL syscall error";
+					return "unknown SSL syscall error";
 				}
 				return "SSL error syscall";
 			default:

--- a/src/net/http_request.c
+++ b/src/net/http_request.c
@@ -237,8 +237,7 @@ ts_http_request_build(HttpRequest *req, size_t *buf_size)
 			{
 				return NULL;
 			}
-			else
-				verified_content_length = true;
+			verified_content_length = true;
 		}
 		http_header_serialize(cur_header, &buf);
 		http_request_serialize_char(CARRIAGE, &buf);

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -29,8 +29,8 @@
 #include "nodes/chunk_append/chunk_append.h"
 #include "loader/lwlocks.h"
 
-#define INVALID_SUBPLAN_INDEX -1
-#define NO_MATCHING_SUBPLANS -2
+#define INVALID_SUBPLAN_INDEX (-1)
+#define NO_MATCHING_SUBPLANS (-2)
 
 typedef struct ParallelChunkAppendState
 {

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -115,7 +115,7 @@ static void choose_next_subplan_non_parallel(ChunkAppendState *state);
 static void choose_next_subplan_for_worker(ChunkAppendState *state);
 
 static List *constify_restrictinfos(PlannerInfo *root, List *restrictinfos);
-static bool can_exclude_chunk(List *constraints, List *restrictinfos);
+static bool can_exclude_chunk(List *constraints, List *baserestrictinfo);
 static void do_startup_exclusion(ChunkAppendState *state);
 static Node *constify_param_mutator(Node *node, void *context);
 static List *constify_restrictinfo_params(PlannerInfo *root, EState *state, List *restrictinfos);

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -476,15 +476,13 @@ get_next_subplan(ChunkAppendState *state, int last_plan)
 		 */
 		return bms_next_member(state->valid_subplans, last_plan);
 	}
-	else
-	{
-		int next_plan = last_plan + 1;
 
-		if (next_plan >= state->num_subplans)
-			return NO_MATCHING_SUBPLANS;
+	int next_plan = last_plan + 1;
 
-		return next_plan;
-	}
+	if (next_plan >= state->num_subplans)
+		return NO_MATCHING_SUBPLANS;
+
+	return next_plan;
 }
 
 static void

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -335,7 +335,8 @@ chunk_append_begin(CustomScanState *node, EState *estate, int eflags)
 static void
 initialize_runtime_exclusion(ChunkAppendState *state)
 {
-	ListCell *lc_clauses, *lc_constraints;
+	ListCell *lc_clauses;
+	ListCell *lc_constraints;
 	int i = 0;
 
 	PlannerGlobal glob = {
@@ -950,7 +951,9 @@ can_exclude_chunk(List *constraints, List *baserestrictinfo)
 static void
 initialize_constraints(ChunkAppendState *state, List *initial_rt_indexes)
 {
-	ListCell *lc_clauses, *lc_plan, *lc_relid;
+	ListCell *lc_clauses;
+	ListCell *lc_plan;
+	ListCell *lc_relid;
 	List *constraints = NIL;
 	EState *estate = state->csstate.ss.ps.state;
 

--- a/src/nodes/chunk_append/planner.c
+++ b/src/nodes/chunk_append/planner.c
@@ -118,7 +118,8 @@ ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path
 
 	if (path->path.pathkeys == NIL)
 	{
-		ListCell *lc_plan, *lc_path;
+		ListCell *lc_plan;
+		ListCell *lc_path;
 		forboth (lc_path, path->custom_paths, lc_plan, custom_plans)
 		{
 			Plan *child_plan = lfirst(lc_plan);
@@ -148,7 +149,8 @@ ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path
 		 * return sorted output. Children not returning sorted output will be
 		 * wrapped in a sort node.
 		 */
-		ListCell *lc_plan, *lc_path;
+		ListCell *lc_plan;
+		ListCell *lc_path;
 		int numCols;
 		AttrNumber *sortColIdx;
 		Oid *sortOperators;
@@ -199,7 +201,8 @@ ts_chunk_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *path
 
 			if (IsA(lfirst(lc_plan), MergeAppend))
 			{
-				ListCell *lc_childpath, *lc_childplan;
+				ListCell *lc_childpath;
+				ListCell *lc_childplan;
 				MergeAppend *merge_plan = castNode(MergeAppend, lfirst(lc_plan));
 				MergeAppendPath *merge_path = castNode(MergeAppendPath, lfirst(lc_path));
 

--- a/src/nodes/chunk_append/transform.c
+++ b/src/nodes/chunk_append/transform.c
@@ -15,7 +15,7 @@
 #include "utils.h"
 
 #define DATATYPE_PAIR(left, right, type1, type2)                                                   \
-	((left == type1 && right == type2) || (left == type2 && right == type1))
+	(((left) == (type1) && (right) == (type2)) || ((left) == (type2) && (right) == (type1)))
 
 /*
  * Cross datatype comparisons between DATE/TIMESTAMP/TIMESTAMPTZ

--- a/src/nodes/chunk_append/transform.c
+++ b/src/nodes/chunk_append/transform.c
@@ -56,7 +56,10 @@ ts_transform_cross_datatype_comparison(Expr *clause)
 			DATATYPE_PAIR(left_type, right_type, TIMESTAMPTZOID, DATEOID))
 		{
 			char *opname = get_opname(op->opno);
-			Oid source_type, target_type, opno, cast_oid;
+			Oid source_type;
+			Oid target_type;
+			Oid opno;
+			Oid cast_oid;
 
 			/*
 			 * if Var is on left side we put cast on right side otherwise

--- a/src/nodes/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch.c
@@ -95,9 +95,9 @@ ts_chunk_dispatch_get_cmd_type(const ChunkDispatch *dispatch)
 }
 
 void
-ts_chunk_dispatch_destroy(ChunkDispatch *cd)
+ts_chunk_dispatch_destroy(ChunkDispatch *dispatch)
 {
-	ts_subspace_store_free(cd->cache);
+	ts_subspace_store_free(dispatch->cache);
 }
 
 static void

--- a/src/nodes/chunk_dispatch_state.h
+++ b/src/nodes/chunk_dispatch_state.h
@@ -36,7 +36,8 @@ typedef struct ChunkDispatchState
 } ChunkDispatchState;
 
 extern bool ts_is_chunk_dispatch_state(PlanState *state);
-extern ChunkDispatchState *ts_chunk_dispatch_state_create(Oid hypertable_oid, Plan *plan);
-extern void ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *parent);
+extern ChunkDispatchState *ts_chunk_dispatch_state_create(Oid hypertable_relid, Plan *plan);
+extern void ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state,
+											   ModifyTableState *mtstate);
 
 #endif /* TIMESCALEDB_CHUNK_DISPATCH_STATE_H */

--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -57,7 +57,8 @@ prepare_constr_expr(Expr *node)
 static inline void
 create_chunk_rri_constraint_expr(ResultRelInfo *rri, Relation rel)
 {
-	int ncheck, i;
+	int ncheck;
+	int i;
 	ConstrCheck *check;
 
 	Assert(rel->rd_att->constr != NULL && rri->ri_ConstraintExprs == NULL);
@@ -579,13 +580,16 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 	int cagg_trig_nargs = 0;
 	int32 cagg_trig_args[2] = { 0, 0 };
 	ChunkInsertState *state;
-	Relation rel, parent_rel, compress_rel = NULL;
+	Relation rel;
+	Relation parent_rel;
+	Relation compress_rel = NULL;
 	MemoryContext old_mcxt;
 	MemoryContext cis_context = AllocSetContextCreate(dispatch->estate->es_query_cxt,
 													  "chunk insert state memory context",
 													  ALLOCSET_DEFAULT_SIZES);
 	OnConflictAction onconflict_action = ts_chunk_dispatch_get_on_conflict_action(dispatch);
-	ResultRelInfo *resrelinfo, *relinfo;
+	ResultRelInfo *resrelinfo;
+	ResultRelInfo *relinfo;
 	bool has_compressed_chunk = (chunk->fd.compressed_chunk_id != 0);
 
 	/* permissions NOT checked here; were checked at hypertable level */

--- a/src/nodes/constraint_aware_append/constraint_aware_append.c
+++ b/src/nodes/constraint_aware_append/constraint_aware_append.c
@@ -120,7 +120,8 @@ ca_append_begin(CustomScanState *node, EState *estate, int eflags)
 	Plan *subplan = copyObject(state->subplan);
 	List *chunk_ri_clauses = lsecond(cscan->custom_private);
 	List *chunk_relids = lthird(cscan->custom_private);
-	List **appendplans, *old_appendplans;
+	List **appendplans;
+	List *old_appendplans;
 	ListCell *lc_plan;
 	ListCell *lc_clauses;
 	ListCell *lc_relid;

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -174,7 +174,9 @@ ts_partitioning_info_create(const char *schema, const char *partfunc, const char
 							DimensionType dimtype, Oid relid)
 {
 	PartitioningInfo *pinfo;
-	Oid columntype, varcollid, funccollid = InvalidOid;
+	Oid columntype;
+	Oid varcollid;
+	Oid funccollid = InvalidOid;
 	Var *var;
 	FuncExpr *expr;
 

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -34,18 +34,18 @@
 #define IS_VALID_CLOSED_PARTITIONING_FUNC(proform, argtype)                                        \
 	((proform)->prorettype == INT4OID && ((proform)->provolatile == PROVOLATILE_IMMUTABLE) &&      \
 	 (proform)->pronargs == 1 &&                                                                   \
-	 ((proform)->proargtypes.values[0] == argtype ||                                               \
+	 ((proform)->proargtypes.values[0] == (argtype) ||                                             \
 	  (proform)->proargtypes.values[0] == ANYELEMENTOID))
 
 #define IS_VALID_OPEN_PARTITIONING_FUNC(proform, argtype)                                          \
 	(IS_VALID_OPEN_DIM_TYPE((proform)->prorettype) &&                                              \
 	 ((proform)->provolatile == PROVOLATILE_IMMUTABLE) && (proform)->pronargs == 1 &&              \
-	 ((proform)->proargtypes.values[0] == argtype ||                                               \
+	 ((proform)->proargtypes.values[0] == (argtype) ||                                             \
 	  (proform)->proargtypes.values[0] == ANYELEMENTOID))
 
 #define IS_VALID_PARTITIONING_FUNC(proform, dimtype, argtype)                                      \
-	((dimtype == DIMENSION_TYPE_OPEN) ? IS_VALID_OPEN_PARTITIONING_FUNC(proform, argtype) :        \
-										IS_VALID_CLOSED_PARTITIONING_FUNC(proform, argtype))
+	(((dimtype) == DIMENSION_TYPE_OPEN) ? IS_VALID_OPEN_PARTITIONING_FUNC(proform, argtype) :      \
+										  IS_VALID_CLOSED_PARTITIONING_FUNC(proform, argtype))
 
 static bool
 closed_dim_partitioning_func_filter(Form_pg_proc form, void *arg)

--- a/src/plan_agg_bookend.c
+++ b/src/plan_agg_bookend.c
@@ -77,8 +77,8 @@ typedef struct MutatorContext
 } MutatorContext;
 
 static bool find_first_last_aggs_walker(Node *node, List **context);
-static bool build_first_last_path(PlannerInfo *root, FirstLastAggInfo *flinfo, Oid eqop, Oid sortop,
-								  bool nulls_first);
+static bool build_first_last_path(PlannerInfo *root, FirstLastAggInfo *fl_info, Oid eqop,
+								  Oid sortop, bool nulls_first);
 static void first_last_qp_callback(PlannerInfo *root, void *extra);
 static Node *mutate_aggref_node(Node *node, MutatorContext *context);
 static void replace_aggref_in_tlist(MinMaxAggPath *minmaxagg_path);

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -119,7 +119,8 @@ static bool
 is_timestamptz_op_interval(Expr *expr)
 {
 	OpExpr *op;
-	Const *c1, *c2;
+	Const *c1;
+	Const *c2;
 
 	if (!IsA(expr, OpExpr))
 		return false;
@@ -177,14 +178,18 @@ const_datum_get_int(Const *cnst)
 static OpExpr *
 constify_timestamptz_op_interval(PlannerInfo *root, OpExpr *constraint)
 {
-	Expr *left, *right;
+	Expr *left;
+	Expr *right;
 	OpExpr *op;
 	bool var_on_left = false;
 	Interval *interval;
-	Const *c_ts, *c_int;
+	Const *c_ts;
+	Const *c_int;
 	Datum constified;
 	PGFunction opfunc;
-	Oid ts_pl_int, ts_mi_int, int_pl_ts;
+	Oid ts_pl_int;
+	Oid ts_mi_int;
+	Oid int_pl_ts;
 
 	/* checked in caller already so only asserting */
 	Assert(constraint->args->length == 2);
@@ -357,7 +362,8 @@ transform_time_bucket_comparison(PlannerInfo *root, OpExpr *op)
 		/* column < value + width */
 		Expr *subst;
 		Datum datum;
-		int64 integralValue, integralWidth;
+		int64 integralValue;
+		int64 integralWidth;
 
 		if (castNode(Const, value)->constisnull || width->constisnull)
 			return op;
@@ -1493,7 +1499,8 @@ propagate_join_quals(PlannerInfo *root, RelOptInfo *rel, CollectQualCtx *ctx)
 	{
 		ListCell *lc_qual;
 		OpExpr *op = lfirst(lc);
-		Var *rel_var, *other_var;
+		Var *rel_var;
+		Var *other_var;
 
 		/*
 		 * join_conditions only has OpExpr with 2 Var as arguments

--- a/src/plan_expand_hypertable.c
+++ b/src/plan_expand_hypertable.c
@@ -357,7 +357,7 @@ transform_time_bucket_comparison(PlannerInfo *root, OpExpr *op)
 
 		return op;
 	}
-	else if (strategy == BTLessStrategyNumber || strategy == BTLessEqualStrategyNumber)
+	if (strategy == BTLessStrategyNumber || strategy == BTLessEqualStrategyNumber)
 	{
 		/* column < value + width */
 		Expr *subst;

--- a/src/planner.c
+++ b/src/planner.c
@@ -86,7 +86,7 @@ typedef struct BaserelInfoEntry
 #define SH_ELEMENT_TYPE BaserelInfoEntry
 #define SH_KEY_TYPE Oid
 #define SH_KEY reloid
-#define SH_EQUAL(tb, a, b) (a == b)
+#define SH_EQUAL(tb, a, b) ((a) == (b))
 #define SH_HASH_KEY(tb, key) murmurhash32(key)
 #define SH_SCOPE static
 #define SH_DECLARE

--- a/src/planner.c
+++ b/src/planner.c
@@ -779,7 +779,7 @@ should_chunk_append(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel, Path *pa
 
 				if (IsA(em_expr, Var) && castNode(Var, em_expr)->varattno == order_attno)
 					return true;
-				else if (IsA(em_expr, FuncExpr) && list_length(path->pathkeys) == 1)
+				if (IsA(em_expr, FuncExpr) && list_length(path->pathkeys) == 1)
 				{
 					FuncExpr *func = castNode(FuncExpr, em_expr);
 					FuncInfo *info = ts_func_cache_get_bucketing_func(func->funcid);

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1412,8 +1412,6 @@ process_relations_in_namespace(GrantStmt *stmt, Name schema_name, Oid namespaceI
 
 	table_endscan(scan);
 	table_close(rel, AccessShareLock);
-
-	return;
 }
 
 /*

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -2569,7 +2569,7 @@ process_index_start(ProcessUtilityArgs *args)
 		ts_cache_release(hcache);
 		return DDL_CONTINUE;
 	}
-	else if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
+	if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 	{
 		/* unique indexes are not allowed on compressed hypertables*/
 		if (stmt->unique || stmt->primary || stmt->isconstraint)

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1014,7 +1014,8 @@ process_truncate(ProcessUtilityArgs *args)
 
 					if (cagg)
 					{
-						Hypertable *mat_ht, *raw_ht;
+						Hypertable *mat_ht;
+						Hypertable *raw_ht;
 						MemoryContext oldctx;
 
 						if (!relation_should_recurse(rv))
@@ -2783,7 +2784,8 @@ process_cluster_start(ProcessUtilityArgs *args)
 		Relation index_rel;
 		List *chunk_indexes;
 		ListCell *lc;
-		MemoryContext old, mcxt;
+		MemoryContext old;
+		MemoryContext mcxt;
 		LockRelId cluster_index_lockid;
 		ChunkIndexMapping **mappings = NULL;
 		int i;
@@ -3302,7 +3304,8 @@ static void
 process_altercontinuousagg_set_with(ContinuousAgg *cagg, Oid view_relid, const List *defelems)
 {
 	WithClauseResult *parse_results;
-	List *pg_options = NIL, *cagg_options = NIL;
+	List *pg_options = NIL;
+	List *cagg_options = NIL;
 
 	continuous_agg_with_clause_perm_check(cagg, view_relid);
 
@@ -3811,7 +3814,8 @@ process_create_rule_start(ProcessUtilityArgs *args)
 static DDLResult
 process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 {
-	List *pg_options = NIL, *compress_options = NIL;
+	List *pg_options = NIL;
+	List *compress_options = NIL;
 	WithClauseResult *parse_results = NULL;
 	List *inpdef = NIL;
 	/* is this a compress table stmt */
@@ -3842,7 +3846,8 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 static DDLResult
 process_altertable_reset_options(AlterTableCmd *cmd, Hypertable *ht)
 {
-	List *pg_options = NIL, *compress_options = NIL;
+	List *pg_options = NIL;
+	List *compress_options = NIL;
 	List *inpdef = NIL;
 	/* is this a compress table stmt */
 	Assert(IsA(cmd->def, List));
@@ -3880,7 +3885,8 @@ process_create_table_as(ProcessUtilityArgs *args)
 	CreateTableAsStmt *stmt = castNode(CreateTableAsStmt, args->parsetree);
 	WithClauseResult *parse_results = NULL;
 	bool is_cagg = false;
-	List *pg_options = NIL, *cagg_options = NIL;
+	List *pg_options = NIL;
+	List *cagg_options = NIL;
 
 	if (get_createtableas_objecttype(stmt) == OBJECT_MATVIEW)
 	{

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -164,8 +164,7 @@ scanner_ctx_get_scanner(ScannerCtx *ctx)
 {
 	if (OidIsValid(ctx->index))
 		return &scanners[ScannerTypeIndex];
-	else
-		return &scanners[ScannerTypeTable];
+	return &scanners[ScannerTypeTable];
 }
 
 TSDLLEXPORT void

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -23,14 +23,14 @@ extern SubspaceStore *ts_subspace_store_init(const Hyperspace *space, MemoryCont
 											 int16 max_items);
 
 /* Store an object associate with the subspace represented by a hypercube */
-extern void ts_subspace_store_add(SubspaceStore *cache, const Hypercube *hc, void *object,
+extern void ts_subspace_store_add(SubspaceStore *store, const Hypercube *hc, void *object,
 								  void (*object_free)(void *));
 
 /* Get the object stored for the subspace that a point is in.
  * Return the object stored or NULL if this subspace is not in the store.
  */
-extern void *ts_subspace_store_get(const SubspaceStore *cache, const Point *target);
-extern void ts_subspace_store_free(SubspaceStore *cache);
-extern MemoryContext ts_subspace_store_mcxt(const SubspaceStore *cache);
+extern void *ts_subspace_store_get(const SubspaceStore *store, const Point *target);
+extern void ts_subspace_store_free(SubspaceStore *store);
+extern MemoryContext ts_subspace_store_mcxt(const SubspaceStore *store);
 
 #endif /* TIMESCALEDB_SUBSPACE_STORE_H */

--- a/src/telemetry/stats.c
+++ b/src/telemetry/stats.c
@@ -45,30 +45,28 @@ classify_hypertable(const Hypertable *ht)
 		 */
 		return RELTYPE_COMPRESSION_HYPERTABLE;
 	}
-	else
+
+	/*
+	 * Not dealing with an internal compression hypertable, but
+	 * could be a materialized hypertable (cagg) unless it is
+	 * distributed.
+	 */
+	switch (ht->fd.replication_factor)
 	{
-		/*
-		 * Not dealing with an internal compression hypertable, but
-		 * could be a materialized hypertable (cagg) unless it is
-		 * distributed.
-		 */
-		switch (ht->fd.replication_factor)
+		case HYPERTABLE_DISTRIBUTED_MEMBER:
+			return RELTYPE_DISTRIBUTED_HYPERTABLE_MEMBER;
+		case HYPERTABLE_REGULAR:
 		{
-			case HYPERTABLE_DISTRIBUTED_MEMBER:
-				return RELTYPE_DISTRIBUTED_HYPERTABLE_MEMBER;
-			case HYPERTABLE_REGULAR:
-			{
-				const ContinuousAgg *cagg = ts_continuous_agg_find_by_mat_hypertable_id(ht->fd.id);
+			const ContinuousAgg *cagg = ts_continuous_agg_find_by_mat_hypertable_id(ht->fd.id);
 
-				if (cagg)
-					return RELTYPE_MATERIALIZED_HYPERTABLE;
+			if (cagg)
+				return RELTYPE_MATERIALIZED_HYPERTABLE;
 
-				return RELTYPE_HYPERTABLE;
-			}
-			default:
-				Assert(ht->fd.replication_factor >= 1);
-				return RELTYPE_DISTRIBUTED_HYPERTABLE;
+			return RELTYPE_HYPERTABLE;
 		}
+		default:
+			Assert(ht->fd.replication_factor >= 1);
+			return RELTYPE_DISTRIBUTED_HYPERTABLE;
 	}
 }
 

--- a/src/telemetry/stats.c
+++ b/src/telemetry/stats.c
@@ -488,7 +488,8 @@ ts_telemetry_stats_gather(TelemetryStats *stats)
 	Relation rel;
 	SysScanDesc scan;
 	Cache *htcache = ts_hypertable_cache_pin();
-	MemoryContext oldmcxt, relmcxt;
+	MemoryContext oldmcxt;
+	MemoryContext relmcxt;
 	StatsContext statsctx = {
 		.stats = stats,
 	};

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -252,7 +252,8 @@ static char *
 get_pgversion_string()
 {
 	StringInfo buf = makeStringInfo();
-	int major, patch;
+	int major;
+	int patch;
 
 	/*
 	 * We have to read the server version from GUC and not use any of

--- a/src/telemetry/telemetry_metadata.c
+++ b/src/telemetry/telemetry_metadata.c
@@ -21,7 +21,8 @@
 void
 ts_telemetry_metadata_add_values(JsonbParseState *state)
 {
-	Datum key, value;
+	Datum key;
+	Datum value;
 	bool key_isnull, value_isnull, include_entry;
 	ScanIterator iterator =
 		ts_scan_iterator_create(METADATA, AccessShareLock, CurrentMemoryContext);

--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -224,7 +224,8 @@ ts_date_bucket(PG_FUNCTION_ARGS)
 	Interval *interval = PG_GETARG_INTERVAL_P(0);
 	DateADT date = PG_GETARG_DATEADT(1);
 	Timestamp origin = DEFAULT_ORIGIN;
-	Timestamp timestamp, result;
+	Timestamp timestamp;
+	Timestamp result;
 	int64 period = -1;
 
 	if (DATE_NOT_FINITE(date))
@@ -384,9 +385,14 @@ ts_time_bucket_ng_date(PG_FUNCTION_ARGS)
 	Interval *interval = PG_GETARG_INTERVAL_P(0);
 	DateADT date = PG_GETARG_DATEADT(1);
 	DateADT origin_date = 0;
-	int origin_year = 2000, origin_month = 1, origin_day = 1;
-	int year, month, day;
-	int delta, bucket_number;
+	int origin_year = 2000;
+	int origin_month = 1;
+	int origin_day = 1;
+	int year;
+	int month;
+	int day;
+	int delta;
+	int bucket_number;
 
 	if ((interval->time != 0) || ((interval->month != 0) && (interval->day != 0)))
 	{
@@ -495,7 +501,8 @@ TSDLLEXPORT Datum
 ts_time_bucket_ng_timezone_origin(PG_FUNCTION_ARGS)
 {
 	Timestamp result;
-	Datum timestamp, origin;
+	Datum timestamp;
+	Datum origin;
 	Datum interval = PG_GETARG_DATUM(0);
 	Datum timestamptz = PG_GETARG_DATUM(1);
 	Datum origintz = PG_GETARG_DATUM(2);

--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -343,14 +343,11 @@ ts_time_bucket_ng_timestamp(PG_FUNCTION_ARGS)
 													 DateADTGetDatum(origin)));
 		return DirectFunctionCall1(date_timestamp, DateADTGetDatum(result));
 	}
-	else
-	{
-		DateADT result;
-		result = DatumGetDateADT(DirectFunctionCall2(ts_time_bucket_ng_date,
-													 PG_GETARG_DATUM(0),
-													 DateADTGetDatum(ts_date)));
-		return DirectFunctionCall1(date_timestamp, DateADTGetDatum(result));
-	}
+
+	DateADT result;
+	result = DatumGetDateADT(
+		DirectFunctionCall2(ts_time_bucket_ng_date, PG_GETARG_DATUM(0), DateADTGetDatum(ts_date)));
+	return DirectFunctionCall1(date_timestamp, DateADTGetDatum(result));
 }
 
 TS_FUNCTION_INFO_V1(ts_time_bucket_ng_timestamptz);

--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -18,35 +18,35 @@
 #define TIME_BUCKET(period, timestamp, offset, min, max, result)                                   \
 	do                                                                                             \
 	{                                                                                              \
-		if (period <= 0)                                                                           \
+		if ((period) <= 0)                                                                         \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),                                     \
 					 errmsg("period must be greater than 0")));                                    \
-		if (offset != 0)                                                                           \
+		if ((offset) != 0)                                                                         \
 		{                                                                                          \
 			/* We need to ensure that the timestamp is in range _after_ the */                     \
 			/* offset is applied: when the offset is positive we need to make */                   \
 			/* sure the resultant time is at least min, and when negative that */                  \
 			/* it is less than the max. */                                                         \
-			offset = offset % period;                                                              \
-			if ((offset > 0 && timestamp < min + offset) ||                                        \
-				(offset < 0 && timestamp > max + offset))                                          \
+			(offset) = (offset) % (period);                                                        \
+			if (((offset) > 0 && (timestamp) < (min) + (offset)) ||                                \
+				((offset) < 0 && (timestamp) > (max) + (offset)))                                  \
 				ereport(ERROR,                                                                     \
 						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),                              \
 						 errmsg("timestamp out of range")));                                       \
-			timestamp -= offset;                                                                   \
+			(timestamp) -= (offset);                                                               \
 		}                                                                                          \
-		result = (timestamp / period) * period;                                                    \
-		if (timestamp < 0 && timestamp % period)                                                   \
+		(result) = ((timestamp) / (period)) * (period);                                            \
+		if ((timestamp) < 0 && (timestamp) % (period))                                             \
 		{                                                                                          \
-			if (result < min + period)                                                             \
+			if ((result) < (min) + (period))                                                       \
 				ereport(ERROR,                                                                     \
 						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),                              \
 						 errmsg("timestamp out of range")));                                       \
 			else                                                                                   \
-				result = result - period;                                                          \
+				(result) = (result) - (period);                                                    \
 		}                                                                                          \
-		result += offset;                                                                          \
+		(result) += (offset);                                                                      \
 	} while (0)
 
 TS_FUNCTION_INFO_V1(ts_int16_bucket);
@@ -102,23 +102,23 @@ ts_int64_bucket(PG_FUNCTION_ARGS)
 #define TIME_BUCKET_TS(period, timestamp, result, shift)                                           \
 	do                                                                                             \
 	{                                                                                              \
-		if (period <= 0)                                                                           \
+		if ((period) <= 0)                                                                         \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),                                     \
 					 errmsg("period must be greater than 0")));                                    \
 		/* shift = shift % period, but use TMODULO */                                              \
 		TMODULO(shift, result, period);                                                            \
                                                                                                    \
-		if ((shift > 0 && timestamp < DT_NOBEGIN + shift) ||                                       \
-			(shift < 0 && timestamp > DT_NOEND + shift))                                           \
+		if (((shift) > 0 && (timestamp) < DT_NOBEGIN + (shift)) ||                                 \
+			((shift) < 0 && (timestamp) > DT_NOEND + (shift)))                                     \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),                                  \
 					 errmsg("timestamp out of range")));                                           \
-		timestamp -= shift;                                                                        \
+		(timestamp) -= (shift);                                                                    \
                                                                                                    \
 		/* result = (timestamp / period) * period */                                               \
 		TMODULO(timestamp, result, period);                                                        \
-		if (timestamp < 0)                                                                         \
+		if ((timestamp) < 0)                                                                       \
 		{                                                                                          \
 			/*                                                                                     \
 			 * need to subtract another period if remainder < 0 this only happens                  \
@@ -126,12 +126,12 @@ ts_int64_bucket(PG_FUNCTION_ARGS)
 			 * after division. Need to subtract another period since division                      \
 			 * truncates toward 0 in C99.                                                          \
 			 */                                                                                    \
-			result = (result * period) - period;                                                   \
+			(result) = ((result) * (period)) - (period);                                           \
 		}                                                                                          \
 		else                                                                                       \
-			result *= period;                                                                      \
+			(result) *= (period);                                                                  \
                                                                                                    \
-		result += shift;                                                                           \
+		(result) += (shift);                                                                       \
 	} while (0)
 
 /* Returns the period in the same representation as Postgres Timestamps.

--- a/src/time_utils.c
+++ b/src/time_utils.c
@@ -505,7 +505,8 @@ ts_subtract_integer_from_now_saturating(Oid now_func, int64 interval, Oid timety
 	Datum now = OidFunctionCall0(now_func);
 	int64 time_min = ts_time_get_min(timetype);
 	int64 time_max = ts_time_get_max(timetype);
-	int64 nowval, res;
+	int64 nowval;
+	int64 res;
 
 	Assert(IS_INTEGER_TYPE(timetype));
 	switch (timetype)

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -405,7 +405,8 @@ ts_catalog_table_info_init(CatalogTableInfo *tables_info, int max_tables,
 		Oid schema_oid;
 		Oid id;
 		const char *sequence_name;
-		Size number_indexes, j;
+		Size number_indexes;
+		Size j;
 
 		schema_oid = get_namespace_oid(table_ary[i].schema_name, false);
 		id = get_relname_relid(table_ary[i].table_name, schema_oid);

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1167,14 +1167,13 @@ ts_continuous_agg_view_type(FormData_continuous_agg *data, const char *schema, c
 	if (CHECK_NAME_MATCH(&data->user_view_schema, schema) &&
 		CHECK_NAME_MATCH(&data->user_view_name, name))
 		return ContinuousAggUserView;
-	else if (CHECK_NAME_MATCH(&data->partial_view_schema, schema) &&
-			 CHECK_NAME_MATCH(&data->partial_view_name, name))
+	if (CHECK_NAME_MATCH(&data->partial_view_schema, schema) &&
+		CHECK_NAME_MATCH(&data->partial_view_name, name))
 		return ContinuousAggPartialView;
-	else if (CHECK_NAME_MATCH(&data->direct_view_schema, schema) &&
-			 CHECK_NAME_MATCH(&data->direct_view_name, name))
+	if (CHECK_NAME_MATCH(&data->direct_view_schema, schema) &&
+		CHECK_NAME_MATCH(&data->direct_view_name, name))
 		return ContinuousAggDirectView;
-	else
-		return ContinuousAggAnyView;
+	return ContinuousAggAnyView;
 }
 
 static FormData_continuous_agg *
@@ -1554,15 +1553,13 @@ generic_time_bucket_ng(const ContinuousAggsBucketFunction *bf, Datum timestamp)
 									   timestamp,
 									   CStringGetTextDatum(bf->timezone));
 		}
-		else
-		{
-			/* custom origin specified */
-			return DirectFunctionCall4(ts_time_bucket_ng_timezone_origin,
-									   IntervalPGetDatum(bf->bucket_width),
-									   timestamp,
-									   TimestampTzGetDatum((TimestampTz) bf->origin),
-									   CStringGetTextDatum(bf->timezone));
-		}
+
+		/* custom origin specified */
+		return DirectFunctionCall4(ts_time_bucket_ng_timezone_origin,
+								   IntervalPGetDatum(bf->bucket_width),
+								   timestamp,
+								   TimestampTzGetDatum((TimestampTz) bf->origin),
+								   CStringGetTextDatum(bf->timezone));
 	}
 
 	if (TIMESTAMP_NOT_FINITE(bf->origin))
@@ -1572,14 +1569,12 @@ generic_time_bucket_ng(const ContinuousAggsBucketFunction *bf, Datum timestamp)
 								   IntervalPGetDatum(bf->bucket_width),
 								   timestamp);
 	}
-	else
-	{
-		/* custom origin specified */
-		return DirectFunctionCall3(ts_time_bucket_ng_timestamp,
-								   IntervalPGetDatum(bf->bucket_width),
-								   timestamp,
-								   TimestampGetDatum(bf->origin));
-	}
+
+	/* custom origin specified */
+	return DirectFunctionCall3(ts_time_bucket_ng_timestamp,
+							   IntervalPGetDatum(bf->bucket_width),
+							   timestamp,
+							   TimestampGetDatum(bf->origin));
 }
 
 /*

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -470,7 +470,9 @@ static const ContinuousAggsBucketFunction *
 bucket_function_deserialize(const char *str)
 {
 	int i;
-	char *begin, *end, *strings[4];
+	char *begin;
+	char *end;
+	char *strings[4];
 	ContinuousAggsBucketFunction *bf;
 
 	/* empty string stands for serialized NULL */
@@ -541,8 +543,12 @@ ts_populate_caggs_info_from_arrays(ArrayType *mat_hypertable_ids, ArrayType *buc
 	Assert(ARR_NDIM(mat_hypertable_ids) == ARR_NDIM(bucket_widths) &&
 		   ARR_NDIM(bucket_functions) == ARR_NDIM(bucket_widths));
 
-	ArrayIterator it_htids, it_widths, it_bfs;
-	Datum array_datum1, array_datum2, array_datum3;
+	ArrayIterator it_htids;
+	ArrayIterator it_widths;
+	ArrayIterator it_bfs;
+	Datum array_datum1;
+	Datum array_datum2;
+	Datum array_datum3;
 	bool isnull1, isnull2, isnull3;
 
 	it_htids = array_create_iterator(mat_hypertable_ids, 0, NULL);
@@ -580,7 +586,9 @@ TSDLLEXPORT void
 ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs, ArrayType **mat_hypertable_ids,
 								 ArrayType **bucket_widths, ArrayType **bucket_functions)
 {
-	ListCell *lc1, *lc2, *lc3;
+	ListCell *lc1;
+	ListCell *lc2;
+	ListCell *lc3;
 	unsigned i;
 
 	Datum *matiddatums = palloc(sizeof(Datum) * list_length(all_caggs->mat_hypertable_ids));
@@ -1629,7 +1637,10 @@ void
 ts_compute_inscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
 													  const ContinuousAggsBucketFunction *bf)
 {
-	Datum start_old, end_old, start_new, end_new;
+	Datum start_old;
+	Datum end_old;
+	Datum start_new;
+	Datum end_new;
 	/*
 	 * It's OK to use TIMESTAMPOID here. Variable-sized buckets can be used
 	 * only for dates, timestamps and timestamptz's. For all these types our
@@ -1666,7 +1677,10 @@ void
 ts_compute_circumscribed_bucketed_refresh_window_variable(int64 *start, int64 *end,
 														  const ContinuousAggsBucketFunction *bf)
 {
-	Datum start_old, end_old, start_new, end_new;
+	Datum start_old;
+	Datum end_old;
+	Datum start_new;
+	Datum end_new;
 
 	/*
 	 * It's OK to use TIMESTAMPOID here.

--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -1226,7 +1226,6 @@ ts_continuous_agg_rename_schema_name(char *old_schema, char *new_schema)
 		if (should_free)
 			heap_freetuple(tuple);
 	}
-	return;
 }
 
 extern void
@@ -1295,7 +1294,6 @@ ts_continuous_agg_rename_view(const char *old_schema, const char *name, const ch
 		if (should_free)
 			heap_freetuple(tuple);
 	}
-	return;
 }
 
 TSDLLEXPORT int32

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -138,7 +138,7 @@ TSDLLEXPORT void ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs,
 extern TSDLLEXPORT ContinuousAgg *
 ts_continuous_agg_find_by_mat_hypertable_id(int32 mat_hypertable_id);
 
-extern TSDLLEXPORT void ts_materialization_invalidation_log_delete_inner(int32 materialization_id);
+extern TSDLLEXPORT void ts_materialization_invalidation_log_delete_inner(int32 mat_hypertable_id);
 
 extern TSDLLEXPORT ContinuousAggHypertableStatus
 ts_continuous_agg_hypertable_status(int32 hypertable_id);

--- a/src/ts_catalog/hypertable_compression.c
+++ b/src/ts_catalog/hypertable_compression.c
@@ -247,7 +247,8 @@ ts_hypertable_compression_rename_column(int32 htid, char *old_column_name, char 
 			bool isnulls[Natts_hypertable_compression];
 			bool repl[Natts_hypertable_compression] = { false };
 			bool should_free;
-			HeapTuple tuple, new_tuple;
+			HeapTuple tuple;
+			HeapTuple new_tuple;
 			TupleDesc tupdesc = ts_scanner_get_tupledesc(ti);
 			found = true;
 			tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);

--- a/src/ts_catalog/tablespace.c
+++ b/src/ts_catalog/tablespace.c
@@ -371,7 +371,8 @@ ts_tablespace_delete(int32 hypertable_id, const char *tspcname, Oid tspcoid)
 		.database_info = ts_catalog_database_info_get(),
 		.stopcount = (NULL != tspcname),
 	};
-	int num_deleted, nkeys = 0;
+	int num_deleted;
+	int nkeys = 0;
 
 	ScanKeyInit(&scankey[nkeys++],
 				Anum_tablespace_hypertable_id_tablespace_name_idx_hypertable_id,

--- a/src/ts_catalog/tablespace.c
+++ b/src/ts_catalog/tablespace.c
@@ -39,18 +39,19 @@ tablespaces_alloc(int capacity)
 }
 
 Tablespace *
-ts_tablespaces_add(Tablespaces *tspcs, const FormData_tablespace *form, Oid tspc_oid)
+ts_tablespaces_add(Tablespaces *tablespaces, const FormData_tablespace *form, Oid tspc_oid)
 {
 	Tablespace *tspc;
 
-	if (tspcs->num_tablespaces >= tspcs->capacity)
+	if (tablespaces->num_tablespaces >= tablespaces->capacity)
 	{
-		tspcs->capacity += TABLESPACE_DEFAULT_CAPACITY;
-		Assert(tspcs->tablespaces); /* repalloc() does not work with NULL argument */
-		tspcs->tablespaces = repalloc(tspcs->tablespaces, sizeof(Tablespace) * tspcs->capacity);
+		tablespaces->capacity += TABLESPACE_DEFAULT_CAPACITY;
+		Assert(tablespaces->tablespaces); /* repalloc() does not work with NULL argument */
+		tablespaces->tablespaces =
+			repalloc(tablespaces->tablespaces, sizeof(Tablespace) * tablespaces->capacity);
 	}
 
-	tspc = &tspcs->tablespaces[tspcs->num_tablespaces++];
+	tspc = &tablespaces->tablespaces[tablespaces->num_tablespaces++];
 	memcpy(&tspc->fd, form, sizeof(FormData_tablespace));
 	tspc->tablespace_oid = tspc_oid;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -119,7 +119,8 @@ static int64 ts_integer_to_internal(Datum time_val, Oid type_oid);
 TSDLLEXPORT int64
 ts_time_value_to_internal(Datum time_val, Oid type_oid)
 {
-	Datum res, tz;
+	Datum res;
+	Datum tz;
 
 	/* Handle custom time types. We currently only support binary coercible
 	 * types */
@@ -425,7 +426,8 @@ ts_get_interval_period_approx(Interval *interval)
 int64
 ts_date_trunc_interval_period_approx(text *units)
 {
-	int decode_type, val;
+	int decode_type;
+	int val;
 	char *lowunits =
 		downcase_truncate_identifier(VARDATA_ANY(units), VARSIZE_ANY_EXHDR(units), false);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -239,12 +239,10 @@ ts_time_value_to_internal_or_infinite(Datum time_val, Oid type_oid,
 						*is_infinite_out = TimevalNegInfinity;
 					return PG_INT64_MIN;
 				}
-				else
-				{
-					if (is_infinite_out != NULL)
-						*is_infinite_out = TimevalPosInfinity;
-					return PG_INT64_MAX;
-				}
+
+				if (is_infinite_out != NULL)
+					*is_infinite_out = TimevalPosInfinity;
+				return PG_INT64_MAX;
 			}
 
 			return ts_time_value_to_internal(time_val, type_oid);
@@ -260,12 +258,10 @@ ts_time_value_to_internal_or_infinite(Datum time_val, Oid type_oid,
 						*is_infinite_out = TimevalNegInfinity;
 					return PG_INT64_MIN;
 				}
-				else
-				{
-					if (is_infinite_out != NULL)
-						*is_infinite_out = TimevalPosInfinity;
-					return PG_INT64_MAX;
-				}
+
+				if (is_infinite_out != NULL)
+					*is_infinite_out = TimevalPosInfinity;
+				return PG_INT64_MAX;
 			}
 
 			return ts_time_value_to_internal(time_val, type_oid);
@@ -281,12 +277,10 @@ ts_time_value_to_internal_or_infinite(Datum time_val, Oid type_oid,
 						*is_infinite_out = TimevalNegInfinity;
 					return PG_INT64_MIN;
 				}
-				else
-				{
-					if (is_infinite_out != NULL)
-						*is_infinite_out = TimevalPosInfinity;
-					return PG_INT64_MAX;
-				}
+
+				if (is_infinite_out != NULL)
+					*is_infinite_out = TimevalPosInfinity;
+				return PG_INT64_MAX;
 			}
 
 			return ts_time_value_to_internal(time_val, type_oid);

--- a/test/src/net/conn_mock.c
+++ b/test/src/net/conn_mock.c
@@ -33,7 +33,6 @@ mock_connect(Connection *conn, const char *host, const char *servname, int port)
 static void
 mock_close(Connection *conn)
 {
-	return;
 }
 
 static ssize_t

--- a/test/src/net/conn_mock.h
+++ b/test/src/net/conn_mock.h
@@ -10,6 +10,6 @@
 
 typedef struct Connection Connection;
 
-extern ssize_t ts_connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buflen);
+extern ssize_t ts_connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buf_len);
 
 #endif /* TIMESCALEDB_CONN_MOCK_H */

--- a/test/src/net/test_http.c
+++ b/test/src/net/test_http.c
@@ -80,7 +80,9 @@ Datum
 ts_test_http_parsing(PG_FUNCTION_ARGS)
 {
 	int num_iterations = PG_GETARG_INT32(0);
-	int bytes, i, j;
+	int bytes;
+	int i;
+	int j;
 
 	srand(time(0));
 
@@ -125,7 +127,8 @@ ts_test_http_parsing(PG_FUNCTION_ARGS)
 Datum
 ts_test_http_parsing_full(PG_FUNCTION_ARGS)
 {
-	int bytes, i;
+	int bytes;
+	int i;
 
 	srand(time(0));
 

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -231,16 +231,14 @@ policy_compression_add(PG_FUNCTION_ARGS)
 							get_rel_name(user_rel_oid))));
 			PG_RETURN_INT32(-1);
 		}
-		else
-		{
-			ts_cache_release(hcache);
-			ereport(WARNING,
-					(errmsg("compression policy already exists for hypertable \"%s\"",
-							get_rel_name(user_rel_oid)),
-					 errdetail("A policy already exists with different arguments."),
-					 errhint("Remove the existing policy before adding a new one.")));
-			PG_RETURN_INT32(-1);
-		}
+
+		ts_cache_release(hcache);
+		ereport(WARNING,
+				(errmsg("compression policy already exists for hypertable \"%s\"",
+						get_rel_name(user_rel_oid)),
+				 errdetail("A policy already exists with different arguments."),
+				 errhint("Remove the existing policy before adding a new one.")));
+		PG_RETURN_INT32(-1);
 	}
 
 	if (dim && IS_TIMESTAMP_TYPE(ts_dimension_get_partition_type(dim)))

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -173,7 +173,9 @@ Datum
 policy_compression_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData proc_name, proc_schema, owner;
+	NameData proc_name;
+	NameData proc_schema;
+	NameData owner;
 	int32 job_id;
 	Oid user_rel_oid = PG_GETARG_OID(0);
 	Datum compress_after_datum = PG_GETARG_DATUM(1);

--- a/tsl/src/bgw_policy/compression_api.c
+++ b/tsl/src/bgw_policy/compression_api.c
@@ -32,7 +32,7 @@
 	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("0"), InvalidOid, -1))
 
 /* Right now, there is an infinite number of retries for compress_chunks jobs */
-#define DEFAULT_MAX_RETRIES -1
+#define DEFAULT_MAX_RETRIES (-1)
 /* Default retry period for reorder_jobs is currently 1 hour */
 #define DEFAULT_RETRY_PERIOD                                                                       \
 	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("1 hour"), InvalidOid, -1))

--- a/tsl/src/bgw_policy/continuous_aggregate_api.c
+++ b/tsl/src/bgw_policy/continuous_aggregate_api.c
@@ -529,12 +529,15 @@ Datum
 policy_refresh_cagg_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData proc_name, proc_schema, owner;
+	NameData proc_name;
+	NameData proc_schema;
+	NameData owner;
 	ContinuousAgg *cagg;
 	CaggPolicyConfig policyconf;
 	int32 job_id;
 	Interval refresh_interval;
-	Oid cagg_oid, owner_id;
+	Oid cagg_oid;
+	Oid owner_id;
 	List *jobs;
 	JsonbParseState *parse_state = NULL;
 	bool if_not_exists;

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -137,7 +137,8 @@ get_window_boundary(const Dimension *dim, const Jsonb *config, int64 (*int_gette
 
 	if (IS_INTEGER_TYPE(partitioning_type))
 	{
-		int64 res, lag = int_getter(config);
+		int64 res;
+		int64 lag = int_getter(config);
 		Oid now_func = ts_get_integer_now_func(dim);
 
 		Assert(now_func);
@@ -348,7 +349,8 @@ policy_refresh_cagg_read_and_validate_config(Jsonb *config, PolicyContinuousAggD
 	Hypertable *mat_ht;
 	const Dimension *open_dim;
 	Oid dim_type;
-	int64 refresh_start, refresh_end;
+	int64 refresh_start;
+	int64 refresh_end;
 
 	materialization_id = policy_continuous_aggregate_get_mat_hypertable_id(config);
 	mat_ht = ts_hypertable_get_by_id(materialization_id);
@@ -476,7 +478,8 @@ policy_recompression_execute(int32 job_id, Jsonb *config)
 	const Dimension *dim;
 	PolicyCompressionData policy_data;
 	bool distributed, used_portalcxt = false;
-	MemoryContext saved_cxt, multitxn_cxt;
+	MemoryContext saved_cxt;
+	MemoryContext multitxn_cxt;
 
 	policy_recompression_read_and_validate_config(config, &policy_data);
 	dim = hyperspace_get_open_dimension(policy_data.hypertable->space, 0);
@@ -568,7 +571,8 @@ job_execute_procedure(FuncExpr *funcexpr)
 bool
 job_execute(BgwJob *job)
 {
-	Const *arg1, *arg2;
+	Const *arg1;
+	Const *arg2;
 	bool portal_created = false;
 	char prokind;
 	Oid proc;

--- a/tsl/src/bgw_policy/job.c
+++ b/tsl/src/bgw_policy/job.c
@@ -146,11 +146,9 @@ get_window_boundary(const Dimension *dim, const Jsonb *config, int64 (*int_gette
 		res = ts_sub_integer_from_now(lag, partitioning_type, now_func);
 		return Int64GetDatum(res);
 	}
-	else
-	{
-		Interval *lag = interval_getter(config);
-		return subtract_interval_from_now(lag, partitioning_type);
-	}
+
+	Interval *lag = interval_getter(config);
+	return subtract_interval_from_now(lag, partitioning_type);
 }
 
 static List *

--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -20,9 +20,9 @@
 #define DEFAULT_MAX_RUNTIME 0
 
 /* Right now, there is an infinite number of retries for custom jobs */
-#define DEFAULT_MAX_RETRIES -1
+#define DEFAULT_MAX_RETRIES (-1)
 /* Default retry period for reorder_jobs is currently 5 minutes */
-#define DEFAULT_RETRY_PERIOD 5 * USECS_PER_MINUTE
+#define DEFAULT_RETRY_PERIOD (5 * USECS_PER_MINUTE)
 
 #define ALTER_JOB_NUM_COLS 8
 

--- a/tsl/src/bgw_policy/policy_utils.h
+++ b/tsl/src/bgw_policy/policy_utils.h
@@ -13,7 +13,7 @@ bool policy_config_check_hypertable_lag_equality(Jsonb *config, const char *json
 												 Oid dim_type, Oid lag_type, Datum lag_datum);
 int64 subtract_integer_from_now_internal(int64 interval, Oid time_dim_type, Oid now_func,
 										 bool *overflow);
-Datum subtract_interval_from_now(Interval *interval, Oid time_dim_type);
+Datum subtract_interval_from_now(Interval *lag, Oid time_dim_type);
 const Dimension *get_open_dimension_for_hypertable(const Hypertable *ht);
 bool policy_get_verbose_log(const Jsonb *config);
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_UTILS_H */

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -41,7 +41,7 @@
 #define DEFAULT_MAX_RUNTIME                                                                        \
 	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("0"), InvalidOid, -1))
 /* Right now, there is an infinite number of retries for reorder jobs */
-#define DEFAULT_MAX_RETRIES -1
+#define DEFAULT_MAX_RETRIES (-1)
 /* Default retry period for reorder_jobs is currently 5 minutes */
 #define DEFAULT_RETRY_PERIOD                                                                       \
 	DatumGetIntervalP(DirectFunctionCall3(interval_in, CStringGetDatum("5 min"), InvalidOid, -1))

--- a/tsl/src/bgw_policy/reorder_api.c
+++ b/tsl/src/bgw_policy/reorder_api.c
@@ -122,7 +122,9 @@ Datum
 policy_reorder_add(PG_FUNCTION_ARGS)
 {
 	NameData application_name;
-	NameData proc_name, proc_schema, owner;
+	NameData proc_name;
+	NameData proc_schema;
+	NameData owner;
 	int32 job_id;
 	const Dimension *dim;
 	Interval schedule_interval = DEFAULT_SCHEDULE_INTERVAL;

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -196,16 +196,14 @@ policy_retention_add(PG_FUNCTION_ARGS)
 							get_rel_name(ht_oid))));
 			PG_RETURN_INT32(-1);
 		}
-		else
-		{
-			ts_cache_release(hcache);
-			ereport(WARNING,
-					(errmsg("retention policy already exists for hypertable \"%s\"",
-							get_rel_name(ht_oid)),
-					 errdetail("A policy already exists with different arguments."),
-					 errhint("Remove the existing policy before adding a new one.")));
-			PG_RETURN_INT32(-1);
-		}
+
+		ts_cache_release(hcache);
+		ereport(WARNING,
+				(errmsg("retention policy already exists for hypertable \"%s\"",
+						get_rel_name(ht_oid)),
+				 errdetail("A policy already exists with different arguments."),
+				 errhint("Remove the existing policy before adding a new one.")));
+		PG_RETURN_INT32(-1);
 	}
 
 	if (IS_INTEGER_TYPE(partitioning_type) && !IS_INTEGER_TYPE(window_type))

--- a/tsl/src/bgw_policy/retention_api.c
+++ b/tsl/src/bgw_policy/retention_api.c
@@ -256,7 +256,9 @@ policy_retention_add(PG_FUNCTION_ARGS)
 
 	/* Next, insert a new job into jobs table */
 	namestrcpy(&application_name, "Retention Policy");
-	NameData proc_name, proc_schema, owner;
+	NameData proc_name;
+	NameData proc_schema;
+	NameData owner;
 	namestrcpy(&proc_name, POLICY_RETENTION_PROC_NAME);
 	namestrcpy(&proc_schema, INTERNAL_SCHEMA_NAME);
 	namestrcpy(&owner, GetUserNameFromId(owner_id, false));

--- a/tsl/src/chunk.c
+++ b/tsl/src/chunk.c
@@ -207,7 +207,8 @@ chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type)
 	ExprContext *econtext;
 	FuncExpr *fexpr;
 	List *args = NIL;
-	int i, num_results = 0;
+	int i;
+	int num_results = 0;
 	SetExprState *state;
 	Oid restype;
 	Oid func_oid;

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -49,7 +49,7 @@
 #define FLOAT4_TYPELEN sizeof(float4)
 #define FLOAT4_TYPEBYVAL true
 #define FLOAT4_TYPEALIGN 'i'
-#define CSTRING_TYPELEN -2
+#define CSTRING_TYPELEN (-2)
 #define CSTRING_TYPEBYVAL false
 #define CSTRING_TYPEALIGN 'c'
 #define INT4_TYPELEN sizeof(int32)
@@ -58,7 +58,7 @@
 #define OID_TYPELEN sizeof(Oid)
 #define OID_TYPEBYVAL true
 #define OID_TYPEALIGN 'i'
-#define CSTRING_ARY_TYPELEN -1
+#define CSTRING_ARY_TYPELEN (-1)
 
 /*
  * Convert a hypercube to a JSONB value.
@@ -633,8 +633,8 @@ enum OpArrayTypeIdx
 	ENCODED_OP_RARG_NAMESPACE,
 };
 
-#define LargSubarrayForOpArray(op_string_array) (&op_string_array[ENCODED_OP_LARG_NAME])
-#define RargSubarrayForOpArray(op_string_array) (&op_string_array[ENCODED_OP_RARG_NAME])
+#define LargSubarrayForOpArray(op_string_array) (&(op_string_array)[ENCODED_OP_LARG_NAME])
+#define RargSubarrayForOpArray(op_string_array) (&(op_string_array)[ENCODED_OP_RARG_NAME])
 
 static void
 convert_type_oid_to_strings(Oid type_id, Datum *result_strings)

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -80,7 +80,8 @@ hypercube_to_jsonb_value(Hypercube *hc, Hyperspace *hs, JsonbParseState **ps)
 
 	for (i = 0; i < hc->num_slices; i++)
 	{
-		JsonbValue k, v;
+		JsonbValue k;
+		JsonbValue v;
 		char *dim_name = NameStr(hs->dimensions[i].fd.column_name);
 		Datum range_start =
 			DirectFunctionCall1(int8_numeric, Int64GetDatum(hc->slices[i]->fd.range_start));
@@ -502,7 +503,8 @@ chunk_api_create_on_data_nodes(const Chunk *chunk, const Hypertable *ht,
 		ChunkDataNode *cdn = async_response_result_get_user_data(res);
 		Datum values[Natts_create_chunk];
 		bool nulls[Natts_create_chunk];
-		const char *schema_name, *table_name;
+		const char *schema_name;
+		const char *table_name;
 		bool created;
 
 		Assert(Natts_create_chunk == tupdesc->natts);
@@ -933,7 +935,8 @@ chunk_update_colstats(Chunk *chunk, int16 attnum, float nullfract, int32 width, 
 	bool replaces[Natts_pg_statistic];
 	HeapTuple stup;
 	HeapTuple oldtup;
-	int i, k;
+	int i;
+	int k;
 	int *slot_kinds;
 
 	rel = try_relation_open(chunk->table_id, ShareUpdateExclusiveLock);
@@ -1143,7 +1146,9 @@ chunk_process_remote_colstats_row(StatsProcessContext *ctx, TupleFactory *tf, Tu
 	Oid valtype_oids[STATISTIC_NUM_SLOTS];
 	ArrayType *value_arrays[STATISTIC_NUM_SLOTS];
 	int *slot_kinds;
-	int i, os_idx, vt_idx;
+	int i;
+	int os_idx;
+	int vt_idx;
 
 	tuple = tuplefactory_make_tuple(tf, res, row, PQbinaryTuples(res));
 	heap_deform_tuple(tuple, tupdesc, values, nulls);

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -20,7 +20,7 @@ extern void chunk_api_create_on_data_nodes(const Chunk *chunk, const Hypertable 
 										   const char *remote_chunk_name, List *data_nodes);
 extern Datum chunk_api_get_chunk_relstats(PG_FUNCTION_ARGS);
 extern Datum chunk_api_get_chunk_colstats(PG_FUNCTION_ARGS);
-extern void chunk_api_update_distributed_hypertable_stats(Oid relid);
+extern void chunk_api_update_distributed_hypertable_stats(Oid table_id);
 extern Datum chunk_create_empty_table(PG_FUNCTION_ARGS);
 extern void chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const Chunk *chunk,
 													const char *node_name);

--- a/tsl/src/chunk_copy.c
+++ b/tsl/src/chunk_copy.c
@@ -258,7 +258,8 @@ chunk_copy_setup(ChunkCopy *cc, Oid chunk_relid, const char *src_node, const cha
 {
 	Hypertable *ht;
 	Cache *hcache;
-	MemoryContext old, mcxt;
+	MemoryContext old;
+	MemoryContext mcxt;
 
 	if (!superuser())
 		ereport(ERROR,
@@ -853,7 +854,8 @@ chunk_copy_operation_get(const char *operation_id)
 	ScanKeyData scankeys[1];
 	ChunkCopy *cc = NULL;
 	int indexid;
-	MemoryContext old, mcxt;
+	MemoryContext old;
+	MemoryContext mcxt;
 
 	/* Objects need to be in long lived context */
 	mcxt =

--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -153,7 +153,6 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 	cxt->srcht = srcht;
 	cxt->compress_ht = compress_ht;
 	cxt->srcht_chunk = srcchunk;
-	return;
 }
 
 static void

--- a/tsl/src/compression/compress_utils.c
+++ b/tsl/src/compression/compress_utils.c
@@ -217,8 +217,10 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	ListCell *lc;
 	List *htcols_list = NIL;
 	const ColumnCompressionInfo **colinfo_array;
-	int i = 0, htcols_listlen;
-	RelationSize before_size, after_size;
+	int i = 0;
+	int htcols_listlen;
+	RelationSize before_size;
+	RelationSize after_size;
 	CompressionStats cstat;
 
 	hcache = ts_hypertable_cache_pin();

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -53,8 +53,8 @@
 #define MAX_ROWS_PER_COMPRESSION 1000
 /* gap in sequence id between rows, potential for adding rows in gap later */
 #define SEQUENCE_NUM_GAP 10
-#define COMPRESSIONCOL_IS_SEGMENT_BY(col) (col->segmentby_column_index > 0)
-#define COMPRESSIONCOL_IS_ORDER_BY(col) (col->orderby_column_index > 0)
+#define COMPRESSIONCOL_IS_SEGMENT_BY(col) ((col)->segmentby_column_index > 0)
+#define COMPRESSIONCOL_IS_ORDER_BY(col) ((col)->orderby_column_index > 0)
 
 static const CompressionAlgorithmDefinition definitions[_END_COMPRESSION_ALGORITHMS] = {
 	[COMPRESSION_ALGORITHM_ARRAY] = ARRAY_ALGORITHM_DEFINITION,

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -80,8 +80,7 @@ DecompressionIterator *(*tsl_get_decompression_iterator_init(CompressionAlgorith
 
 	if (reverse)
 		return definitions[algorithm].iterator_init_reverse;
-	else
-		return definitions[algorithm].iterator_init_forward;
+	return definitions[algorithm].iterator_init_forward;
 }
 
 typedef struct SegmentInfo

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -220,7 +220,8 @@ truncate_relation(Oid table_oid)
 	 *  be a lock upgrade. */
 	Relation rel = table_open(table_oid, AccessExclusiveLock);
 	Oid toast_relid;
-	int pages, visible;
+	int pages;
+	int visible;
 	float tuples;
 
 	/* Chunks should never have fks into them, but double check */
@@ -1484,8 +1485,13 @@ extern void
 update_compressed_chunk_relstats(Oid uncompressed_relid, Oid compressed_relid)
 {
 	double rowcnt;
-	int comp_pages, uncomp_pages, comp_visible, uncomp_visible;
-	float comp_tuples, uncomp_tuples, out_tuples;
+	int comp_pages;
+	int uncomp_pages;
+	int comp_visible;
+	int uncomp_visible;
+	float comp_tuples;
+	float uncomp_tuples;
+	float out_tuples;
 	Chunk *uncompressed_chunk = ts_chunk_get_by_relid(uncompressed_relid, true);
 	Chunk *compressed_chunk = ts_chunk_get_by_relid(compressed_relid, true);
 
@@ -1534,7 +1540,8 @@ compress_row_init(int srcht_id, Relation in_rel, Relation out_rel)
 {
 	ListCell *lc;
 	List *htcols_list = NIL;
-	int i = 0, cclen;
+	int i = 0;
+	int cclen;
 	const ColumnCompressionInfo **ccinfo;
 	TupleDesc in_desc = RelationGetDescr(in_rel);
 	TupleDesc out_desc = RelationGetDescr(out_rel);
@@ -1587,7 +1594,8 @@ compress_row_exec(CompressSingleRowState *cr, TupleTableSlot *slot)
 static TupleTableSlot *
 compress_singlerow(CompressSingleRowState *cr, TupleTableSlot *in_slot)
 {
-	Datum *invalues, *out_values;
+	Datum *invalues;
+	Datum *out_values;
 	bool *out_isnull;
 	TupleTableSlot *out_slot = cr->out_slot;
 	RowCompressor *row_compressor = &cr->row_compressor;

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -153,7 +153,7 @@ static Tuplesortstate *compress_chunk_sort_relation(Relation in_rel, int n_keys,
 static void row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_desc,
 								Relation compressed_table, int num_compression_infos,
 								const ColumnCompressionInfo **column_compression_info,
-								int16 *column_offsets, int16 num_compressed_columns,
+								int16 *column_offsets, int16 num_columns_in_compressed_table,
 								bool need_bistate);
 static void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
 											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -145,7 +145,7 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 extern CompressionStorage compression_get_toast_storage(CompressionAlgorithms algo);
 extern CompressionStats compress_chunk(Oid in_table, Oid out_table,
 									   const ColumnCompressionInfo **column_compression_info,
-									   int num_columns);
+									   int num_compression_infos);
 extern void decompress_chunk(Oid in_table, Oid out_table);
 
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -750,7 +750,7 @@ validate_existing_constraints(Hypertable *ht, CompressColInfo *colinfo)
 		 */
 		if (form->contype == CONSTRAINT_CHECK || form->contype == CONSTRAINT_TRIGGER)
 			continue;
-		else if (form->contype == CONSTRAINT_EXCLUSION)
+		if (form->contype == CONSTRAINT_EXCLUSION)
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -1046,11 +1046,9 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 		compresscolinfo_add_catalog_entries(&compress_cols, ht->fd.id);
 		return true;
 	}
-	else
-	{
-		compress_htid = create_compression_table(ownerid, &compress_cols);
-		ts_hypertable_set_compressed(ht, compress_htid);
-	}
+
+	compress_htid = create_compression_table(ownerid, &compress_cols);
+	ts_hypertable_set_compressed(ht, compress_htid);
 
 	compresscolinfo_add_catalog_entries(&compress_cols, ht->fd.id);
 	/*add the constraints to the new compressed hypertable */

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -210,7 +210,9 @@ compresscolinfo_init(CompressColInfo *cc, Oid srctbl_relid, List *segmentby_cols
 {
 	Relation rel;
 	TupleDesc tupdesc;
-	int i, colno, attno;
+	int i;
+	int colno;
+	int attno;
 	int16 *segorder_colindex;
 	int seg_attnolen = 0;
 	ListCell *lc;
@@ -759,7 +761,8 @@ validate_existing_constraints(Hypertable *ht, CompressColInfo *colinfo)
 		}
 		else
 		{
-			int j, numkeys;
+			int j;
+			int numkeys;
 			int16 *attnums;
 			bool is_null;
 			/* Extract the conkey array, ie, attnums of PK's columns */

--- a/tsl/src/compression/datum_serialize.h
+++ b/tsl/src/compression/datum_serialize.h
@@ -27,24 +27,24 @@ BinaryStringEncoding datum_serializer_binary_string_encoding(DatumSerializer *se
 
 /* serialize to bytes in memory. */
 Size datum_get_bytes_size(DatumSerializer *serializer, Size start_offset, Datum val);
-char *datum_to_bytes_and_advance(DatumSerializer *serializer, char *start, Size *max_size,
-								 Datum val);
+char *datum_to_bytes_and_advance(DatumSerializer *serializer, char *ptr, Size *max_size,
+								 Datum datum);
 
 /* serialize to a binary string (for send functions) */
-void type_append_to_binary_string(Oid type_oid, StringInfo data);
+void type_append_to_binary_string(Oid type_oid, StringInfo buffer);
 void datum_append_to_binary_string(DatumSerializer *serializer, BinaryStringEncoding encoding,
-								   StringInfo data, Datum datum);
+								   StringInfo buffer, Datum datum);
 
 /* DESERIALIZATION */
 typedef struct DatumDeserializer DatumDeserializer;
 DatumDeserializer *create_datum_deserializer(Oid type);
 
 /* deserialization from bytes in memory */
-Datum bytes_to_datum_and_advance(DatumDeserializer *deserializer, const char **bytes);
+Datum bytes_to_datum_and_advance(DatumDeserializer *deserializer, const char **ptr);
 
 /* deserialization from binary strings (for recv functions) */
 Datum binary_string_to_datum(DatumDeserializer *deserializer, BinaryStringEncoding encoding,
-							 StringInfo data);
-Oid binary_string_get_type(StringInfo data);
+							 StringInfo buffer);
+Oid binary_string_get_type(StringInfo buffer);
 
 #endif

--- a/tsl/src/compression/dictionary.h
+++ b/tsl/src/compression/dictionary.h
@@ -31,13 +31,13 @@ extern void *dictionary_compressor_finish(DictionaryCompressor *compressor);
 
 extern DecompressionIterator *
 tsl_dictionary_decompression_iterator_from_datum_forward(Datum dictionary_compressed,
-														 Oid element_oid);
+														 Oid element_type);
 extern DecompressResult
 dictionary_decompression_iterator_try_next_forward(DecompressionIterator *iter);
 
 extern DecompressionIterator *
 tsl_dictionary_decompression_iterator_from_datum_reverse(Datum dictionary_compressed,
-														 Oid element_oid);
+														 Oid element_type);
 extern DecompressResult
 dictionary_decompression_iterator_try_next_reverse(DecompressionIterator *iter);
 

--- a/tsl/src/compression/gorilla.h
+++ b/tsl/src/compression/gorilla.h
@@ -79,7 +79,7 @@ extern void gorilla_compressor_append_value(GorillaCompressor *compressor, uint6
 extern void *gorilla_compressor_finish(GorillaCompressor *compressor);
 
 extern DecompressionIterator *
-gorilla_decompression_iterator_from_datum_forward(Datum dictionary_compressed, Oid element_type);
+gorilla_decompression_iterator_from_datum_forward(Datum gorilla_compressed, Oid element_type);
 extern DecompressResult
 gorilla_decompression_iterator_try_next_forward(DecompressionIterator *iter);
 
@@ -88,7 +88,7 @@ gorilla_decompression_iterator_from_datum_reverse(Datum gorilla_compressed, Oid 
 extern DecompressResult
 gorilla_decompression_iterator_try_next_reverse(DecompressionIterator *iter);
 
-extern void gorilla_compressed_send(CompressedDataHeader *compressed, StringInfo buffer);
+extern void gorilla_compressed_send(CompressedDataHeader *header, StringInfo buffer);
 extern Datum gorilla_compressed_recv(StringInfo buf);
 
 extern Datum tsl_gorilla_compressor_append(PG_FUNCTION_ARGS);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -220,7 +220,7 @@ static int32 mattablecolumninfo_create_materialization_table(
 	MatTableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
 	CAggTimebucketInfo *origquery_tblinfo, bool create_addl_index, char *tablespacename,
 	char *table_access_method, ObjectAddress *mataddress);
-static Query *mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *matcolinfo,
+static Query *mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *mattblinfo,
 														  Query *userview_query);
 
 static void caggtimebucketinfo_init(CAggTimebucketInfo *src, int32 hypertable_id,
@@ -2255,10 +2255,10 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 }
 
 DDLResult
-tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *pstmt,
+tsl_process_continuous_agg_viewstmt(Node *stmt_node, const char *query_string, void *pstmt,
 									WithClauseResult *with_clause_options)
 {
-	const CreateTableAsStmt *stmt = castNode(CreateTableAsStmt, node);
+	const CreateTableAsStmt *stmt = castNode(CreateTableAsStmt, stmt_node);
 	CAggTimebucketInfo timebucket_exprinfo;
 	Oid nspid;
 	ViewStmt viewstmt = {

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -94,22 +94,22 @@
 #define SWITCH_TO_TS_USER(schemaname, newuid, saved_uid, saved_secctx)                             \
 	do                                                                                             \
 	{                                                                                              \
-		if (schemaname &&                                                                          \
+		if ((schemaname) &&                                                                        \
 			strncmp(schemaname, INTERNAL_SCHEMA_NAME, strlen(INTERNAL_SCHEMA_NAME)) == 0)          \
-			newuid = ts_catalog_database_info_get()->owner_uid;                                    \
+			(newuid) = ts_catalog_database_info_get()->owner_uid;                                  \
 		else                                                                                       \
-			newuid = InvalidOid;                                                                   \
-		if (newuid != InvalidOid)                                                                  \
+			(newuid) = InvalidOid;                                                                 \
+		if ((newuid) != InvalidOid)                                                                \
 		{                                                                                          \
-			GetUserIdAndSecContext(&saved_uid, &saved_secctx);                                     \
-			SetUserIdAndSecContext(uid, saved_secctx | SECURITY_LOCAL_USERID_CHANGE);              \
+			GetUserIdAndSecContext(&(saved_uid), &(saved_secctx));                                 \
+			SetUserIdAndSecContext(uid, (saved_secctx) | SECURITY_LOCAL_USERID_CHANGE);            \
 		}                                                                                          \
 	} while (0)
 
 #define RESTORE_USER(newuid, saved_uid, saved_secctx)                                              \
 	do                                                                                             \
 	{                                                                                              \
-		if (newuid != InvalidOid)                                                                  \
+		if ((newuid) != InvalidOid)                                                                \
 			SetUserIdAndSecContext(saved_uid, saved_secctx);                                       \
 	} while (0);
 
@@ -139,15 +139,15 @@
 #define CAGG_MAKEQUERY(selquery, srcquery)                                                         \
 	do                                                                                             \
 	{                                                                                              \
-		selquery = makeNode(Query);                                                                \
-		selquery->commandType = CMD_SELECT;                                                        \
-		selquery->querySource = srcquery->querySource;                                             \
-		selquery->queryId = srcquery->queryId;                                                     \
-		selquery->canSetTag = srcquery->canSetTag;                                                 \
-		selquery->utilityStmt = copyObject(srcquery->utilityStmt);                                 \
-		selquery->resultRelation = 0;                                                              \
-		selquery->hasAggs = true;                                                                  \
-		selquery->hasRowSecurity = false;                                                          \
+		(selquery) = makeNode(Query);                                                              \
+		(selquery)->commandType = CMD_SELECT;                                                      \
+		(selquery)->querySource = (srcquery)->querySource;                                         \
+		(selquery)->queryId = (srcquery)->queryId;                                                 \
+		(selquery)->canSetTag = (srcquery)->canSetTag;                                             \
+		(selquery)->utilityStmt = copyObject((srcquery)->utilityStmt);                             \
+		(selquery)->resultRelation = 0;                                                            \
+		(selquery)->hasAggs = true;                                                                \
+		(selquery)->hasRowSecurity = false;                                                        \
 	} while (0);
 
 typedef struct MatTableColumnInfo

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -2250,8 +2250,6 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 
 	/* Step 5 create trigger on raw hypertable -specified in the user view query*/
 	cagg_add_trigger_hypertable(origquery_ht->htoid, origquery_ht->htid);
-
-	return;
 }
 
 DDLResult

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -2280,14 +2280,12 @@ tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *
 							stmt->into->rel->relname)));
 			return DDL_DONE;
 		}
-		else
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_DUPLICATE_TABLE),
-					 errmsg("continuous aggregate \"%s\" already exists", stmt->into->rel->relname),
-					 errhint("Drop or rename the existing continuous aggregate"
-							 " first or use another name.")));
-		}
+
+		ereport(ERROR,
+				(errcode(ERRCODE_DUPLICATE_TABLE),
+				 errmsg("continuous aggregate \"%s\" already exists", stmt->into->rel->relname),
+				 errhint("Drop or rename the existing continuous aggregate"
+						 " first or use another name.")));
 	}
 	if (!with_clause_options[ContinuousViewOptionCompress].is_default)
 	{
@@ -2451,7 +2449,7 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 		user_tle = lfirst_node(TargetEntry, lc2);
 		if (view_tle->resjunk && user_tle->resjunk)
 			break;
-		else if (view_tle->resjunk || user_tle->resjunk)
+		if (view_tle->resjunk || user_tle->resjunk)
 		{
 			/* This should never happen but if it ever does it's safer to
 			 * error here instead of creating broken view definitions. */

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -234,8 +234,7 @@ continuous_agg_trigfn(PG_FUNCTION_ARGS)
 						 parent_hypertable_id);
 	if (!TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event))
 		return PointerGetDatum(trigdata->tg_trigtuple);
-	else
-		return PointerGetDatum(trigdata->tg_newtuple);
+	return PointerGetDatum(trigdata->tg_newtuple);
 }
 
 /*

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -203,8 +203,10 @@ continuous_agg_trigfn(PG_FUNCTION_ARGS)
 	 * rows (which act like deletes) and once with the new rows.
 	 */
 	TriggerData *trigdata = (TriggerData *) fcinfo->context;
-	char *hypertable_id_str, *parent_hypertable_id_str;
-	int32 hypertable_id, parent_hypertable_id = 0;
+	char *hypertable_id_str;
+	char *parent_hypertable_id_str;
+	int32 hypertable_id;
+	int32 parent_hypertable_id = 0;
 	bool is_distributed_hypertable_trigger = false;
 	if (trigdata->tg_trigger->tgnargs < 0)
 		elog(ERROR, "must supply hypertable id");

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -771,7 +771,9 @@ move_invalidations_from_hyper_to_cagg_log(const CaggInvalidationState *state)
 	const CaggsInfo *all_caggs = state->all_caggs;
 	int32 hyper_id = state->raw_hypertable_id;
 	int32 last_cagg_hyper_id;
-	ListCell *lc1, *lc2, *lc3;
+	ListCell *lc1;
+	ListCell *lc2;
+	ListCell *lc3;
 
 	last_cagg_hyper_id = llast_int(all_caggs->mat_hypertable_ids);
 
@@ -1032,7 +1034,9 @@ static void
 invalidation_state_init(CaggInvalidationState *state, int32 mat_hypertable_id,
 						int32 raw_hypertable_id, Oid dimtype, const CaggsInfo *all_caggs)
 {
-	ListCell *lc1, *lc2, *lc3;
+	ListCell *lc1;
+	ListCell *lc2;
+	ListCell *lc3;
 	bool PG_USED_FOR_ASSERTS_ONLY found = false;
 
 	state->mat_hypertable_id = mat_hypertable_id;
@@ -1430,7 +1434,8 @@ remote_invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertab
 	if (dist_res)
 	{
 		unsigned num_dist_res = ts_dist_cmd_response_count(dist_res);
-		int64 start_time, end_time;
+		int64 start_time;
+		int64 end_time;
 		InternalTimeRange merged_window = {
 			.type = refresh_window->type,
 			.start = TS_TIME_NOEND, /* initial state invalid */

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -317,27 +317,22 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 				 */
 				return ts_time_get_nobegin(refresh_window->type);
 			}
-			else
-			{
-				/* For fixed-sized buckets return min (start of time) */
-				return ts_time_get_min(refresh_window->type);
-			}
+
+			/* For fixed-sized buckets return min (start of time) */
+			return ts_time_get_min(refresh_window->type);
 		}
-		else
+
+		int64 maxval = ts_time_value_to_internal(maxdat, refresh_window->type);
+
+		if (ts_continuous_agg_bucket_width_variable(cagg))
 		{
-			int64 maxval = ts_time_value_to_internal(maxdat, refresh_window->type);
-
-			if (ts_continuous_agg_bucket_width_variable(cagg))
-			{
-				return ts_compute_beginning_of_the_next_bucket_variable(maxval,
-																		cagg->bucket_function);
-			}
-
-			int64 bucket_width = ts_continuous_agg_bucket_width(cagg);
-			int64 bucket_start = ts_time_bucket_by_type(bucket_width, maxval, refresh_window->type);
-			/* Add one bucket to get to the end of the last bucket */
-			return ts_time_saturating_add(bucket_start, bucket_width, refresh_window->type);
+			return ts_compute_beginning_of_the_next_bucket_variable(maxval, cagg->bucket_function);
 		}
+
+		int64 bucket_width = ts_continuous_agg_bucket_width(cagg);
+		int64 bucket_start = ts_time_bucket_by_type(bucket_width, maxval, refresh_window->type);
+		/* Add one bucket to get to the end of the last bucket */
+		return ts_time_saturating_add(bucket_start, bucket_width, refresh_window->type);
 	}
 
 	return refresh_window->end;

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -116,7 +116,6 @@ continuous_agg_update_materialization(SchemaAndName partial_view,
 
 	res = SPI_finish();
 	Assert(res == SPI_OK_FINISH);
-	return;
 }
 
 static bool

--- a/tsl/src/continuous_aggs/materialize.c
+++ b/tsl/src/continuous_aggs/materialize.c
@@ -181,18 +181,16 @@ internal_to_time_value_or_infinite(int64 internal, Oid time_type, bool *is_infin
 			*is_infinite_out = true;
 		return time_range_internal_to_min_time_value(time_type);
 	}
-	else if (internal == PG_INT64_MAX)
+	if (internal == PG_INT64_MAX)
 	{
 		if (is_infinite_out != NULL)
 			*is_infinite_out = true;
 		return time_range_internal_to_max_time_value(time_type);
 	}
-	else
-	{
-		if (is_infinite_out != NULL)
-			*is_infinite_out = false;
-		return ts_internal_to_time_value(internal, time_type);
-	}
+
+	if (is_infinite_out != NULL)
+		*is_infinite_out = false;
+	return ts_internal_to_time_value(internal, time_type);
 }
 
 static TimeRange

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -515,18 +515,16 @@ data_node_bootstrap_extension(TSConnection *conn)
 								  quote_literal_cstr(ts_extension_get_version()));
 		return true;
 	}
-	else
-	{
-		ereport(NOTICE,
-				(errmsg("extension \"%s\" already exists on data node, skipping",
-						PQgetvalue(res, 0, 0)),
-				 errdetail("TimescaleDB extension version on %s:%s was %s.",
-						   PQhost(remote_connection_get_pg_conn(conn)),
-						   PQport(remote_connection_get_pg_conn(conn)),
-						   PQgetvalue(res, 0, 1))));
-		data_node_validate_extension(conn);
-		return false;
-	}
+
+	ereport(NOTICE,
+			(errmsg("extension \"%s\" already exists on data node, skipping",
+					PQgetvalue(res, 0, 0)),
+			 errdetail("TimescaleDB extension version on %s:%s was %s.",
+					   PQhost(remote_connection_get_pg_conn(conn)),
+					   PQport(remote_connection_get_pg_conn(conn)),
+					   PQgetvalue(res, 0, 1))));
+	data_node_validate_extension(conn);
+	return false;
 }
 
 /* Add dist_uuid on the remote node.
@@ -870,12 +868,11 @@ data_node_attach(PG_FUNCTION_ARGS)
 								get_rel_name(table_id))));
 				PG_RETURN_DATUM(create_hypertable_data_node_datum(fcinfo, node));
 			}
-			else
-				ereport(ERROR,
-						(errcode(ERRCODE_TS_DATA_NODE_ALREADY_ATTACHED),
-						 errmsg("data node \"%s\" is already attached to hypertable \"%s\"",
-								node_name,
-								get_rel_name(table_id))));
+			ereport(ERROR,
+					(errcode(ERRCODE_TS_DATA_NODE_ALREADY_ATTACHED),
+					 errmsg("data node \"%s\" is already attached to hypertable \"%s\"",
+							node_name,
+							get_rel_name(table_id))));
 		}
 	}
 
@@ -1175,8 +1172,7 @@ data_node_hypertable_get_by_node_name(const Hypertable *ht, const char *node_nam
 		hdn = lfirst(lc);
 		if (namestrcmp(&hdn->fd.node_name, node_name) == 0)
 			break;
-		else
-			hdn = NULL;
+		hdn = NULL;
 	}
 
 	if (hdn == NULL)

--- a/tsl/src/debug.c
+++ b/tsl/src/debug.c
@@ -89,7 +89,8 @@ static void
 append_var_expr(StringInfo buf, const Node *expr, const List *rtable)
 {
 	const Var *var = (const Var *) expr;
-	char *relname, *attname;
+	char *relname;
+	char *attname;
 
 	switch (var->varno)
 	{

--- a/tsl/src/deparse.h
+++ b/tsl/src/deparse.h
@@ -48,7 +48,7 @@ const char *deparse_get_tabledef_commands_concat(Oid relid);
 
 DeparsedHypertableCommands *deparse_get_distributed_hypertable_create_command(Hypertable *ht);
 
-const char *deparse_func_call(FunctionCallInfo finfo);
+const char *deparse_func_call(FunctionCallInfo fcinfo);
 const char *deparse_oid_function_call_coll(Oid funcid, Oid collation, unsigned int num_args, ...);
 const char *deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname);
 const char *deparse_create_trigger(CreateTrigStmt *stmt);

--- a/tsl/src/dist_util.c
+++ b/tsl/src/dist_util.c
@@ -60,10 +60,9 @@ dist_util_membership(void)
 
 	if (isnull)
 		return DIST_MEMBER_NONE;
-	else if (uuid_matches(dist_id, local_get_uuid(&isnull)))
+	if (uuid_matches(dist_id, local_get_uuid(&isnull)))
 		return DIST_MEMBER_ACCESS_NODE;
-	else
-		return DIST_MEMBER_DATA_NODE;
+	return DIST_MEMBER_DATA_NODE;
 }
 
 const char *
@@ -119,10 +118,9 @@ dist_util_set_id_with_uuid_check(Datum dist_id, bool check_uuid)
 	{
 		if (uuid_matches(dist_id, dist_util_get_id()))
 			return false;
-		else
-			ereport(ERROR,
-					(errcode(ERRCODE_TS_DATA_NODE_ASSIGNMENT_ALREADY_EXISTS),
-					 (errmsg("database is already a member of a distributed database"))));
+		ereport(ERROR,
+				(errcode(ERRCODE_TS_DATA_NODE_ASSIGNMENT_ALREADY_EXISTS),
+				 (errmsg("database is already a member of a distributed database"))));
 	}
 
 	Datum uuid = local_get_uuid(&isnull);

--- a/tsl/src/dist_util.c
+++ b/tsl/src/dist_util.c
@@ -237,7 +237,8 @@ dist_util_remote_compressed_chunk_info(PG_FUNCTION_ARGS)
 {
 	char *node_name;
 	StringInfo query_str;
-	Name schema_name, table_name;
+	Name schema_name;
+	Name table_name;
 	/* Strict function */
 	if (PG_NARGS() != 3 || PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
 		PG_RETURN_NULL();
@@ -257,7 +258,8 @@ dist_util_remote_hypertable_index_info(PG_FUNCTION_ARGS)
 {
 	char *node_name;
 	StringInfo query_str;
-	Name schema_name, index_name;
+	Name schema_name;
+	Name index_name;
 	/* Strict function */
 	if (PG_NARGS() != 3 || PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2))
 		PG_RETURN_NULL();
@@ -334,8 +336,12 @@ bool
 dist_util_is_compatible_version(const char *data_node_version, const char *access_node_version,
 								bool *is_old_version)
 {
-	unsigned int data_node_major, data_node_minor, data_node_patch;
-	unsigned int access_node_major, access_node_minor, access_node_patch;
+	unsigned int data_node_major;
+	unsigned int data_node_minor;
+	unsigned int data_node_patch;
+	unsigned int access_node_major;
+	unsigned int access_node_minor;
+	unsigned int access_node_patch;
 
 	Assert(is_old_version);
 	Assert(data_node_version);

--- a/tsl/src/dist_util.c
+++ b/tsl/src/dist_util.c
@@ -111,12 +111,12 @@ dist_util_set_id(Datum dist_id)
 }
 
 static bool
-dist_util_set_id_with_uuid_check(Datum dist_id, bool check_uuid)
+dist_util_set_id_with_uuid_check(Datum dist_uuid, bool check_uuid)
 {
 	bool isnull;
 	if (dist_util_membership() != DIST_MEMBER_NONE)
 	{
-		if (uuid_matches(dist_id, dist_util_get_id()))
+		if (uuid_matches(dist_uuid, dist_util_get_id()))
 			return false;
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_DATA_NODE_ASSIGNMENT_ALREADY_EXISTS),
@@ -124,7 +124,7 @@ dist_util_set_id_with_uuid_check(Datum dist_id, bool check_uuid)
 	}
 
 	Datum uuid = local_get_uuid(&isnull);
-	if (check_uuid && !isnull && uuid_matches(dist_id, uuid))
+	if (check_uuid && !isnull && uuid_matches(dist_uuid, uuid))
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_DATA_NODE_INVALID_CONFIG),
 				 (errmsg("cannot add the current database as a data node to itself"),
@@ -134,7 +134,7 @@ dist_util_set_id_with_uuid_check(Datum dist_id, bool check_uuid)
 						  "instance or that the 'database' parameter refers to a "
 						  "different database."))));
 
-	ts_metadata_insert(METADATA_DISTRIBUTED_UUID_KEY_NAME, dist_id, UUIDOID, true);
+	ts_metadata_insert(METADATA_DISTRIBUTED_UUID_KEY_NAME, dist_uuid, UUIDOID, true);
 	return true;
 }
 

--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -202,7 +202,7 @@ static void deparseReturningList(StringInfo buf, RangeTblEntry *rte, Index rtind
 static void deparseColumnRef(StringInfo buf, int varno, int varattno, RangeTblEntry *rte,
 							 bool qualify_col);
 static void deparseRelation(StringInfo buf, Relation rel);
-static void deparseExpr(Expr *expr, deparse_expr_cxt *context);
+static void deparseExpr(Expr *node, deparse_expr_cxt *context);
 static void deparseVar(Var *node, deparse_expr_cxt *context);
 static void deparseConst(Const *node, deparse_expr_cxt *context, int showtype);
 static void deparseParam(Param *node, deparse_expr_cxt *context);

--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -866,7 +866,8 @@ deparseDistinctClause(StringInfo buf, deparse_expr_cxt *context, List *pathkeys)
 {
 	PlannerInfo *root = context->root;
 	Query *query = root->parse;
-	ListCell *l, *dc_l;
+	ListCell *l;
+	ListCell *dc_l;
 	bool first = true, varno_assigned = false;
 	Index varno = 0; /* mostly to quell compiler warning, handled via varno_assigned */
 	RangeTblEntry *dc_rte;
@@ -922,7 +923,8 @@ deparseDistinctClause(StringInfo buf, deparse_expr_cxt *context, List *pathkeys)
 		 * corresponding relation. If the DISTINCT ON columns are not a prefix
 		 * of these pathkeys, we cannot push it down.
 		 */
-		ListCell *distinct_cell, *pathkey_cell;
+		ListCell *distinct_cell;
+		ListCell *pathkey_cell;
 		forboth (distinct_cell, query->distinctClause, pathkey_cell, pathkeys)
 		{
 			SortGroupClause *sgc = lfirst_node(SortGroupClause, distinct_cell);

--- a/tsl/src/fdw/deparse.h
+++ b/tsl/src/fdw/deparse.h
@@ -49,7 +49,7 @@ extern List *build_tlist_to_deparse(RelOptInfo *foreignrel);
 extern void deparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel, List *tlist,
 									List *remote_where, List *remote_having, List *pathkeys,
 									bool is_subquery, List **retrieved_attrs, List **params_list,
-									DataNodeChunkAssignment *swa);
+									DataNodeChunkAssignment *sca);
 
 extern const char *get_jointype_name(JoinType jointype);
 extern void deparseStringLiteral(StringInfo buf, const char *val);

--- a/tsl/src/fdw/modify_exec.c
+++ b/tsl/src/fdw/modify_exec.c
@@ -85,7 +85,7 @@ typedef struct TsFdwModifyState
 } TsFdwModifyState;
 
 #define TS_FDW_MODIFY_STATE_SIZE(num_data_nodes)                                                   \
-	(sizeof(TsFdwModifyState) + (sizeof(TsFdwDataNodeState) * num_data_nodes))
+	(sizeof(TsFdwModifyState) + (sizeof(TsFdwDataNodeState) * (num_data_nodes)))
 
 static void
 initialize_fdw_data_node_state(TsFdwDataNodeState *fdw_data_node, TSConnectionId id)

--- a/tsl/src/fdw/option.h
+++ b/tsl/src/fdw/option.h
@@ -9,7 +9,7 @@
 #include <postgres.h>
 
 extern void option_validate(List *options_list, Oid catalog);
-extern List *option_extract_extension_list(const char *extensionsString, bool warn_on_missing);
+extern List *option_extract_extension_list(const char *extensions_string, bool warn_on_missing);
 extern bool option_get_from_options_list_int(List *options, const char *optionname, int *value);
 
 #endif /* TIMESCALEDB_TSL_FDW_OPTION_H */

--- a/tsl/src/nodes/async_append.h
+++ b/tsl/src/nodes/async_append.h
@@ -32,6 +32,6 @@ typedef struct AsyncScanState
 	void (*fetch_data)(struct AsyncScanState *state);
 } AsyncScanState;
 
-extern void async_append_add_paths(PlannerInfo *root, RelOptInfo *hyper_rel);
+extern void async_append_add_paths(PlannerInfo *root, RelOptInfo *final_rel);
 
 #endif

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -709,7 +709,7 @@ chunk_joininfo_mutator(Node *node, CompressionInfo *context)
 
 		return (Node *) compress_var;
 	}
-	else if (IsA(node, RestrictInfo))
+	if (IsA(node, RestrictInfo))
 	{
 		RestrictInfo *oldinfo = (RestrictInfo *) node;
 		RestrictInfo *newinfo = makeNode(RestrictInfo);

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -68,7 +68,9 @@ static PathKey *
 make_pathkey_from_compressed(PlannerInfo *root, Index compressed_relid, Expr *expr, Oid ordering_op,
 							 bool nulls_first)
 {
-	Oid opfamily, opcintype, collation;
+	Oid opfamily;
+	Oid opcintype;
+	Oid collation;
 	int16 strategy;
 
 	/* Find the operator in pg_amop --- failure shouldn't happen */
@@ -98,7 +100,9 @@ prepend_ec_for_seqnum(PlannerInfo *root, CompressionInfo *info, SortInfo *sort_i
 {
 	MemoryContext oldcontext = MemoryContextSwitchTo(root->planner_cxt);
 
-	Oid opfamily, opcintype, equality_op;
+	Oid opfamily;
+	Oid opcintype;
+	Oid equality_op;
 	int16 strategy;
 	List *opfamilies;
 	EquivalenceClass *newec = makeNode(EquivalenceClass);
@@ -511,7 +515,8 @@ compressed_reltarget_add_var_for_column(RelOptInfo *compressed_rel, Oid compress
 
 	*attrs_used = bms_add_member(*attrs_used, attnum);
 
-	Oid typid, collid;
+	Oid typid;
+	Oid collid;
 	int32 typmod;
 	get_atttypetypmodcoll(compressed_relid, attnum, &typid, &typmod, &collid);
 	compressed_rel->reltarget->exprs =

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -470,7 +470,7 @@ decompress_chunk_create_tuple(DecompressChunkState *state)
 							batch_done = true;
 							continue;
 						}
-						else if (batch_done)
+						if (batch_done)
 						{
 							/*
 							 * since the count column is the first column batch_done

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -189,7 +189,9 @@ static Expr *
 pushdown_op_to_segment_meta_min_max(QualPushdownContext *context, List *expr_args, Oid op_oid,
 									Oid op_collation)
 {
-	Expr *leftop, *rightop, *expr;
+	Expr *leftop;
+	Expr *rightop;
+	Expr *expr;
 	Var *var_with_segment_meta;
 	TypeCacheEntry *tce;
 	int strategy;

--- a/tsl/src/nodes/gapfill/exec.c
+++ b/tsl/src/nodes/gapfill/exec.c
@@ -749,8 +749,7 @@ gapfill_exec(CustomScanState *node)
 				 */
 				if (state->multigroup && !state->groups_initialized)
 					return NULL;
-				else
-					state->state = FETCHED_LAST;
+				state->state = FETCHED_LAST;
 			}
 		}
 
@@ -1112,7 +1111,7 @@ gapfill_state_initialize_columns(GapFillState *state)
 			state->groups_initialized = false;
 			continue;
 		}
-		else if (IsA(expr, FuncExpr))
+		if (IsA(expr, FuncExpr))
 		{
 			/* locf and interpolate will be toplevel function calls in the gapfill node */
 			if (strncmp(get_func_name(castNode(FuncExpr, expr)->funcid),

--- a/tsl/src/nodes/gapfill/exec.c
+++ b/tsl/src/nodes/gapfill/exec.c
@@ -380,7 +380,8 @@ static bool
 is_boundary_expr(Node *node, CollectBoundaryContext *context)
 {
 	OpExpr *op;
-	Node *left, *right;
+	Node *left;
+	Node *right;
 
 	if (!IsA(node, OpExpr))
 		return false;
@@ -468,7 +469,8 @@ infer_gapfill_boundary(GapFillState *state, GapFillBoundary boundary)
 	Var *ts_var;
 	TypeCacheEntry *tce = lookup_type_cache(state->gapfill_typid, TYPECACHE_BTREE_OPFAMILY);
 	int strategy;
-	Oid lefttype, righttype;
+	Oid lefttype;
+	Oid righttype;
 	List *quals;
 
 	int64 boundary_value = 0;
@@ -1255,7 +1257,8 @@ gapfill_exec_expr(GapFillState *state, Expr *expr, bool *isnull)
 Expr *
 gapfill_adjust_varnos(GapFillState *state, Expr *expr)
 {
-	ListCell *lc_var, *lc_tle;
+	ListCell *lc_var;
+	ListCell *lc_tle;
 	List *vars = pull_var_clause((Node *) expr, 0);
 	List *tlist = castNode(CustomScan, state->csstate.ss.ps.plan)->custom_scan_tlist;
 

--- a/tsl/src/nodes/gapfill/interpolate.c
+++ b/tsl/src/nodes/gapfill/interpolate.c
@@ -174,8 +174,11 @@ void
 gapfill_interpolate_calculate(GapFillInterpolateColumnState *column, GapFillState *state,
 							  int64 time, Datum *value, bool *isnull)
 {
-	int64 x, x0, x1;
-	Datum y0, y1;
+	int64 x;
+	int64 x0;
+	int64 x1;
+	Datum y0;
+	Datum y1;
 
 	/* only evaluate expr for first tuple */
 	if (column->prev.isnull && column->lookup_before && time == state->gapfill_start)

--- a/tsl/src/nodes/skip_scan/exec.c
+++ b/tsl/src/nodes/skip_scan/exec.c
@@ -298,19 +298,18 @@ skip_scan_exec(CustomScanState *node)
 					skip_scan_update_key(state, result);
 					return result;
 				}
+
+				/*
+				 * if there are no more values that satisfy
+				 * the skip constraint we are either done
+				 * for NULLS FIRST ordering or need to check
+				 * for NULLs if we have NULLS LAST ordering
+				 */
+				if (has_nulls_last(state))
+					skip_scan_switch_stage(state, SS_NULLS_LAST);
 				else
-				{
-					/*
-					 * if there are no more values that satisfy
-					 * the skip constraint we are either done
-					 * for NULLS FIRST ordering or need to check
-					 * for NULLs if we have NULLS LAST ordering
-					 */
-					if (has_nulls_last(state))
-						skip_scan_switch_stage(state, SS_NULLS_LAST);
-					else
-						skip_scan_switch_stage(state, SS_END);
-				}
+					skip_scan_switch_stage(state, SS_END);
+
 				break;
 
 			case SS_NULLS_LAST:

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -322,7 +322,8 @@ static ChunkAppendPath *
 copy_chunk_append_path(ChunkAppendPath *ca, List *subpaths)
 {
 	ListCell *lc;
-	double total_cost = 0, rows = 0;
+	double total_cost = 0;
+	double rows = 0;
 	ChunkAppendPath *new = palloc(sizeof(ChunkAppendPath));
 	memcpy(new, ca, sizeof(ChunkAppendPath));
 	new->cpath.custom_paths = subpaths;

--- a/tsl/src/partialize_finalize.c
+++ b/tsl/src/partialize_finalize.c
@@ -450,7 +450,8 @@ tsl_finalize_agg_sfunc(PG_FUNCTION_ARGS)
 	bytea *inner_agg_serialized_state = PG_ARGISNULL(5) ? NULL : PG_GETARG_BYTEA_P(5);
 	bool inner_agg_serialized_state_isnull = PG_ARGISNULL(5) ? true : false;
 	Datum inner_agg_deserialized_state;
-	MemoryContext fa_context, old_context;
+	MemoryContext fa_context;
+	MemoryContext old_context;
 
 	if (!AggCheckCallContext(fcinfo, &fa_context) || !IsA(fcinfo->context, AggState))
 	{
@@ -529,7 +530,8 @@ Datum
 tsl_finalize_agg_ffunc(PG_FUNCTION_ARGS)
 {
 	FATransitionState *tstate = PG_ARGISNULL(0) ? NULL : (FATransitionState *) PG_GETARG_POINTER(0);
-	MemoryContext fa_context, old_context;
+	MemoryContext fa_context;
+	MemoryContext old_context;
 	Datum result = tstate->per_group_state->trans_value;
 	bool result_isnull = tstate->per_group_state->trans_value_isnull;
 

--- a/tsl/src/remote/async.h
+++ b/tsl/src/remote/async.h
@@ -92,7 +92,7 @@ extern AsyncRequest *async_request_send_with_stmt_params_elevel_res_format(
 extern AsyncRequest *async_request_send_prepare(TSConnection *conn, const char *sql_statement,
 												int n_params);
 extern AsyncRequest *async_request_send_prepared_stmt(PreparedStmt *stmt,
-													  const char *const *paramValues);
+													  const char *const *param_values);
 extern AsyncRequest *async_request_send_prepared_stmt_with_params(PreparedStmt *stmt,
 																  StmtParams *params,
 																  int res_format);
@@ -107,7 +107,7 @@ extern AsyncResponseResult *async_request_wait_any_result(AsyncRequest *request)
 extern AsyncResponse *async_request_cleanup_result(AsyncRequest *req, TimestampTz endtime);
 
 /* Returns on successful commands, throwing errors otherwise */
-extern void async_request_wait_ok_command(AsyncRequest *set);
+extern void async_request_wait_ok_command(AsyncRequest *req);
 extern PreparedStmt *async_request_wait_prepared_statement(AsyncRequest *request);
 
 /* Async Response */

--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -402,7 +402,9 @@ create_tuple_from_conn_entry(const ConnectionCacheEntry *entry, const TupleDesc 
 	Datum values[Natts_show_conn];
 	bool nulls[Natts_show_conn] = { false };
 	PGconn *pgconn = remote_connection_get_pg_conn(entry->conn);
-	NameData conn_node_name, conn_user_name, conn_db;
+	NameData conn_node_name;
+	NameData conn_user_name;
+	NameData conn_db;
 	const char *username = GetUserNameFromId(entry->id.user_id, true);
 
 	namestrcpy(&conn_node_name, remote_connection_node_name(entry->conn));

--- a/tsl/src/remote/dist_commands.c
+++ b/tsl/src/remote/dist_commands.c
@@ -89,7 +89,8 @@ DistCmdResult *
 ts_dist_multi_cmds_params_invoke_on_data_nodes(List *cmd_descriptors, List *data_nodes,
 											   bool transactional)
 {
-	ListCell *lc_data_node, *lc_cmd_descr;
+	ListCell *lc_data_node;
+	ListCell *lc_cmd_descr;
 	List *requests = NIL;
 	DistCmdResult *results;
 

--- a/tsl/src/remote/dist_commands.h
+++ b/tsl/src/remote/dist_commands.h
@@ -22,7 +22,7 @@ typedef struct DistCmdDescr
 extern DistCmdResult *ts_dist_multi_cmds_params_invoke_on_data_nodes(List *cmd_descriptors,
 																	 List *data_nodes,
 																	 bool transactional);
-extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes(const char *sql, List *node_names,
+extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes(const char *sql, List *data_nodes,
 													   bool transactional);
 extern DistCmdResult *ts_dist_cmd_params_invoke_on_data_nodes(const char *sql, StmtParams *params,
 															  List *data_nodes, bool transactional);

--- a/tsl/src/remote/dist_ddl.c
+++ b/tsl/src/remote/dist_ddl.c
@@ -499,7 +499,8 @@ dist_ddl_process_grant_on_database(const GrantStmt *stmt)
 	const char *dbname;
 	bool dbmatch;
 	List *cmd_descriptors = NIL;
-	ListCell *i, *j;
+	ListCell *i;
+	ListCell *j;
 
 	if (dist_util_membership() != DIST_MEMBER_ACCESS_NODE)
 		return;

--- a/tsl/src/remote/tuplefactory.c.orig
+++ b/tsl/src/remote/tuplefactory.c.orig
@@ -1,0 +1,408 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+/*
+ * This file contains source code that was copied and/or modified from
+ * the PostgreSQL database, which is licensed under the open-source
+ * PostgreSQL License. Please see the NOTICE at the top level
+ * directory for a copy of the PostgreSQL License.
+ */
+#include <postgres.h>
+#include <access/htup_details.h>
+#include <access/sysattr.h>
+#include <catalog/pg_type.h>
+#include <libpq-fe.h>
+#include <miscadmin.h>
+#include <optimizer/restrictinfo.h>
+#include <parser/parsetree.h>
+#include <utils/builtins.h>
+#include <utils/float.h>
+#include <utils/guc.h>
+#include <utils/memutils.h>
+#include <utils/rel.h>
+#include <utils/syscache.h>
+
+#include <guc.h>
+#include "utils.h"
+#include "src/utils.h"
+#include "compat/compat.h"
+#include "remote/data_format.h"
+#include "tuplefactory.h"
+
+/*
+ * Identify the attribute where data conversion fails.
+ */
+typedef struct ConversionLocation
+{
+	Relation rel;		  /* foreign table's relcache entry. */
+	AttrNumber cur_attno; /* attribute number being processed, or 0 */
+
+	/*
+	 * In case of foreign join push down, fdw_scan_tlist is used to identify
+	 * the Var node corresponding to the error location and
+	 * ss->ps.state gives access to the RTEs of corresponding relation
+	 * to get the relation name and attribute name.
+	 */
+	ScanState *ss;
+} ConversionLocation;
+
+typedef struct TupleFactory
+{
+	MemoryContext temp_mctx;
+	TupleDesc tupdesc;
+	Datum *values;
+	bool *nulls;
+	List *retrieved_attrs;
+	AttConvInMetadata *attconv;
+	ConversionLocation errpos;
+	ErrorContextCallback errcallback;
+	bool per_tuple_mctx_reset;
+} TupleFactory;
+
+/*
+ * Callback function which is called when error occurs during column value
+ * conversion.  Print names of column and relation.
+ */
+static void
+conversion_error_callback(void *arg)
+{
+	const char *attname = NULL;
+	const char *relname = NULL;
+	bool is_wholerow = false;
+	ConversionLocation *errpos = (ConversionLocation *) arg;
+
+	if (errpos->rel)
+	{
+		/* error occurred in a scan against a foreign table */
+		TupleDesc tupdesc = RelationGetDescr(errpos->rel);
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, errpos->cur_attno - 1);
+
+		if (errpos->cur_attno > 0 && errpos->cur_attno <= tupdesc->natts)
+			attname = NameStr(attr->attname);
+		else if (errpos->cur_attno == SelfItemPointerAttributeNumber)
+			attname = "ctid";
+
+		relname = RelationGetRelationName(errpos->rel);
+	}
+	else
+	{
+		/* error occurred in a scan against a foreign join */
+		ScanState *ss = errpos->ss;
+		List *tlist = NIL;
+		EState *estate = ss->ps.state;
+
+		if (IsA(ss->ps.plan, ForeignScan))
+		{
+			ForeignScan *fsplan = (ForeignScan *) ss->ps.plan;
+			tlist = fsplan->fdw_scan_tlist;
+		}
+		else if (IsA(ss->ps.plan, CustomScan))
+		{
+			CustomScan *csplan = (CustomScan *) ss->ps.plan;
+
+			tlist = csplan->scan.plan.targetlist;
+		}
+
+		if (tlist == NIL)
+		{
+			elog(ERROR,
+<<<<<<< HEAD
+				 "unknown scan node type %s in error callback",
+				 ts_get_node_name((Node *) ss->ps.plan));
+=======
+				 "unknown scan node type %d in error callback",
+				 ts_get_node_name(ss->ps.plan));
+>>>>>>> c99bf70e... Fix clang-tidy warning `bugprone-macro-parentheses`
+		}
+
+		TargetEntry *tle = list_nth_node(TargetEntry, tlist, errpos->cur_attno - 1);
+
+		/*
+		 * Target list can have Vars and expressions.  For Vars, we can get
+		 * its relation, however for expressions we can't.  Thus for
+		 * expressions, just show generic context message.
+		 */
+		if (IsA(tle->expr, Var))
+		{
+			RangeTblEntry *rte;
+			Var *var = (Var *) tle->expr;
+
+			rte = rt_fetch(var->varno, estate->es_range_table);
+
+			if (var->varattno == 0)
+				is_wholerow = true;
+			else
+				attname = get_attname(rte->relid, var->varattno, false);
+
+			relname = get_rel_name(rte->relid);
+		}
+		else
+			errcontext("processing expression at position %d in select list", errpos->cur_attno);
+	}
+
+	if (relname)
+	{
+		if (is_wholerow)
+			errcontext("whole-row reference to foreign table \"%s\"", relname);
+		else if (attname)
+			errcontext("column \"%s\" of foreign table \"%s\"", attname, relname);
+	}
+}
+
+static TupleFactory *
+tuplefactory_create_common(TupleDesc tupdesc, List *retrieved_attrs, bool force_text)
+{
+	TupleFactory *tf = palloc0(sizeof(TupleFactory));
+
+	tf->temp_mctx = AllocSetContextCreate(CurrentMemoryContext,
+										  "tuple factory temporary data",
+										  ALLOCSET_DEFAULT_SIZES);
+
+	tf->tupdesc = tupdesc;
+	tf->retrieved_attrs = retrieved_attrs;
+	tf->attconv = data_format_create_att_conv_in_metadata(tf->tupdesc, force_text);
+	tf->values = (Datum *) palloc0(tf->tupdesc->natts * sizeof(Datum));
+	tf->nulls = (bool *) palloc(tf->tupdesc->natts * sizeof(bool));
+
+	/* Initialize to nulls for any columns not present in result */
+	memset(tf->nulls, true, tf->tupdesc->natts * sizeof(bool));
+
+	return tf;
+}
+
+TupleFactory *
+tuplefactory_create_for_tupdesc(TupleDesc tupdesc, bool force_text)
+{
+	List *retrieved_attrs = NIL;
+	int i;
+
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		if (!TupleDescAttr(tupdesc, i)->attisdropped)
+			retrieved_attrs = lappend_int(retrieved_attrs, i + 1);
+	}
+
+	return tuplefactory_create_common(tupdesc, retrieved_attrs, force_text);
+}
+
+static TupleFactory *
+tuplefactory_create(Relation rel, ScanState *ss, List *retrieved_attrs)
+{
+	TupleFactory *tf;
+	TupleDesc tupdesc;
+
+	Assert(!(rel && ss) && (rel || ss));
+
+	if (NULL != rel)
+		tupdesc = RelationGetDescr(rel);
+	else
+		tupdesc = ss->ss_ScanTupleSlot->tts_tupleDescriptor;
+
+	tf =
+		tuplefactory_create_common(tupdesc, retrieved_attrs, !ts_guc_enable_connection_binary_data);
+	tf->errpos.rel = rel;
+	tf->errpos.cur_attno = 0;
+	tf->errpos.ss = ss;
+	tf->errcallback.callback = conversion_error_callback;
+	tf->errcallback.arg = (void *) &tf->errpos;
+	tf->errcallback.previous = error_context_stack;
+	tf->per_tuple_mctx_reset = true;
+
+	return tf;
+}
+
+TupleFactory *
+tuplefactory_create_for_rel(Relation rel, List *retrieved_attrs)
+{
+	return tuplefactory_create(rel, NULL, retrieved_attrs);
+}
+
+TupleFactory *
+tuplefactory_create_for_scan(ScanState *ss, List *retrieved_attrs)
+{
+	return tuplefactory_create(NULL, ss, retrieved_attrs);
+}
+
+bool
+tuplefactory_is_binary(TupleFactory *tf)
+{
+	return tf->attconv->binary;
+}
+
+void
+tuplefactory_set_per_tuple_mctx_reset(TupleFactory *tf, bool reset)
+{
+	tf->per_tuple_mctx_reset = reset;
+}
+
+void
+tuplefactory_reset_mctx(TupleFactory *tf)
+{
+	MemoryContextReset(tf->temp_mctx);
+}
+
+int
+tuplefactory_get_nattrs(TupleFactory *tf)
+{
+	return tf->tupdesc->natts;
+}
+
+ItemPointer
+tuplefactory_make_virtual_tuple(TupleFactory *tf, PGresult *res, int row, int format, Datum *values,
+								bool *nulls)
+{
+	ItemPointer ctid = NULL;
+	ListCell *lc;
+	int j;
+
+	Assert(row < PQntuples(res));
+
+	/* Install error callback */
+	if (tf->errcallback.callback != NULL)
+	{
+		tf->errcallback.previous = error_context_stack;
+		error_context_stack = &tf->errcallback;
+	}
+
+	/*
+	 * i indexes columns in the relation, j indexes columns in the PGresult.
+	 */
+	j = 0;
+	foreach (lc, tf->retrieved_attrs)
+	{
+		int i = lfirst_int(lc);
+		char *valstr = NULL;
+
+		const int len = PQgetlength(res, row, j);
+		/* we assume that value is NULL is length is 0 */
+		if (len == 0)
+			valstr = NULL;
+		else
+		{
+			valstr = PQgetvalue(res, row, j);
+		}
+
+		/*
+		 * Note that this attno is an index inside fdw_scan_tlist, not inside
+		 * tupdesc.
+		 */
+		tf->errpos.cur_attno = j + 1;
+
+		/*
+		 * convert value to internal representation
+		 *
+		 * Note: we ignore system columns other than ctid and oid in result
+		 */
+		if (i > 0)
+		{
+			/* ordinary column */
+			Assert(i <= tf->tupdesc->natts);
+			nulls[i - 1] = (valstr == NULL);
+
+			if (format == FORMAT_TEXT)
+			{
+				Assert(!tf->attconv->binary);
+				/* Apply the input function even to nulls, to support domains */
+				values[i - 1] = InputFunctionCall(&tf->attconv->conv_funcs[i - 1],
+												  valstr,
+												  tf->attconv->ioparams[i - 1],
+												  tf->attconv->typmods[i - 1]);
+			}
+			else
+			{
+				Assert(tf->attconv->binary);
+				if (valstr != NULL)
+				{
+					StringInfoData si = { .data = valstr, .len = len };
+					values[i - 1] = ReceiveFunctionCall(&tf->attconv->conv_funcs[i - 1],
+														&si,
+														tf->attconv->ioparams[i - 1],
+														tf->attconv->typmods[i - 1]);
+				}
+				else
+					values[i - 1] = PointerGetDatum(NULL);
+			}
+		}
+		else if (i == SelfItemPointerAttributeNumber)
+		{
+			/* ctid */
+			if (valstr != NULL)
+			{
+				Datum datum;
+				if (format == FORMAT_TEXT)
+					datum = DirectFunctionCall1(tidin, CStringGetDatum(valstr));
+				else
+				{
+					StringInfoData si = { .data = valstr, .len = len };
+					datum = DirectFunctionCall1(tidrecv, PointerGetDatum(&si));
+				}
+				ctid = (ItemPointer) DatumGetPointer(datum);
+			}
+		}
+		tf->errpos.cur_attno = 0;
+		j++;
+	}
+
+	/* Uninstall error context callback. */
+	if (tf->errcallback.callback != NULL)
+		error_context_stack = tf->errcallback.previous;
+
+	/*
+	 * Check we got the expected number of columns.  Note: j == 0 and
+	 * PQnfields == 1 is expected, since deparse emits a NULL if no columns.
+	 */
+	if (j > 0 && j != PQnfields(res))
+		elog(ERROR, "remote query result does not match the foreign table");
+
+	return ctid;
+}
+
+HeapTuple
+tuplefactory_make_tuple(TupleFactory *tf, PGresult *res, int row, int format)
+{
+	/*
+	 * Do the following work in a temp context that we reset after each tuple.
+	 * This cleans up not only the data we have direct access to, but any
+	 * cruft the I/O functions might leak.
+	 */
+	MemoryContext oldcontext = MemoryContextSwitchTo(tf->temp_mctx);
+
+	ItemPointer ctid = tuplefactory_make_virtual_tuple(tf, res, row, format, tf->values, tf->nulls);
+
+	/*
+	 * Build the result tuple in caller's memory context.
+	 */
+	MemoryContextSwitchTo(oldcontext);
+
+	HeapTuple tuple = heap_form_tuple(tf->tupdesc, tf->values, tf->nulls);
+
+	/*
+	 * If we have a CTID to return, install it in both t_self and t_ctid.
+	 * t_self is the normal place, but if the tuple is converted to a
+	 * composite Datum, t_self will be lost; setting t_ctid allows CTID to be
+	 * preserved during EvalPlanQual re-evaluations (see ROW_MARK_COPY code).
+	 */
+	if (ctid)
+		tuple->t_self = tuple->t_data->t_ctid = *ctid;
+
+	/*
+	 * Stomp on the xmin, xmax, and cmin fields from the tuple created by
+	 * heap_form_tuple.  heap_form_tuple actually creates the tuple with
+	 * DatumTupleFields, not HeapTupleFields, but the executor expects
+	 * HeapTupleFields and will happily extract system columns on that
+	 * assumption.  If we don't do this then, for example, the tuple length
+	 * ends up in the xmin field, which isn't what we want.
+	 */
+	HeapTupleHeaderSetXmax(tuple->t_data, InvalidTransactionId);
+	HeapTupleHeaderSetXmin(tuple->t_data, InvalidTransactionId);
+	HeapTupleHeaderSetCmin(tuple->t_data, InvalidTransactionId);
+
+	/* Clean up */
+	if (tf->per_tuple_mctx_reset)
+		tuplefactory_reset_mctx(tf);
+
+	return tuple;
+}

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -391,8 +391,8 @@ remote_txn_abort(RemoteTxn *entry)
 	/* Already in bad state */
 	if (remote_connection_xact_is_transitioning(entry->conn))
 		return false;
-	else if (in_error_recursion_trouble() ||
-			 PQstatus(remote_connection_get_pg_conn(entry->conn)) == CONNECTION_BAD)
+	if (in_error_recursion_trouble() ||
+		PQstatus(remote_connection_get_pg_conn(entry->conn)) == CONNECTION_BAD)
 	{
 		/*
 		 * Don't try to recover the connection if we're already in error

--- a/tsl/src/remote/txn.h
+++ b/tsl/src/remote/txn.h
@@ -24,7 +24,7 @@ typedef enum
 /* actions */
 extern void remote_txn_init(RemoteTxn *entry, TSConnection *conn);
 extern RemoteTxn *remote_txn_begin_on_connection(TSConnection *conn);
-extern void remote_txn_begin(RemoteTxn *entry, int txnlevel);
+extern void remote_txn_begin(RemoteTxn *entry, int curlevel);
 extern bool remote_txn_abort(RemoteTxn *entry);
 extern void remote_txn_write_persistent_record(RemoteTxn *entry);
 extern void remote_txn_deallocate_prepared_stmts_if_needed(RemoteTxn *entry);
@@ -49,7 +49,7 @@ extern void remote_txn_report_prepare_transaction_result(RemoteTxn *txn, bool su
 
 /* Persitent record */
 extern RemoteTxnId *remote_txn_persistent_record_write(TSConnectionId id);
-extern bool remote_txn_persistent_record_exists(const RemoteTxnId *gid);
+extern bool remote_txn_persistent_record_exists(const RemoteTxnId *parsed);
 extern int remote_txn_persistent_record_delete_for_data_node(Oid foreign_server_oid,
 															 const char *gid);
 

--- a/tsl/src/remote/txn_resolve.c
+++ b/tsl/src/remote/txn_resolve.c
@@ -70,8 +70,10 @@ remote_txn_heal_data_node(PG_FUNCTION_ARGS)
 	 */
 	PGresult *res;
 	int row;
-	List *in_progress_txn_gids = NIL, *healed_txn_gids = NIL;
-	int non_ts_txns = 0, ntuples;
+	List *in_progress_txn_gids = NIL;
+	List *healed_txn_gids = NIL;
+	int non_ts_txns = 0;
+	int ntuples;
 #ifdef TS_DEBUG
 	int n_gid_errors = 0; /* how many errors to induce? */
 #endif

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -614,7 +614,9 @@ static void
 copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 			   bool *pSwapToastByContent, TransactionId *pFreezeXid, MultiXactId *pCutoffMulti)
 {
-	Relation NewHeap, OldHeap, OldIndex;
+	Relation NewHeap;
+	Relation OldHeap;
+	Relation OldIndex;
 	Relation relRelation;
 	HeapTuple reltup;
 	Form_pg_class relform;
@@ -627,7 +629,9 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 	TransactionId FreezeXid;
 	MultiXactId MultiXactCutoff;
 	bool use_sort;
-	double num_tuples = 0, tups_vacuumed = 0, tups_recently_dead = 0;
+	double num_tuples = 0;
+	double tups_vacuumed = 0;
+	double tups_recently_dead = 0;
 	BlockNumber num_pages;
 	int elevel = verbose ? INFO : DEBUG2;
 	PGRUsage ru0;
@@ -1018,9 +1022,12 @@ swap_relation_files(Oid r1, Oid r2, bool swap_toast_by_content, bool is_internal
 					TransactionId frozenXid, MultiXactId cutoffMulti)
 {
 	Relation relRelation;
-	HeapTuple reltup1, reltup2;
-	Form_pg_class relform1, relform2;
-	Oid relfilenode1, relfilenode2;
+	HeapTuple reltup1;
+	HeapTuple reltup2;
+	Form_pg_class relform1;
+	Form_pg_class relform2;
+	Oid relfilenode1;
+	Oid relfilenode2;
 	Oid swaptemp;
 	char swptmpchr;
 
@@ -1146,7 +1153,8 @@ swap_relation_files(Oid r1, Oid r2, bool swap_toast_by_content, bool is_internal
 			 * something more selective than deleteDependencyRecordsFor() to
 			 * get rid of just the link we want.
 			 */
-			ObjectAddress baseobject, toastobject;
+			ObjectAddress baseobject;
+			ObjectAddress toastobject;
 			long count;
 
 			/*
@@ -1201,7 +1209,8 @@ swap_relation_files(Oid r1, Oid r2, bool swap_toast_by_content, bool is_internal
 	if (swap_toast_by_content && relform1->relkind == RELKIND_TOASTVALUE &&
 		relform2->relkind == RELKIND_TOASTVALUE)
 	{
-		Oid toastIndex1, toastIndex2;
+		Oid toastIndex1;
+		Oid toastIndex2;
 
 		/* Get valid index for each relation */
 		toastIndex1 = toast_get_valid_index(r1, AccessExclusiveLock);

--- a/tsl/test/expected/remote_connection.out
+++ b/tsl/test/expected/remote_connection.out
@@ -45,7 +45,6 @@ INSERT INTO "S 1"."T 1"
 -- ===================================================================
 -- run tests
 -- ===================================================================
-\set VERBOSITY verbose
 SELECT * FROM test.get_connection_stats();
  connections_created | connections_closed | results_created | results_cleared 
 ---------------------+--------------------+-----------------+-----------------
@@ -54,8 +53,7 @@ SELECT * FROM test.get_connection_stats();
 
 \set ON_ERROR_STOP 0
 SELECT test.send_remote_query_that_generates_exception();
-ERROR:  XX000: bad query error thrown from test
-LOCATION:  ts_test_bad_remote_query, connection.c:184
+ERROR:  bad query error thrown from test
 \set ON_ERROR_STOP 1
 SELECT * FROM test.get_connection_stats();
  connections_created | connections_closed | results_created | results_cleared 

--- a/tsl/test/sql/remote_connection.sql
+++ b/tsl/test/sql/remote_connection.sql
@@ -56,7 +56,6 @@ INSERT INTO "S 1"."T 1"
 -- run tests
 -- ===================================================================
 
-\set VERBOSITY verbose
 SELECT * FROM test.get_connection_stats();
 \set ON_ERROR_STOP 0
 SELECT test.send_remote_query_that_generates_exception();

--- a/tsl/test/src/remote/connection.c
+++ b/tsl/test/src/remote/connection.c
@@ -107,7 +107,8 @@ test_simple_queries()
 static void
 test_connection_and_result_leaks()
 {
-	TSConnection *conn, *subconn;
+	TSConnection *conn;
+	TSConnection *subconn;
 	PGresult *res;
 	RemoteConnectionStats *stats;
 

--- a/tsl/test/src/remote/connection.c
+++ b/tsl/test/src/remote/connection.c
@@ -100,9 +100,9 @@ test_simple_queries()
 }
 
 #define ASSERT_NUM_OPEN_CONNECTIONS(stats, num)                                                    \
-	TestAssertTrue((((stats)->connections_created - (stats)->connections_closed) == num))
+	TestAssertTrue((((stats)->connections_created - (stats)->connections_closed) == (num)))
 #define ASSERT_NUM_OPEN_RESULTS(stats, num)                                                        \
-	TestAssertTrue((((stats)->results_created - (stats)->results_cleared) == num))
+	TestAssertTrue((((stats)->results_created - (stats)->results_cleared) == (num)))
 
 static void
 test_connection_and_result_leaks()

--- a/tsl/test/src/remote/remote_exec.c
+++ b/tsl/test/src/remote/remote_exec.c
@@ -207,7 +207,9 @@ ts_remote_exec_get_result_strings(PG_FUNCTION_ARGS)
 	List *data_node_list = NIL;
 	FuncCallContext *funcctx;
 	PGresult *result;
-	unsigned node_i, nodes_tuples, num_dist_res;
+	unsigned node_i;
+	unsigned nodes_tuples;
+	unsigned num_dist_res;
 
 	if (SRF_IS_FIRSTCALL())
 	{
@@ -260,7 +262,9 @@ ts_remote_exec_get_result_strings(PG_FUNCTION_ARGS)
 
 		char **fields = palloc(sizeof(*fields) * PQnfields(result));
 		Datum *cstrings = palloc(sizeof(*cstrings) * PQnfields(result));
-		int i, cstrings_count, tup_num;
+		int i;
+		int cstrings_count;
+		int tup_num;
 		ArrayType *array = NULL;
 
 		tup_num = funcctx->call_cntr - nodes_tuples;


### PR DESCRIPTION
Use the `--fix` option to fix automatically.

Each commit fixes one kind of warnings.