### PR TITLE
Add GUC "bgw_launcher_poll_time"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If you use compression with a non-default collation on a segmentby-column you mi
 * #4169 Add support for chunk exclusion on DELETE to PG14
 * #4209 Add support for chunk exclusion on UPDATE to PG14
 * #4301 Add support for bulk inserts in COPY operator
+* #4330 Add GUC "bgw_launcher_poll_time"
 
 **Bugfixes**
 * #3899 Fix segfault in Continuous Aggregates
@@ -21,6 +22,7 @@ If you use compression with a non-default collation on a segmentby-column you mi
 * #4236 Fix potential wrong order of results for compressed hypertable with a non-default collation
 * #4255 Fix option "timescaledb.create_group_indexes"
 * #4300 Fix refresh window cap for cagg refresh policy
+* #4330 Add GUC "bgw_launcher_poll_time"
 
 **Thanks**
 * @jsoref for fixing various misspellings in code, comments and documentation

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -82,13 +82,6 @@ typedef enum SchedulerState
 #define BGW_LAUNCHER_RESTART_TIME_S 60
 #endif
 
-/* WaitLatch expects a long */
-#ifdef TS_DEBUG
-#define BGW_LAUNCHER_POLL_TIME_MS 10L
-#else
-#define BGW_LAUNCHER_POLL_TIME_MS 60000L
-#endif
-
 static volatile sig_atomic_t got_SIGHUP = false;
 
 static void launcher_sighup(SIGNAL_ARGS)
@@ -779,7 +772,7 @@ ts_bgw_cluster_launcher_main(PG_FUNCTION_ARGS)
 
 		wl_rc = WaitLatch(MyLatch,
 						  WL_LATCH_SET | WL_POSTMASTER_DEATH | WL_TIMEOUT,
-						  BGW_LAUNCHER_POLL_TIME_MS,
+						  (long) ts_guc_bgw_launcher_poll_time,
 						  PG_WAIT_EXTENSION);
 		ResetLatch(MyLatch);
 		if (wl_rc & WL_POSTMASTER_DEATH)

--- a/src/loader/loader.h
+++ b/src/loader/loader.h
@@ -14,4 +14,15 @@ extern bool ts_loader_extension_exists(void);
 
 extern void ts_loader_extension_check(void);
 
+/* WaitLatch expects a long, so make sure to cast the value */
+/* Default value for timescaledb.launcher_poll_time */
+#ifdef TS_DEBUG
+#define BGW_LAUNCHER_POLL_TIME_MS 10
+#else
+#define BGW_LAUNCHER_POLL_TIME_MS 60000
+#endif
+
+/* GUC to control launcher timeout */
+extern int ts_guc_bgw_launcher_poll_time;
+
 #endif /* TIMESCALEDB_LOADER_H */


### PR DESCRIPTION
This GUC permits configuring the TIMEOUT parameter
for the background worker launcher in the loader.

Fixes #4217