### PR TITLE
Enable now() usage in plan-time chunk exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ If you use compression with a non-default collation on a segmentby-column you mi
 * #4209 Add support for chunk exclusion on UPDATE to PG14
 * #4301 Add support for bulk inserts in COPY operator
 * #4330 Add GUC "bgw_launcher_poll_time"
+* #4340 Enable now() usage in plan-time chunk exclusion
 
 **Bugfixes**
 * #3899 Fix segfault in Continuous Aggregates

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -535,3 +535,14 @@ get_reindex_options(ReindexStmt *stmt)
 #endif
 
 #endif /* TIMESCALEDB_COMPAT_H */
+
+/*
+ * PostgreSQL < 14 does not have F_TIMESTAMPTZ_GT macro but instead has
+ * the oid of that function as F_TIMESTAMP_GT even though the signature
+ * is with timestamptz but the name of the underlying C function is
+ * timestamp_gt.
+ */
+#if PG14_LT
+#define F_TIMESTAMPTZ_GE F_TIMESTAMP_GE
+#define F_TIMESTAMPTZ_GT F_TIMESTAMP_GT
+#endif

--- a/src/guc.c
+++ b/src/guc.c
@@ -55,6 +55,7 @@ bool ts_guc_enable_runtime_exclusion = true;
 bool ts_guc_enable_constraint_exclusion = true;
 bool ts_guc_enable_qual_propagation = true;
 bool ts_guc_enable_cagg_reorder_groupby = true;
+bool ts_guc_enable_now_constify = true;
 TSDLLEXPORT bool ts_guc_enable_transparent_decompression = true;
 bool ts_guc_enable_per_data_node_queries = true;
 bool ts_guc_enable_async_append = true;
@@ -220,6 +221,17 @@ _guc_init(void)
 							 "Enable group by reordering",
 							 "Enable group by clause reordering for continuous aggregates",
 							 &ts_guc_enable_cagg_reorder_groupby,
+							 true,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("timescaledb.enable_now_constify",
+							 "Enable now() constify",
+							 "Enable constifying now() in query constraints",
+							 &ts_guc_enable_now_constify,
 							 true,
 							 PGC_USERSET,
 							 0,

--- a/src/guc.h
+++ b/src/guc.h
@@ -23,6 +23,7 @@ extern bool ts_guc_enable_qual_propagation;
 extern bool ts_guc_enable_runtime_exclusion;
 extern bool ts_guc_enable_constraint_exclusion;
 extern bool ts_guc_enable_cagg_reorder_groupby;
+extern bool ts_guc_enable_now_constify;
 extern TSDLLEXPORT bool ts_guc_enable_transparent_decompression;
 extern TSDLLEXPORT bool ts_guc_enable_per_data_node_queries;
 extern TSDLLEXPORT bool ts_guc_enable_async_append;

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/planner.c
     ${CMAKE_CURRENT_SOURCE_DIR}/add_hashagg.c
     ${CMAKE_CURRENT_SOURCE_DIR}/agg_bookend.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/constify_now.c
     ${CMAKE_CURRENT_SOURCE_DIR}/expand_hypertable.c
     ${CMAKE_CURRENT_SOURCE_DIR}/partialize.c)
 target_sources(${PROJECT_NAME} PRIVATE ${SOURCES})

--- a/src/planner/add_hashagg.c
+++ b/src/planner/add_hashagg.c
@@ -27,7 +27,7 @@
 #include "estimate.h"
 
 /* This optimization adds a HashAggregate plan to many group by queries.
- * In plain postgres, many time-series queries will not use a the hash aggregate
+ * In plain postgres, many time-series queries will not use a hash aggregate
  * because the planner will incorrectly assume that the number of rows is much larger than
  * it actually is and will use the less efficient GroupAggregate instead of a HashAggregate
  * to prevent running out of memory.

--- a/src/planner/constify_now.c
+++ b/src/planner/constify_now.c
@@ -1,0 +1,213 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#include <postgres.h>
+#include <access/xact.h>
+#include <datatype/timestamp.h>
+#include <nodes/makefuncs.h>
+#include <optimizer/optimizer.h>
+#include <utils/fmgroids.h>
+
+#include "cache.h"
+#include "dimension.h"
+#include "hypertable.h"
+#include "hypertable_cache.h"
+#include "planner.h"
+
+/*
+ * This implements an optimization to allow now() expression to be
+ * used during plan time chunk exclusions. Since now() is stable it
+ * would not normally be considered for plan time chunk exclusion.
+ * To enable this behaviour we convert `column > now()` expressions
+ * into `column > const AND column > now()`. Assuming that times
+ * always moves forward this is safe even for prepared statements.
+ *
+ * We consider the following expressions valid for this optimization:
+ * - Var > now()
+ * - Var >= now()
+ * - Var > now() - Interval
+ * - Var > now() + Interval
+ * - Var >= now() - Interval
+ * - Var >= now() + Interval
+ *
+ * Additionally Interval needs to be Const and not contain day or month
+ * components as those would be affected by timezone, which can change
+ * between executions of a prepared statement.
+ */
+static const Dimension *
+get_hypertable_dimension(Oid relid)
+{
+	Hypertable *ht = ts_planner_get_hypertable(relid, CACHE_FLAG_CHECK);
+	if (!ht)
+		return NULL;
+	return hyperspace_get_open_dimension(ht->space, 0);
+}
+
+static bool
+is_valid_now_expr(OpExpr *op, List *rtable)
+{
+	/* Var > or Var >= */
+	if ((op->opfuncid != F_TIMESTAMPTZ_GT && op->opfuncid != F_TIMESTAMPTZ_GE) ||
+		!IsA(linitial(op->args), Var))
+		return false;
+
+	/*
+	 * Check that the constraint is actually on a partitioning
+	 * column. We only check for match on first open dimension
+	 * because that will be the time column.
+	 */
+	Var *var = linitial_node(Var, op->args);
+	Assert(var->varno <= list_length(rtable));
+	RangeTblEntry *rte = list_nth(rtable, var->varno - 1);
+
+	const Dimension *dim = get_hypertable_dimension(rte->relid);
+	if (!dim || dim->fd.column_type != TIMESTAMPTZOID || dim->column_attno != var->varattno)
+		return false;
+
+	/* Var > now() or Var >= now() */
+	if (IsA(lsecond(op->args), FuncExpr) && lsecond_node(FuncExpr, op->args)->funcid == F_NOW)
+		return true;
+
+	if (!IsA(lsecond(op->args), OpExpr))
+		return false;
+
+	/* Var >|>= now() +|- Const */
+	OpExpr *op_inner = lsecond_node(OpExpr, op->args);
+	if ((op_inner->opfuncid != F_TIMESTAMPTZ_MI_INTERVAL &&
+		 op_inner->opfuncid != F_TIMESTAMPTZ_PL_INTERVAL) ||
+		!IsA(linitial(op_inner->args), FuncExpr) ||
+		linitial_node(FuncExpr, op_inner->args)->funcid != F_NOW ||
+		!IsA(lsecond(op_inner->args), Const))
+		return false;
+
+	/*
+	 * The consttype check should not be necessary since the
+	 * operators we whitelist above already mandates it.
+	 */
+	Const *c = lsecond_node(Const, op_inner->args);
+	Assert(c->consttype == INTERVALOID);
+	if (c->constisnull || c->consttype != INTERVALOID)
+		return false;
+
+	Interval *offset = DatumGetIntervalP(c->constvalue);
+	/*
+	 * We don't consider day or month intervals safe here as
+	 * they are affected by timezones and therefore not
+	 * safe to evaluate during planning.
+	 */
+	if (offset->day != 0 || offset->month != 0)
+		return false;
+
+	return true;
+}
+
+static Const *
+make_now_const()
+{
+	return makeConst(TIMESTAMPTZOID,
+					 -1,
+					 InvalidOid,
+					 sizeof(TimestampTz),
+#ifdef TS_DEBUG
+					 ts_get_mock_time_or_current_time(),
+#else
+					 TimestampTzGetDatum(GetCurrentTransactionStartTimestamp()),
+#endif
+					 false,
+					 FLOAT8PASSBYVAL);
+}
+
+/* returns a copy of the expression with the now() call constified */
+/*
+ * op will be OpExpr with Var > now() - Expr
+ */
+static OpExpr *
+constify_now_expr(PlannerInfo *root, OpExpr *op)
+{
+	op = copyObject(op);
+	if (IsA(lsecond(op->args), FuncExpr))
+	{
+		/*
+		 * Sanity check that this is a supported expression. We should never
+		 * end here if it isn't since this is checked in is_valid_now_expr.
+		 */
+		Assert(lsecond_node(FuncExpr, op->args)->funcid == F_NOW);
+		lsecond(op->args) = make_now_const();
+
+		return op;
+	}
+	else
+	{
+		OpExpr *op_inner = lsecond_node(OpExpr, op->args);
+		/*
+		 * Sanity check that this is a supported expression. We should never
+		 * end here if it isn't since this is checked in is_valid_now_expr.
+		 */
+		Assert(linitial_node(FuncExpr, op_inner->args)->funcid == F_NOW);
+		linitial(op_inner->args) = make_now_const();
+
+		/*
+		 * Normally estimate_expression_value is not safe to use during planning
+		 * since it also evaluates stable expressions. Since we only allow a
+		 * very limited subset of expressions for this optimization it is safe
+		 * for those expressions we allowed earlier.
+		 * estimate_expression_value should always be able to completely constify
+		 * the expression due to the restrictions we impose on the expressions
+		 * supported.
+		 */
+		lsecond(op->args) = estimate_expression_value(root, (Node *) op_inner);
+		Assert(IsA(lsecond(op->args), Const));
+		return op;
+	}
+}
+
+Node *
+ts_constify_now(PlannerInfo *root, List *rtable, Node *node)
+{
+	Assert(node);
+
+	switch (nodeTag(node))
+	{
+		case T_OpExpr:
+			if (is_valid_now_expr(castNode(OpExpr, node), rtable))
+			{
+				List *args =
+					list_make2(copyObject(node), constify_now_expr(root, castNode(OpExpr, node)));
+				return (Node *) makeBoolExpr(AND_EXPR, args, -1);
+			}
+			break;
+		case T_BoolExpr:
+		{
+			List *additions = NIL;
+			ListCell *lc;
+			BoolExpr *be = castNode(BoolExpr, node);
+
+			/* We only look for top-level AND */
+			if (be->boolop != AND_EXPR)
+				return node;
+
+			foreach (lc, be->args)
+			{
+				if (IsA(lfirst(lc), OpExpr) && is_valid_now_expr(lfirst_node(OpExpr, lc), rtable))
+				{
+					OpExpr *op = lfirst_node(OpExpr, lc);
+					additions = lappend(additions, constify_now_expr(root, op));
+				}
+			}
+
+			if (additions)
+			{
+				be->args = list_concat(be->args, additions);
+			}
+
+			break;
+		}
+		default:
+			break;
+	}
+
+	return node;
+}

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -86,6 +86,7 @@ typedef enum PartializeAggFixAggref
 	TS_FIX_AGGREF = 1
 } PartializeAggFixAggref;
 
+Hypertable *ts_planner_get_hypertable(const Oid relid, const unsigned int flags);
 bool has_partialize_function(Query *parse, PartializeAggFixAggref fix_aggref);
 bool ts_plan_process_partialize_agg(PlannerInfo *root, RelOptInfo *output_rel);
 
@@ -93,5 +94,6 @@ extern void ts_plan_add_hashagg(PlannerInfo *root, RelOptInfo *input_rel, RelOpt
 extern void ts_preprocess_first_last_aggregates(PlannerInfo *root, List *tlist);
 extern void ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel);
 extern void ts_plan_expand_timebucket_annotate(PlannerInfo *root, RelOptInfo *rel);
+extern Node *ts_constify_now(PlannerInfo *root, List *rtable, Node *node);
 
 #endif /* TIMESCALEDB_PLANNER_H */

--- a/test/expected/append-12.out
+++ b/test/expected/append-12.out
@@ -9,6 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
+SET timescaledb.enable_now_constify TO false;
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
  enable_memoize 

--- a/test/expected/append-13.out
+++ b/test/expected/append-13.out
@@ -9,6 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
+SET timescaledb.enable_now_constify TO false;
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
  enable_memoize 

--- a/test/expected/append-14.out
+++ b/test/expected/append-14.out
@@ -9,6 +9,7 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 \gset
 SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
+SET timescaledb.enable_now_constify TO false;
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
  enable_memoize 

--- a/test/sql/append.sql.in
+++ b/test/sql/append.sql.in
@@ -11,6 +11,8 @@ SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') as "TEST_LOAD_NAME",
 SELECT format('\! diff -u --label "Unoptimized results" --label "Optimized results" %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_OPTIMIZED') as "DIFF_CMD"
 \gset
 
+SET timescaledb.enable_now_constify TO false;
+
 -- disable memoize node to make EXPLAIN output comparable between PG14 and previous versions
 SELECT CASE WHEN current_setting('server_version_num')::int/10000 >= 14 THEN set_config('enable_memoize','off',false) ELSE 'off' END AS enable_memoize;
 

--- a/tsl/test/shared/expected/constify_now-12.out
+++ b/tsl/test/shared/expected/constify_now-12.out
@@ -1,0 +1,507 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_chunk_append TO false;
+SET timescaledb.enable_constraint_aware_append TO false;
+SET timescaledb.current_timestamp_mock TO '1990-01-01';
+\set PREFIX 'EXPLAIN (COSTS OFF, SUMMARY OFF, TIMING OFF)'
+-- test valid variants we are optimizing
+-- all of these should have a constified value as filter
+-- none of these initial tests will actually exclude chunks
+-- because we want to see the constified now expression in
+-- EXPLAIN output
+:PREFIX SELECT FROM metrics WHERE time > now();
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now();
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '24h'::interval;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() + '10m'::interval;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() - '10m'::interval;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+-- test multiple constraints
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND device_id = 2;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND (device_id = 2 OR device_id = 3);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+(10 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND time >= now() - '10m'::interval;
+                                                                                                                             QUERY PLAN                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+-- variants we don't optimize
+-- we do not allow interval with day or month components
+:PREFIX SELECT FROM metrics WHERE time > now() - '1d'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '1week'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '1month'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now()::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE round(EXTRACT(EPOCH FROM now())) > 0.5;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Append
+   ->  Result
+         One-Time Filter: (round(date_part('epoch'::text, now())) > '0.5'::double precision)
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  Result
+         One-Time Filter: (round(date_part('epoch'::text, now())) > '0.5'::double precision)
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  Result
+         One-Time Filter: (round(date_part('epoch'::text, now())) > '0.5'::double precision)
+         ->  Seq Scan on _hyper_X_X_chunk
+(10 rows)
+
+-- we only modify top-level ANDed now() expressions
+:PREFIX SELECT FROM metrics WHERE time > now() - '1m'::interval OR time > now() + '1m'::interval;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+(22 rows)
+
+:PREFIX SELECT FROM metrics WHERE device_id = 2 OR (time > now() - '1m'::interval AND time > now() + '1m'::interval);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+(22 rows)
+
+-- CTE
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics WHERE time > now()
+) SELECT FROM q1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics
+) SELECT FROM q1 WHERE time > now();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+(7 rows)
+
+-- JOIN
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m2
+         ->  Seq Scan on _hyper_X_X_chunk m2_1
+         ->  Seq Scan on _hyper_X_X_chunk m2_2
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m1
+         ->  Seq Scan on _hyper_X_X_chunk m1_1
+         ->  Seq Scan on _hyper_X_X_chunk m1_2
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now() AND m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(16 rows)
+
+-- only top-level constraints in WHERE clause are constified
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now());
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m2
+         ->  Seq Scan on _hyper_X_X_chunk m2_1
+         ->  Seq Scan on _hyper_X_X_chunk m2_2
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1
+                     Index Cond: ("time" > now())
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+                     Index Cond: ("time" > now())
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+                     Index Cond: ("time" > now())
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now()) WHERE m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1
+               Index Cond: ("time" > now())
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+               Index Cond: ("time" > now())
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+               Index Cond: ("time" > now())
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(16 rows)
+
+-- test UPDATE
+:PREFIX UPDATE metrics SET v0 = 0.1, v1 = EXTRACT(EPOCH FROM now()) WHERE time > now();
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Update on metrics
+   Update on metrics
+   Update on _hyper_X_X_chunk
+   Update on _hyper_X_X_chunk
+   Update on _hyper_X_X_chunk
+   ->  Seq Scan on metrics
+         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+-- test DELETE
+:PREFIX DELETE FROM metrics WHERE time > now();
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Delete on metrics
+   Delete on metrics
+   Delete on _hyper_X_X_chunk
+   Delete on _hyper_X_X_chunk
+   Delete on _hyper_X_X_chunk
+   ->  Seq Scan on metrics
+         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+-- test chunks actually get excluded
+-- should exclude all
+SET timescaledb.current_timestamp_mock TO '2010-01-01';
+:PREFIX SELECT FROM metrics WHERE time > now();
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+-- should exclude all but 1 chunk
+SET timescaledb.current_timestamp_mock TO '2000-01-14';
+:PREFIX SELECT FROM metrics WHERE time > now();
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+   Index Cond: (("time" > now()) AND ("time" > 'Fri Jan 14 00:00:00 2000 PST'::timestamp with time zone))
+(2 rows)
+
+CREATE TABLE const_now(time timestamptz, time2 timestamptz, value float);
+-- does not apply to non-hypertables
+:PREFIX SELECT FROM const_now WHERE time > now();
+         QUERY PLAN         
+----------------------------
+ Seq Scan on const_now
+   Filter: ("time" > now())
+(2 rows)
+
+SELECT table_name FROM create_hypertable('const_now','time');
+NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ const_now
+(1 row)
+
+INSERT INTO const_now SELECT '2000-01-01','2000-01-01',0.5;
+-- should have one time filter false
+:PREFIX SELECT FROM const_now WHERE time > now();
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+-- no constification because it's not partitioning column
+:PREFIX SELECT FROM const_now WHERE time2 > now();
+           QUERY PLAN           
+--------------------------------
+ Seq Scan on _hyper_X_X_chunk
+   Filter: (time2 > now())
+(2 rows)
+
+DROP TABLE const_now;
+-- test prepared statements
+CREATE TABLE prep_const_now(time timestamptz, device int, value float);
+SELECT table_name FROM create_hypertable('prep_const_now', 'time');
+NOTICE:  adding not-null constraint to column "time"
+   table_name   
+----------------
+ prep_const_now
+(1 row)
+
+INSERT INTO prep_const_now SELECT '3000-01-02', 1, 0.2;
+INSERT INTO prep_const_now SELECT '3001-01-02', 2, 0.3;
+INSERT INTO prep_const_now SELECT '3002-01-02', 3, 0.4;
+SET timescaledb.current_timestamp_mock TO '3001-01-01';
+PREPARE p1 AS SELECT FROM prep_const_now WHERE time > now();
+:PREFIX EXECUTE p1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+(5 rows)
+
+EXECUTE p1;
+--
+(2 rows)
+
+SET timescaledb.current_timestamp_mock TO '3002-01-01';
+-- plan won't change cause the query didnt get replanned
+:PREFIX EXECUTE p1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+(5 rows)
+
+EXECUTE p1;
+--
+(2 rows)
+
+DROP TABLE prep_const_now;

--- a/tsl/test/shared/expected/constify_now-13.out
+++ b/tsl/test/shared/expected/constify_now-13.out
@@ -1,0 +1,507 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_chunk_append TO false;
+SET timescaledb.enable_constraint_aware_append TO false;
+SET timescaledb.current_timestamp_mock TO '1990-01-01';
+\set PREFIX 'EXPLAIN (COSTS OFF, SUMMARY OFF, TIMING OFF)'
+-- test valid variants we are optimizing
+-- all of these should have a constified value as filter
+-- none of these initial tests will actually exclude chunks
+-- because we want to see the constified now expression in
+-- EXPLAIN output
+:PREFIX SELECT FROM metrics WHERE time > now();
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now();
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '24h'::interval;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() + '10m'::interval;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() - '10m'::interval;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+-- test multiple constraints
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND device_id = 2;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND (device_id = 2 OR device_id = 3);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+(10 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND time >= now() - '10m'::interval;
+                                                                                                                             QUERY PLAN                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+-- variants we don't optimize
+-- we do not allow interval with day or month components
+:PREFIX SELECT FROM metrics WHERE time > now() - '1d'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '1week'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '1month'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now()::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE round(EXTRACT(EPOCH FROM now())) > 0.5;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Append
+   ->  Result
+         One-Time Filter: (round(date_part('epoch'::text, now())) > '0.5'::double precision)
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  Result
+         One-Time Filter: (round(date_part('epoch'::text, now())) > '0.5'::double precision)
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  Result
+         One-Time Filter: (round(date_part('epoch'::text, now())) > '0.5'::double precision)
+         ->  Seq Scan on _hyper_X_X_chunk
+(10 rows)
+
+-- we only modify top-level ANDed now() expressions
+:PREFIX SELECT FROM metrics WHERE time > now() - '1m'::interval OR time > now() + '1m'::interval;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+(22 rows)
+
+:PREFIX SELECT FROM metrics WHERE device_id = 2 OR (time > now() - '1m'::interval AND time > now() + '1m'::interval);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+(22 rows)
+
+-- CTE
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics WHERE time > now()
+) SELECT FROM q1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics
+) SELECT FROM q1 WHERE time > now();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+(7 rows)
+
+-- JOIN
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m2_1
+         ->  Seq Scan on _hyper_X_X_chunk m2_2
+         ->  Seq Scan on _hyper_X_X_chunk m2_3
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m1_1
+         ->  Seq Scan on _hyper_X_X_chunk m1_2
+         ->  Seq Scan on _hyper_X_X_chunk m1_3
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now() AND m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(16 rows)
+
+-- only top-level constraints in WHERE clause are constified
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now());
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m2_1
+         ->  Seq Scan on _hyper_X_X_chunk m2_2
+         ->  Seq Scan on _hyper_X_X_chunk m2_3
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+                     Index Cond: ("time" > now())
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+                     Index Cond: ("time" > now())
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+                     Index Cond: ("time" > now())
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now()) WHERE m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+               Index Cond: ("time" > now())
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+               Index Cond: ("time" > now())
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+               Index Cond: ("time" > now())
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(16 rows)
+
+-- test UPDATE
+:PREFIX UPDATE metrics SET v0 = 0.1, v1 = EXTRACT(EPOCH FROM now()) WHERE time > now();
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Update on metrics
+   Update on metrics
+   Update on _hyper_X_X_chunk metrics_1
+   Update on _hyper_X_X_chunk metrics_2
+   Update on _hyper_X_X_chunk metrics_3
+   ->  Seq Scan on metrics
+         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_1
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_2
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_3
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+-- test DELETE
+:PREFIX DELETE FROM metrics WHERE time > now();
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Delete on metrics
+   Delete on metrics
+   Delete on _hyper_X_X_chunk metrics_1
+   Delete on _hyper_X_X_chunk metrics_2
+   Delete on _hyper_X_X_chunk metrics_3
+   ->  Seq Scan on metrics
+         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_1
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_2
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_3
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+-- test chunks actually get excluded
+-- should exclude all
+SET timescaledb.current_timestamp_mock TO '2010-01-01';
+:PREFIX SELECT FROM metrics WHERE time > now();
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+-- should exclude all but 1 chunk
+SET timescaledb.current_timestamp_mock TO '2000-01-14';
+:PREFIX SELECT FROM metrics WHERE time > now();
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+   Index Cond: (("time" > now()) AND ("time" > 'Fri Jan 14 00:00:00 2000 PST'::timestamp with time zone))
+(2 rows)
+
+CREATE TABLE const_now(time timestamptz, time2 timestamptz, value float);
+-- does not apply to non-hypertables
+:PREFIX SELECT FROM const_now WHERE time > now();
+         QUERY PLAN         
+----------------------------
+ Seq Scan on const_now
+   Filter: ("time" > now())
+(2 rows)
+
+SELECT table_name FROM create_hypertable('const_now','time');
+NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ const_now
+(1 row)
+
+INSERT INTO const_now SELECT '2000-01-01','2000-01-01',0.5;
+-- should have one time filter false
+:PREFIX SELECT FROM const_now WHERE time > now();
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+-- no constification because it's not partitioning column
+:PREFIX SELECT FROM const_now WHERE time2 > now();
+           QUERY PLAN           
+--------------------------------
+ Seq Scan on _hyper_X_X_chunk
+   Filter: (time2 > now())
+(2 rows)
+
+DROP TABLE const_now;
+-- test prepared statements
+CREATE TABLE prep_const_now(time timestamptz, device int, value float);
+SELECT table_name FROM create_hypertable('prep_const_now', 'time');
+NOTICE:  adding not-null constraint to column "time"
+   table_name   
+----------------
+ prep_const_now
+(1 row)
+
+INSERT INTO prep_const_now SELECT '3000-01-02', 1, 0.2;
+INSERT INTO prep_const_now SELECT '3001-01-02', 2, 0.3;
+INSERT INTO prep_const_now SELECT '3002-01-02', 3, 0.4;
+SET timescaledb.current_timestamp_mock TO '3001-01-01';
+PREPARE p1 AS SELECT FROM prep_const_now WHERE time > now();
+:PREFIX EXECUTE p1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+(5 rows)
+
+EXECUTE p1;
+--
+(2 rows)
+
+SET timescaledb.current_timestamp_mock TO '3002-01-01';
+-- plan won't change cause the query didnt get replanned
+:PREFIX EXECUTE p1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+(5 rows)
+
+EXECUTE p1;
+--
+(2 rows)
+
+DROP TABLE prep_const_now;

--- a/tsl/test/shared/expected/constify_now-14.out
+++ b/tsl/test/shared/expected/constify_now-14.out
@@ -1,0 +1,506 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_chunk_append TO false;
+SET timescaledb.enable_constraint_aware_append TO false;
+SET timescaledb.current_timestamp_mock TO '1990-01-01';
+\set PREFIX 'EXPLAIN (COSTS OFF, SUMMARY OFF, TIMING OFF)'
+-- test valid variants we are optimizing
+-- all of these should have a constified value as filter
+-- none of these initial tests will actually exclude chunks
+-- because we want to see the constified now expression in
+-- EXPLAIN output
+:PREFIX SELECT FROM metrics WHERE time > now();
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now();
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= now()) AND ("time" >= 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '24h'::interval;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() - '@ 24 hours'::interval)) AND ("time" > 'Sun Dec 31 00:00:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() + '10m'::interval;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > (now() + '@ 10 mins'::interval)) AND ("time" > 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() - '10m'::interval;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval;
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+-- test multiple constraints
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND device_id = 2;
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_device_id_time_idx on _hyper_X_X_chunk
+         Index Cond: ((device_id = 2) AND ("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND (device_id = 2 OR device_id = 3);
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+   ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone))
+         Filter: ((device_id = 2) OR (device_id = 3))
+(10 rows)
+
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND time >= now() - '10m'::interval;
+                                                                                                                             QUERY PLAN                                                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" >= (now() + '@ 10 mins'::interval)) AND ("time" >= (now() - '@ 10 mins'::interval)) AND ("time" >= 'Mon Jan 01 00:10:00 1990 PST'::timestamp with time zone) AND ("time" >= 'Sun Dec 31 23:50:00 1989 PST'::timestamp with time zone))
+(7 rows)
+
+-- variants we don't optimize
+-- we do not allow interval with day or month components
+:PREFIX SELECT FROM metrics WHERE time > now() - '1d'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 day'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '1week'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 7 days'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now() - '1month'::interval;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE time > now()::date;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now())::date)
+(7 rows)
+
+:PREFIX SELECT FROM metrics WHERE round(EXTRACT(EPOCH FROM now())) > 0.5;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Append
+   ->  Result
+         One-Time Filter: (round(EXTRACT(epoch FROM now()), 0) > 0.5)
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  Result
+         One-Time Filter: (round(EXTRACT(epoch FROM now()), 0) > 0.5)
+         ->  Seq Scan on _hyper_X_X_chunk
+   ->  Result
+         One-Time Filter: (round(EXTRACT(epoch FROM now()), 0) > 0.5)
+         ->  Seq Scan on _hyper_X_X_chunk
+(10 rows)
+
+-- we only modify top-level ANDed now() expressions
+:PREFIX SELECT FROM metrics WHERE time > now() - '1m'::interval OR time > now() + '1m'::interval;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: (("time" > (now() - '@ 1 min'::interval)) OR ("time" > (now() + '@ 1 min'::interval)))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() - '@ 1 min'::interval))
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: ("time" > (now() + '@ 1 min'::interval))
+(22 rows)
+
+:PREFIX SELECT FROM metrics WHERE device_id = 2 OR (time > now() - '1m'::interval AND time > now() + '1m'::interval);
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+   ->  Bitmap Heap Scan on _hyper_X_X_chunk
+         Recheck Cond: ((device_id = 2) OR (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval))))
+         ->  BitmapOr
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_device_id_time_idx
+                     Index Cond: (device_id = 2)
+               ->  Bitmap Index Scan on _hyper_X_X_chunk_metrics_time_idx
+                     Index Cond: (("time" > (now() - '@ 1 min'::interval)) AND ("time" > (now() + '@ 1 min'::interval)))
+(22 rows)
+
+-- CTE
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics WHERE time > now()
+) SELECT FROM q1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(7 rows)
+
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics
+) SELECT FROM q1 WHERE time > now();
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+   ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > now())
+(7 rows)
+
+-- JOIN
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m2_1
+         ->  Seq Scan on _hyper_X_X_chunk m2_2
+         ->  Seq Scan on _hyper_X_X_chunk m2_3
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m1_1
+         ->  Seq Scan on _hyper_X_X_chunk m1_2
+         ->  Seq Scan on _hyper_X_X_chunk m1_3
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now() AND m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+               Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(16 rows)
+
+-- only top-level constraints in WHERE clause are constified
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now());
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk m2_1
+         ->  Seq Scan on _hyper_X_X_chunk m2_2
+         ->  Seq Scan on _hyper_X_X_chunk m2_3
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+                     Index Cond: ("time" > now())
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+                     Index Cond: ("time" > now())
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+                     Index Cond: ("time" > now())
+(13 rows)
+
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now()) WHERE m2.time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Nested Loop
+   ->  Append
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_1
+               Index Cond: ("time" > now())
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_2
+               Index Cond: ("time" > now())
+         ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m1_3
+               Index Cond: ("time" > now())
+   ->  Materialize
+         ->  Append
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk m2_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(16 rows)
+
+-- test UPDATE
+:PREFIX UPDATE metrics SET v0 = 0.1, v1 = EXTRACT(EPOCH FROM now()) WHERE time > now();
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Update on metrics
+         Update on _hyper_X_X_chunk metrics_1
+         Update on _hyper_X_X_chunk metrics_2
+         Update on _hyper_X_X_chunk metrics_3
+         ->  Result
+               ->  Append
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_1
+                           Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_2
+                           Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+                     ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_3
+                           Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(13 rows)
+
+-- test DELETE
+:PREFIX DELETE FROM metrics WHERE time > now();
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (HypertableModify)
+   ->  Delete on metrics
+         Delete on _hyper_X_X_chunk metrics_1
+         Delete on _hyper_X_X_chunk metrics_2
+         Delete on _hyper_X_X_chunk metrics_3
+         ->  Append
+               ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_1
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_2
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+               ->  Index Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk metrics_3
+                     Index Cond: (("time" > now()) AND ("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone))
+(12 rows)
+
+-- test chunks actually get excluded
+-- should exclude all
+SET timescaledb.current_timestamp_mock TO '2010-01-01';
+:PREFIX SELECT FROM metrics WHERE time > now();
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+-- should exclude all but 1 chunk
+SET timescaledb.current_timestamp_mock TO '2000-01-14';
+:PREFIX SELECT FROM metrics WHERE time > now();
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Index Only Scan using _hyper_X_X_chunk_metrics_time_idx on _hyper_X_X_chunk
+   Index Cond: (("time" > now()) AND ("time" > 'Fri Jan 14 00:00:00 2000 PST'::timestamp with time zone))
+(2 rows)
+
+CREATE TABLE const_now(time timestamptz, time2 timestamptz, value float);
+-- does not apply to non-hypertables
+:PREFIX SELECT FROM const_now WHERE time > now();
+         QUERY PLAN         
+----------------------------
+ Seq Scan on const_now
+   Filter: ("time" > now())
+(2 rows)
+
+SELECT table_name FROM create_hypertable('const_now','time');
+NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ const_now
+(1 row)
+
+INSERT INTO const_now SELECT '2000-01-01','2000-01-01',0.5;
+-- should have one time filter false
+:PREFIX SELECT FROM const_now WHERE time > now();
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+-- no constification because it's not partitioning column
+:PREFIX SELECT FROM const_now WHERE time2 > now();
+           QUERY PLAN           
+--------------------------------
+ Seq Scan on _hyper_X_X_chunk
+   Filter: (time2 > now())
+(2 rows)
+
+DROP TABLE const_now;
+-- test prepared statements
+CREATE TABLE prep_const_now(time timestamptz, device int, value float);
+SELECT table_name FROM create_hypertable('prep_const_now', 'time');
+NOTICE:  adding not-null constraint to column "time"
+   table_name   
+----------------
+ prep_const_now
+(1 row)
+
+INSERT INTO prep_const_now SELECT '3000-01-02', 1, 0.2;
+INSERT INTO prep_const_now SELECT '3001-01-02', 2, 0.3;
+INSERT INTO prep_const_now SELECT '3002-01-02', 3, 0.4;
+SET timescaledb.current_timestamp_mock TO '3001-01-01';
+PREPARE p1 AS SELECT FROM prep_const_now WHERE time > now();
+:PREFIX EXECUTE p1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+(5 rows)
+
+EXECUTE p1;
+--
+(2 rows)
+
+SET timescaledb.current_timestamp_mock TO '3002-01-01';
+-- plan won't change cause the query didnt get replanned
+:PREFIX EXECUTE p1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+   ->  Index Only Scan using _hyper_X_X_chunk_prep_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: (("time" > now()) AND ("time" > 'Thu Jan 01 00:00:00 3001 PST'::timestamp with time zone))
+(5 rows)
+
+EXECUTE p1;
+--
+(2 rows)
+
+DROP TABLE prep_const_now;

--- a/tsl/test/shared/expected/constify_timestamptz_op_interval.out
+++ b/tsl/test/shared/expected/constify_timestamptz_op_interval.out
@@ -6,6 +6,7 @@
 -- otherwise those would remove the chunks from the plan during execution
 SET timescaledb.enable_chunk_append TO FALSE;
 SET timescaledb.enable_constraint_aware_append TO FALSE;
+SET timescaledb.enable_now_constify TO FALSE;
 -- plan query on complete hypertable to get a list of the chunks
 :PREFIX
 SELECT time

--- a/tsl/test/shared/expected/ordered_append_join-12.out
+++ b/tsl/test/shared/expected/ordered_append_join-12.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_now_constify TO FALSE;
 SELECT
        format('include/%s.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
        format('%s/shared/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED",

--- a/tsl/test/shared/expected/ordered_append_join-13.out
+++ b/tsl/test/shared/expected/ordered_append_join-13.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_now_constify TO FALSE;
 SELECT
        format('include/%s.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
        format('%s/shared/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED",

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -1,6 +1,7 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+SET timescaledb.enable_now_constify TO FALSE;
 SELECT
        format('include/%s.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
        format('%s/shared/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED",

--- a/tsl/test/shared/sql/.gitignore
+++ b/tsl/test/shared/sql/.gitignore
@@ -1,4 +1,5 @@
 /continuous_aggs_compression-*.sql
+/constify_now-*.sql
 /dist_remote_error-*.sql
 /gapfill-*.sql
 /generated_columns-*.sql

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -13,6 +13,10 @@ set(TEST_FILES_SHARED
     extension.sql
     subtract_integer_from_now.sql)
 
+set(TEST_TEMPLATES_SHARED
+    gapfill.sql.in generated_columns.sql.in ordered_append.sql.in
+    ordered_append_join.sql.in transparent_decompress_chunk.sql.in)
+
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   list(APPEND TEST_FILES_SHARED memoize.sql)
 endif()
@@ -20,11 +24,8 @@ endif()
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES_SHARED dist_remote_error.sql timestamp_limits.sql
        with_clause_parser.sql)
+  list(APPEND TEST_TEMPLATES_SHARED constify_now.sql.in)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
-
-set(TEST_TEMPLATES_SHARED
-    gapfill.sql.in generated_columns.sql.in ordered_append.sql.in
-    ordered_append_join.sql.in transparent_decompress_chunk.sql.in)
 
 # Regression tests that vary with PostgreSQL version. Generated test files are
 # put in the original source directory since all tests must be in the same

--- a/tsl/test/shared/sql/constify_now.sql.in
+++ b/tsl/test/shared/sql/constify_now.sql.in
@@ -1,0 +1,106 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+SET timescaledb.enable_chunk_append TO false;
+SET timescaledb.enable_constraint_aware_append TO false;
+SET timescaledb.current_timestamp_mock TO '1990-01-01';
+
+\set PREFIX 'EXPLAIN (COSTS OFF, SUMMARY OFF, TIMING OFF)'
+
+-- test valid variants we are optimizing
+-- all of these should have a constified value as filter
+-- none of these initial tests will actually exclude chunks
+-- because we want to see the constified now expression in
+-- EXPLAIN output
+:PREFIX SELECT FROM metrics WHERE time > now();
+:PREFIX SELECT FROM metrics WHERE time >= now();
+:PREFIX SELECT FROM metrics WHERE time > now() - '24h'::interval;
+:PREFIX SELECT FROM metrics WHERE time > now() + '10m'::interval;
+:PREFIX SELECT FROM metrics WHERE time >= now() - '10m'::interval;
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval;
+
+-- test multiple constraints
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND device_id = 2;
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND (device_id = 2 OR device_id = 3);
+:PREFIX SELECT FROM metrics WHERE time >= now() + '10m'::interval AND time >= now() - '10m'::interval;
+
+-- variants we don't optimize
+-- we do not allow interval with day or month components
+:PREFIX SELECT FROM metrics WHERE time > now() - '1d'::interval;
+:PREFIX SELECT FROM metrics WHERE time > now() - '1week'::interval;
+:PREFIX SELECT FROM metrics WHERE time > now() - '1month'::interval;
+:PREFIX SELECT FROM metrics WHERE time > now()::date;
+:PREFIX SELECT FROM metrics WHERE round(EXTRACT(EPOCH FROM now())) > 0.5;
+
+-- we only modify top-level ANDed now() expressions
+:PREFIX SELECT FROM metrics WHERE time > now() - '1m'::interval OR time > now() + '1m'::interval;
+:PREFIX SELECT FROM metrics WHERE device_id = 2 OR (time > now() - '1m'::interval AND time > now() + '1m'::interval);
+
+-- CTE
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics WHERE time > now()
+) SELECT FROM q1;
+
+:PREFIX WITH q1 AS (
+  SELECT * FROM metrics
+) SELECT FROM q1 WHERE time > now();
+
+-- JOIN
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now();
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m2.time > now();
+:PREFIX SELECT FROM metrics m1, metrics m2 WHERE m1.time > now() AND m2.time > now();
+
+-- only top-level constraints in WHERE clause are constified
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now());
+:PREFIX SELECT FROM metrics m1 INNER JOIN metrics m2 ON (m1.time > now()) WHERE m2.time > now();
+
+-- test UPDATE
+:PREFIX UPDATE metrics SET v0 = 0.1, v1 = EXTRACT(EPOCH FROM now()) WHERE time > now();
+
+-- test DELETE
+:PREFIX DELETE FROM metrics WHERE time > now();
+
+-- test chunks actually get excluded
+-- should exclude all
+SET timescaledb.current_timestamp_mock TO '2010-01-01';
+:PREFIX SELECT FROM metrics WHERE time > now();
+
+-- should exclude all but 1 chunk
+SET timescaledb.current_timestamp_mock TO '2000-01-14';
+:PREFIX SELECT FROM metrics WHERE time > now();
+
+CREATE TABLE const_now(time timestamptz, time2 timestamptz, value float);
+
+-- does not apply to non-hypertables
+:PREFIX SELECT FROM const_now WHERE time > now();
+
+SELECT table_name FROM create_hypertable('const_now','time');
+INSERT INTO const_now SELECT '2000-01-01','2000-01-01',0.5;
+
+-- should have one time filter false
+:PREFIX SELECT FROM const_now WHERE time > now();
+
+-- no constification because it's not partitioning column
+:PREFIX SELECT FROM const_now WHERE time2 > now();
+
+DROP TABLE const_now;
+
+-- test prepared statements
+CREATE TABLE prep_const_now(time timestamptz, device int, value float);
+SELECT table_name FROM create_hypertable('prep_const_now', 'time');
+
+INSERT INTO prep_const_now SELECT '3000-01-02', 1, 0.2;
+INSERT INTO prep_const_now SELECT '3001-01-02', 2, 0.3;
+INSERT INTO prep_const_now SELECT '3002-01-02', 3, 0.4;
+
+SET timescaledb.current_timestamp_mock TO '3001-01-01';
+PREPARE p1 AS SELECT FROM prep_const_now WHERE time > now();
+:PREFIX EXECUTE p1;
+EXECUTE p1;
+SET timescaledb.current_timestamp_mock TO '3002-01-01';
+-- plan won't change cause the query didnt get replanned
+:PREFIX EXECUTE p1;
+EXECUTE p1;
+
+DROP TABLE prep_const_now;

--- a/tsl/test/shared/sql/constify_timestamptz_op_interval.sql
+++ b/tsl/test/shared/sql/constify_timestamptz_op_interval.sql
@@ -7,8 +7,8 @@
 -- otherwise those would remove the chunks from the plan during execution
 
 SET timescaledb.enable_chunk_append TO FALSE;
-
 SET timescaledb.enable_constraint_aware_append TO FALSE;
+SET timescaledb.enable_now_constify TO FALSE;
 
 -- plan query on complete hypertable to get a list of the chunks
 :PREFIX

--- a/tsl/test/shared/sql/ordered_append_join.sql.in
+++ b/tsl/test/shared/sql/ordered_append_join.sql.in
@@ -2,6 +2,8 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+SET timescaledb.enable_now_constify TO FALSE;
+
 SELECT
        format('include/%s.sql', :'TEST_BASE_NAME') as "TEST_QUERY_NAME",
        format('%s/shared/results/%s_results_uncompressed.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') as "TEST_RESULTS_UNCOMPRESSED",


### PR DESCRIPTION
This implements an optimization to allow now() expression to be
used during plan time chunk exclusions. Since now() is stable it
would not normally be considered for plan time chunk exclusion.
To enable this behaviour we convert `column > now()` expressions
into `column > const AND column > now()`. Assuming that time
always moves forward this is save even for prepared statements.
This optimization works for SELECT, UPDATE and DELETE.
On hypertables with many chunks this can lead to a considerable
speedup for certain queries.

The following expressions are supported:
- column > now()
- column >= now()
- column > now() - Interval
- column > now() + Interval
- column >= now() - Interval
- column >= now() + Interval

Interval must not have a day or month component as those depend
on timezone settings.

Some microbenchmark to show the improvements, I did best of five
for all of the queries.

-- hypertable with 1k chunks
-- with optimization
select * from metrics1k where time > now() - '5m'::interval;
Time: 3.090 ms

-- without optimization
select * from metrics1k where time > now() - '5m'::interval;
Time: 145.640 ms

-- hypertable with 5k chunks
-- with optimization
select * from metrics5k where time > now() - '5m'::interval;
Time: 4.317 ms

-- without optimization
select * from metrics5k where time > now() - '5m'::interval;
Time: 775.259 ms

-- hypertable with 10k chunks
-- with optimization
select * from metrics10k where time > now() - '5m'::interval;
Time: 4.853 ms

-- without optimization
select * from metrics10k where time > now() - '5m'::interval;
Time: 1766.319 ms (00:01.766)

-- hypertable with 20k chunks
-- with optimization
select * from metrics20k where time > now() - '5m'::interval;
Time: 6.141 ms

-- without optimization
select * from metrics20k where time > now() - '5m'::interval;
Time: 3321.968 ms (00:03.322)

Speedup with 1k chunks: 47x
Speedup with 5k chunks: 179x
Speedup with 10k chunks: 363x
Speedup with 20k chunks: 540x