### PR TITLE
Bump pg version in update test

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        pg: ["12.10", "13.6", "14.2"]
+        pg: ["12.11", "13.7", "14.3"]
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}
@@ -44,7 +44,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        pg: ["12.10", "13.6", "14.2"]
+        pg: ["12.11", "13.7", "14.3"]
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}


### PR DESCRIPTION
Bump PG versions to 12.11, 13.7 and 14.3 in update tests. The update
test was skipped with the previous PG version bump because upstream
docker images were not yet available which we rely on in the update
test.