### PR TITLE
Fix sqlsmith CI workflow

### DIFF
--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -6,6 +6,10 @@ SET client_min_messages TO ERROR;
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
+-- this is a noop in our regression tests but allows us to use this
+-- dataset more easily in other tests like the sqlsmith test
+SELECT current_database() AS "TEST_DBNAME" \gset
+
 CREATE SCHEMA test;
 
 -- create normal hypertable with dropped columns, each chunk will have different attribute numbers
@@ -97,7 +101,7 @@ SET client_min_messages TO ERROR;
 \c data_node_3
 SET client_min_messages TO ERROR;
 \ir :TEST_SUPPORT_FILE
-\c :TEST_DBNAME :ROLE_SUPERUSER;
+\c :TEST_DBNAME
 SET client_min_messages TO ERROR;
 \ir :TEST_SUPPORT_FILE
 \o


### PR DESCRIPTION
Commit 3b35da76 changed the setup script for regresscheck-shared
to no longer be usable directly by the sqlsmith workflow. This
patch set TEST_DBNAME at the top of the script so it is easier
to use the script outside of regression check environment.