### PR TITLE
Fix a crash in the copy multi-buffer optimization

### DIFF
--- a/test/expected/copy-12.out
+++ b/test/expected/copy-12.out
@@ -174,7 +174,7 @@ CREATE TABLE "hyper_copy" (
     "time" bigint NOT NULL,
     "value" double precision NOT NULL
 );
-SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 2);
     create_hypertable    
 -------------------------
  (6,public,hyper_copy,t)
@@ -240,6 +240,15 @@ SELECT count(*) FROM hyper_copy;
  count 
 -------
    125
+(1 row)
+
+-- Insert data into the chunks in random order
+COPY hyper_copy FROM STDIN DELIMITER ',' NULL AS 'null';
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   154
 (1 row)
 
 RESET client_min_messages;

--- a/test/expected/copy-13.out
+++ b/test/expected/copy-13.out
@@ -174,7 +174,7 @@ CREATE TABLE "hyper_copy" (
     "time" bigint NOT NULL,
     "value" double precision NOT NULL
 );
-SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 2);
     create_hypertable    
 -------------------------
  (6,public,hyper_copy,t)
@@ -240,6 +240,15 @@ SELECT count(*) FROM hyper_copy;
  count 
 -------
    125
+(1 row)
+
+-- Insert data into the chunks in random order
+COPY hyper_copy FROM STDIN DELIMITER ',' NULL AS 'null';
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   154
 (1 row)
 
 RESET client_min_messages;

--- a/test/expected/copy-14.out
+++ b/test/expected/copy-14.out
@@ -174,7 +174,7 @@ CREATE TABLE "hyper_copy" (
     "time" bigint NOT NULL,
     "value" double precision NOT NULL
 );
-SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 2);
     create_hypertable    
 -------------------------
  (6,public,hyper_copy,t)
@@ -240,6 +240,15 @@ SELECT count(*) FROM hyper_copy;
  count 
 -------
    125
+(1 row)
+
+-- Insert data into the chunks in random order
+COPY hyper_copy FROM STDIN DELIMITER ',' NULL AS 'null';
+DEBUG:  Using optimized multi-buffer copy operation (CIM_MULTI_CONDITIONAL).
+SELECT count(*) FROM hyper_copy;
+ count 
+-------
+   154
 (1 row)
 
 RESET client_min_messages;

--- a/test/sql/copy.sql.in
+++ b/test/sql/copy.sql.in
@@ -120,7 +120,7 @@ CREATE TABLE "hyper_copy" (
     "value" double precision NOT NULL
 );
 
-SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 10);
+SELECT create_hypertable('hyper_copy', 'time', chunk_time_interval => 2);
 
 -- First copy call with default client_min_messages, to get rid of the 
 -- building index "_hyper_XXX_chunk_hyper_copy_time_idx" on table "_hyper_XXX_chunk" serially
@@ -173,6 +173,41 @@ CREATE TRIGGER hyper_copy_trigger_insert_after
     FOR EACH ROW EXECUTE FUNCTION empty_test_trigger(); 
 
 \copy hyper_copy FROM data/copy_data.csv WITH csv header;
+
+SELECT count(*) FROM hyper_copy;
+
+-- Insert data into the chunks in random order
+COPY hyper_copy FROM STDIN DELIMITER ',' NULL AS 'null';
+5,1
+7,1
+1,1
+0,5
+15,3
+0,7
+17,2
+20,1
+5,6
+19,1
+18,2
+17,1
+16,1
+15,1
+14,1
+13,1
+12,1
+11,1
+10,1
+11,1
+12,2
+13,2
+14,2
+15,2
+16,2
+17,2
+18,2
+19,2
+20,2
+\.
 
 SELECT count(*) FROM hyper_copy;
 


### PR DESCRIPTION
This patch solves a crash in the multi-buffer copy optimization,
which was introduced in commit bbb2f414d2090efd2d8533b464584157860ce49a.

This patch handles closed chunks (e.g., caused by timescaledb.max_open_
chunks_per_insert) properly. The problem is addressed by:

1) Re-reading the ChunkInsertState before the data is stored, which
   ensures that the underlying table is open.

2) A TSCopyMultiInsertBuffer is deleted after the data of the buffer
   is flushed. So, operations like table_finish_bulk_insert are
   executed and the associated chunk can properly be closed.