### PR TITLE
Change materialization hypertable indexes

### DIFF
--- a/tsl/test/expected/cagg_query-12.out
+++ b/tsl/test/expected/cagg_query-12.out
@@ -802,7 +802,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST, lasth DESC NULLS LAST
 LIMIT 10;
  location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
 ----------+------------------------------+------+------+--------+-------+---------+---------

--- a/tsl/test/expected/cagg_query-13.out
+++ b/tsl/test/expected/cagg_query-13.out
@@ -802,7 +802,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST, lasth DESC NULLS LAST
 LIMIT 10;
  location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
 ----------+------------------------------+------+------+--------+-------+---------+---------

--- a/tsl/test/expected/cagg_query-14.out
+++ b/tsl/test/expected/cagg_query-14.out
@@ -802,7 +802,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST, lasth DESC NULLS LAST
 LIMIT 10;
  location |            timec             | sumt | sumh | firsth | lasth | maxtemp | mintemp 
 ----------+------------------------------+------+------+--------+-------+---------+---------

--- a/tsl/test/expected/continuous_aggs-12.out
+++ b/tsl/test/expected/continuous_aggs-12.out
@@ -1732,27 +1732,30 @@ with (timescaledb.continuous, timescaledb.create_group_indexes=true) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol
+	symbol,
+	symbol + symbol AS symbol2
 from test_group_idx
-group by bucket, symbol;
+group by bucket, symbol, symbol2;
 NOTICE:  refreshing continuous aggregate "cagg_index_true"
 create materialized view cagg_index_false
 with (timescaledb.continuous, timescaledb.create_group_indexes=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol
+	symbol,
+	symbol + symbol AS symbol2
 from test_group_idx
-group by bucket, symbol;
+group by bucket, symbol, symbol2;
 NOTICE:  refreshing continuous aggregate "cagg_index_false"
 create materialized view cagg_index_default
 with (timescaledb.continuous) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol
+	symbol,
+	symbol + symbol AS symbol2
 from test_group_idx
-group by bucket, symbol;
+group by bucket, symbol, symbol2;
 NOTICE:  refreshing continuous aggregate "cagg_index_default"
 -- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca
@@ -1774,36 +1777,36 @@ join pg_class c
 where tablename in (select materialization_hypertable_name from timescaledb_information.continuous_aggregates
 where view_name like 'cagg_index_%')
 order by tablename;
--[ RECORD 1 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+-[ RECORD 1 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------
 schemaname | _timescaledb_internal
 tablename  | _materialized_hypertable_49
 indexname  | _materialized_hypertable_49_bucket_idx
 tablespace | 
 indexdef   | CREATE INDEX _materialized_hypertable_49_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (bucket DESC)
--[ RECORD 2 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+-[ RECORD 2 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------
 schemaname | _timescaledb_internal
 tablename  | _materialized_hypertable_49
-indexname  | _materialized_hypertable_49_symbol_bucket_idx
+indexname  | _materialized_hypertable_49_symbol_symbol2_bucket_idx
 tablespace | 
-indexdef   | CREATE INDEX _materialized_hypertable_49_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (symbol, bucket DESC)
--[ RECORD 3 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+indexdef   | CREATE INDEX _materialized_hypertable_49_symbol_symbol2_bucket_idx ON _timescaledb_internal._materialized_hypertable_49 USING btree (symbol, symbol2, bucket DESC)
+-[ RECORD 3 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------
 schemaname | _timescaledb_internal
 tablename  | _materialized_hypertable_50
 indexname  | _materialized_hypertable_50_bucket_idx
 tablespace | 
 indexdef   | CREATE INDEX _materialized_hypertable_50_bucket_idx ON _timescaledb_internal._materialized_hypertable_50 USING btree (bucket DESC)
--[ RECORD 4 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+-[ RECORD 4 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------
 schemaname | _timescaledb_internal
 tablename  | _materialized_hypertable_51
 indexname  | _materialized_hypertable_51_bucket_idx
 tablespace | 
 indexdef   | CREATE INDEX _materialized_hypertable_51_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (bucket DESC)
--[ RECORD 5 ]-------------------------------------------------------------------------------------------------------------------------------------------------
+-[ RECORD 5 ]------------------------------------------------------------------------------------------------------------------------------------------------------------------
 schemaname | _timescaledb_internal
 tablename  | _materialized_hypertable_51
-indexname  | _materialized_hypertable_51_symbol_bucket_idx
+indexname  | _materialized_hypertable_51_symbol_symbol2_bucket_idx
 tablespace | 
-indexdef   | CREATE INDEX _materialized_hypertable_51_symbol_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (symbol, bucket DESC)
+indexdef   | CREATE INDEX _materialized_hypertable_51_symbol_symbol2_bucket_idx ON _timescaledb_internal._materialized_hypertable_51 USING btree (symbol, symbol2, bucket DESC)
 
 \x off
 --

--- a/tsl/test/expected/continuous_aggs_deprecated.out
+++ b/tsl/test/expected/continuous_aggs_deprecated.out
@@ -898,13 +898,11 @@ FROM _timescaledb_catalog.continuous_agg ca
 INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_with_test')
 order by indexname;
-                   indexname                   |                                                                     indexdef                                                                      
------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------
- _materialized_hypertable_20_grp_5_5_timec_idx | CREATE INDEX _materialized_hypertable_20_grp_5_5_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (grp_5_5, timec DESC)
- _materialized_hypertable_20_grp_6_6_timec_idx | CREATE INDEX _materialized_hypertable_20_grp_6_6_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (grp_6_6, timec DESC)
- _materialized_hypertable_20_grp_7_7_timec_idx | CREATE INDEX _materialized_hypertable_20_grp_7_7_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (grp_7_7, timec DESC)
- _materialized_hypertable_20_timec_idx         | CREATE INDEX _materialized_hypertable_20_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (timec DESC)
-(4 rows)
+                           indexname                           |                                                                                      indexdef                                                                                       
+---------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ _materialized_hypertable_20_grp_5_5_grp_6_6_grp_7_7_timec_idx | CREATE INDEX _materialized_hypertable_20_grp_5_5_grp_6_6_grp_7_7_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (grp_5_5, grp_6_6, grp_7_7, timec DESC)
+ _materialized_hypertable_20_timec_idx                         | CREATE INDEX _materialized_hypertable_20_timec_idx ON _timescaledb_internal._materialized_hypertable_20 USING btree (timec DESC)
+(2 rows)
 
 DROP MATERIALIZED VIEW mat_with_test;
 --no additional indexes

--- a/tsl/test/sql/cagg_query.sql.in
+++ b/tsl/test/sql/cagg_query.sql.in
@@ -291,7 +291,7 @@ SELECT m1.location, m1.timec, sumt, sumh, firsth, lasth, maxtemp, mintemp
 FROM mat_m1 m1 RIGHT JOIN mat_m2 m2
 ON (m1.location = m2.location
 AND m1.timec = m2.timec)
-ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST
+ORDER BY m1.location COLLATE "C" NULLS LAST, m1.timec DESC NULLS LAST, firsth NULLS LAST, lasth DESC NULLS LAST
 LIMIT 10;
 
 ROLLBACK;

--- a/tsl/test/sql/continuous_aggs.sql.in
+++ b/tsl/test/sql/continuous_aggs.sql.in
@@ -1245,27 +1245,30 @@ with (timescaledb.continuous, timescaledb.create_group_indexes=true) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol
+	symbol,
+	symbol + symbol AS symbol2
 from test_group_idx
-group by bucket, symbol;
+group by bucket, symbol, symbol2;
 
 create materialized view cagg_index_false
 with (timescaledb.continuous, timescaledb.create_group_indexes=false) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol
+	symbol,
+	symbol + symbol AS symbol2
 from test_group_idx
-group by bucket, symbol;
+group by bucket, symbol, symbol2;
 
 create materialized view cagg_index_default
 with (timescaledb.continuous) as
 select
 	time_bucket('1 day', "time") as bucket,
 	sum(value),
-	symbol
+	symbol,
+	symbol + symbol AS symbol2
 from test_group_idx
-group by bucket, symbol;
+group by bucket, symbol, symbol2;
 
 -- see corresponding materialization_hypertables
 select view_name, materialization_hypertable_name from timescaledb_information.continuous_aggregates ca


### PR DESCRIPTION
Nowadays for the Continuous Aggregate materialization hypertable we
add additional indexes. Those additional indexes are one for each
group-by column plus time bucket expression and it can lead to
unsusable indexes.
    
This PR change the current logic to add just one additional composite
index including all group-by columns plus the time bucket expression.