### PR TITLE
Fix crash and other issues in telemetry reporter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ If you use compression with a non-default collation on a segmentby-column you mi
 * #4269 Fix bad Continuous Aggregate view definition reported in #4233
 * #4300 Fix refresh window cap for cagg refresh policy
 * #4330 Add GUC "bgw_launcher_poll_time"
+* #4358 Fix crash and other issues in telemetry reporter
 
 **Thanks**
 * @jsoref for fixing various misspellings in code, comments and documentation
+* @abrownsword for reporting a bug in the telemetry reporter and testing the fix
 
 ## 2.6.1 (2022-04-11)
 This release is patch release. We recommend that you upgrade at the next available opportunity.

--- a/tsl/test/isolation/expected/telemetry.out
+++ b/tsl/test/isolation/expected/telemetry.out
@@ -1,0 +1,26 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_wp_enable s2_telemetry_report s1_drop_chunks s1_decompress s1_insert_new_chunk s1_compress s1_wp_release
+step s1_wp_enable: SELECT debug_waitpoint_enable('telemetry_classify_relation');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_telemetry_report: SELECT t INTO telemetry FROM get_telemetry_report() t; <waiting ...>
+step s1_drop_chunks: SELECT count(*) FROM drop_chunks('compress', timestamptz '2020-01-20 15:00');
+count
+-----
+    0
+(1 row)
+
+step s1_decompress: SELECT decompress_chunk(c) INTO decompressed_chunks FROM show_chunks('compress') c ORDER BY c LIMIT 10;
+step s1_insert_new_chunk: INSERT INTO compress VALUES ('2020-03-01'::timestamptz, 1, 33.3);
+step s1_compress: SELECT compress_chunk(c) INTO compressed_chunks FROM show_chunks('compress') c ORDER BY c DESC LIMIT 1;
+step s1_wp_release: SELECT debug_waitpoint_release('telemetry_classify_relation');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_telemetry_report: <... completed>

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TEST_TEMPLATES_MODULE reorder_deadlock.spec.in
 set(TEST_TEMPLATES_MODULE_DEBUG
     reorder_vs_insert.spec.in reorder_vs_select.spec.in
     remote_create_chunk.spec.in dist_restore_point.spec.in
-    cagg_drop_chunks.spec.in)
+    cagg_drop_chunks.spec.in telemetry.spec.in)
 
 # These tests are using markers for the isolation tests (to avoid race
 # conditions causing differing output), which were added after 12.7, 13.3, and

--- a/tsl/test/isolation/specs/telemetry.spec.in
+++ b/tsl/test/isolation/specs/telemetry.spec.in
@@ -1,0 +1,36 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+setup {
+  CREATE TABLE compress (time timestamptz, color int, temp float);
+  SELECT create_hypertable('compress', 'time', 'color', 2, chunk_time_interval => interval '1 week');
+  INSERT INTO compress
+  SELECT t, ceil(random() * 10)::int, random() * 30
+  FROM generate_series('2020-01-20'::timestamptz, '2020-02-20', '10m') t;
+  ALTER TABLE compress SET (timescaledb.compress = TRUE);
+  SELECT compress_chunk(c) FROM show_chunks('compress') c ORDER BY c LIMIT 10;
+
+  CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_enable';
+
+  CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_release';
+}
+
+teardown {
+  DROP TABLE compress;
+}
+
+session "s1"
+step "s1_wp_enable"           { SELECT debug_waitpoint_enable('telemetry_classify_relation'); }
+step "s1_wp_release"      { SELECT debug_waitpoint_release('telemetry_classify_relation'); }
+step "s1_decompress"	{ SELECT decompress_chunk(c) INTO decompressed_chunks FROM show_chunks('compress') c ORDER BY c LIMIT 10; }
+step "s1_insert_new_chunk" { INSERT INTO compress VALUES ('2020-03-01'::timestamptz, 1, 33.3); }
+step "s1_drop_chunks"   { SELECT count(*) FROM drop_chunks('compress', timestamptz '2020-01-20 15:00'); }
+step "s1_compress"      { SELECT compress_chunk(c) INTO compressed_chunks FROM show_chunks('compress') c ORDER BY c DESC LIMIT 1; }
+
+session "s2"
+step "s2_telemetry_report" { SELECT t INTO telemetry FROM get_telemetry_report() t; }
+
+permutation "s1_wp_enable" "s2_telemetry_report" "s1_drop_chunks" "s1_decompress" "s1_insert_new_chunk" "s1_compress" "s1_wp_release"


### PR DESCRIPTION
Make the following changes to the telemetry reporter background
worker:

- Add a read lock to the current relation that the reporter collects
  stats for. This lock protects against concurrent deletion of the
  relation, which could lead to errors that would prevent the reporter
  from completing its report.
- Set an active snapshot in the telemetry background process for use
  when scanning a relation for stats collection.

- Reopen the scan iterator when collecting chunk compression stats for
  a relation instead of keeping it open and restarting the scan. The
  previous approach seems to cause crashes due to memory corruption of
  the scan state. Unfortunately, the exact cause has not been
  identified, but the change has been verified to work on a live
  running instance (thanks to @abrownsword for the help with
  reproducing the crash and testing fixes).

Fixes https://github.com/timescale/timescaledb/issues/4266