### PR TITLE
Remove dead code

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -2488,7 +2488,7 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 	remove_old_and_new_rte_from_query(direct_query);
 	CAggTimebucketInfo timebucket_exprinfo = cagg_validate_query(direct_query, finalized);
 
-	mattablecolumninfo_init(&mattblinfo, (finalized ? NIL : copyObject(direct_query->groupClause)));
+	mattablecolumninfo_init(&mattblinfo, copyObject(direct_query->groupClause));
 	fqi.finalized = finalized;
 	finalizequery_init(&fqi, direct_query, &mattblinfo);
 


### PR DESCRIPTION
Remove noop ternary operator in cagg_rebuild_view_definition. We
return if finalized is true on line 2475 so the NIL would never
be reached in the ternary operator. Found by coverity.