### PR TITLE
SKIP telemetry test on PG12.0

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -133,10 +133,10 @@ if event_type != "pull_request":
 
   # add debug test for first supported PG12 version
   # most of the IGNORES are the isolation tests because the output format has changed between versions
-  # chunk_utils and tablespace are skipped because of use after free bugs in postgres 12.0 which those tests hit
+  # chunk_utils, telemetry and tablespace are skipped because of use after free bugs in postgres 12.0 which those tests hit
   pg12_debug_earliest = {
     "pg": PG12_EARLIEST,
-    "installcheck_args": "SKIPS='chunk_utils tablespace' IGNORES='cluster-12 compression_ddl cagg_concurrent_refresh cagg_concurrent_refresh_dist_ht cagg_drop_chunks cagg_insert cagg_multi cagg_multi_dist_ht cagg_policy deadlock_drop_chunks_compress deadlock_recompress_chunk concurrent_query_and_drop_chunks deadlock_dropchunks_select debug_notice dist_gapfill_pushdown-12 dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback'"
+    "installcheck_args": "SKIPS='chunk_utils tablespace telemetry' IGNORES='cluster-12 compression_ddl cagg_concurrent_refresh cagg_concurrent_refresh_dist_ht cagg_drop_chunks cagg_insert cagg_multi cagg_multi_dist_ht cagg_policy deadlock_drop_chunks_compress deadlock_recompress_chunk concurrent_query_and_drop_chunks deadlock_dropchunks_select debug_notice dist_gapfill_pushdown-12 dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback'"
   }
   m["include"].append(build_debug_config(pg12_debug_earliest))
 


### PR DESCRIPTION
With recent refactorings the telemetry test seems to trigger the
same use-after-free bug that got triggered by tablespace test so
we skip that test on PG12.0 as well.