### PR TITLE
Fix PG13.2 nightly CI failures

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -143,7 +143,7 @@ if event_type != "pull_request":
   # add debug test for first supported PG13 version
   pg13_debug_earliest = {
     "pg": PG13_EARLIEST,
-    "installcheck_args": "SKIPS='deadlock_recompress_chunk' IGNORES='compression_ddl cagg_concurrent_refresh cagg_concurrent_refresh_dist_ht cagg_drop_chunks cagg_insert cagg_multi cagg_multi_dist_ht deadlock_drop_chunks_compress deadlock_recompress_chunk concurrent_query_and_drop_chunks deadlock_dropchunks_select dist_gapfill_pushdown-13 dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback telemetry'"
+    "installcheck_args": "SKIPS='deadlock_recompress_chunk 001_extension' IGNORES='compression_ddl cagg_concurrent_refresh cagg_concurrent_refresh_dist_ht cagg_drop_chunks cagg_insert cagg_multi cagg_multi_dist_ht deadlock_drop_chunks_compress deadlock_recompress_chunk concurrent_query_and_drop_chunks deadlock_dropchunks_select dist_gapfill_pushdown-13 dist_restore_point dropchunks_race insert_dropchunks_race isolation_nop multi_transaction_indexing read_committed_insert read_uncommitted_insert remote_create_chunk reorder_deadlock reorder_vs_insert reorder_vs_insert_other_chunk reorder_vs_select repeatable_read_insert serializable_insert serializable_insert_rollback telemetry'"
   }
   m["include"].append(build_debug_config(pg13_debug_earliest))
 

--- a/test/pg_prove.sh
+++ b/test/pg_prove.sh
@@ -16,9 +16,11 @@
 PROVE_TESTS=${PROVE_TESTS:-}
 PROVE=${PROVE:-prove}
 
+echo "SKIPS: ${SKIPS}"
+
 # If PROVE_TESTS is specified then run those subset of TAP tests even if
 # TESTS is also specified
-if [ -z "$PROVE_TESTS" ]
+if [ -z "$PROVE_TESTS" ] && [ -z "${SKIPS}" ]
 then
     # Exit early if we are running with TESTS=expr
     if [ -n "$TESTS" ]
@@ -26,6 +28,27 @@ then
         exit 0
     fi
     FINAL_TESTS=$(ls -1 t/*.pl 2>/dev/null)
+elif [ -z "$PROVE_TESTS" ] && [ -n "${SKIPS}" ]
+then
+    ALL_TESTS=$(ls -1 t/*.pl 2>/dev/null)
+    FILTERED_TESTS=""
+    # disable path expansion to make SKIPS='*' work
+    set -f
+
+    # to support wildcards in SKIPS we match the SKIPS
+    # list against the actual list of tests
+    for test_name in ${ALL_TESTS}; do
+      for test_pattern in ${SKIPS}; do
+        # shellcheck disable=SC2053
+        # We do want to match globs in $test_pattern here.
+        if [[ $test_name == t/${test_pattern}.pl ]]; then
+          continue 2
+        fi
+      done
+      FILTERED_TESTS="${FILTERED_TESTS}\n${test_name}"
+    done
+    FINAL_TESTS=$(echo -e "${FILTERED_TESTS}" | tr '\n' ' ' | sed -e 's/^ *//')
+
 else
     FINAL_TESTS=$PROVE_TESTS
 fi


### PR DESCRIPTION
The 001_extension test uses the background_psql function which is not
present in the 13.2 PostgresNode module. This function is only
available in PG 13.5+.

https://github.com/postgres/postgres/commit/a9d0a540

Disable-check: commit-count
