### PR TITLE
Add initializer to auto variable

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -1344,7 +1344,7 @@ static void
 drop_data_node_database(const ForeignServer *server)
 {
 	ListCell *lc;
-	TSConnection *conn;
+	TSConnection *conn = NULL;
 	Oid userid = GetUserId();
 	TSConnectionId connid = {
 		.server_id = server->serverid,


### PR DESCRIPTION
Compilers are not smart enough to check that `conn` is initialized
inside the loop so not initializing it gives an error. Added an
initializer to the auto variable to get rid of the error.