### PR TITLE
Set statement_timeout for test instances

### DIFF
--- a/test/postgresql.conf.in
+++ b/test/postgresql.conf.in
@@ -6,6 +6,7 @@ shared_preload_libraries=timescaledb
 max_worker_processes=24
 autovacuum=false
 random_page_cost=1.0
+statement_timeout=10s
 timescaledb.license='apache'
 @TELEMETRY_DEFAULT_SETTING@
 timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -3,6 +3,7 @@ shared_preload_libraries=timescaledb
 max_worker_processes=24
 autovacuum=false
 random_page_cost=1.0
+statement_timeout=10s
 @TELEMETRY_DEFAULT_SETTING@
 timescaledb.last_tuned='1971-02-03 04:05:06.789012 -0300'
 timescaledb.last_tuned_version='0.0.1'


### PR DESCRIPTION
This patch sets a 10 second statement timeout so any statement
taking longer than that will get canceled by postgres. For our
tests no single statement should take longer than that anyway
but quite regularly bgw tests get stuck and run into much longer
5 minute timeout imposed elsewhere.