### PR TITLE
Adjust coccinelle and shellcheck CI config

### DIFF
--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -3,6 +3,8 @@ name: Coccinelle
 on:
   pull_request:
   push:
+    branches:
+      - prerelease_test
 jobs:
   coccinelle:
     name: Coccinelle

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -3,6 +3,8 @@ name: Shellcheck
 on:
   pull_request:
   push:
+    branches:
+      - prerelease_test
 jobs:
   shellcheck:
     name: Shellcheck


### PR DESCRIPTION
Currently coccinelle and shellcheck get run an additional time
for every merged commit to master. This patch adjusts the config
so they are only run on pull request or on push to prerelease_test
instead of push to any branch, similar to how all the other
workflows are set up.