### PR TITLE
Faster lookup of chunks by point

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -128,6 +128,9 @@ typedef struct ChunkScanEntry
 {
 	int32 chunk_id;
 	ChunkStub *stub;
+
+	/* Used for fast chunk search where we don't want to build chunk stubs. */
+	int32 num_dimension_constraints;
 } ChunkScanEntry;
 
 /*
@@ -140,12 +143,12 @@ typedef struct DisplayKeyData
 } DisplayKeyData;
 
 extern void ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti);
-extern Chunk *ts_chunk_create_from_point(const Hypertable *ht, const Point *p, const char *schema,
-										 const char *prefix);
+extern Chunk *ts_chunk_find_for_point(const Hypertable *ht, const Point *p);
+extern Chunk *ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *schema,
+										const char *prefix);
 
 extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id, int16 num_constraints, const char relkind);
 extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id, int16 num_constraints);
-extern Chunk *ts_chunk_find(const Hypertable *ht, const Point *p, bool lock_slices);
 extern TSDLLEXPORT Chunk *ts_chunk_copy(const Chunk *chunk);
 extern TSDLLEXPORT Chunk *ts_chunk_get_by_name_with_memory_context(const char *schema_name,
 																   const char *table_name,

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -44,6 +44,9 @@ typedef struct Hypercube Hypercube;
 
 extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit,
 												   const ScanTupLock *tuplock);
+
+extern void ts_dimension_slice_scan_list(int32 dimension_id, int64 coordinate, List **dest);
+
 extern DimensionVec *
 ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy,
 									int64 start_value, StrategyNumber end_strategy, int64 end_value,

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -131,10 +131,10 @@ extern TSDLLEXPORT void ts_hypertable_check_partitioning(const Hypertable *ht,
 extern int ts_hypertable_reset_associated_schema_name(const char *associated_schema);
 extern TSDLLEXPORT Oid ts_hypertable_id_to_relid(int32 hypertable_id);
 extern TSDLLEXPORT int32 ts_hypertable_relid_to_id(Oid relid);
-extern TSDLLEXPORT Chunk *ts_hypertable_find_chunk_if_exists(const Hypertable *h,
+extern TSDLLEXPORT Chunk *ts_hypertable_find_chunk_for_point(const Hypertable *h,
 															 const Point *point);
-extern TSDLLEXPORT Chunk *ts_hypertable_get_or_create_chunk(const Hypertable *h,
-															const Point *point);
+extern TSDLLEXPORT Chunk *ts_hypertable_create_chunk_for_point(const Hypertable *h,
+															   const Point *point);
 extern Oid ts_hypertable_relid(RangeVar *rv);
 extern TSDLLEXPORT bool ts_is_hypertable(Oid relid);
 extern bool ts_hypertable_has_tablespace(const Hypertable *ht, Oid tspc_oid);

--- a/tsl/src/remote/dist_copy.c
+++ b/tsl/src/remote/dist_copy.c
@@ -763,16 +763,18 @@ reset_copy_connection_state(CopyConnectionState *state)
 static Chunk *
 get_target_chunk(Hypertable *ht, Point *p, CopyConnectionState *state)
 {
-	Chunk *chunk = ts_hypertable_find_chunk_if_exists(ht, p);
+	Chunk *chunk = ts_hypertable_find_chunk_for_point(ht, p);
 
 	if (chunk == NULL)
 	{
-		/* Here we need to create a new chunk.  However, any in-progress copy operations
-		 * will be tying up the connection we need to create the chunk on a data node.  Since
-		 * the data nodes for the new chunk aren't yet known, just close all in progress COPYs
-		 * before creating the chunk. */
+		/*
+		 * Here we might need to create a new chunk. However, any in-progress
+		 * copy operations will be tying up the connection we need to create the
+		 * chunk on a data node.  Since the data nodes for the new chunk aren't
+		 * yet known, just close all in progress COPYs before creating the chunk.
+		 */
 		reset_copy_connection_state(state);
-		chunk = ts_hypertable_get_or_create_chunk(ht, p);
+		chunk = ts_hypertable_create_chunk_for_point(ht, p);
 	}
 
 	return chunk;


### PR DESCRIPTION
Don't keep the chunk constraints while searching. The number of
candidate chunks can be very large, so keeping these constraints is a
lot of work and uses a lot of memory. For finding the matching chunk,
it is enough to track the number of dimensions that matched a given
chunk id. After finding the chunk id, we can look up only the matching
chunk data with the usual function.

This saves some work when doing INSERTs.

Gives 10%-30% speedup on my COPY tests that touch a lot of chunks.

Part of #4285