### PR TITLE
Support intervals with month component when constifying now()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ accidentally triggering the load of a previous DB version.**
 **Features**
 * #4374 Remove constified now() constraints from plan
 * #4393 Support intervals with day component when constifying now()
+* #4397 Support intervals with month component when constifying now()
 
 ## 2.7.0 (2022-05-24)
 

--- a/tsl/test/shared/expected/constify_now-12.out
+++ b/tsl/test/shared/expected/constify_now-12.out
@@ -78,6 +78,12 @@ QUERY PLAN
    Index Cond: ("time" > (now() - '@ 7 days'::interval))
 (2 rows)
 
+:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
+QUERY PLAN
+ Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+   Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(2 rows)
+
 -- test bitmapheapscan
 SET enable_indexscan TO false;
 :PREFIX SELECT FROM const_now WHERE time > now();
@@ -111,16 +117,6 @@ QUERY PLAN
 (2 rows)
 
 -- variants we don't optimize
--- we do not allow interval with month components
-:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
-QUERY PLAN
- Append
-   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
-         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
-   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
-         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
-(5 rows)
-
 :PREFIX SELECT FROM const_now WHERE time > now()::date;
 QUERY PLAN
  Append
@@ -411,5 +407,48 @@ QUERY PLAN
    ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
          Index Cond: ("time" > (now() - '@ 1 day'::interval))
 (5 rows)
+
+TRUNCATE const_now_dst;
+SELECT set_chunk_time_interval('const_now_dst','1 day'::interval, 'time');
+ set_chunk_time_interval 
+ 
+(1 row)
+
+-- test month calculation safety buffer
+SET timescaledb.current_timestamp_mock TO '2001-03-1 0:30:00+00';
+INSERT INTO const_now_dst SELECT generate_series('2001-01-28'::timestamptz, '2001-02-01', '1day'::interval);
+set timezone to 'utc+1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(11 rows)
+
+set timezone to 'utc-1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(11 rows)
 
 DROP TABLE const_now_dst;

--- a/tsl/test/shared/expected/constify_now-13.out
+++ b/tsl/test/shared/expected/constify_now-13.out
@@ -78,6 +78,12 @@ QUERY PLAN
    Index Cond: ("time" > (now() - '@ 7 days'::interval))
 (2 rows)
 
+:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
+QUERY PLAN
+ Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+   Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(2 rows)
+
 -- test bitmapheapscan
 SET enable_indexscan TO false;
 :PREFIX SELECT FROM const_now WHERE time > now();
@@ -111,16 +117,6 @@ QUERY PLAN
 (2 rows)
 
 -- variants we don't optimize
--- we do not allow interval with month components
-:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
-QUERY PLAN
- Append
-   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
-         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
-   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
-         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
-(5 rows)
-
 :PREFIX SELECT FROM const_now WHERE time > now()::date;
 QUERY PLAN
  Append
@@ -411,5 +407,48 @@ QUERY PLAN
    ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
          Index Cond: ("time" > (now() - '@ 1 day'::interval))
 (5 rows)
+
+TRUNCATE const_now_dst;
+SELECT set_chunk_time_interval('const_now_dst','1 day'::interval, 'time');
+ set_chunk_time_interval 
+ 
+(1 row)
+
+-- test month calculation safety buffer
+SET timescaledb.current_timestamp_mock TO '2001-03-1 0:30:00+00';
+INSERT INTO const_now_dst SELECT generate_series('2001-01-28'::timestamptz, '2001-02-01', '1day'::interval);
+set timezone to 'utc+1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(11 rows)
+
+set timezone to 'utc-1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(11 rows)
 
 DROP TABLE const_now_dst;

--- a/tsl/test/shared/expected/constify_now-14.out
+++ b/tsl/test/shared/expected/constify_now-14.out
@@ -78,6 +78,12 @@ QUERY PLAN
    Index Cond: ("time" > (now() - '@ 7 days'::interval))
 (2 rows)
 
+:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
+QUERY PLAN
+ Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+   Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(2 rows)
+
 -- test bitmapheapscan
 SET enable_indexscan TO false;
 :PREFIX SELECT FROM const_now WHERE time > now();
@@ -111,16 +117,6 @@ QUERY PLAN
 (2 rows)
 
 -- variants we don't optimize
--- we do not allow interval with month components
-:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
-QUERY PLAN
- Append
-   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
-         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
-   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
-         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
-(5 rows)
-
 :PREFIX SELECT FROM const_now WHERE time > now()::date;
 QUERY PLAN
  Append
@@ -408,5 +404,48 @@ QUERY PLAN
    ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
          Index Cond: ("time" > (now() - '@ 1 day'::interval))
 (5 rows)
+
+TRUNCATE const_now_dst;
+SELECT set_chunk_time_interval('const_now_dst','1 day'::interval, 'time');
+ set_chunk_time_interval 
+ 
+(1 row)
+
+-- test month calculation safety buffer
+SET timescaledb.current_timestamp_mock TO '2001-03-1 0:30:00+00';
+INSERT INTO const_now_dst SELECT generate_series('2001-01-28'::timestamptz, '2001-02-01', '1day'::interval);
+set timezone to 'utc+1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(11 rows)
+
+set timezone to 'utc-1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_dst_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (now() - '@ 1 mon'::interval))
+(11 rows)
 
 DROP TABLE const_now_dst;

--- a/tsl/test/shared/sql/constify_now.sql.in
+++ b/tsl/test/shared/sql/constify_now.sql.in
@@ -32,6 +32,7 @@ INSERT INTO const_now SELECT '3000-01-01','3000-01-01',2,0.5;
 :PREFIX SELECT FROM const_now WHERE time > now() - '2d'::interval;
 :PREFIX SELECT FROM const_now WHERE time > now() + '3d'::interval;
 :PREFIX SELECT FROM const_now WHERE time > now() - '1week'::interval;
+:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
 
 -- test bitmapheapscan
 SET enable_indexscan TO false;
@@ -44,8 +45,6 @@ RESET enable_indexscan;
 :PREFIX SELECT FROM const_now WHERE time >= now() + '10m'::interval AND time >= now() - '10m'::interval;
 
 -- variants we don't optimize
--- we do not allow interval with month components
-:PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
 :PREFIX SELECT FROM const_now WHERE time > now()::date;
 :PREFIX SELECT FROM const_now WHERE round(EXTRACT(EPOCH FROM now())) > 0.5;
 
@@ -142,6 +141,19 @@ SET timescaledb.current_timestamp_mock TO '2022-03-28 1:15+0';
 
 -- must have 2 chunks in plan
 :PREFIX SELECT FROM const_now_dst WHERE time > now() - '1day'::interval;
+
+TRUNCATE const_now_dst;
+SELECT set_chunk_time_interval('const_now_dst','1 day'::interval, 'time');
+
+-- test month calculation safety buffer
+SET timescaledb.current_timestamp_mock TO '2001-03-1 0:30:00+00';
+INSERT INTO const_now_dst SELECT generate_series('2001-01-28'::timestamptz, '2001-02-01', '1day'::interval);
+set timezone to 'utc+1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
+set timezone to 'utc-1';
+-- must have 5 chunks in plan
+:PREFIX SELECT * FROM const_now_dst WHERE time > now() - '1 month'::interval;
 
 DROP TABLE const_now_dst;
 


### PR DESCRIPTION
When dealing with Intervals with month component timezone changes
can result in multiple day differences in the outcome of these
calculations due to different month lengths. When dealing with
months we add a 7 day safety buffer.
For all these calculations it is fine if we exclude less chunks
than strictly required for the operation, additional exclusion
with exact values will happen in the executor. But under no
circumstances must we exclude too much cause there would be
no way for the executor to get those chunks back.