### PR TITLE
Replace pg_atoi with pg_strtoint16/32

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -655,7 +655,7 @@ get_server_port()
 {
 	const char *const portstr =
 		GetConfigOption("port", /* missing_ok= */ false, /* restrict_privileged= */ false);
-	return pg_atoi(portstr, sizeof(int32), 0);
+	return pg_strtoint32(portstr);
 }
 
 /* set_distid may need to be false for some otherwise invalid configurations

--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -293,7 +293,7 @@ is_local_connection(const PGconn *conn)
 		return true;
 
 	/* A TCP connection must match both the port and localhost address */
-	port = pg_atoi(PQport(conn), sizeof(int32), '\0');
+	port = pg_strtoint32(PQport(conn));
 
 	return (port == PostPortNumber) && is_loopback_host_or_addr(host);
 }
@@ -418,7 +418,7 @@ create_tuple_from_conn_entry(const ConnectionCacheEntry *entry, const TupleDesc 
 	values[AttrNumberGetAttrOffset(Anum_show_conn_user_name)] = NameGetDatum(&conn_user_name);
 	values[AttrNumberGetAttrOffset(Anum_show_conn_host)] = CStringGetTextDatum(PQhost(pgconn));
 	values[AttrNumberGetAttrOffset(Anum_show_conn_port)] =
-		Int32GetDatum(pg_atoi(PQport(pgconn), sizeof(int32), '\0'));
+		Int32GetDatum(pg_strtoint32(PQport(pgconn)));
 	values[AttrNumberGetAttrOffset(Anum_show_conn_db)] = NameGetDatum(&conn_db);
 	values[AttrNumberGetAttrOffset(Anum_show_conn_backend_pid)] =
 		Int32GetDatum(PQbackendPID(pgconn));

--- a/tsl/test/src/test_compression.c
+++ b/tsl/test/src/test_compression.c
@@ -566,13 +566,13 @@ TS_FUNCTION_INFO_V1(ts_compression_custom_type_in);
 TS_FUNCTION_INFO_V1(ts_compression_custom_type_out);
 TS_FUNCTION_INFO_V1(ts_compression_custom_type_eq);
 
-/* basically int2in but returns by refrence */
+/* basically int2in but returns by reference */
 Datum
 ts_compression_custom_type_in(PG_FUNCTION_ARGS)
 {
 	char *num = PG_GETARG_CSTRING(0);
 	int16 *val = palloc(sizeof(*val));
-	*val = pg_atoi(num, sizeof(int16), '\0');
+	*val = pg_strtoint16(num);
 
 	PG_RETURN_POINTER(val);
 }


### PR DESCRIPTION
PG 15 removes pg_atoi, so this patch changes all callers to use
pg_strtoint16/32.

https://github.com/postgres/postgres/commit/73508475