### PR TITLE
Use our implementation of find_em_expr_for_rel for PG15+

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -475,9 +475,10 @@ get_reindex_options(ReindexStmt *stmt)
 /* find_em_expr_for_rel was in postgres_fdw in PG12 but got
  * moved out of contrib in PG13. So we map to our own function
  * for PG12 only and use postgres implementation when it is
- * available.
+ * available. PG15 removed the function again from postgres
+ * core code so for PG15+ we fall back to our own implementation.
  */
-#if PG12
+#if PG12 || PG15_GE
 #define find_em_expr_for_rel ts_find_em_expr_for_rel
 #endif
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -720,7 +720,7 @@ ts_get_appendrelinfo(PlannerInfo *root, Index rti, bool missing_ok)
 	return NULL;
 }
 
-#if PG12
+#if PG12 || PG15_GE
 /*
  * Find an equivalence class member expression, all of whose Vars, come from
  * the indicated relation.
@@ -729,6 +729,8 @@ ts_get_appendrelinfo(PlannerInfo *root, Index rti, bool missing_ok)
  * contrib/postgres_fdw/postgres_fdw.c in postgres source.
  * This function was moved to postgres main in PG13 so we only need this
  * backport for PG12 in later versions we will use the postgres implementation.
+ * PG15 removes the function again from postgres code, so we use our own
+ * implementation for PG15+ again.
  */
 Expr *
 ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)

--- a/src/utils.h
+++ b/src/utils.h
@@ -104,7 +104,7 @@ extern TSDLLEXPORT void *ts_create_struct_from_slot(TupleTableSlot *slot, Memory
 extern TSDLLEXPORT AppendRelInfo *ts_get_appendrelinfo(PlannerInfo *root, Index rti,
 													   bool missing_ok);
 
-#if PG12
+#if PG12 || PG15_GE
 extern TSDLLEXPORT Expr *ts_find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel);
 #endif
 


### PR DESCRIPTION
PG13 added an implementation of find_em_expr_for_rel to postgres
core code. Which is removed again in PG15. This patch adjusts
our macros to deal with the removal in PG15.

https://github.com/postgres/postgres/commit/f3dd9fe1