### PR TITLE
Try to enable ON CONFLICT ON CONSTRAINT

### DIFF
--- a/src/nodes/hypertable_modify.c
+++ b/src/nodes/hypertable_modify.c
@@ -617,13 +617,6 @@ ts_hypertable_modify_path_create(PlannerInfo *root, ModifyTablePath *mtpath, Hyp
 
 	Index rti = mtpath->nominalRelation;
 
-	if (root->parse->onConflict && OidIsValid(root->parse->onConflict->constraint))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("hypertables do not support ON CONFLICT statements that reference "
-						"constraints"),
-				 errhint("Use column names to infer indexes instead.")));
-
 	if (mtpath->operation == CMD_INSERT)
 	{
 		if (hypertable_is_distributed(ht) && ts_guc_max_insert_batch_size > 0)

--- a/test/expected/rowsecurity-12.out
+++ b/test/expected/rowsecurity-12.out
@@ -4919,12 +4919,10 @@ ERROR:  new row violates row-level security policy for table "r1"
 INSERT INTO r1 VALUES (10)
     ON CONFLICT (a) DO UPDATE SET a = 30;
 ERROR:  new row violates row-level security policy for table "r1"
---will error out because of constraint names not supported on hypertables.
---leaving this in since we still want this to error when/if this gets fixed for hypertables.
+-- ON CONFLICT ON CONSTRAINT
 INSERT INTO r1 VALUES (10)
     ON CONFLICT ON CONSTRAINT r1_pkey DO UPDATE SET a = 30;
-ERROR:  hypertables do not support ON CONFLICT statements that reference constraints
-HINT:  Use column names to infer indexes instead.
+ERROR:  new row violates row-level security policy for table "r1"
 DROP TABLE r1;
 -- Check dependency handling
 RESET SESSION AUTHORIZATION;

--- a/test/expected/rowsecurity-13.out
+++ b/test/expected/rowsecurity-13.out
@@ -4919,12 +4919,10 @@ ERROR:  new row violates row-level security policy for table "r1"
 INSERT INTO r1 VALUES (10)
     ON CONFLICT (a) DO UPDATE SET a = 30;
 ERROR:  new row violates row-level security policy for table "r1"
---will error out because of constraint names not supported on hypertables.
---leaving this in since we still want this to error when/if this gets fixed for hypertables.
+-- ON CONFLICT ON CONSTRAINT
 INSERT INTO r1 VALUES (10)
     ON CONFLICT ON CONSTRAINT r1_pkey DO UPDATE SET a = 30;
-ERROR:  hypertables do not support ON CONFLICT statements that reference constraints
-HINT:  Use column names to infer indexes instead.
+ERROR:  new row violates row-level security policy for table "r1"
 DROP TABLE r1;
 -- Check dependency handling
 RESET SESSION AUTHORIZATION;

--- a/test/expected/rowsecurity-14.out
+++ b/test/expected/rowsecurity-14.out
@@ -4896,12 +4896,10 @@ ERROR:  new row violates row-level security policy for table "r1"
 INSERT INTO r1 VALUES (10)
     ON CONFLICT (a) DO UPDATE SET a = 30;
 ERROR:  new row violates row-level security policy for table "r1"
---will error out because of constraint names not supported on hypertables.
---leaving this in since we still want this to error when/if this gets fixed for hypertables.
+-- ON CONFLICT ON CONSTRAINT
 INSERT INTO r1 VALUES (10)
     ON CONFLICT ON CONSTRAINT r1_pkey DO UPDATE SET a = 30;
-ERROR:  hypertables do not support ON CONFLICT statements that reference constraints
-HINT:  Use column names to infer indexes instead.
+ERROR:  new row violates row-level security policy for table "r1"
 DROP TABLE r1;
 -- Check dependency handling
 RESET SESSION AUTHORIZATION;

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -28,12 +28,16 @@ SELECT * FROM upsert_test;
  Fri Jan 20 09:00:01 2017 | 23.8 | yellow
 (1 row)
 
--- Referencing constraints by name does not yet work on Hypertables. Check for proper error message.
-\set ON_ERROR_STOP 0
+-- Test ON CONFLICT ON CONSTRAINT
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 12.3, 'yellow') ON CONFLICT ON CONSTRAINT upsert_test_pkey
 DO UPDATE SET temp = 12.3 RETURNING time, temp, color;
-ERROR:  hypertables do not support ON CONFLICT statements that reference constraints
+           time           | temp | color  
+--------------------------+------+--------
+ Fri Jan 20 09:00:01 2017 | 12.3 | yellow
+(1 row)
+
 -- Test that update generates error on conflicts
+\set ON_ERROR_STOP 0
 INSERT INTO upsert_test VALUES ('2017-01-21T09:00:01', 22.5, 'yellow') RETURNING *;
            time           | temp | color  
 --------------------------+------+--------
@@ -86,7 +90,7 @@ NOTICE:  adding not-null constraint to column "time"
  (3,public,upsert_test_multi_unique,t)
 (1 row)
 
-CREATE UNIQUE INDEX multi_time_temp_idx ON upsert_test_multi_unique (time, temp);
+ALTER TABLE upsert_test_multi_unique ADD CONSTRAINT multi_time_temp UNIQUE (time, temp);
 CREATE UNIQUE INDEX multi_time_color_idx ON upsert_test_multi_unique (time, color);
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'yellow');
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-21T09:00:01', 25.9, 'yellow');
@@ -102,7 +106,7 @@ SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
 
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'blue') ON CONFLICT (time, temp)
 DO UPDATE SET color = 'blue';
-INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'orange') ON CONFLICT (time, temp)
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'orange') ON CONFLICT ON CONSTRAINT multi_time_temp
 DO UPDATE SET color = excluded.color;
 SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
            time           | temp | color  
@@ -123,15 +127,20 @@ SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
 (3 rows)
 
 \set ON_ERROR_STOP 0
+-- Here the constraint in the ON CONFLICT clause is not the one that is
+-- actually violated by the INSERT, so it should still fail.
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'purple') ON CONFLICT (time, color)
 DO UPDATE set temp = 23.5;
-ERROR:  duplicate key value violates unique constraint "_hyper_3_3_chunk_multi_time_temp_idx"
+ERROR:  duplicate key value violates unique constraint "3_2_multi_time_temp"
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 22.5, 'orange') ON CONFLICT ON CONSTRAINT multi_time_temp
+DO UPDATE set color = 'orange';
+ERROR:  duplicate key value violates unique constraint "_hyper_3_3_chunk_multi_time_color_idx"
 \set ON_ERROR_STOP 1
 CREATE TABLE upsert_test_space(time timestamp, device_id_1 char(20), to_drop int, temp float, color text);
 --drop two columns; create one.
 ALTER TABLE upsert_test_space DROP to_drop;
 ALTER TABLE upsert_test_space DROP device_id_1, ADD device_id char(20);
-CREATE UNIQUE INDEX time_space_idx ON upsert_test_space (time, device_id);
+ALTER TABLE upsert_test_space ADD CONSTRAINT time_space_constraint UNIQUE (time, device_id);
 SELECT create_hypertable('upsert_test_space', 'time', 'device_id', 2, partitioning_func=>'_timescaledb_internal.get_partition_for_key'::regproc);
 NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
@@ -146,7 +155,9 @@ INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20
 (1 row)
 
 INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev2', 25.9, 'yellow');
-INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 23.5, 'orange') ON CONFLICT (time, device_id)
+INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 23.5, 'green') ON CONFLICT (time, device_id)
+DO UPDATE SET color = excluded.color;
+INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 23.5, 'orange') ON CONFLICT ON CONSTRAINT time_space_constraint
 DO UPDATE SET color = excluded.color;
 INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev2', 23.5, 'orange3') ON CONFLICT (time, device_id)
 DO UPDATE SET color = excluded.color||' (originally '|| upsert_test_space.color ||')' RETURNING *;
@@ -181,6 +192,12 @@ DO NOTHING RETURNING *;
 --------------------------+------+---------+----------------------
  Fri Jan 20 09:00:01 2017 | 23.5 | orange5 | dev5                
 (1 row)
+
+INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev5', 23.5, 'orange6') ON CONFLICT ON CONSTRAINT time_space_constraint
+DO NOTHING RETURNING *;
+ time | temp | color | device_id 
+------+------+-------+-----------
+(0 rows)
 
 --restore a column with the same name as a previously deleted one;
 ALTER TABLE upsert_test_space ADD device_id_1 char(20);

--- a/test/sql/rowsecurity.sql.in
+++ b/test/sql/rowsecurity.sql.in
@@ -1778,8 +1778,8 @@ INSERT INTO r1 VALUES (10)
 -- SELECT permissions)
 INSERT INTO r1 VALUES (10)
     ON CONFLICT (a) DO UPDATE SET a = 30;
---will error out because of constraint names not supported on hypertables.
---leaving this in since we still want this to error when/if this gets fixed for hypertables.
+
+-- ON CONFLICT ON CONSTRAINT
 INSERT INTO r1 VALUES (10)
     ON CONFLICT ON CONSTRAINT r1_pkey DO UPDATE SET a = 30;
 

--- a/test/sql/upsert.sql
+++ b/test/sql/upsert.sql
@@ -10,12 +10,12 @@ DO UPDATE SET temp = 23.8 RETURNING *;
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 78.4, 'yellow') ON CONFLICT DO NOTHING;
 SELECT * FROM upsert_test;
 
--- Referencing constraints by name does not yet work on Hypertables. Check for proper error message.
-\set ON_ERROR_STOP 0
+-- Test ON CONFLICT ON CONSTRAINT
 INSERT INTO upsert_test VALUES ('2017-01-20T09:00:01', 12.3, 'yellow') ON CONFLICT ON CONSTRAINT upsert_test_pkey
 DO UPDATE SET temp = 12.3 RETURNING time, temp, color;
 
 -- Test that update generates error on conflicts
+\set ON_ERROR_STOP 0
 INSERT INTO upsert_test VALUES ('2017-01-21T09:00:01', 22.5, 'yellow') RETURNING *;
 UPDATE upsert_test SET time = '2017-01-20T09:00:01';
 \set ON_ERROR_STOP 1
@@ -35,7 +35,7 @@ SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
 -- Test with multiple UNIQUE indexes
 CREATE TABLE upsert_test_multi_unique(time timestamp, temp float, color text);
 SELECT create_hypertable('upsert_test_multi_unique', 'time');
-CREATE UNIQUE INDEX multi_time_temp_idx ON upsert_test_multi_unique (time, temp);
+ALTER TABLE upsert_test_multi_unique ADD CONSTRAINT multi_time_temp UNIQUE (time, temp);
 CREATE UNIQUE INDEX multi_time_color_idx ON upsert_test_multi_unique (time, color);
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'yellow');
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-21T09:00:01', 25.9, 'yellow');
@@ -44,26 +44,33 @@ INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'purpl
 SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 25.9, 'blue') ON CONFLICT (time, temp)
 DO UPDATE SET color = 'blue';
-INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'orange') ON CONFLICT (time, temp)
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'orange') ON CONFLICT ON CONSTRAINT multi_time_temp
 DO UPDATE SET color = excluded.color;
 SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-21T09:00:01', 45.7, 'yellow') ON CONFLICT (time, color)
 DO UPDATE SET temp = 45.7;
+
 SELECT * FROM upsert_test_multi_unique ORDER BY time, color DESC;
 \set ON_ERROR_STOP 0
+-- Here the constraint in the ON CONFLICT clause is not the one that is
+-- actually violated by the INSERT, so it should still fail.
 INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 23.5, 'purple') ON CONFLICT (time, color)
 DO UPDATE set temp = 23.5;
+INSERT INTO upsert_test_multi_unique VALUES ('2017-01-20T09:00:01', 22.5, 'orange') ON CONFLICT ON CONSTRAINT multi_time_temp
+DO UPDATE set color = 'orange';
 \set ON_ERROR_STOP 1
 
 CREATE TABLE upsert_test_space(time timestamp, device_id_1 char(20), to_drop int, temp float, color text);
 --drop two columns; create one.
 ALTER TABLE upsert_test_space DROP to_drop;
 ALTER TABLE upsert_test_space DROP device_id_1, ADD device_id char(20);
-CREATE UNIQUE INDEX time_space_idx ON upsert_test_space (time, device_id);
+ALTER TABLE upsert_test_space ADD CONSTRAINT time_space_constraint UNIQUE (time, device_id);
 SELECT create_hypertable('upsert_test_space', 'time', 'device_id', 2, partitioning_func=>'_timescaledb_internal.get_partition_for_key'::regproc);
 INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 25.9, 'yellow') RETURNING *;
 INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev2', 25.9, 'yellow');
-INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 23.5, 'orange') ON CONFLICT (time, device_id)
+INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 23.5, 'green') ON CONFLICT (time, device_id)
+DO UPDATE SET color = excluded.color;
+INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev1', 23.5, 'orange') ON CONFLICT ON CONSTRAINT time_space_constraint
 DO UPDATE SET color = excluded.color;
 
 INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev2', 23.5, 'orange3') ON CONFLICT (time, device_id)
@@ -78,6 +85,9 @@ INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20
 DO NOTHING RETURNING *;
 
 INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev5', 23.5, 'orange5') ON CONFLICT (time, device_id)
+DO NOTHING RETURNING *;
+
+INSERT INTO upsert_test_space (time, device_id, temp, color) VALUES ('2017-01-20T09:00:01', 'dev5', 23.5, 'orange6') ON CONFLICT ON CONSTRAINT time_space_constraint
 DO NOTHING RETURNING *;
 
 --restore a column with the same name as a previously deleted one;

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -1382,7 +1382,44 @@ VALUES ('2017-09-02 06:09', 6)
 ON CONFLICT(time,device) DO NOTHING;
 ERROR:  could not find arbiter index for hypertable index "disttable_pkey" on chunk "_dist_hyper_1_9_chunk"
 HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT(time,device,"Color") DO NOTHING;
+ERROR:  could not find arbiter index for hypertable index "disttable_color_unique" on chunk "_dist_hyper_1_9_chunk"
+HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT ON CONSTRAINT disttable_color_unique DO NOTHING;
+ERROR:  could not find arbiter index for hypertable index "disttable_color_unique" on chunk "_dist_hyper_1_9_chunk"
+HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
 \set VERBOSITY terse
+SELECT * FROM disttable ORDER BY disttable;
+             time             | device | temp | Color 
+------------------------------+--------+------+-------
+ Sun Jan 01 06:01:00 2017 PST |      1 |  1.1 |      
+ Sun Jan 01 06:05:00 2017 PST |      1 |  1.4 |      
+ Sun Jan 01 08:01:00 2017 PST |      1 |  1.2 |      
+ Sun Jan 01 08:11:00 2017 PST |      3 |  2.3 |      
+ Sun Jan 01 09:11:00 2017 PST |      3 |  2.1 |      
+ Sun Jan 01 09:21:00 2017 PST |      3 |  2.2 |      
+ Mon Jan 02 08:01:00 2017 PST |      2 |  1.3 |      
+ Mon Jan 02 08:21:00 2017 PST |      2 |  1.5 |      
+ Mon Jan 02 09:01:00 2017 PST |      2 |  1.4 |      
+ Sat Sep 02 06:09:00 2017 PDT |      4 |  9.8 |     1
+ Sat Sep 02 06:09:00 2017 PDT |      6 | 10.5 |     2
+ Sun Sep 03 06:18:00 2017 PDT |      9 |  8.7 |     3
+ Sun Jul 01 06:01:00 2018 PDT |     13 |  1.4 |      
+ Sun Jul 01 06:21:00 2018 PDT |     13 |  1.5 |      
+ Sun Jul 01 07:01:00 2018 PDT |     13 |  1.4 |      
+ Sun Jul 01 08:01:00 2018 PDT |     29 |  1.5 |      
+ Sun Jul 01 08:21:00 2018 PDT |     29 |  1.2 |      
+ Sun Jul 01 09:11:00 2018 PDT |     90 |  2.7 |      
+ Sun Jul 01 09:21:00 2018 PDT |     90 |  2.8 |      
+ Mon Jul 02 08:01:00 2018 PDT |     87 |  1.6 |      
+ Mon Jul 02 09:01:00 2018 PDT |     87 |  1.4 |      
+ Mon Jul 02 09:21:00 2018 PDT |     87 |  1.8 |      
+(22 rows)
+
 -- ON CONFLICT only works with DO NOTHING for now
 INSERT INTO disttable (time, device, "Color", temp)
 VALUES ('2017-09-09 08:13', 7, 3, 27.5)

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -1381,7 +1381,44 @@ VALUES ('2017-09-02 06:09', 6)
 ON CONFLICT(time,device) DO NOTHING;
 ERROR:  could not find arbiter index for hypertable index "disttable_pkey" on chunk "_dist_hyper_1_9_chunk"
 HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT(time,device,"Color") DO NOTHING;
+ERROR:  could not find arbiter index for hypertable index "disttable_color_unique" on chunk "_dist_hyper_1_9_chunk"
+HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT ON CONSTRAINT disttable_color_unique DO NOTHING;
+ERROR:  could not find arbiter index for hypertable index "disttable_color_unique" on chunk "_dist_hyper_1_9_chunk"
+HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
 \set VERBOSITY terse
+SELECT * FROM disttable ORDER BY disttable;
+             time             | device | temp | Color 
+------------------------------+--------+------+-------
+ Sun Jan 01 06:01:00 2017 PST |      1 |  1.1 |      
+ Sun Jan 01 06:05:00 2017 PST |      1 |  1.4 |      
+ Sun Jan 01 08:01:00 2017 PST |      1 |  1.2 |      
+ Sun Jan 01 08:11:00 2017 PST |      3 |  2.3 |      
+ Sun Jan 01 09:11:00 2017 PST |      3 |  2.1 |      
+ Sun Jan 01 09:21:00 2017 PST |      3 |  2.2 |      
+ Mon Jan 02 08:01:00 2017 PST |      2 |  1.3 |      
+ Mon Jan 02 08:21:00 2017 PST |      2 |  1.5 |      
+ Mon Jan 02 09:01:00 2017 PST |      2 |  1.4 |      
+ Sat Sep 02 06:09:00 2017 PDT |      4 |  9.8 |     1
+ Sat Sep 02 06:09:00 2017 PDT |      6 | 10.5 |     2
+ Sun Sep 03 06:18:00 2017 PDT |      9 |  8.7 |     3
+ Sun Jul 01 06:01:00 2018 PDT |     13 |  1.4 |      
+ Sun Jul 01 06:21:00 2018 PDT |     13 |  1.5 |      
+ Sun Jul 01 07:01:00 2018 PDT |     13 |  1.4 |      
+ Sun Jul 01 08:01:00 2018 PDT |     29 |  1.5 |      
+ Sun Jul 01 08:21:00 2018 PDT |     29 |  1.2 |      
+ Sun Jul 01 09:11:00 2018 PDT |     90 |  2.7 |      
+ Sun Jul 01 09:21:00 2018 PDT |     90 |  2.8 |      
+ Mon Jul 02 08:01:00 2018 PDT |     87 |  1.6 |      
+ Mon Jul 02 09:01:00 2018 PDT |     87 |  1.4 |      
+ Mon Jul 02 09:21:00 2018 PDT |     87 |  1.8 |      
+(22 rows)
+
 -- ON CONFLICT only works with DO NOTHING for now
 INSERT INTO disttable (time, device, "Color", temp)
 VALUES ('2017-09-09 08:13', 7, 3, 27.5)

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -1385,7 +1385,44 @@ VALUES ('2017-09-02 06:09', 6)
 ON CONFLICT(time,device) DO NOTHING;
 ERROR:  could not find arbiter index for hypertable index "disttable_pkey" on chunk "_dist_hyper_1_9_chunk"
 HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT(time,device,"Color") DO NOTHING;
+ERROR:  could not find arbiter index for hypertable index "disttable_color_unique" on chunk "_dist_hyper_1_9_chunk"
+HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT ON CONSTRAINT disttable_color_unique DO NOTHING;
+ERROR:  could not find arbiter index for hypertable index "disttable_color_unique" on chunk "_dist_hyper_1_9_chunk"
+HINT:  Omit the index inference specification for the distributed hypertable in the ON CONFLICT clause.
 \set VERBOSITY terse
+SELECT * FROM disttable ORDER BY disttable;
+             time             | device | temp | Color 
+------------------------------+--------+------+-------
+ Sun Jan 01 06:01:00 2017 PST |      1 |  1.1 |      
+ Sun Jan 01 06:05:00 2017 PST |      1 |  1.4 |      
+ Sun Jan 01 08:01:00 2017 PST |      1 |  1.2 |      
+ Sun Jan 01 08:11:00 2017 PST |      3 |  2.3 |      
+ Sun Jan 01 09:11:00 2017 PST |      3 |  2.1 |      
+ Sun Jan 01 09:21:00 2017 PST |      3 |  2.2 |      
+ Mon Jan 02 08:01:00 2017 PST |      2 |  1.3 |      
+ Mon Jan 02 08:21:00 2017 PST |      2 |  1.5 |      
+ Mon Jan 02 09:01:00 2017 PST |      2 |  1.4 |      
+ Sat Sep 02 06:09:00 2017 PDT |      4 |  9.8 |     1
+ Sat Sep 02 06:09:00 2017 PDT |      6 | 10.5 |     2
+ Sun Sep 03 06:18:00 2017 PDT |      9 |  8.7 |     3
+ Sun Jul 01 06:01:00 2018 PDT |     13 |  1.4 |      
+ Sun Jul 01 06:21:00 2018 PDT |     13 |  1.5 |      
+ Sun Jul 01 07:01:00 2018 PDT |     13 |  1.4 |      
+ Sun Jul 01 08:01:00 2018 PDT |     29 |  1.5 |      
+ Sun Jul 01 08:21:00 2018 PDT |     29 |  1.2 |      
+ Sun Jul 01 09:11:00 2018 PDT |     90 |  2.7 |      
+ Sun Jul 01 09:21:00 2018 PDT |     90 |  2.8 |      
+ Mon Jul 02 08:01:00 2018 PDT |     87 |  1.6 |      
+ Mon Jul 02 09:01:00 2018 PDT |     87 |  1.4 |      
+ Mon Jul 02 09:21:00 2018 PDT |     87 |  1.8 |      
+(22 rows)
+
 -- ON CONFLICT only works with DO NOTHING for now
 INSERT INTO disttable (time, device, "Color", temp)
 VALUES ('2017-09-09 08:13', 7, 3, 27.5)

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -424,7 +424,17 @@ $$);
 INSERT INTO disttable
 VALUES ('2017-09-02 06:09', 6)
 ON CONFLICT(time,device) DO NOTHING;
+
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT(time,device,"Color") DO NOTHING;
+
+INSERT INTO disttable
+VALUES ('2017-09-02 06:09', 6)
+ON CONFLICT ON CONSTRAINT disttable_color_unique DO NOTHING;
 \set VERBOSITY terse
+
+SELECT * FROM disttable ORDER BY disttable;
 
 -- ON CONFLICT only works with DO NOTHING for now
 INSERT INTO disttable (time, device, "Color", temp)


### PR DESCRIPTION
Looks like it might work since we started to rely on Postgres' arbiter
index inference.

Fixes https://github.com/timescale/timescaledb/issues/1094