### PR TITLE
Install clang-tidy-9 explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ if(LINTER)
 
   if(CLANG_TIDY)
     message(STATUS "Linter support (clang-tidy) enabled")
+    execute_process(COMMAND ${CLANG_TIDY} --version)
     if(LINTER_STRICT)
       set(CMAKE_C_CLANG_TIDY
           "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses;--warnings-as-errors=*"

--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -50,7 +50,7 @@ def build_debug_config(overrides):
     "tsdb_build_args": "-DCODECOVERAGE=ON -DWARNINGS_AS_ERRORS=ON",
     "installcheck_args": "IGNORES='bgw_db_scheduler'",
     "coverage": True,
-    "extra_packages": "clang-9 llvm-9 llvm-9-dev llvm-9-tools",
+    "extra_packages": "clang-9 llvm-9 llvm-9-dev llvm-9-tools clang-tidy-9",
     "llvm_config": "llvm-config-9",
     "clang": "clang-9",
     "os": "ubuntu-20.04",


### PR DESCRIPTION
Looks like we might have used some other version that is installed by
default.