### PR TITLE
Don't force clang-tidy on

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DREQUIRE_ALL_TESTS=ON -DLINTER_STRICT=ON -DLINTER=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DREQUIRE_ALL_TESTS=ON -DLINTER_STRICT=ON -DCMAKE_VERBOSE_MAKEFILE=ON
         make -j $MAKE_JOBS -C build
         make -C build install
 


### PR DESCRIPTION
If the compiler is gcc, clang-tidy might not recognize some of its
flags and error out. It will be enabled by default if the compiler is
clang.