### PR TITLE
Fix crash during insert into distributed hypertable

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -80,10 +80,11 @@ jobs:
       shell: bash
       run: |
         if compgen -G "/tmp/core*" > /dev/null; then
-          apt-get install postgresql-${{ matrix.pg_major }}-dbgsym >/dev/null
+          PG_MAJOR=$(echo "${{ matrix.pg }}" | sed -e 's![.].*!!')
+          apt-get install postgresql-${PG_MAJOR}-dbgsym >/dev/null
           for file in /tmp/core*
           do
-            gdb /usr/lib/postgresql/${{ matrix.pg_major }}/bin/postgres -c $file <<<'bt full' | tee -a stacktraces.log
+            gdb /usr/lib/postgresql/${PG_MAJOR}/bin/postgres -c $file <<<'bt full' | tee -a stacktraces.log
           done
           echo "::set-output name=coredumps::true"
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ accidentally triggering the load of a previous DB version.**
 * #4393 Support intervals with day component when constifying now()
 * #4397 Support intervals with month component when constifying now()
 
+**Thanks**
+@nikugogoi for reporting a bug with CTEs and upserts on distributed hypertables
+
 ## 2.7.0 (2022-05-24)
 
 This release adds major new features since the 2.6.1 release.

--- a/src/nodes/chunk_dispatch_state.h
+++ b/src/nodes/chunk_dispatch_state.h
@@ -10,6 +10,8 @@
 #include <nodes/execnodes.h>
 #include <nodes/parsenodes.h>
 
+#include "export.h"
+
 typedef struct ChunkDispatch ChunkDispatch;
 typedef struct Cache Cache;
 
@@ -35,7 +37,7 @@ typedef struct ChunkDispatchState
 	ResultRelInfo *rri;
 } ChunkDispatchState;
 
-extern bool ts_is_chunk_dispatch_state(PlanState *state);
+extern TSDLLEXPORT bool ts_is_chunk_dispatch_state(PlanState *state);
 extern ChunkDispatchState *ts_chunk_dispatch_state_create(Oid hypertable_oid, Plan *plan);
 extern void ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *parent);
 

--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -710,10 +710,6 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 										  RelationGetDescr(rel),
 										  gettext_noop("could not convert row type"));
 
-	// relinfo->ri_RootToPartitionMap = state->hyper_to_chunk_map;
-	// relinfo->ri_PartitionTupleSlot = table_slot_create(relinfo->ri_RelationDesc,
-	// &state->estate->es_tupleTable);
-
 	adjust_projections(state, dispatch, RelationGetForm(rel)->reltype);
 
 	if (has_compressed_chunk)

--- a/tsl/src/nodes/data_node_copy.c
+++ b/tsl/src/nodes/data_node_copy.c
@@ -35,12 +35,21 @@ typedef struct DataNodeCopyPath
 	ModifyTablePath *mtpath;
 	Index hypertable_rti; /* range table index of Hypertable */
 	int subplan_index;
+	Path *chunk_dispatch; /* The planner can inject, e.g., Result nodes
+						   * inbetween the chunk_dispatch path and the
+						   * DataNodeCopyPath, so keep a pointer directly to
+						   * the ChunkDispatchPath. */
 } DataNodeCopyPath;
 
 /*
- * DataNodeCopy dispatches tuples to data nodes using batching. It inserts
- * itself below a ModifyTable node in the plan and subsequent execution tree,
- * like so:
+ * DataNodeCopy turns a client's INSERT on the access node into a COPY between
+ * the access node and data nodes. This is more efficient than the regular
+ * text or binary PG protocol which typically requires setting up a prepared
+ * statement. Note that DataNodeCopy cannot be used for all INSERTs, e.g., it
+ * doesn't support ON CONFLICT statements or RETURNING clauses if there are
+ * triggers that could modify the inserted tuples when returned by data
+ * nodes. The DataNodeCopy node inserts itself below a ModifyTable node in the
+ * plan and subsequent execution tree, like so:
  *
  *          --------------------   Set "direct modify plans" to
  *          | HypertableInsert |   signal ModifyTable to only
@@ -74,6 +83,7 @@ typedef struct DataNodeCopyState
 	Cache *hcache;
 	Hypertable *ht;
 	RemoteCopyContext *copy_ctx;
+	ChunkDispatchState *cds;
 } DataNodeCopyState;
 
 /*
@@ -131,6 +141,7 @@ data_node_copy_begin(CustomScanState *node, EState *estate, int eflags)
 		.options = NIL,
 	};
 
+	dncs->cds = NULL;
 	dncs->ht = ts_hypertable_cache_get_cache_and_entry(rel->rd_id, CACHE_FLAG_NONE, &dncs->hcache);
 	Assert(hypertable_is_distributed(dncs->ht));
 
@@ -138,6 +149,30 @@ data_node_copy_begin(CustomScanState *node, EState *estate, int eflags)
 		use_binary_encoding = false;
 
 	ps = ExecInitNode(subplan, estate, eflags);
+
+	switch (nodeTag(ps))
+	{
+		case T_ResultState:
+		{
+			/* The planner injected a Result node so we need to get the
+			 * ChunkDispatchState from the Result's child */
+			const ResultState *result = castNode(ResultState, ps);
+			PlanState *child = result->ps.lefttree;
+
+			if (child != NULL && ts_is_chunk_dispatch_state(child))
+				dncs->cds = (ChunkDispatchState *) child;
+			break;
+		}
+		case T_CustomScanState:
+			if (ts_is_chunk_dispatch_state(ps))
+				dncs->cds = (ChunkDispatchState *) ps;
+			break;
+		default:
+			break;
+	}
+
+	if (NULL == dncs->cds)
+		elog(ERROR, "unexpected child plan node %d for DataNodeCopy", nodeTag(ps));
 
 	node->custom_ps = list_make1(ps);
 	dncs->rel = rel;
@@ -150,20 +185,22 @@ data_node_copy_begin(CustomScanState *node, EState *estate, int eflags)
 }
 
 /*
- * Execute the remote INSERT.
+ * Execute the INSERT using remote COPY.
  *
  * This is called every time the parent asks for a new tuple. Read the child
- * scan node and buffer until there's a full batch, then flush by sending to
- * data node(s). If there's a returning statement, we return the flushed tuples
- * one-by-one, or continue reading more tuples from the child until there's a
- * NULL tuple.
+ * scan node and send the resulting tuple on the data node connection in
+ * COPY_IN state.
+ *
+ * Note that a tuple is only returned to the parent node in case RETURNING is
+ * specified. Otherwise, process all tuples and return an empty slot to the
+ * parent ModifyTableState.
  */
 static TupleTableSlot *
 data_node_copy_exec(CustomScanState *node)
 {
 	DataNodeCopyState *dncs = (DataNodeCopyState *) node;
 	PlanState *substate = linitial(dncs->cstate.custom_ps);
-	ChunkDispatchState *cds = (ChunkDispatchState *) substate;
+	ChunkDispatchState *cds = dncs->cds;
 	EState *estate = node->ss.ps.state;
 #if PG14_LT
 	ResultRelInfo *rri_saved = estate->es_result_relation_info;
@@ -171,7 +208,7 @@ data_node_copy_exec(CustomScanState *node)
 	ResultRelInfo *rri_saved = linitial_node(ResultRelInfo, estate->es_opened_result_relations);
 #endif
 	TupleTableSlot *slot;
-	bool has_returning = rri_saved->ri_projectReturning != NULL;
+	bool has_returning = castNode(ModifyTable, cds->mtstate->ps.plan)->returningLists != NIL;
 
 #if PG14_LT
 	/* Initially, the result relation should always match the hypertable.  */
@@ -231,6 +268,8 @@ data_node_copy_exec(CustomScanState *node)
 	Assert(node->ss.ps.state->es_result_relation_info->ri_RelationDesc->rd_id == dncs->rel->rd_id);
 	Assert(node->ss.ps.state->es_result_relation_info->ri_usesFdwDirectModify);
 #endif
+
+	Assert(TupIsNull(slot) || has_returning);
 
 	return slot;
 }
@@ -396,6 +435,7 @@ data_node_copy_plan_create(PlannerInfo *root, RelOptInfo *rel, struct CustomPath
 	Assert(list_length(custom_plans) == 1);
 
 	subplan = linitial(custom_plans);
+
 	cscan->methods = &data_node_copy_plan_methods;
 	cscan->custom_plans = custom_plans;
 	cscan->scan.scanrelid = 0;
@@ -428,6 +468,7 @@ data_node_copy_path_create(PlannerInfo *root, ModifyTablePath *mtpath, Index hyp
 	sdpath->mtpath = mtpath;
 	sdpath->hypertable_rti = hypertable_rti;
 	sdpath->subplan_index = subplan_index;
+	sdpath->chunk_dispatch = subpath;
 
 	return &sdpath->cpath.path;
 }

--- a/tsl/src/nodes/data_node_dispatch.c
+++ b/tsl/src/nodes/data_node_dispatch.c
@@ -175,6 +175,7 @@ typedef struct DataNodeDispatchState
 								 * standard ScanSlot in the ScanState because
 								 * CustomNode sets it up to be a
 								 * VirtualTuple. */
+	ChunkDispatchState *cds;
 } DataNodeDispatchState;
 
 /*
@@ -325,6 +326,30 @@ data_node_dispatch_begin(CustomScanState *node, EState *estate, int eflags)
 	Assert(NIL != available_nodes);
 
 	ps = ExecInitNode(subplan, estate, eflags);
+
+	switch (nodeTag(ps))
+	{
+		case T_ResultState:
+		{
+			/* The planner injected a Result node so we need to get the
+			 * ChunkDispatchState from the Result's child */
+			const ResultState *result = castNode(ResultState, ps);
+			PlanState *child = result->ps.lefttree;
+
+			if (child != NULL && ts_is_chunk_dispatch_state(child))
+				sds->cds = (ChunkDispatchState *) child;
+			break;
+		}
+		case T_CustomScanState:
+			if (ts_is_chunk_dispatch_state(ps))
+				sds->cds = (ChunkDispatchState *) ps;
+			break;
+		default:
+			break;
+	}
+
+	if (NULL == sds->cds)
+		elog(ERROR, "unexpected child plan node %d for DataNodeDispatch", nodeTag(ps));
 
 	node->custom_ps = list_make1(ps);
 	sds->state = SD_READ;
@@ -681,7 +706,7 @@ static int64
 handle_read(DataNodeDispatchState *sds)
 {
 	PlanState *substate = linitial(sds->cstate.custom_ps);
-	ChunkDispatchState *cds = (ChunkDispatchState *) substate;
+	ChunkDispatchState *cds = sds->cds;
 	EState *estate = sds->cstate.ss.ps.state;
 #if PG14_LT
 	ResultRelInfo *rri_saved = estate->es_result_relation_info;
@@ -725,7 +750,7 @@ handle_read(DataNodeDispatchState *sds)
 
 			/* While we could potentially support triggers on frontend nodes,
 			 * the triggers should exists also on the remote node and will be
-			 * executed there. For new, the safest bet is to avoid triggers on
+			 * executed there. For now, the safest bet is to avoid triggers on
 			 * the frontend. */
 			if (trigdesc && (trigdesc->trig_insert_after_row || trigdesc->trig_insert_before_row))
 				elog(ERROR, "cannot insert into remote chunk with row triggers");
@@ -808,8 +833,7 @@ handle_flush(DataNodeDispatchState *sds)
 static TupleTableSlot *
 get_returning_tuple(DataNodeDispatchState *sds)
 {
-	ChunkDispatchState *cds = (ChunkDispatchState *) linitial(sds->cstate.custom_ps);
-	ResultRelInfo *rri = cds->rri;
+	ResultRelInfo *rri = sds->cds->rri;
 	TupleTableSlot *res_slot = sds->batch_slot;
 	TupleTableSlot *slot = sds->cstate.ss.ss_ScanTupleSlot;
 	ExprContext *econtext;
@@ -893,8 +917,7 @@ static TupleTableSlot *
 handle_returning(DataNodeDispatchState *sds)
 {
 	EState *estate = sds->cstate.ss.ps.state;
-	ChunkDispatchState *cds = (ChunkDispatchState *) linitial(sds->cstate.custom_ps);
-	ResultRelInfo *rri = cds->rri;
+	ResultRelInfo *rri = sds->cds->rri;
 	TupleTableSlot *slot = sds->cstate.ss.ss_ScanTupleSlot;
 	bool done = false;
 	MemoryContext oldcontext;

--- a/tsl/test/shared/expected/dist_queries.out
+++ b/tsl/test/shared/expected/dist_queries.out
@@ -17,3 +17,63 @@ ORDER BY id;
   4
 (4 rows)
 
+-- Test query that inserts a Result node between ChunkDispatch and
+-- DataNodeDispatch/DataNodeCopy. Fix for bug
+-- https://github.com/timescale/timescaledb/issues/4339
+SET timescaledb.enable_distributed_insert_with_copy=false;
+BEGIN;
+WITH upsert AS (
+  UPDATE matches
+  SET day = day - 1
+  WHERE location = 'old trafford'
+  RETURNING *
+) INSERT INTO matches (day, location, team1, team2)
+SELECT 9, 'old trafford', 'MNU', 'MNC'
+WHERE NOT EXISTS (SELECT 1 FROM upsert);
+SELECT * FROM matches ORDER BY 1,2,3,4;
+ day |   location   | team1 | team2 
+-----+--------------+-------+-------
+   1 | camp nou     | BAR   | RMD
+   6 | anfield      | LIV   | ARS
+   9 | old trafford | MNU   | MNC
+(3 rows)
+
+ROLLBACK;
+SET timescaledb.enable_distributed_insert_with_copy=true;
+BEGIN;
+WITH upsert AS (
+  UPDATE matches
+  SET day = day - 1
+  WHERE location = 'old trafford'
+  RETURNING *
+) INSERT INTO matches (day, location, team1, team2)
+SELECT 9, 'old trafford', 'MNU', 'MNC'
+WHERE NOT EXISTS (SELECT 1 FROM upsert);
+SELECT * FROM matches ORDER BY 1,2,3,4;
+ day |   location   | team1 | team2 
+-----+--------------+-------+-------
+   1 | camp nou     | BAR   | RMD
+   6 | anfield      | LIV   | ARS
+   9 | old trafford | MNU   | MNC
+(3 rows)
+
+ROLLBACK;
+-- Reference. The two queries above should be like this one:
+BEGIN;
+WITH upsert AS (
+  UPDATE matches_reference
+  SET day = day - 1
+  WHERE location = 'old trafford'
+  RETURNING *
+) INSERT INTO matches_reference (day, location, team1, team2)
+SELECT 9, 'old trafford', 'MNU', 'MNC'
+WHERE NOT EXISTS (SELECT 1 FROM upsert);
+SELECT * FROM matches_reference ORDER BY 1,2,3,4;
+ day |   location   | team1 | team2 
+-----+--------------+-------+-------
+   1 | camp nou     | BAR   | RMD
+   6 | anfield      | LIV   | ARS
+   9 | old trafford | MNU   | MNC
+(3 rows)
+
+ROLLBACK;

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -287,3 +287,21 @@ INSERT INTO disttable_with_ct VALUES
     ('2019-01-01 01:01', 'ts-1-10-20-30', 1.1, 'a'),
     ('2019-01-01 01:02', 'ts-1-11-20-30', 2.0, repeat('abc', 1000000)); -- TOAST
 
+-- Createt table to test fix for https://github.com/timescale/timescaledb/issues/4339
+CREATE TABLE matches (
+  day INT NOT NULL,
+  location TEXT NOT NULL,
+  team1 TEXT NOT NULL,
+  team2 TEXT NOT NULL
+);
+
+SELECT create_distributed_hypertable('matches', 'day', 'location', chunk_time_interval => 5);
+INSERT INTO matches
+VALUES
+  (1, 'camp nou', 'BAR', 'RMD'),
+  (6, 'anfield', 'LIV', 'ARS');
+
+-- Create a reference table (non hypertable) to compare results
+CREATE TABLE matches_reference (LIKE matches);
+INSERT INTO matches_reference SELECT * FROM matches;
+


### PR DESCRIPTION
For certain inserts on a distributed hypertable, e.g., involving CTEs
and upserts, plans can be generated that weren't properly handled by
the DataNodeCopy and DataNodeDispatch execution nodes. In particular,
the nodes expect ChunkDispatch as a child node, but PostgreSQL can
sometimes insert a Result node above ChunkDispatch, causing the crash.

Further, behavioral changes in PG14 also caused the DataNodeCopy node
to sometimes wrongly believe a RETURNING clause was present. The check
for returning clauses has been updated to fix this issue.

Fixes #4339

Disable-Check: Commit-Count