### PR TITLE
Don't redefine PGDLLEXPORT

### DIFF
--- a/src/export.h
+++ b/src/export.h
@@ -10,32 +10,6 @@
 
 #include "config.h"
 
-/* Definitions for symbol exports */
-
-#define TS_CAT(x, y) x##y
-
-#define TS_EMPTY(x) (TS_CAT(x, 87628) == 87628)
-
-#if defined(_WIN32) && !defined(WIN32)
-#define WIN32
-#endif
-
-#if !defined(WIN32) && !defined(__CYGWIN__)
-#if __GNUC__ >= 4
-#if defined(PGDLLEXPORT)
-#if TS_EMPTY(PGDLLEXPORT)
-/* PGDLLEXPORT is defined but empty. We can safely undef it. */
-#undef PGDLLEXPORT
-#else
-#error "PGDLLEXPORT is already defined"
-#endif
-#endif /* defined(PGDLLEXPORT) */
-#define PGDLLEXPORT __attribute__((visibility("default")))
-#else
-#error "Unsupported GNUC version"
-#endif /* __GNUC__ */
-#endif
-
 /*
  * On windows, symbols shared across modules have to be marked "export" in the
  * main TimescaleDb module and "import" in the submodule. Since we want to use the


### PR DESCRIPTION
This code was introduced in 027b7b29 but unfortunatelly the commit message
doesn't clarify the need to redefine PGDLLEXORT. It should be defined correctly
by Postgres and we shouldn't touch it.

This was not a problem until recently. This code is not going to work with
the upcoming support of Meson build system in the upstream, and as long as
this code is present the extension can't be tested for compatibility with
the upstream.

Per discussion:
https://www.postgresql.org/message-id/20220602152257.szbstfitf3lwdssp%40alap3.anarazel.de