### PR TITLE
Fix removal of constified constraints

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1101,6 +1101,9 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 	if (!rte->inh && ts_rte_is_marked_for_expansion(rte))
 		reenable_inheritance(root, rel, rti, rte);
 
+	if (ts_guc_enable_optimizations)
+		ts_planner_constraint_cleanup(root, rel);
+
 	/* Call other extensions. Do it after table expansion. */
 	if (prev_set_rel_pathlist_hook != NULL)
 		(*prev_set_rel_pathlist_hook)(root, rel, rti, rte);
@@ -1114,8 +1117,6 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 			break;
 		case TS_REL_CHUNK:
 		case TS_REL_CHUNK_CHILD:
-			if (ts_guc_enable_optimizations)
-				ts_planner_constraint_cleanup(root, rel);
 
 			if (IS_UPDL_CMD(root->parse))
 			{

--- a/tsl/test/shared/expected/constify_now-12.out
+++ b/tsl/test/shared/expected/constify_now-12.out
@@ -254,7 +254,7 @@ QUERY PLAN
    Update on const_now
    Update on _hyper_X_X_chunk
    ->  Seq Scan on const_now
-         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+         Filter: ("time" > now())
    ->  Index Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
          Index Cond: ("time" > now())
 (7 rows)
@@ -266,7 +266,7 @@ QUERY PLAN
    Delete on const_now
    Delete on _hyper_X_X_chunk
    ->  Seq Scan on const_now
-         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+         Filter: ("time" > now())
    ->  Index Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
          Index Cond: ("time" > now())
 (7 rows)

--- a/tsl/test/shared/expected/constify_now-13.out
+++ b/tsl/test/shared/expected/constify_now-13.out
@@ -254,7 +254,7 @@ QUERY PLAN
    Update on const_now
    Update on _hyper_X_X_chunk const_now_1
    ->  Seq Scan on const_now
-         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+         Filter: ("time" > now())
    ->  Index Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk const_now_1
          Index Cond: ("time" > now())
 (7 rows)
@@ -266,7 +266,7 @@ QUERY PLAN
    Delete on const_now
    Delete on _hyper_X_X_chunk const_now_1
    ->  Seq Scan on const_now
-         Filter: (("time" > 'Mon Jan 01 00:00:00 1990 PST'::timestamp with time zone) AND ("time" > now()))
+         Filter: ("time" > now())
    ->  Index Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk const_now_1
          Index Cond: ("time" > now())
 (7 rows)


### PR DESCRIPTION
Commit dcb7dcc5 removed the constified intermediate values used
during hypertable expansion but only did so completely for PG14.
For PG12 and PG13 some constraints remained in the plan.