### PR TITLE
Fix segfault in subscription_exec

### DIFF
--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -276,6 +276,9 @@ tsl_subscription_exec(PG_FUNCTION_ARGS)
 	List *parsetree_list;
 	ListCell *parsetree_item;
 
+	if (!subscription_cmd)
+		PG_RETURN_VOID();
+
 	/*
 	 * Subscription command needs a superuser
 	 * so switch to that context. But first check that the passed in user has atleast

--- a/tsl/test/t/002_chunk_copy_move.pl
+++ b/tsl/test/t/002_chunk_copy_move.pl
@@ -109,6 +109,10 @@ for my $node ($an, $dn1, $dn2)
 	$node->safe_psql('postgres', "ALTER ROLE testrole REPLICATION;");
 }
 
+#Check that the function does not segfault on NULL arguments
+($ret, $stdout, $stderr) = $an->psql('postgres',
+	"SELECT timescaledb_experimental.subscription_exec(NULL)");
+
 #Check that function errors out if any non SUBSCRIPTON command is passed to it
 ($ret, $stdout, $stderr) = $an->psql('postgres',
 	"SET ROLE testrole; SELECT timescaledb_experimental.subscription_exec('DROP ROLE testrole')"


### PR DESCRIPTION
Add a check for NULL input to subscription_exec as the function
currently segfaults on NULL input. Found by sqlsmith.