### PR TITLE
Fix perms in copy/move chunk

### DIFF
--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -83,11 +83,6 @@ LINE 1: ...ROM _timescaledb_internal.create_chunk('chunkapi',' {"time: ...
                                                              ^
 DETAIL:  Token "device" is invalid.
 CONTEXT:  JSON data, line 1:  {"time: [1515024000000000] "device...
--- Valid chunk, but no permissions
-SET ROLE :ROLE_DEFAULT_PERM_USER_2;
-SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', 'ChunkSchema', 'My_chunk_Table_name');
-ERROR:  permission denied for table "chunkapi"
-DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- Test create_chunk_table for errors
@@ -135,11 +130,6 @@ LINE 1: ...imescaledb_internal.create_chunk_table('chunkapi',' {"time: ...
                                                              ^
 DETAIL:  Token "device" is invalid.
 CONTEXT:  JSON data, line 1:  {"time: [1515024000000000] "device...
--- Valid chunk, but no permissions
-SET ROLE :ROLE_DEFAULT_PERM_USER_2;
-SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
-ERROR:  permission denied for table "chunkapi"
-DETAIL:  Insert privileges required on "chunkapi" to create chunks.
 \set ON_ERROR_STOP 1
 -- Test that granting insert on tables allow create_chunk to be
 -- called. This will also create a chunk that does not collide and has

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -43,9 +43,6 @@ SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": ["1514419
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [1515024000000000], "device": [-9223372036854775808, 1073741823]}');
 -- Bad slices json
 SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time: [1515024000000000] "device": [-9223372036854775808, 1073741823]}');
--- Valid chunk, but no permissions
-SET ROLE :ROLE_DEFAULT_PERM_USER_2;
-SELECT * FROM _timescaledb_internal.create_chunk('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', 'ChunkSchema', 'My_chunk_Table_name');
 \set ON_ERROR_STOP 1
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
@@ -72,9 +69,6 @@ SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": ["1
 SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
 -- Bad slices json
 SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time: [1515024000000000] "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
--- Valid chunk, but no permissions
-SET ROLE :ROLE_DEFAULT_PERM_USER_2;
-SELECT * FROM _timescaledb_internal.create_chunk_table('chunkapi',' {"time": [1515024000000000, 1519024000000000], "device": [-9223372036854775808, 1073741823]}', '_timescaledb_internal','_hyper_1_1_chunk');
 \set ON_ERROR_STOP 1
 
 -- Test that granting insert on tables allow create_chunk to be


### PR DESCRIPTION
We mandate that a superuser or a user with REPLICATION privileges can
invoke copy_chunk or move_chunk procedures. Internally, many stages
are carried out to complete the activity and different stages need
different user permissions. To keep things uniform we now switch to the
bootstrap superuser in each stage. Care is taken to ensure that the
original hypertable ownership is retained on the new chunk post the
move operation.