### PR TITLE
Add stateful partition mappings

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -128,7 +128,32 @@ SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension', '')
 
 SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.dimension', 'id'), '');
 
--- A dimension slice defines a keyspace range along a dimension axis.
+-- A dimension partition represents the current division of a (space)
+-- dimension into partitions, and the mapping of those partitions to
+-- data nodes. When a chunk is created, it will use the partition and
+-- data nodes information in this table to decide range and node
+-- placement of the chunk.
+--
+-- Normally, only closed/space dimensions are pre-partitioned and
+-- present in this table. The dimension stretches from -INF to +INF
+-- and the range_start value for a partition represents where the
+-- partition starts, stretching to the start of the next partition
+-- (non-inclusive). There is no range_end since it is implicit by the
+-- start of the next partition and thus uses less space. Having no end
+-- also makes it easier to split partitions by inserting a new row
+-- instead of potentially updating multiple rows.
+CREATE TABLE _timescaledb_catalog.dimension_partition (
+  dimension_id integer NOT NULL REFERENCES _timescaledb_catalog.dimension (id) ON DELETE CASCADE,
+  range_start bigint NOT NULL,
+  data_nodes name[] NULL,
+  UNIQUE (dimension_id, range_start)
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension_partition', '');
+
+-- A dimension slice defines a keyspace range along a dimension
+-- axis. A chunk references a slice in each of its dimensions, forming
+-- a hypercube.
 CREATE TABLE _timescaledb_catalog.dimension_slice (
   id serial NOT NULL,
   dimension_id integer NOT NULL,

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,4 +1,11 @@
 DROP FUNCTION IF EXISTS @extschema@.add_retention_policy(REGCLASS, "any", BOOL);
-
 DROP FUNCTION IF EXISTS @extschema@.add_compression_policy(REGCLASS, "any", BOOL);
 DROP FUNCTION IF EXISTS @extschema@.detach_data_node;
+CREATE TABLE _timescaledb_catalog.dimension_partition (
+  dimension_id integer NOT NULL REFERENCES _timescaledb_catalog.dimension (id) ON DELETE CASCADE,
+  range_start bigint NOT NULL,
+  data_nodes name[] NULL,
+  UNIQUE (dimension_id, range_start)
+);
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension_partition', '');
+GRANT SELECT ON _timescaledb_catalog.dimension_partition TO PUBLIC;

--- a/sql/updates/post-update.sql
+++ b/sql/updates/post-update.sql
@@ -123,3 +123,12 @@ BEGIN
     END IF;
   END IF;
 END $$;
+
+
+-- Create dimension partition information for existing space-partitioned hypertables
+CREATE FUNCTION _timescaledb_internal.update_dimension_partition(hypertable REGCLASS) RETURNS VOID AS '@MODULE_PATHNAME@', 'ts_dimension_partition_update' LANGUAGE C VOLATILE;
+SELECT _timescaledb_internal.update_dimension_partition(format('%I.%I', h.schema_name, h.table_name))
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.dimension d ON (d.hypertable_id = h.id)
+WHERE d.interval_length IS NULL; 
+DROP FUNCTION _timescaledb_internal.update_dimension_partition;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -15,3 +15,10 @@ CREATE FUNCTION @extschema@.detach_data_node(
     repartition            BOOLEAN = TRUE
 ) RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_data_node_detach' LANGUAGE C VOLATILE;
+
+DROP FUNCTION _timescaledb_internal.attach_osm_table_chunk( hypertable REGCLASS, chunk REGCLASS);
+DROP FUNCTION _timescaledb_internal.alter_job_set_hypertable_id( job_id INTEGER, hypertable REGCLASS );
+DROP FUNCTION _timescaledb_internal.unfreeze_chunk( chunk REGCLASS);
+-- Drop dimension partition metadata table
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.dimension_partition;
+DROP TABLE IF EXISTS _timescaledb_catalog.dimension_partition;

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -970,9 +970,8 @@ chunk_assign_data_nodes(const Chunk *chunk, const Hypertable *ht)
 
 	foreach (lc, htnodes)
 	{
-		HypertableDataNode *htnode = lfirst(lc);
-		ForeignServer *foreign_server =
-			GetForeignServerByName(NameStr(htnode->fd.node_name), false);
+		const char *dn = lfirst(lc);
+		ForeignServer *foreign_server = GetForeignServerByName(dn, false);
 		ChunkDataNode *chunk_data_node = palloc0(sizeof(ChunkDataNode));
 
 		/*

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -13,6 +13,7 @@
 #include <catalog/pg_type.h>
 
 #include "ts_catalog/catalog.h"
+#include "ts_catalog/dimension_partition.h"
 #include "export.h"
 #include "time_utils.h"
 
@@ -34,6 +35,7 @@ typedef struct Dimension
 	AttrNumber column_attno;
 	Oid main_table_relid;
 	PartitioningInfo *partitioning;
+	DimensionPartitionInfo *dimension_partitions;
 } Dimension;
 
 #define IS_OPEN_DIMENSION(d) ((d)->type == DIMENSION_TYPE_OPEN)

--- a/src/hypercube.c
+++ b/src/hypercube.c
@@ -10,6 +10,7 @@
 #include "export.h"
 #include "hypercube.h"
 #include "dimension_vector.h"
+#include "ts_catalog/dimension_partition.h"
 
 /*
  * A hypercube represents the partition bounds of a hypertable chunk.
@@ -291,15 +292,26 @@ ts_hypercube_calculate_from_point(const Hyperspace *hs, const Point *p, const Sc
 		const Dimension *dim = &hs->dimensions[i];
 		int64 value = p->coordinates[i];
 		bool found = false;
+		bool check_for_existing_slice = false;
 
 		/* Assert that dimensions are in ascending order */
 		Assert(i == 0 || dim->fd.id > hs->dimensions[i - 1].fd.id);
 
+		if (NULL != dim->dimension_partitions)
+		{
+			const DimensionPartition *dp =
+				ts_dimension_partition_find(dim->dimension_partitions, value);
+
+			cube->slices[i] =
+				ts_dimension_slice_create(dp->dimension_id, dp->range_start, dp->range_end);
+			check_for_existing_slice = true;
+			found = true;
+		}
 		/*
 		 * If this is an aligned dimension, we'd like to reuse any existing
 		 * slice that covers the coordinate in the dimension
 		 */
-		if (dim->fd.aligned)
+		else if (dim->fd.aligned)
 		{
 			DimensionVec *vec;
 
@@ -319,7 +331,11 @@ ts_hypercube_calculate_from_point(const Hyperspace *hs, const Point *p, const Sc
 			 * the range of a new slice
 			 */
 			cube->slices[i] = ts_dimension_calculate_default_slice(dim, value);
+			check_for_existing_slice = true;
+		}
 
+		if (check_for_existing_slice)
+		{
 			/*
 			 * Check if there's already an existing slice with the calculated
 			 * range. If a slice already exists, use that slice's ID instead

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -17,6 +17,7 @@
 #include "scanner.h"
 #include "scan_iterator.h"
 #include "ts_catalog/tablespace.h"
+#include "ts_catalog/dimension_partition.h"
 
 #define OLD_INSERT_BLOCKER_NAME "insert_blocker"
 #define INSERT_BLOCKER_NAME "ts_insert_blocker"
@@ -155,12 +156,15 @@ extern TSDLLEXPORT List *ts_hypertable_get_data_node_name_list(const Hypertable 
 extern TSDLLEXPORT List *ts_hypertable_get_data_node_serverids_list(const Hypertable *ht);
 extern TSDLLEXPORT List *ts_hypertable_get_available_data_nodes(const Hypertable *ht,
 																bool error_if_missing);
+extern TSDLLEXPORT List *ts_hypertable_get_available_data_node_names(const Hypertable *ht,
+																	 bool error_if_missing);
 extern TSDLLEXPORT List *ts_hypertable_get_available_data_node_server_oids(const Hypertable *ht);
 extern TSDLLEXPORT HypertableType ts_hypertable_get_type(const Hypertable *ht);
 extern TSDLLEXPORT void ts_hypertable_func_call_on_data_nodes(const Hypertable *ht,
 															  FunctionCallInfo fcinfo);
 extern TSDLLEXPORT int16 ts_validate_replication_factor(int32 replication_factor, bool is_null,
-														bool is_dist_call);
+														bool is_dist_call, int num_data_nodes,
+														const char *hypertable_name);
 extern TSDLLEXPORT Datum ts_hypertable_get_open_dim_max_value(const Hypertable *ht,
 															  int dimension_index, bool *isnull);
 
@@ -168,6 +172,7 @@ extern TSDLLEXPORT bool ts_hypertable_has_compression_table(const Hypertable *ht
 extern TSDLLEXPORT void ts_hypertable_formdata_fill(FormData_hypertable *fd, const TupleInfo *ti);
 extern TSDLLEXPORT void ts_hypertable_scan_by_name(ScanIterator *iterator, const char *schema,
 												   const char *name);
+extern TSDLLEXPORT bool ts_hypertable_update_dimension_partitions(const Hypertable *ht);
 
 #define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock)                       \
 	ts_hypertable_scan_with_memory_context(schema,                                                 \

--- a/src/ts_catalog/CMakeLists.txt
+++ b/src/ts_catalog/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/chunk_data_node.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compression_chunk_size.c
     ${CMAKE_CURRENT_SOURCE_DIR}/continuous_agg.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/dimension_partition.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hypertable_compression.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hypertable_data_node.c
     ${CMAKE_CURRENT_SOURCE_DIR}/metadata.c

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -36,6 +36,10 @@ static const TableInfoDef catalog_table_names[_MAX_CATALOG_TABLES + 1] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = DIMENSION_TABLE_NAME,
 	},
+	[DIMENSION_PARTITION] = {
+		.schema_name = CATALOG_SCHEMA_NAME,
+		.table_name = DIMENSION_PARTITION_TABLE_NAME,
+	},
 	[DIMENSION_SLICE] = {
 		.schema_name = CATALOG_SCHEMA_NAME,
 		.table_name = DIMENSION_SLICE_TABLE_NAME,
@@ -138,6 +142,12 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.names = (char *[]) {
 			[DIMENSION_ID_IDX] = "dimension_pkey",
 			[DIMENSION_HYPERTABLE_ID_COLUMN_NAME_IDX] = "dimension_hypertable_id_column_name_key",
+		},
+	},
+	[DIMENSION_PARTITION] = {
+		.length = _MAX_DIMENSION_PARTITION_INDEX,
+		.names = (char *[]) {
+			[DIMENSION_PARTITION_DIMENSION_ID_RANGE_START_IDX] = "dimension_partition_dimension_id_range_start_key",
 		},
 	},
 	[DIMENSION_SLICE] = {
@@ -273,6 +283,7 @@ static const char *catalog_table_serial_id_names[_MAX_CATALOG_TABLES] = {
 	[HYPERTABLE] = CATALOG_SCHEMA_NAME ".hypertable_id_seq",
 	[HYPERTABLE_DATA_NODE] = NULL,
 	[DIMENSION] = CATALOG_SCHEMA_NAME ".dimension_id_seq",
+	[DIMENSION_PARTITION] = NULL,
 	[DIMENSION_SLICE] = CATALOG_SCHEMA_NAME ".dimension_slice_id_seq",
 	[CHUNK] = CATALOG_SCHEMA_NAME ".chunk_id_seq",
 	[CHUNK_CONSTRAINT] = CATALOG_SCHEMA_NAME ".chunk_constraint_name",
@@ -748,6 +759,7 @@ ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation)
 		case HYPERTABLE:
 		case HYPERTABLE_DATA_NODE:
 		case DIMENSION:
+		case DIMENSION_PARTITION:
 		case CONTINUOUS_AGG:
 			relid = ts_catalog_get_cache_proxy_id(catalog, CACHE_TYPE_HYPERTABLE);
 			CacheInvalidateRelcacheByRelid(relid);

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -36,6 +36,7 @@ typedef enum CatalogTable
 	HYPERTABLE = 0,
 	HYPERTABLE_DATA_NODE,
 	DIMENSION,
+	DIMENSION_PARTITION,
 	DIMENSION_SLICE,
 	CHUNK,
 	CHUNK_CONSTRAINT,
@@ -287,6 +288,51 @@ enum
 	DIMENSION_ID_IDX = 0,
 	DIMENSION_HYPERTABLE_ID_COLUMN_NAME_IDX,
 	_MAX_DIMENSION_INDEX,
+};
+
+/******************************
+ *
+ * Dimension partition table definitions
+ *
+ ******************************/
+
+#define DIMENSION_PARTITION_TABLE_NAME "dimension_partition"
+
+enum Anum_dimension_partition
+{
+	Anum_dimension_partition_dimension_id = 1,
+	Anum_dimension_partition_range_start,
+	Anum_dimension_partition_data_nodes,
+	_Anum_dimension_partition_max,
+};
+
+#define Natts_dimension_partition (_Anum_dimension_partition_max - 1)
+
+typedef struct FormData_dimension_partition
+{
+	int32 dimension_id;
+	int64 range_start;
+	/* Variable-length fields start here. The first variable-length field can
+	 * still be accessed directly via the C struct */
+	ArrayType *data_nodes;
+} FormData_dimension_partition;
+
+typedef FormData_dimension_partition *Form_dimension_partition;
+
+enum Anum_dimension_partition_dimension_id_range_start_idx
+{
+	Anum_dimension_partition_dimension_id_range_start_idx_dimension_id = 1,
+	Anum_dimension_partition_dimension_id_range_start_idx_range_start,
+	_Anum_dimension_partition_dimension_id_range_start_idx_max,
+};
+
+#define Natts_dimension_partition_dimension_id_range_start_idx                                     \
+	(_Anum_dimension_partition_dimension_id_range_start_idx_max - 1)
+
+enum
+{
+	DIMENSION_PARTITION_DIMENSION_ID_RANGE_START_IDX = 0,
+	_MAX_DIMENSION_PARTITION_INDEX,
 };
 
 /******************************

--- a/src/ts_catalog/dimension_partition.c
+++ b/src/ts_catalog/dimension_partition.c
@@ -1,0 +1,415 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#include <postgres.h>
+#include <access/heapam.h>
+#include <access/xact.h>
+#include <catalog/catalog.h>
+#include <commands/tablecmds.h>
+#include <nodes/parsenodes.h>
+#include <utils/array.h>
+#include <utils/palloc.h>
+#include <utils/rel.h>
+#include <utils/builtins.h>
+#include <utils/snapmgr.h>
+
+#include "ts_catalog/catalog.h"
+#include "dimension.h"
+#include "dimension_slice.h"
+#include "dimension_partition.h"
+#include "hypertable_cache.h"
+#include "scanner.h"
+#include "config.h"
+
+#include "compat/compat.h"
+
+static ScanIterator
+ts_dimension_partition_scan_iterator_create(LOCKMODE lockmode)
+{
+	ScanIterator it = ts_scan_iterator_create(DIMENSION_PARTITION, lockmode, CurrentMemoryContext);
+	it.ctx.flags |= SCANNER_F_NOEND_AND_NOCLOSE;
+
+	return it;
+}
+
+static void
+ts_dimension_partition_scan_iterator_set_dimension_id(ScanIterator *it, int32 dimension_id,
+													  const ScanTupLock *tuplock)
+{
+	it->ctx.index = catalog_get_index(ts_catalog_get(),
+									  DIMENSION_PARTITION,
+									  DIMENSION_PARTITION_DIMENSION_ID_RANGE_START_IDX);
+	ts_scan_iterator_scan_key_reset(it);
+	ts_scan_iterator_scan_key_init(
+		it,
+		Anum_dimension_partition_dimension_id_range_start_idx_dimension_id,
+		BTEqualStrategyNumber,
+		F_INT4EQ,
+		Int32GetDatum(dimension_id));
+	it->ctx.tuplock = tuplock;
+}
+
+/*
+ * Comparison function for dimension partitions.
+ *
+ * Used to sort arrays of partitions on range_start and to lookup a partition
+ * using binary search.
+ */
+static int
+dimpart_cmp(const void *key, const void *node)
+{
+	const DimensionPartition *dp_key = *((const DimensionPartition **) key);
+	const DimensionPartition *dp_node = *((const DimensionPartition **) node);
+
+	/* If the key's range is enclosed (or exactly matches) the partition,
+	 * there's a match */
+	if (dp_key->range_start >= dp_node->range_start && dp_key->range_end < dp_node->range_end)
+		return 0;
+	else if (dp_key->range_start < dp_node->range_start)
+		return -1;
+	else
+	{
+		Assert(dp_key->range_start > dp_node->range_start);
+		return 1;
+	}
+}
+
+static DimensionPartition *
+dimpart_create(const HeapTuple tup, const TupleDesc tupdesc)
+{
+	DimensionPartition *dp = palloc0(sizeof(DimensionPartition));
+	Datum values[Natts_dimension_partition];
+	bool isnull[Natts_dimension_partition] = { false };
+
+	heap_deform_tuple(tup, tupdesc, values, isnull);
+
+	dp->dimension_id =
+		DatumGetInt32(values[AttrNumberGetAttrOffset(Anum_dimension_partition_dimension_id)]);
+	dp->range_start =
+		DatumGetInt64(values[AttrNumberGetAttrOffset(Anum_dimension_partition_range_start)]);
+	dp->range_end = DIMENSION_SLICE_MAXVALUE;
+	dp->data_nodes = NIL;
+
+	if (!isnull[AttrNumberGetAttrOffset(Anum_dimension_partition_data_nodes)])
+	{
+		ArrayIterator arrit;
+		bool elem_isnull = false;
+		ArrayType *arr = DatumGetArrayTypeP(
+			values[AttrNumberGetAttrOffset(Anum_dimension_partition_data_nodes)]);
+		Datum elem = (Datum) NULL;
+
+		arrit = array_create_iterator(arr, 0, NULL);
+
+		while (array_iterate(arrit, &elem, &elem_isnull))
+		{
+			if (!elem_isnull)
+			{
+				const char *dn = NameStr(*DatumGetName(elem));
+				dp->data_nodes = lappend(dp->data_nodes, pstrdup(dn));
+			}
+		}
+
+		array_free_iterator(arrit);
+	}
+
+	return dp;
+}
+
+/*
+ * Get the current dimension partitions.
+ *
+ * The partitions are read into an array which is sorted so that it can be
+ * binary searched.
+ */
+DimensionPartitionInfo *
+ts_dimension_partition_info_get(int32 dimension_id)
+{
+	ScanIterator it;
+	DimensionPartitionInfo *dpi;
+	DimensionPartition **partitions;
+	unsigned int count = 0;
+#ifdef TS_DEBUG
+	/* Use a low number of initial max partitions in DEBUG in order to "hit"
+	 * array expansion below */
+	unsigned int max_partitions = 2;
+#else
+	unsigned int max_partitions = 20;
+#endif
+
+	it = ts_dimension_partition_scan_iterator_create(AccessShareLock);
+	ts_dimension_partition_scan_iterator_set_dimension_id(&it, dimension_id, NULL);
+	/* Create a temporary array for partitions, which is likely too big */
+	partitions = palloc0(sizeof(DimensionPartition *) * max_partitions);
+
+	ts_scanner_foreach(&it)
+	{
+		bool should_free = false;
+		HeapTuple tup = ts_scan_iterator_fetch_heap_tuple(&it, false, &should_free);
+		TupleDesc tupdesc = ts_scan_iterator_tupledesc(&it);
+		DimensionPartition *dp;
+
+		if (count >= max_partitions)
+		{
+			max_partitions = count + 10;
+			partitions = repalloc(partitions, sizeof(DimensionPartition *) * max_partitions);
+		}
+
+		dp = dimpart_create(tup, tupdesc);
+
+		if (count > 0)
+			partitions[count - 1]->range_end = dp->range_start;
+
+		partitions[count++] = dp;
+
+		if (should_free)
+			heap_freetuple(tup);
+	}
+
+	ts_scan_iterator_close(&it);
+
+	if (count == 0)
+	{
+		pfree(partitions);
+		return NULL;
+	}
+	else if (count > 1)
+	{
+		partitions[count - 2]->range_end = partitions[count - 1]->range_start;
+	}
+
+	dpi = palloc0(sizeof(DimensionPartitionInfo));
+	dpi->num_partitions = count;
+	dpi->partitions = palloc0(sizeof(DimensionPartition *) * count);
+	memcpy(dpi->partitions, partitions, sizeof(DimensionPartition *) * count);
+	qsort(partitions, count, sizeof(DimensionPartition *), dimpart_cmp);
+	pfree(partitions);
+
+	return dpi;
+}
+
+/*
+ * Find a partition using binary search.
+ */
+const DimensionPartition *
+ts_dimension_partition_find(const DimensionPartitionInfo *dpi, int64 coord)
+{
+	const DimensionPartition **dp_found;
+	const DimensionPartition dp = {
+		.range_start = coord,
+		.range_end = coord,
+	};
+	const DimensionPartition *dp_key = &dp;
+
+	dp_found = bsearch(&dp_key,
+					   dpi->partitions,
+					   dpi->num_partitions,
+					   sizeof(DimensionPartition *),
+					   dimpart_cmp);
+
+	if (!dp_found)
+		elog(ERROR, "no partitions available");
+
+	Assert((*dp_found)->range_start <= coord);
+	Assert((*dp_found)->range_end > coord);
+
+	return *dp_found;
+}
+
+static List *
+get_replica_nodes(List *data_nodes, unsigned int index, int replication_factor)
+{
+	List *replica_nodes = NIL;
+	int max_replicas = replication_factor;
+	int i;
+
+	/* Check for single-node case */
+	if (data_nodes == NIL)
+		return NIL;
+
+	/* Can't have more replicas than we have data nodes */
+	if (max_replicas > list_length(data_nodes))
+		max_replicas = list_length(data_nodes);
+
+	for (i = 0; i < max_replicas; i++)
+	{
+		int list_index = (index + i) % list_length(data_nodes);
+		replica_nodes = lappend(replica_nodes, list_nth(data_nodes, list_index));
+	}
+
+	return replica_nodes;
+}
+
+static HeapTuple
+create_dimension_partition_tuple(Relation rel, const DimensionPartition *dp)
+{
+	TupleDesc tupdesc = RelationGetDescr(rel);
+	Datum values[Natts_dimension_partition];
+	bool nulls[Natts_dimension_partition] = { false };
+	int i = 0;
+
+	values[AttrNumberGetAttrOffset(Anum_dimension_partition_dimension_id)] =
+		Int32GetDatum(dp->dimension_id);
+	values[AttrNumberGetAttrOffset(Anum_dimension_partition_range_start)] =
+		Int64GetDatum(dp->range_start);
+
+	if (dp->data_nodes == NIL)
+	{
+		nulls[AttrNumberGetAttrOffset(Anum_dimension_partition_data_nodes)] = true;
+	}
+	else
+	{
+		Datum *dn_datums = palloc(sizeof(Datum) * list_length(dp->data_nodes));
+		ArrayType *dn_arr;
+		ListCell *lc;
+
+		foreach (lc, dp->data_nodes)
+		{
+			const char *dn = lfirst(lc);
+			dn_datums[i++] = CStringGetDatum(dn);
+		}
+
+		dn_arr = construct_array(dn_datums,
+								 list_length(dp->data_nodes),
+								 NAMEOID,
+								 NAMEDATALEN,
+								 false,
+								 TYPALIGN_CHAR);
+		values[AttrNumberGetAttrOffset(Anum_dimension_partition_data_nodes)] =
+			PointerGetDatum(dn_arr);
+	}
+
+	return heap_form_tuple(tupdesc, values, nulls);
+}
+
+static void
+dimension_partition_info_delete(int dimension_id, int scanflags, LOCKMODE lockmode)
+{
+	ScanIterator it;
+	CatalogSecurityContext sec_ctx;
+
+	it = ts_dimension_partition_scan_iterator_create(lockmode);
+	ts_dimension_partition_scan_iterator_set_dimension_id(&it, dimension_id, NULL);
+	it.ctx.flags = scanflags;
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+
+	ts_scanner_foreach(&it)
+	{
+		const TupleInfo *ti = ts_scan_iterator_tuple_info(&it);
+		ts_catalog_delete_tid_only(ti->scanrel, &ti->slot->tts_tid);
+	}
+
+	ts_catalog_restore_user(&sec_ctx);
+	ts_scan_iterator_close(&it);
+}
+
+/*
+ * Delete all dimension partitions for a given dimension.
+ */
+void
+ts_dimension_partition_info_delete(int dimension_id)
+{
+	dimension_partition_info_delete(dimension_id, SCANNER_F_NOFLAGS, RowExclusiveLock);
+}
+
+/*
+ * Recreate dimension partitions based on changes to one or more of these
+ * variables:
+ *
+ * - number of partitions
+ * - list of data nodes
+ * - replication factor
+ */
+DimensionPartitionInfo *
+ts_dimension_partition_info_recreate(int32 dimension_id, unsigned int num_partitions,
+									 List *data_nodes, int replication_factor)
+{
+	int64 partition_size = DIMENSION_SLICE_CLOSED_MAX / ((int64) num_partitions);
+	int64 range_start = DIMENSION_SLICE_MINVALUE;
+	Catalog *catalog = ts_catalog_get();
+	Oid relid = catalog_get_table_id(catalog, DIMENSION_PARTITION);
+	DimensionPartitionInfo *dpi;
+	DimensionPartition **partitions;
+	Relation rel;
+	unsigned int i;
+
+	Assert(num_partitions > 0);
+	Assert(data_nodes == NIL || replication_factor > 0);
+
+	/* Delete all partitions for the dimension */
+	dimension_partition_info_delete(dimension_id, SCANNER_F_KEEPLOCK, RowExclusiveLock);
+
+	/* Lock already held */
+	rel = table_open(relid, NoLock);
+
+	partitions = palloc0(sizeof(DimensionPartition *) * num_partitions);
+
+	for (i = 0; i < num_partitions; i++)
+	{
+		int64 range_end =
+			(i == (num_partitions - 1)) ? DIMENSION_SLICE_CLOSED_MAX : range_start + partition_size;
+		DimensionPartition *dp;
+		CatalogSecurityContext sec_ctx;
+		HeapTuple tuple;
+
+		dp = palloc0(sizeof(DimensionPartition));
+		*dp = (DimensionPartition){
+			.dimension_id = dimension_id,
+			.range_start = range_start,
+			.range_end = range_end,
+			.data_nodes = get_replica_nodes(data_nodes, i, replication_factor),
+		};
+
+		ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+		tuple = create_dimension_partition_tuple(rel, dp);
+		ts_catalog_insert_only(rel, tuple);
+		ts_catalog_restore_user(&sec_ctx);
+		heap_freetuple(tuple);
+
+		partitions[i] = dp;
+
+		/* Hash values for space partitions are in range 0 to INT32_MAX, so
+		 * the first partition covers 0 to partition size (although the start
+		 * is written as -INF) */
+		if (range_start == DIMENSION_SLICE_MINVALUE)
+			range_start = 0;
+
+		range_start += partition_size;
+	}
+
+	table_close(rel, RowExclusiveLock);
+
+	/* Sort the partitions so that we can later use binary search */
+	qsort(partitions, num_partitions, sizeof(DimensionPartition *), dimpart_cmp);
+
+	/* Make changes visible */
+	CommandCounterIncrement();
+
+	dpi = palloc(sizeof(DimensionPartitionInfo));
+	dpi->partitions = partitions;
+	dpi->num_partitions = num_partitions;
+
+	return dpi;
+}
+
+/*
+ * Manually update the dimension partition state for a hypertable.
+ *
+ * Used mostly when updating from a TimescaleDB version that didn't have this
+ * state previously.
+ */
+TS_FUNCTION_INFO_V1(ts_dimension_partition_update);
+
+Datum
+ts_dimension_partition_update(PG_FUNCTION_ARGS)
+{
+	Oid hypertable_relid = PG_GETARG_OID(0);
+	Cache *hcache;
+	const Hypertable *ht =
+		ts_hypertable_cache_get_cache_and_entry(hypertable_relid, CACHE_FLAG_NONE, &hcache);
+	ts_hypertable_update_dimension_partitions(ht);
+	ts_cache_release(hcache);
+	PG_RETURN_VOID();
+}

--- a/src/ts_catalog/dimension_partition.h
+++ b/src/ts_catalog/dimension_partition.h
@@ -1,0 +1,35 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+#ifndef TIMESCALEDB_DIMENSION_PARTITION_H
+#define TIMESCALEDB_DIMENSION_PARTITION_H
+
+#include <postgres.h>
+
+#include "scan_iterator.h"
+
+typedef struct DimensionPartition
+{
+	int32 dimension_id;
+	int64 range_start;
+	int64 range_end;
+	List *data_nodes;
+} DimensionPartition;
+
+typedef struct DimensionPartitionInfo
+{
+	unsigned int num_partitions;
+	DimensionPartition **partitions;
+} DimensionPartitionInfo;
+
+extern DimensionPartitionInfo *ts_dimension_partition_info_get(int32 dimension_id);
+extern const DimensionPartition *ts_dimension_partition_find(const DimensionPartitionInfo *dpi,
+															 int64 coord);
+extern TSDLLEXPORT DimensionPartitionInfo *
+ts_dimension_partition_info_recreate(int32 dimension_id, unsigned int num_partitions,
+									 List *data_nodes, int replication_factor);
+extern void ts_dimension_partition_info_delete(int dimension_id);
+
+#endif /* TIMESCALEDB_DIMENSION_PARTITION_H */

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -207,6 +207,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
  _timescaledb_catalog | continuous_aggs_invalidation_threshold           | table | super_user
  _timescaledb_catalog | continuous_aggs_materialization_invalidation_log | table | super_user
  _timescaledb_catalog | dimension                                        | table | super_user
+ _timescaledb_catalog | dimension_partition                              | table | super_user
  _timescaledb_catalog | dimension_slice                                  | table | super_user
  _timescaledb_catalog | hypertable                                       | table | super_user
  _timescaledb_catalog | hypertable_compression                           | table | super_user
@@ -214,7 +215,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
  _timescaledb_catalog | metadata                                         | table | super_user
  _timescaledb_catalog | remote_txn                                       | table | super_user
  _timescaledb_catalog | tablespace                                       | table | super_user
-(20 rows)
+(21 rows)
 
 \dt "_timescaledb_internal".*
                           List of relations

--- a/test/expected/partition.out
+++ b/test/expected/partition.out
@@ -512,3 +512,13 @@ INSERT INTO part_time_func_null_ret VALUES (1530214157.134, 23.4, 'dev1'),
                                            (1533214157.8734, 22.3, 'dev7');
 ERROR:  partitioning function "public.time_partfunc_null_ret" returned NULL
 \set ON_ERROR_STOP 1
+-- Test manually refreshing dimension partitions used in update
+-- script. Mostly to keep codecov happy.
+CREATE FUNCTION _timescaledb_internal.update_dimension_partition(hypertable REGCLASS) RETURNS VOID AS :MODULE_PATHNAME, 'ts_dimension_partition_update' LANGUAGE C VOLATILE;
+SELECT _timescaledb_internal.update_dimension_partition('part_custom_dim');
+ update_dimension_partition 
+----------------------------
+ 
+(1 row)
+
+DROP FUNCTION _timescaledb_internal.update_dimension_partition;

--- a/test/sql/partition.sql
+++ b/test/sql/partition.sql
@@ -301,3 +301,9 @@ SELECT create_hypertable('part_time_func_null_ret', 'time', time_partitioning_fu
 INSERT INTO part_time_func_null_ret VALUES (1530214157.134, 23.4, 'dev1'),
                                            (1533214157.8734, 22.3, 'dev7');
 \set ON_ERROR_STOP 1
+
+-- Test manually refreshing dimension partitions used in update
+-- script. Mostly to keep codecov happy.
+CREATE FUNCTION _timescaledb_internal.update_dimension_partition(hypertable REGCLASS) RETURNS VOID AS :MODULE_PATHNAME, 'ts_dimension_partition_update' LANGUAGE C VOLATILE;
+SELECT _timescaledb_internal.update_dimension_partition('part_custom_dim');
+DROP FUNCTION _timescaledb_internal.update_dimension_partition;

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -551,7 +551,7 @@ RESET ROLE;
 TRUNCATE disttable;
 SELECT * FROM delete_data_node('data_node_1', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
-NOTICE:  the number of partitions in dimension "device" was decreased to 1
+NOTICE:  the number of partitions in dimension "device" of hypertable "disttable" was decreased to 1
  delete_data_node 
 ------------------
  t

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -10,6 +10,15 @@ psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
 \set DN_DBNAME_4 :TEST_DBNAME _4
 \set DN_DBNAME_5 :TEST_DBNAME _5
 \set DN_DBNAME_6 :TEST_DBNAME _6
+-- View to see dimension partitions. Note RIGHT JOIN to see that
+-- dimension partitions are cleaned up (deleted) properly.
+CREATE VIEW hypertable_partitions AS
+SELECT table_name, dimension_id, range_start, data_nodes
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.dimension d ON (d.hypertable_id = h.id)
+RIGHT JOIN _timescaledb_catalog.dimension_partition dp ON (dp.dimension_id = d.id)
+ORDER BY dimension_id, range_start;
+GRANT SELECT ON hypertable_partitions TO :ROLE_1;
 -- Add data nodes using TimescaleDB data_node management API.
 SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => :'DN_DBNAME_1');
   node_name  |   host    | port  |    database    | node_created | database_created | extension_created 
@@ -109,7 +118,6 @@ SELECT node_name, "options" FROM timescaledb_information.data_nodes ORDER BY nod
  data_node_3 | {host=localhost,port=55432,dbname=db_data_node_3}
 (3 rows)
 
--- Delete a data node
 SELECT * FROM delete_data_node('data_node_3');
  delete_data_node 
 ------------------
@@ -160,6 +168,11 @@ SELECT * FROM delete_data_node('data_node_2');
 SELECT node_name, "options" FROM timescaledb_information.data_nodes ORDER BY node_name;
  node_name | options 
 -----------+---------
+(0 rows)
+
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id | range_start | data_nodes 
+------------+--------------+-------------+------------
 (0 rows)
 
 -- Cleanup databases
@@ -252,6 +265,14 @@ WHERE column_name = 'device';
 -------------+------------
  device      |          2
 (1 row)
+
+-- Dimension partitions should be created
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id |     range_start      |  data_nodes   
+------------+--------------+----------------------+---------------
+ disttable  |            2 | -9223372036854775808 | {data_node_1}
+ disttable  |            2 |           1073741823 | {data_node_2}
+(2 rows)
 
 -- All data nodes with USAGE should be added.
 SELECT hdn.node_name
@@ -362,6 +383,11 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 ----------+---------------+-----------
 (0 rows)
 
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id | range_start | data_nodes 
+------------+--------------+-------------+------------
+(0 rows)
+
 -- Now create tables as cluster user
 CREATE TABLE disttable(time timestamptz, device int, temp float);
 \set ON_ERROR_STOP 0
@@ -373,7 +399,7 @@ ERROR:  table "disttable" is not a hypertable
 SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', replication_factor => 0, data_nodes => '{ "data_node_2", "data_node_4" }');
 ERROR:  invalid replication factor
 SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', replication_factor => 32768);
-ERROR:  invalid replication factor
+ERROR:  replication factor too large for hypertable "disttable"
 SELECT * FROM create_hypertable('disttable', 'time', replication_factor => -1);
 ERROR:  invalid replication factor
 SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', replication_factor => -1);
@@ -517,16 +543,30 @@ ERROR:  invalid chunk: cannot be NULL
 \set ON_ERROR_STOP 1
 -- Deleting a data node removes the "foreign" chunk table(s) that
 -- reference that data node as "primary" and should also remove the
--- hypertable_data_node and chunk_data_node mappings for that data node.  In
--- the future we might want to fallback to a replica data node for those
--- chunks that have multiple data nodes so that the chunk is not removed
--- unnecessarily. We use force => true b/c data_node_2 contains chunks.
+-- hypertable_data_node and chunk_data_node mappings for that data
+-- node.  In the future we might want to fallback to a replica data
+-- node for those chunks that have multiple data nodes so that the
+-- chunk is not removed unnecessarily. We use force => true b/c
+-- data_node_2 contains chunks.  Dimension partitions should also be
+-- updated to reflect the loss of the data node.
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id |     range_start      |        data_nodes         
+------------+--------------+----------------------+---------------------------
+ disttable  |            6 | -9223372036854775808 | {data_node_2,data_node_3}
+(1 row)
+
 SELECT * FROM delete_data_node('data_node_2', force => true);
 WARNING:  distributed hypertable "disttable" is under-replicated
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
  delete_data_node 
 ------------------
  t
+(1 row)
+
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id |     range_start      |  data_nodes   
+------------+--------------+----------------------+---------------
+ disttable  |            6 | -9223372036854775808 | {data_node_3}
 (1 row)
 
 SELECT * FROM test.show_subtables('disttable');
@@ -884,6 +924,13 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
         7 |             3 | data_node_2
 (6 rows)
 
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id |     range_start      |        data_nodes         
+------------+--------------+----------------------+---------------------------
+ disttable  |            9 | -9223372036854775808 | {data_node_1,data_node_2}
+ disttable  |            9 |           1073741823 | {data_node_2,data_node_3}
+(2 rows)
+
 -- Add additional hypertable
 CREATE TABLE disttable_2(time timestamptz, device int, temp float);
 SELECT * FROM create_distributed_hypertable('disttable_2', 'time', 'device', 2, replication_factor => 2, data_nodes => '{"data_node_1", "data_node_2", "data_node_3"}');
@@ -976,7 +1023,17 @@ ERROR:  table "devices" is not a hypertable
 SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_1', 'devices');
 ERROR:  table "devices" is not a hypertable
 \set ON_ERROR_STOP 1
--- Force block all data nodes
+-- Force block all data nodes. Dimension partition information should
+-- be updated to elide blocked data nodes
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |        data_nodes         
+-------------+--------------+----------------------+---------------------------
+ disttable   |            9 | -9223372036854775808 | {data_node_2,data_node_3}
+ disttable   |            9 |           1073741823 | {data_node_3,data_node_2}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_2,data_node_3}
+ disttable_2 |           11 |           1073741823 | {data_node_3,data_node_2}
+(4 rows)
+
 SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_2', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable_2"
@@ -984,6 +1041,15 @@ WARNING:  insufficient number of data nodes for distributed hypertable "disttabl
 ------------------
                 2
 (1 row)
+
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |  data_nodes   
+-------------+--------------+----------------------+---------------
+ disttable   |            9 | -9223372036854775808 | {data_node_3}
+ disttable   |            9 |           1073741823 | {data_node_3}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_3}
+ disttable_2 |           11 |           1073741823 | {data_node_3}
+(4 rows)
 
 SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_1', force => true);
 NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "disttable"
@@ -993,6 +1059,15 @@ NOTICE:  new chunks already blocked on data node "data_node_1" for hypertable "d
                 0
 (1 row)
 
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |  data_nodes   
+-------------+--------------+----------------------+---------------
+ disttable   |            9 | -9223372036854775808 | {data_node_3}
+ disttable   |            9 |           1073741823 | {data_node_3}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_3}
+ disttable_2 |           11 |           1073741823 | {data_node_3}
+(4 rows)
+
 SELECT * FROM timescaledb_experimental.block_new_chunks('data_node_3', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable_2"
@@ -1000,6 +1075,15 @@ WARNING:  insufficient number of data nodes for distributed hypertable "disttabl
 ------------------
                 2
 (1 row)
+
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      | data_nodes 
+-------------+--------------+----------------------+------------
+ disttable   |            9 | -9223372036854775808 | 
+ disttable   |            9 |           1073741823 | 
+ disttable_2 |           11 | -9223372036854775808 | 
+ disttable_2 |           11 |           1073741823 | 
+(4 rows)
 
 -- All data nodes are blocked
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
@@ -1025,17 +1109,44 @@ SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_1');
                 2
 (1 row)
 
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |  data_nodes   
+-------------+--------------+----------------------+---------------
+ disttable   |            9 | -9223372036854775808 | {data_node_1}
+ disttable   |            9 |           1073741823 | {data_node_1}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_1}
+ disttable_2 |           11 |           1073741823 | {data_node_1}
+(4 rows)
+
 SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_2');
  allow_new_chunks 
 ------------------
                 2
 (1 row)
 
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |        data_nodes         
+-------------+--------------+----------------------+---------------------------
+ disttable   |            9 | -9223372036854775808 | {data_node_1,data_node_2}
+ disttable   |            9 |           1073741823 | {data_node_2,data_node_1}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_1,data_node_2}
+ disttable_2 |           11 |           1073741823 | {data_node_2,data_node_1}
+(4 rows)
+
 SELECT * FROM timescaledb_experimental.allow_new_chunks('data_node_3');
  allow_new_chunks 
 ------------------
                 2
 (1 row)
+
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |        data_nodes         
+-------------+--------------+----------------------+---------------------------
+ disttable   |            9 | -9223372036854775808 | {data_node_1,data_node_2}
+ disttable   |            9 |           1073741823 | {data_node_2,data_node_3}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_1,data_node_2}
+ disttable_2 |           11 |           1073741823 | {data_node_2,data_node_3}
+(4 rows)
 
 SELECT table_name, node_name, block_chunks
 FROM _timescaledb_catalog.hypertable_data_node dn,
@@ -1091,13 +1202,32 @@ NOTICE:  data node "data_node_2" is not attached to hypertable "disttable_2", sk
 (1 row)
 
 -- force detach data node to become under-replicated for new data
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |        data_nodes         
+-------------+--------------+----------------------+---------------------------
+ disttable   |            9 | -9223372036854775808 | {data_node_1,data_node_2}
+ disttable   |            9 |           1073741823 | {data_node_2,data_node_3}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_1,data_node_3}
+ disttable_2 |           11 |           1073741823 | {data_node_3,data_node_1}
+(4 rows)
+
 SELECT * FROM detach_data_node('data_node_3', 'disttable_2', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable_2"
-NOTICE:  the number of partitions in dimension "device" was decreased to 1
+NOTICE:  the number of partitions in dimension "device" of hypertable "disttable_2" was decreased to 1
  detach_data_node 
 ------------------
                 1
 (1 row)
+
+-- Dimension partitions should be updated to no longer list the data
+-- node for the hypertable
+SELECT * FROM hypertable_partitions;
+ table_name  | dimension_id |     range_start      |        data_nodes         
+-------------+--------------+----------------------+---------------------------
+ disttable   |            9 | -9223372036854775808 | {data_node_1,data_node_2}
+ disttable   |            9 |           1073741823 | {data_node_2,data_node_3}
+ disttable_2 |           11 | -9223372036854775808 | {data_node_1}
+(3 rows)
 
 SELECT foreign_table_name, foreign_server_name
 FROM information_schema.foreign_tables
@@ -1186,7 +1316,7 @@ ORDER BY foreign_table_name;
 
 SELECT * FROM detach_data_node('data_node_2', 'disttable', force => true);
 WARNING:  insufficient number of data nodes for distributed hypertable "disttable"
-NOTICE:  the number of partitions in dimension "device" was decreased to 1
+NOTICE:  the number of partitions in dimension "device" of hypertable "disttable" was decreased to 1
  detach_data_node 
 ------------------
                 1

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -9,6 +9,7 @@ psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set DATA_NODE_4 :TEST_DBNAME _4
 \set TABLESPACE_1 :TEST_DBNAME _1
 \set TABLESPACE_2 :TEST_DBNAME _2
 SELECT
@@ -25,6 +26,15 @@ FROM (VALUES (:'DATA_NODE_1'), (:'DATA_NODE_2'), (:'DATA_NODE_3')) v (name);
 (3 rows)
 
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+-- View to see dimension partitions. Note RIGHT JOIN to see that
+-- dimension partitions are cleaned up (deleted) properly.
+CREATE VIEW hypertable_partitions AS
+SELECT table_name, dimension_id, range_start, data_nodes
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.dimension d ON (d.hypertable_id = h.id)
+RIGHT JOIN _timescaledb_catalog.dimension_partition dp ON (dp.dimension_id = d.id)
+ORDER BY dimension_id, range_start;
+GRANT SELECT ON hypertable_partitions TO :ROLE_1;
 -- Import testsupport.sql file to data nodes
 \unset ECHO
 SET ROLE :ROLE_1;
@@ -54,7 +64,15 @@ WARNING:  insufficient number of partitions for dimension "device"
              1 | public      | disttable  | t
 (1 row)
 
--- Increase the number of partitions. Expect warning since still too low
+-- Increase the number of partitions. Expect warning since still too
+-- low. Dimension partitions should be updated to reflect new
+-- partitioning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+(1 row)
+
 SELECT * FROM set_number_partitions('disttable', 2);
 WARNING:  insufficient number of partitions for dimension "device"
  set_number_partitions 
@@ -62,13 +80,35 @@ WARNING:  insufficient number of partitions for dimension "device"
  
 (1 row)
 
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |           1073741823 | {db_dist_hypertable_2}
+(2 rows)
+
 -- Set number of partitions equal to the number of servers should not
 -- raise a warning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |           1073741823 | {db_dist_hypertable_2}
+(2 rows)
+
 SELECT * FROM set_number_partitions('disttable', 3, 'device');
  set_number_partitions 
 -----------------------
  
 (1 row)
+
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |            715827882 | {db_dist_hypertable_2}
+ disttable  |            2 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
 
 -- Show the number of slices
 SELECT h.table_name, d.column_name, d.num_slices
@@ -84,11 +124,35 @@ AND h.table_name = 'disttable';
 -- This table tests both 1-dimensional tables and under-replication
 -- (replication_factor > num_data_nodes).
 CREATE TABLE underreplicated(time timestamptz, device int, temp float);
+\set ON_ERROR_STOP 0
+-- can't create an under-replicated hypertable
+SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
+ERROR:  replication factor too large for hypertable "underreplicated"
+\set ON_ERROR_STOP 1
+-- can create under-replicated hypertable byf force detaching a data node
+RESET ROLE;
+SELECT * FROM add_data_node(:'DATA_NODE_4', host => 'localhost', database => :'DATA_NODE_4');
+      node_name       |   host    | port  |       database       | node_created | database_created | extension_created 
+----------------------+-----------+-------+----------------------+--------------+------------------+-------------------
+ db_dist_hypertable_4 | localhost | 55432 | db_dist_hypertable_4 | t            | t                | t
+(1 row)
+
+GRANT USAGE ON FOREIGN SERVER :DATA_NODE_4 TO PUBLIC;
+SET ROLE :ROLE_1;
 SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
              2 | public      | underreplicated | t
+(1 row)
+
+--create new session to clear out connections
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SELECT * FROM delete_data_node(:'DATA_NODE_4', force => true, drop_database => true);
+WARNING:  insufficient number of data nodes for distributed hypertable "underreplicated"
+ delete_data_node 
+------------------
+ t
 (1 row)
 
 SET ROLE :ROLE_1;
@@ -184,11 +248,10 @@ INSERT INTO disttable VALUES
  Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
-         ->  Custom Scan (DataNodeDispatch)
-               Batch size: 1000
+         ->  Custom Scan (DataNodeCopy)
                ->  Custom Scan (ChunkDispatch)
                      ->  Result
-(7 rows)
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 INSERT INTO disttable VALUES
@@ -199,15 +262,14 @@ INSERT INTO disttable VALUES
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable
-         ->  Custom Scan (DataNodeDispatch)
+         ->  Custom Scan (DataNodeCopy)
                Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
-               Batch size: 1000
-               Remote SQL: INSERT INTO public.disttable("time", device, temp) VALUES ($1, $2, $3), ..., ($2998, $2999, $3000)
+               Remote SQL: COPY public.disttable ("time", device, temp) FROM STDIN WITH (FORMAT binary)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                      ->  Result
                            Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
-(12 rows)
+(11 rows)
 
 -- Create some chunks through insertion
 INSERT INTO disttable VALUES
@@ -363,6 +425,14 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1,2,3;
         5 |             2 | db_dist_hypertable_2
         6 |             2 | db_dist_hypertable_3
 (6 rows)
+
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |            715827882 | {db_dist_hypertable_2}
+ disttable  |            2 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
 
 -- Show that chunks are created on data nodes and that each data node
 -- has their own unique slice in the space (device) dimension.
@@ -1955,12 +2025,20 @@ CREATE TABLE "Table\\Schema"."Param_Table"("time Col %#^#@$#" timestamptz, __reg
 SELECT * FROM create_distributed_hypertable('"Table\\Schema"."Param_Table"', 'time Col %#^#@$#', partitioning_column => '__region',
 associated_schema_name => 'T3sTSch', associated_table_prefix => 'test*pre_', chunk_time_interval => interval '1 week',
 create_default_indexes => FALSE, if_not_exists => TRUE, replication_factor => 2,
-data_nodes => ARRAY[:'DATA_NODE_3']);
-WARNING:  only one data node was assigned to the hypertable
+data_nodes => ARRAY[:'DATA_NODE_2', :'DATA_NODE_3']);
 NOTICE:  adding not-null constraint to column "time Col %#^#@$#"
  hypertable_id |  schema_name  | table_name  | created 
 ---------------+---------------+-------------+---------
              4 | Table\\Schema | Param_Table | t
+(1 row)
+
+-- Test detach and attach data node
+SELECT * FROM detach_data_node(:'DATA_NODE_2', '"Table\\Schema"."Param_Table"', force => true, drop_remote_data => true);
+WARNING:  insufficient number of data nodes for distributed hypertable "Param_Table"
+NOTICE:  the number of partitions in dimension "__region" of hypertable "Param_Table" was decreased to 1
+ detach_data_node 
+------------------
+                1
 (1 row)
 
 -- Test attach_data_node. First show dimensions and currently attached
@@ -2024,7 +2102,7 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', '"Table\\Schema"."Param_Table"', 
 WARNING:  insufficient number of partitions for dimension "__region"
  hypertable_id | node_hypertable_id |      node_name       
 ---------------+--------------------+----------------------
-             4 |                  3 | db_dist_hypertable_2
+             4 |                  4 | db_dist_hypertable_2
 (1 row)
 
 -- Number of slices should not be increased
@@ -2118,7 +2196,7 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 --+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
  1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
  2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 4|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 
@@ -2130,8 +2208,8 @@ id|hypertable_id|column_name     |column_type             |aligned|num_slices|pa
  1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
  2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
  3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
 (5 rows)
 
 
@@ -2186,7 +2264,7 @@ ts_insert_blocker|     7|_timescaledb_internal.insert_blocker
 
 -- Verify that repartitioning works as expected on detach_data_node
 SELECT * FROM detach_data_node(:'DATA_NODE_1', '"Table\\Schema"."Param_Table"', repartition => true);
-NOTICE:  the number of partitions in dimension "__region" was decreased to 2
+NOTICE:  the number of partitions in dimension "__region" of hypertable "Param_Table" was decreased to 2
  detach_data_node 
 ------------------
                 1
@@ -2303,7 +2381,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
  hypertable_id | node_hypertable_id |      node_name       
 ---------------+--------------------+----------------------
-             5 |                  4 | db_dist_hypertable_2
+             5 |                  5 | db_dist_hypertable_2
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -2349,12 +2427,12 @@ id|hypertable_id|column_name     |column_type             |aligned|num_slices|pa
  1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
  2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
  3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
 (9 rows)
 
 
@@ -3177,10 +3255,10 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      15|            8|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
-      16|            8|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
-      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      15|            9|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
+      16|            9|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
+      17|            9|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            9|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (4 rows)
 
 
@@ -3249,8 +3327,8 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      17|            9|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            9|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (2 rows)
 
 
@@ -3349,7 +3427,7 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-18|           10|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
 (1 row)
 
 
@@ -3400,8 +3478,8 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-19|           10|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-18|           10|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
 (2 rows)
 
 
@@ -3466,8 +3544,8 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-19|           10|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-18|           10|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
 (2 rows)
 
 
@@ -3838,8 +3916,8 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                           
 --------+-------------+---------------------+-----------------------+-------+---------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
 (2 rows)
 
 
@@ -3859,12 +3937,30 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
  
 (1 row)
 
+-- Dimension partitions should be updated to account for replication
+-- to additional data nodes
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
+
 SELECT * FROM set_replication_factor('hyper', 3);
 WARNING:  hypertable "hyper" is under-replicated
  set_replication_factor 
 ------------------------
  
 (1 row)
+
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |                            data_nodes                            
+------------+--------------+----------------------+------------------------------------------------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1,db_dist_hypertable_2,db_dist_hypertable_3}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2,db_dist_hypertable_3,db_dist_hypertable_1}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3,db_dist_hypertable_1,db_dist_hypertable_2}
+(3 rows)
 
 INSERT INTO hyper VALUES ('2017-01-02 07:11', 1, 1.7);
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
@@ -3889,8 +3985,8 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                           
 --------+-------------+---------------------+-----------------------+-------+---------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
 (2 rows)
 
 
@@ -3934,9 +4030,9 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3964,6 +4060,14 @@ WARNING:  hypertable "hyper" is under-replicated
  
 (1 row)
 
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |                 data_nodes                  
+------------+--------------+----------------------+---------------------------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1,db_dist_hypertable_2}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2,db_dist_hypertable_3}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3,db_dist_hypertable_1}
+(3 rows)
+
 INSERT INTO hyper VALUES ('2017-03-01 06:01', 1, 15.1);
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
     SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
@@ -3989,10 +4093,10 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      26|           15|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
 (4 rows)
 
 
@@ -4045,11 +4149,11 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      26|           15|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
-      27|           15|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
 (5 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -9,6 +9,7 @@ psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set DATA_NODE_4 :TEST_DBNAME _4
 \set TABLESPACE_1 :TEST_DBNAME _1
 \set TABLESPACE_2 :TEST_DBNAME _2
 SELECT
@@ -25,6 +26,15 @@ FROM (VALUES (:'DATA_NODE_1'), (:'DATA_NODE_2'), (:'DATA_NODE_3')) v (name);
 (3 rows)
 
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+-- View to see dimension partitions. Note RIGHT JOIN to see that
+-- dimension partitions are cleaned up (deleted) properly.
+CREATE VIEW hypertable_partitions AS
+SELECT table_name, dimension_id, range_start, data_nodes
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.dimension d ON (d.hypertable_id = h.id)
+RIGHT JOIN _timescaledb_catalog.dimension_partition dp ON (dp.dimension_id = d.id)
+ORDER BY dimension_id, range_start;
+GRANT SELECT ON hypertable_partitions TO :ROLE_1;
 -- Import testsupport.sql file to data nodes
 \unset ECHO
 SET ROLE :ROLE_1;
@@ -54,7 +64,15 @@ WARNING:  insufficient number of partitions for dimension "device"
              1 | public      | disttable  | t
 (1 row)
 
--- Increase the number of partitions. Expect warning since still too low
+-- Increase the number of partitions. Expect warning since still too
+-- low. Dimension partitions should be updated to reflect new
+-- partitioning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+(1 row)
+
 SELECT * FROM set_number_partitions('disttable', 2);
 WARNING:  insufficient number of partitions for dimension "device"
  set_number_partitions 
@@ -62,13 +80,35 @@ WARNING:  insufficient number of partitions for dimension "device"
  
 (1 row)
 
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |           1073741823 | {db_dist_hypertable_2}
+(2 rows)
+
 -- Set number of partitions equal to the number of servers should not
 -- raise a warning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |           1073741823 | {db_dist_hypertable_2}
+(2 rows)
+
 SELECT * FROM set_number_partitions('disttable', 3, 'device');
  set_number_partitions 
 -----------------------
  
 (1 row)
+
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |            715827882 | {db_dist_hypertable_2}
+ disttable  |            2 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
 
 -- Show the number of slices
 SELECT h.table_name, d.column_name, d.num_slices
@@ -84,11 +124,35 @@ AND h.table_name = 'disttable';
 -- This table tests both 1-dimensional tables and under-replication
 -- (replication_factor > num_data_nodes).
 CREATE TABLE underreplicated(time timestamptz, device int, temp float);
+\set ON_ERROR_STOP 0
+-- can't create an under-replicated hypertable
+SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
+ERROR:  replication factor too large for hypertable "underreplicated"
+\set ON_ERROR_STOP 1
+-- can create under-replicated hypertable byf force detaching a data node
+RESET ROLE;
+SELECT * FROM add_data_node(:'DATA_NODE_4', host => 'localhost', database => :'DATA_NODE_4');
+      node_name       |   host    | port  |       database       | node_created | database_created | extension_created 
+----------------------+-----------+-------+----------------------+--------------+------------------+-------------------
+ db_dist_hypertable_4 | localhost | 55432 | db_dist_hypertable_4 | t            | t                | t
+(1 row)
+
+GRANT USAGE ON FOREIGN SERVER :DATA_NODE_4 TO PUBLIC;
+SET ROLE :ROLE_1;
 SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
              2 | public      | underreplicated | t
+(1 row)
+
+--create new session to clear out connections
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SELECT * FROM delete_data_node(:'DATA_NODE_4', force => true, drop_database => true);
+WARNING:  insufficient number of data nodes for distributed hypertable "underreplicated"
+ delete_data_node 
+------------------
+ t
 (1 row)
 
 SET ROLE :ROLE_1;
@@ -184,11 +248,10 @@ INSERT INTO disttable VALUES
  Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
-         ->  Custom Scan (DataNodeDispatch)
-               Batch size: 1000
+         ->  Custom Scan (DataNodeCopy)
                ->  Custom Scan (ChunkDispatch)
                      ->  Result
-(7 rows)
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 INSERT INTO disttable VALUES
@@ -199,15 +262,14 @@ INSERT INTO disttable VALUES
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable
-         ->  Custom Scan (DataNodeDispatch)
+         ->  Custom Scan (DataNodeCopy)
                Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
-               Batch size: 1000
-               Remote SQL: INSERT INTO public.disttable("time", device, temp) VALUES ($1, $2, $3), ..., ($2998, $2999, $3000)
+               Remote SQL: COPY public.disttable ("time", device, temp) FROM STDIN WITH (FORMAT binary)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                      ->  Result
                            Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
-(12 rows)
+(11 rows)
 
 -- Create some chunks through insertion
 INSERT INTO disttable VALUES
@@ -363,6 +425,14 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1,2,3;
         5 |             2 | db_dist_hypertable_2
         6 |             2 | db_dist_hypertable_3
 (6 rows)
+
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |            715827882 | {db_dist_hypertable_2}
+ disttable  |            2 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
 
 -- Show that chunks are created on data nodes and that each data node
 -- has their own unique slice in the space (device) dimension.
@@ -1954,12 +2024,20 @@ CREATE TABLE "Table\\Schema"."Param_Table"("time Col %#^#@$#" timestamptz, __reg
 SELECT * FROM create_distributed_hypertable('"Table\\Schema"."Param_Table"', 'time Col %#^#@$#', partitioning_column => '__region',
 associated_schema_name => 'T3sTSch', associated_table_prefix => 'test*pre_', chunk_time_interval => interval '1 week',
 create_default_indexes => FALSE, if_not_exists => TRUE, replication_factor => 2,
-data_nodes => ARRAY[:'DATA_NODE_3']);
-WARNING:  only one data node was assigned to the hypertable
+data_nodes => ARRAY[:'DATA_NODE_2', :'DATA_NODE_3']);
 NOTICE:  adding not-null constraint to column "time Col %#^#@$#"
  hypertable_id |  schema_name  | table_name  | created 
 ---------------+---------------+-------------+---------
              4 | Table\\Schema | Param_Table | t
+(1 row)
+
+-- Test detach and attach data node
+SELECT * FROM detach_data_node(:'DATA_NODE_2', '"Table\\Schema"."Param_Table"', force => true, drop_remote_data => true);
+WARNING:  insufficient number of data nodes for distributed hypertable "Param_Table"
+NOTICE:  the number of partitions in dimension "__region" of hypertable "Param_Table" was decreased to 1
+ detach_data_node 
+------------------
+                1
 (1 row)
 
 -- Test attach_data_node. First show dimensions and currently attached
@@ -2023,7 +2101,7 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', '"Table\\Schema"."Param_Table"', 
 WARNING:  insufficient number of partitions for dimension "__region"
  hypertable_id | node_hypertable_id |      node_name       
 ---------------+--------------------+----------------------
-             4 |                  3 | db_dist_hypertable_2
+             4 |                  4 | db_dist_hypertable_2
 (1 row)
 
 -- Number of slices should not be increased
@@ -2117,7 +2195,7 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 --+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
  1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
  2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 4|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 
@@ -2129,8 +2207,8 @@ id|hypertable_id|column_name     |column_type             |aligned|num_slices|pa
  1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
  2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
  3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
 (5 rows)
 
 
@@ -2185,7 +2263,7 @@ ts_insert_blocker|     7|_timescaledb_internal.insert_blocker
 
 -- Verify that repartitioning works as expected on detach_data_node
 SELECT * FROM detach_data_node(:'DATA_NODE_1', '"Table\\Schema"."Param_Table"', repartition => true);
-NOTICE:  the number of partitions in dimension "__region" was decreased to 2
+NOTICE:  the number of partitions in dimension "__region" of hypertable "Param_Table" was decreased to 2
  detach_data_node 
 ------------------
                 1
@@ -2302,7 +2380,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
  hypertable_id | node_hypertable_id |      node_name       
 ---------------+--------------------+----------------------
-             5 |                  4 | db_dist_hypertable_2
+             5 |                  5 | db_dist_hypertable_2
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -2348,12 +2426,12 @@ id|hypertable_id|column_name     |column_type             |aligned|num_slices|pa
  1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
  2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
  3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
 (9 rows)
 
 
@@ -3176,10 +3254,10 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      15|            8|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
-      16|            8|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
-      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      15|            9|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
+      16|            9|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
+      17|            9|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            9|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (4 rows)
 
 
@@ -3248,8 +3326,8 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      17|            9|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            9|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (2 rows)
 
 
@@ -3348,7 +3426,7 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-18|           10|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
 (1 row)
 
 
@@ -3399,8 +3477,8 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-19|           10|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-18|           10|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
 (2 rows)
 
 
@@ -3465,8 +3543,8 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-19|           10|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-18|           10|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
 (2 rows)
 
 
@@ -3837,8 +3915,8 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                           
 --------+-------------+---------------------+-----------------------+-------+---------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
 (2 rows)
 
 
@@ -3858,12 +3936,30 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
  
 (1 row)
 
+-- Dimension partitions should be updated to account for replication
+-- to additional data nodes
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
+
 SELECT * FROM set_replication_factor('hyper', 3);
 WARNING:  hypertable "hyper" is under-replicated
  set_replication_factor 
 ------------------------
  
 (1 row)
+
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |                            data_nodes                            
+------------+--------------+----------------------+------------------------------------------------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1,db_dist_hypertable_2,db_dist_hypertable_3}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2,db_dist_hypertable_3,db_dist_hypertable_1}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3,db_dist_hypertable_1,db_dist_hypertable_2}
+(3 rows)
 
 INSERT INTO hyper VALUES ('2017-01-02 07:11', 1, 1.7);
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
@@ -3888,8 +3984,8 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                           
 --------+-------------+---------------------+-----------------------+-------+---------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
 (2 rows)
 
 
@@ -3933,9 +4029,9 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3963,6 +4059,14 @@ WARNING:  hypertable "hyper" is under-replicated
  
 (1 row)
 
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |                 data_nodes                  
+------------+--------------+----------------------+---------------------------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1,db_dist_hypertable_2}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2,db_dist_hypertable_3}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3,db_dist_hypertable_1}
+(3 rows)
+
 INSERT INTO hyper VALUES ('2017-03-01 06:01', 1, 15.1);
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
     SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
@@ -3988,10 +4092,10 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      26|           15|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
 (4 rows)
 
 
@@ -4044,11 +4148,11 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      26|           15|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
-      27|           15|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
 (5 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -9,6 +9,7 @@ psql:include/remote_exec.sql:5: NOTICE:  schema "test" already exists, skipping
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set DATA_NODE_4 :TEST_DBNAME _4
 \set TABLESPACE_1 :TEST_DBNAME _1
 \set TABLESPACE_2 :TEST_DBNAME _2
 SELECT
@@ -25,6 +26,15 @@ FROM (VALUES (:'DATA_NODE_1'), (:'DATA_NODE_2'), (:'DATA_NODE_3')) v (name);
 (3 rows)
 
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+-- View to see dimension partitions. Note RIGHT JOIN to see that
+-- dimension partitions are cleaned up (deleted) properly.
+CREATE VIEW hypertable_partitions AS
+SELECT table_name, dimension_id, range_start, data_nodes
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.dimension d ON (d.hypertable_id = h.id)
+RIGHT JOIN _timescaledb_catalog.dimension_partition dp ON (dp.dimension_id = d.id)
+ORDER BY dimension_id, range_start;
+GRANT SELECT ON hypertable_partitions TO :ROLE_1;
 -- Import testsupport.sql file to data nodes
 \unset ECHO
 SET ROLE :ROLE_1;
@@ -54,7 +64,15 @@ WARNING:  insufficient number of partitions for dimension "device"
              1 | public      | disttable  | t
 (1 row)
 
--- Increase the number of partitions. Expect warning since still too low
+-- Increase the number of partitions. Expect warning since still too
+-- low. Dimension partitions should be updated to reflect new
+-- partitioning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+(1 row)
+
 SELECT * FROM set_number_partitions('disttable', 2);
 WARNING:  insufficient number of partitions for dimension "device"
  set_number_partitions 
@@ -62,13 +80,35 @@ WARNING:  insufficient number of partitions for dimension "device"
  
 (1 row)
 
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |           1073741823 | {db_dist_hypertable_2}
+(2 rows)
+
 -- Set number of partitions equal to the number of servers should not
 -- raise a warning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |           1073741823 | {db_dist_hypertable_2}
+(2 rows)
+
 SELECT * FROM set_number_partitions('disttable', 3, 'device');
  set_number_partitions 
 -----------------------
  
 (1 row)
+
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |            715827882 | {db_dist_hypertable_2}
+ disttable  |            2 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
 
 -- Show the number of slices
 SELECT h.table_name, d.column_name, d.num_slices
@@ -84,11 +124,35 @@ AND h.table_name = 'disttable';
 -- This table tests both 1-dimensional tables and under-replication
 -- (replication_factor > num_data_nodes).
 CREATE TABLE underreplicated(time timestamptz, device int, temp float);
+\set ON_ERROR_STOP 0
+-- can't create an under-replicated hypertable
+SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
+ERROR:  replication factor too large for hypertable "underreplicated"
+\set ON_ERROR_STOP 1
+-- can create under-replicated hypertable byf force detaching a data node
+RESET ROLE;
+SELECT * FROM add_data_node(:'DATA_NODE_4', host => 'localhost', database => :'DATA_NODE_4');
+      node_name       |   host    | port  |       database       | node_created | database_created | extension_created 
+----------------------+-----------+-------+----------------------+--------------+------------------+-------------------
+ db_dist_hypertable_4 | localhost | 55432 | db_dist_hypertable_4 | t            | t                | t
+(1 row)
+
+GRANT USAGE ON FOREIGN SERVER :DATA_NODE_4 TO PUBLIC;
+SET ROLE :ROLE_1;
 SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |   table_name    | created 
 ---------------+-------------+-----------------+---------
              2 | public      | underreplicated | t
+(1 row)
+
+--create new session to clear out connections
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SELECT * FROM delete_data_node(:'DATA_NODE_4', force => true, drop_database => true);
+WARNING:  insufficient number of data nodes for distributed hypertable "underreplicated"
+ delete_data_node 
+------------------
+ t
 (1 row)
 
 SET ROLE :ROLE_1;
@@ -184,11 +248,10 @@ INSERT INTO disttable VALUES
  Custom Scan (HypertableModify)
  Insert on distributed hypertable disttable
    ->  Insert on disttable
-         ->  Custom Scan (DataNodeDispatch)
-               Batch size: 1000
+         ->  Custom Scan (DataNodeCopy)
                ->  Custom Scan (ChunkDispatch)
                      ->  Result
-(7 rows)
+(6 rows)
 
 EXPLAIN (VERBOSE, COSTS FALSE)
 INSERT INTO disttable VALUES
@@ -199,15 +262,14 @@ INSERT INTO disttable VALUES
  Insert on distributed hypertable public.disttable
    Data nodes: db_dist_hypertable_1, db_dist_hypertable_2, db_dist_hypertable_3
    ->  Insert on public.disttable
-         ->  Custom Scan (DataNodeDispatch)
+         ->  Custom Scan (DataNodeCopy)
                Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
-               Batch size: 1000
-               Remote SQL: INSERT INTO public.disttable("time", device, temp) VALUES ($1, $2, $3), ..., ($2998, $2999, $3000)
+               Remote SQL: COPY public.disttable ("time", device, temp) FROM STDIN WITH (FORMAT binary)
                ->  Custom Scan (ChunkDispatch)
                      Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
                      ->  Result
                            Output: 'Sun Jan 01 06:01:00 2017 PST'::timestamp with time zone, 1, NULL::integer, '1.1'::double precision
-(12 rows)
+(11 rows)
 
 -- Create some chunks through insertion
 INSERT INTO disttable VALUES
@@ -367,6 +429,14 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1,2,3;
         5 |             2 | db_dist_hypertable_2
         6 |             2 | db_dist_hypertable_3
 (6 rows)
+
+SELECT * FROM hypertable_partitions;
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ disttable  |            2 | -9223372036854775808 | {db_dist_hypertable_1}
+ disttable  |            2 |            715827882 | {db_dist_hypertable_2}
+ disttable  |            2 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
 
 -- Show that chunks are created on data nodes and that each data node
 -- has their own unique slice in the space (device) dimension.
@@ -1958,12 +2028,20 @@ CREATE TABLE "Table\\Schema"."Param_Table"("time Col %#^#@$#" timestamptz, __reg
 SELECT * FROM create_distributed_hypertable('"Table\\Schema"."Param_Table"', 'time Col %#^#@$#', partitioning_column => '__region',
 associated_schema_name => 'T3sTSch', associated_table_prefix => 'test*pre_', chunk_time_interval => interval '1 week',
 create_default_indexes => FALSE, if_not_exists => TRUE, replication_factor => 2,
-data_nodes => ARRAY[:'DATA_NODE_3']);
-WARNING:  only one data node was assigned to the hypertable
+data_nodes => ARRAY[:'DATA_NODE_2', :'DATA_NODE_3']);
 NOTICE:  adding not-null constraint to column "time Col %#^#@$#"
  hypertable_id |  schema_name  | table_name  | created 
 ---------------+---------------+-------------+---------
              4 | Table\\Schema | Param_Table | t
+(1 row)
+
+-- Test detach and attach data node
+SELECT * FROM detach_data_node(:'DATA_NODE_2', '"Table\\Schema"."Param_Table"', force => true, drop_remote_data => true);
+WARNING:  insufficient number of data nodes for distributed hypertable "Param_Table"
+NOTICE:  the number of partitions in dimension "__region" of hypertable "Param_Table" was decreased to 1
+ detach_data_node 
+------------------
+                1
 (1 row)
 
 -- Test attach_data_node. First show dimensions and currently attached
@@ -2027,7 +2105,7 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', '"Table\\Schema"."Param_Table"', 
 WARNING:  insufficient number of partitions for dimension "__region"
  hypertable_id | node_hypertable_id |      node_name       
 ---------------+--------------------+----------------------
-             4 |                  3 | db_dist_hypertable_2
+             4 |                  4 | db_dist_hypertable_2
 (1 row)
 
 -- Number of slices should not be increased
@@ -2121,7 +2199,7 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 --+-------------+---------------+----------------------+-----------------------+--------------+------------------------+------------------------+-----------------+-----------------+------------------------+------------------
  1|public       |disttable      |_timescaledb_internal |_dist_hyper_1          |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
  2|public       |underreplicated|_timescaledb_internal |_dist_hyper_2          |             1|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
- 3|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
+ 4|Table\\Schema|Param_Table    |T3sTSch               |test*pre_              |             2|_timescaledb_internal   |calculate_chunk_interval|                0|                0|                        |                -1
 (3 rows)
 
 
@@ -2133,8 +2211,8 @@ id|hypertable_id|column_name     |column_type             |aligned|num_slices|pa
  1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
  2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
  3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
 (5 rows)
 
 
@@ -2189,7 +2267,7 @@ ts_insert_blocker|     7|_timescaledb_internal.insert_blocker
 
 -- Verify that repartitioning works as expected on detach_data_node
 SELECT * FROM detach_data_node(:'DATA_NODE_1', '"Table\\Schema"."Param_Table"', repartition => true);
-NOTICE:  the number of partitions in dimension "__region" was decreased to 2
+NOTICE:  the number of partitions in dimension "__region" of hypertable "Param_Table" was decreased to 2
  detach_data_node 
 ------------------
                 1
@@ -2306,7 +2384,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
  hypertable_id | node_hypertable_id |      node_name       
 ---------------+--------------------+----------------------
-             5 |                  4 | db_dist_hypertable_2
+             5 |                  5 | db_dist_hypertable_2
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -2352,12 +2430,12 @@ id|hypertable_id|column_name     |column_type             |aligned|num_slices|pa
  1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
  2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
  3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
 (9 rows)
 
 
@@ -3183,10 +3261,10 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      15|            8|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
-      16|            8|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
-      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      15|            9|_timescaledb_internal|_dist_hyper_10_27_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [-9223372036854775808, 715827882]}
+      16|            9|_timescaledb_internal|_dist_hyper_10_29_chunk|r      |{"time": [1482969600000000, 1483574400000000], "device": [715827882, 1431655764]}          
+      17|            9|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            9|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (4 rows)
 
 
@@ -3255,8 +3333,8 @@ FROM show_chunks('disttable_drop_chunks')
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      17|            8|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
-      18|            8|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
+      17|            9|_timescaledb_internal|_dist_hyper_10_30_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [-9223372036854775808, 715827882]}
+      18|            9|_timescaledb_internal|_dist_hyper_10_31_chunk|r      |{"time": [1530144000000000, 1530748800000000], "device": [715827882, 1431655764]}          
 (2 rows)
 
 
@@ -3355,7 +3433,7 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-18|           10|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
 (1 row)
 
 
@@ -3406,8 +3484,8 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-19|           10|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-18|           10|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
 (2 rows)
 
 
@@ -3472,8 +3550,8 @@ WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
 id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
 --+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-19|           10|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-18|           10|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
 (2 rows)
 
 
@@ -3844,8 +3922,8 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                           
 --------+-------------+---------------------+-----------------------+-------+---------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
 (2 rows)
 
 
@@ -3865,12 +3943,30 @@ chunk_id|hypertable_id|schema_name          |table_name             |relkind|sli
  
 (1 row)
 
+-- Dimension partitions should be updated to account for replication
+-- to additional data nodes
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |       data_nodes       
+------------+--------------+----------------------+------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3}
+(3 rows)
+
 SELECT * FROM set_replication_factor('hyper', 3);
 WARNING:  hypertable "hyper" is under-replicated
  set_replication_factor 
 ------------------------
  
 (1 row)
+
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |                            data_nodes                            
+------------+--------------+----------------------+------------------------------------------------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1,db_dist_hypertable_2,db_dist_hypertable_3}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2,db_dist_hypertable_3,db_dist_hypertable_1}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3,db_dist_hypertable_1,db_dist_hypertable_2}
+(3 rows)
 
 INSERT INTO hyper VALUES ('2017-01-02 07:11', 1, 1.7);
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
@@ -3895,8 +3991,8 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                           
 --------+-------------+---------------------+-----------------------+-------+---------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}
 (2 rows)
 
 
@@ -3940,9 +4036,9 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
 (3 rows)
 
 
@@ -3970,6 +4066,14 @@ WARNING:  hypertable "hyper" is under-replicated
  
 (1 row)
 
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+ table_name | dimension_id |     range_start      |                 data_nodes                  
+------------+--------------+----------------------+---------------------------------------------
+ hyper      |           29 | -9223372036854775808 | {db_dist_hypertable_1,db_dist_hypertable_2}
+ hyper      |           29 |            715827882 | {db_dist_hypertable_2,db_dist_hypertable_3}
+ hyper      |           29 |           1431655764 | {db_dist_hypertable_3,db_dist_hypertable_1}
+(3 rows)
+
 INSERT INTO hyper VALUES ('2017-03-01 06:01', 1, 15.1);
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
     SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
@@ -3995,10 +4099,10 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      26|           15|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
 (4 rows)
 
 
@@ -4051,11 +4155,11 @@ NOTICE:  [db_dist_hypertable_2]:
 NOTICE:  [db_dist_hypertable_2]:
 chunk_id|hypertable_id|schema_name          |table_name             |relkind|slices                                                                                     
 --------+-------------+---------------------+-----------------------+-------+-------------------------------------------------------------------------------------------
-      23|           15|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
-      24|           15|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
-      25|           15|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
-      26|           15|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
-      27|           15|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
+      23|           16|_timescaledb_internal|_dist_hyper_17_47_chunk|r      |{"time": [1483336800000000, 1483401600000000], "device": [715827882, 1431655764]}          
+      24|           16|_timescaledb_internal|_dist_hyper_17_50_chunk|r      |{"time": [1515801600000000, 1515866400000000], "device": [715827882, 1431655764]}          
+      25|           16|_timescaledb_internal|_dist_hyper_17_52_chunk|r      |{"time": [1485928800000000, 1485993600000000], "device": [-9223372036854775808, 715827882]}
+      26|           16|_timescaledb_internal|_dist_hyper_17_53_chunk|r      |{"time": [1488326400000000, 1488391200000000], "device": [-9223372036854775808, 715827882]}
+      27|           16|_timescaledb_internal|_dist_hyper_17_54_chunk|r      |{"time": [1491048000000000, 1491112800000000], "device": [715827882, 1431655764]}          
 (5 rows)
 
 

--- a/tsl/test/expected/dist_triggers.out
+++ b/tsl/test/expected/dist_triggers.out
@@ -95,6 +95,15 @@ SELECT * FROM create_distributed_hypertable('hyper', 'time', 'device_id', 3, chu
              1 | public      | hyper      | t
 (1 row)
 
+SELECT * FROM _timescaledb_catalog.dimension_partition
+ORDER BY 1,2;
+ dimension_id |     range_start      |      data_nodes      
+--------------+----------------------+----------------------
+            2 | -9223372036854775808 | {db_dist_triggers_1}
+            2 |            715827882 | {db_dist_triggers_2}
+            2 |           1431655764 | {db_dist_triggers_1}
+(3 rows)
+
 -- FAILURE cases
 \set ON_ERROR_STOP 0
 -- Check that CREATE TRIGGER fails if a trigger already exists on a data node.
@@ -298,6 +307,15 @@ SELECT attach_data_node(:'DATA_NODE_3', 'hyper');
 --------------------------
  (1,1,db_dist_triggers_3)
 (1 row)
+
+SELECT * FROM _timescaledb_catalog.dimension_partition
+ORDER BY 1,2;
+ dimension_id |     range_start      |      data_nodes      
+--------------+----------------------+----------------------
+            2 | -9223372036854775808 | {db_dist_triggers_1}
+            2 |            715827882 | {db_dist_triggers_2}
+            2 |           1431655764 | {db_dist_triggers_3}
+(3 rows)
 
 -- Show that triggers are created on the new data node after attaching
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_3'],

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -158,7 +158,7 @@ ERROR:  cannot execute detach_data_node() in a read-only transaction
 \set ON_ERROR_STOP 1
 SET default_transaction_read_only TO off;
 SELECT * FROM detach_data_node(:'DATA_NODE_2', 'disttable');
-NOTICE:  the number of partitions in dimension "device" was decreased to 1
+NOTICE:  the number of partitions in dimension "device" of hypertable "disttable" was decreased to 1
  detach_data_node 
 ------------------
                 1

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -16,6 +16,7 @@
 \set DATA_NODE_1 :TEST_DBNAME _1
 \set DATA_NODE_2 :TEST_DBNAME _2
 \set DATA_NODE_3 :TEST_DBNAME _3
+\set DATA_NODE_4 :TEST_DBNAME _4
 \set TABLESPACE_1 :TEST_DBNAME _1
 \set TABLESPACE_2 :TEST_DBNAME _2
 SELECT
@@ -27,6 +28,16 @@ SELECT (add_data_node (name, host => 'localhost', DATABASE => name)).*
 FROM (VALUES (:'DATA_NODE_1'), (:'DATA_NODE_2'), (:'DATA_NODE_3')) v (name);
 
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+
+-- View to see dimension partitions. Note RIGHT JOIN to see that
+-- dimension partitions are cleaned up (deleted) properly.
+CREATE VIEW hypertable_partitions AS
+SELECT table_name, dimension_id, range_start, data_nodes
+FROM _timescaledb_catalog.hypertable h
+INNER JOIN _timescaledb_catalog.dimension d ON (d.hypertable_id = h.id)
+RIGHT JOIN _timescaledb_catalog.dimension_partition dp ON (dp.dimension_id = d.id)
+ORDER BY dimension_id, range_start;
+GRANT SELECT ON hypertable_partitions TO :ROLE_1;
 
 -- Import testsupport.sql file to data nodes
 \unset ECHO
@@ -63,12 +74,18 @@ CREATE TABLE disttable(time timestamptz, device int CHECK (device > 0), color in
 
 SELECT * FROM create_distributed_hypertable('disttable', 'time', 'device', 1);
 
--- Increase the number of partitions. Expect warning since still too low
+-- Increase the number of partitions. Expect warning since still too
+-- low. Dimension partitions should be updated to reflect new
+-- partitioning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
 SELECT * FROM set_number_partitions('disttable', 2);
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
 
 -- Set number of partitions equal to the number of servers should not
 -- raise a warning.
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
 SELECT * FROM set_number_partitions('disttable', 3, 'device');
+SELECT * FROM hypertable_partitions WHERE table_name = 'disttable';
 
 -- Show the number of slices
 SELECT h.table_name, d.column_name, d.num_slices
@@ -79,8 +96,21 @@ AND h.table_name = 'disttable';
 -- This table tests both 1-dimensional tables and under-replication
 -- (replication_factor > num_data_nodes).
 CREATE TABLE underreplicated(time timestamptz, device int, temp float);
+
+\set ON_ERROR_STOP 0
+-- can't create an under-replicated hypertable
+SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
+\set ON_ERROR_STOP 1
+-- can create under-replicated hypertable byf force detaching a data node
+RESET ROLE;
+SELECT * FROM add_data_node(:'DATA_NODE_4', host => 'localhost', database => :'DATA_NODE_4');
+GRANT USAGE ON FOREIGN SERVER :DATA_NODE_4 TO PUBLIC;
+SET ROLE :ROLE_1;
 SELECT * FROM create_hypertable('underreplicated', 'time', replication_factor => 4);
 
+--create new session to clear out connections
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SELECT * FROM delete_data_node(:'DATA_NODE_4', force => true, drop_database => true);
 SET ROLE :ROLE_1;
 
 CREATE OR REPLACE FUNCTION test_trigger()
@@ -224,6 +254,7 @@ FROM show_chunks('disttable');
 -- Show that there are assigned node_chunk_id:s in chunk data node mappings
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1,2,3;
 
+SELECT * FROM hypertable_partitions;
 -- Show that chunks are created on data nodes and that each data node
 -- has their own unique slice in the space (device) dimension.
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
@@ -584,7 +615,10 @@ CREATE TABLE "Table\\Schema"."Param_Table"("time Col %#^#@$#" timestamptz, __reg
 SELECT * FROM create_distributed_hypertable('"Table\\Schema"."Param_Table"', 'time Col %#^#@$#', partitioning_column => '__region',
 associated_schema_name => 'T3sTSch', associated_table_prefix => 'test*pre_', chunk_time_interval => interval '1 week',
 create_default_indexes => FALSE, if_not_exists => TRUE, replication_factor => 2,
-data_nodes => ARRAY[:'DATA_NODE_3']);
+data_nodes => ARRAY[:'DATA_NODE_2', :'DATA_NODE_3']);
+
+-- Test detach and attach data node
+SELECT * FROM detach_data_node(:'DATA_NODE_2', '"Table\\Schema"."Param_Table"', force => true, drop_remote_data => true);
 
 -- Test attach_data_node. First show dimensions and currently attached
 -- servers.  The number of slices in the space dimension should equal
@@ -1189,7 +1223,12 @@ SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE
     FROM show_chunks('hyper');
 $$);
 
+-- Dimension partitions should be updated to account for replication
+-- to additional data nodes
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
 SELECT * FROM set_replication_factor('hyper', 3);
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
+
 INSERT INTO hyper VALUES ('2017-01-02 07:11', 1, 1.7);
 
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
@@ -1205,6 +1244,7 @@ SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE
 $$);
 
 SELECT * FROM set_replication_factor('hyper', 2);
+SELECT * FROM hypertable_partitions WHERE table_name = 'hyper';
 
 INSERT INTO hyper VALUES ('2017-03-01 06:01', 1, 15.1);
 

--- a/tsl/test/sql/dist_triggers.sql
+++ b/tsl/test/sql/dist_triggers.sql
@@ -122,6 +122,9 @@ CREATE TRIGGER z_test_trigger_all_after
 --- hypertable and some triggers after so that we test both cases.
 SELECT * FROM create_distributed_hypertable('hyper', 'time', 'device_id', 3, chunk_time_interval => 10, data_nodes => ARRAY[:'DATA_NODE_1', :'DATA_NODE_2']);
 
+SELECT * FROM _timescaledb_catalog.dimension_partition
+ORDER BY 1,2;
+
 -- FAILURE cases
 \set ON_ERROR_STOP 0
 
@@ -251,6 +254,8 @@ $$);
 -- Attach a new data node and show that the hypertable is created on
 -- the node, including its triggers.
 SELECT attach_data_node(:'DATA_NODE_3', 'hyper');
+SELECT * FROM _timescaledb_catalog.dimension_partition
+ORDER BY 1,2;
 
 -- Show that triggers are created on the new data node after attaching
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_3'],


### PR DESCRIPTION
Add a new metadata table `dimension_partition` which explicitly and
statefully details how a space dimension is split into partitions, and
(in the case of multi-node) which data nodes are responsible for
storing chunks in each partition. Previously, partition and data nodes
were assigned dynamically based on the current state when creating a
chunk.

This is the first in a series of changes that will add more advanced
functionality over time. For now, the metadata table simply writes out
what was previously computed dynamically in code. Future code changes
will alter the behavior to do smarter updates to the partitions when,
e.g., adding and removing data nodes.

The idea of the `dimension_partition` table is to minimize changes in
the partition to data node mappings across various events, such as
changes in the number of data nodes, number of partitions, or the
replication factor, which affect the mappings. For example, increasing
the number of partitions from 3 to 4 currently leads to redefining all
partition ranges and data node mappings to account for the new
partition. Complete repartitioning can be disruptive to multi-node
deployments. With stateful mappings, it is possible to split an
existing partition without affecting the other partitions (similar to
partitioning using consistent hashing).

Note that the dimension partition table expresses the current state of
space partitions; i.e., the space-dimension constraints and data nodes
to be assigned to new chunks. Existing chunks are not affected by
changes in the dimension partition table, although an external job
could rewrite, move, or copy chunks as desired to comply with the
current dimension partition state. As such, the dimension partition
table represents the "desired" space partitioning state.


Part of #4125