### PR TITLE
Fix tests to be resilient to possible PG planner changes.

### DIFF
--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -669,7 +669,7 @@ ORDER BY c.id;
 \set QUERY1 'SELECT show_chunks(\'drop_chunk_test1\', newer_than=>5)::NAME'
 \set QUERY2 'SELECT drop_chunks(\'drop_chunk_test1\', newer_than=>5, verbose => true)::NAME'
 \set ECHO errors
-psql:include/query_result_test_equal.sql:14: INFO:  dropping chunk _timescaledb_internal._hyper_1_5_chunk
+psql:include/query_result_test_equal.sql:16: INFO:  dropping chunk _timescaledb_internal._hyper_1_5_chunk
  Different Rows | Total Rows from Query 1 | Total Rows from Query 2 
 ----------------+-------------------------+-------------------------
               0 |                       1 |                       1

--- a/test/sql/include/query_result_test_equal.sql
+++ b/test/sql/include/query_result_test_equal.sql
@@ -3,6 +3,8 @@
 -- LICENSE-APACHE for a copy of the license.
 
 --expects QUERY1 and QUERY2 to be set, expects data can be compared
+set enable_hashjoin = off;
+set enable_mergejoin = on;
 with query1 AS (
   SELECT row_number() OVER(ORDER BY q.*) row_number, * FROM (:QUERY1) as q
 ),
@@ -12,3 +14,5 @@ query2 AS (
 SELECT count(*) FILTER (WHERE query1.row_number IS DISTINCT FROM query2.row_number OR query1.show_chunks IS DISTINCT FROM query2.drop_chunks) AS "Different Rows",
 coalesce(max(query1.row_number), 0) AS "Total Rows from Query 1", coalesce(max(query2.row_number), 0) AS "Total Rows from Query 2"
 FROM query1 FULL OUTER JOIN query2 ON (query1.row_number = query2.row_number);
+reset enable_hashjoin;
+reset enable_mergejoin;


### PR DESCRIPTION
When running Timescaledb tests with a custom build of PostgreSQL 14 (with modified planner code), I noticed that some **alter** and **chunk_utils** tests fail:
[regression.diff.txt](https://github.com/timescale/timescaledb/files/8918266/regression.diff.txt)

I found that it was due to different plans e.g. in alter.sql. I got:
[modified.txt](https://github.com/timescale/timescaledb/files/8918311/modified.txt)
instead of 
[original.txt](https://github.com/timescale/timescaledb/files/8918318/original.txt)

This leads to change in the order of calls of _drop_chunks_ and _show_chunks_ which is not expected by the test.

In a current PR I propose a quick fix for the problem.

(for easy reproduction of planner change there can be used planner hacking from the patch, though I found the problem other way. It was due to custom modified PostgreSQL code)
[0001-Patch-to-reproduce-tests-fail.patch.txt](https://github.com/timescale/timescaledb/files/8918275/0001-Patch-to-reproduce-tests-fail.patch.txt)
)

