### PR TITLE
Keep locks after reading job status

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -591,7 +591,6 @@ ts_bgw_job_find(int32 bgw_job_id, MemoryContext mctx, bool fail_if_not_found)
 		elog(ERROR, "job %d not found", bgw_job_id);
 
 	return job;
-	;
 }
 
 static void
@@ -1210,6 +1209,6 @@ ts_bgw_job_insert_relation(Name application_name, Interval *schedule_interval,
 	ts_catalog_insert_values(rel, desc, values, nulls);
 	ts_catalog_restore_user(&sec_ctx);
 
-	table_close(rel, RowExclusiveLock);
+	table_close(rel, NoLock);
 	return values[AttrNumberGetAttrOffset(Anum_bgw_job_id)];
 }

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -134,7 +134,10 @@ ts_bgw_start_worker(const char *name, const BgwParams *bgw_params)
 	/* handle needs to be allocated in long-lived memory context */
 	MemoryContextSwitchTo(scheduler_mctx);
 	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+	{
+		elog(NOTICE, "unable to register background worker");
 		handle = NULL;
+	}
 	MemoryContextSwitchTo(scratch_mctx);
 
 	return handle;

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -69,8 +69,8 @@ ts_bgw_db_scheduler_test_main(PG_FUNCTION_ARGS)
 
 	memcpy(&bgw_params, MyBgworkerEntry->bgw_extra, sizeof(bgw_params));
 
-	elog(WARNING, "scheduler user id %u", bgw_params.user_oid);
-	elog(WARNING, "running a test in the background: db=%u ttl=%d", db_oid, bgw_params.ttl);
+	elog(NOTICE, "scheduler user id %u", bgw_params.user_oid);
+	elog(NOTICE, "running a test in the background: db=%u ttl=%d", db_oid, bgw_params.ttl);
 
 	BackgroundWorkerInitializeConnectionByOid(db_oid, bgw_params.user_oid, 0);
 


### PR DESCRIPTION
When reading the job status table `bgw_job_stat` and after that
updating it, locks where released after the read, allowing a competing
session to update the job status and trigger a concurrent update error
either in a session doing the update or in the scheduler. Since the
scheduler does not recover after aborting with an error, this caused
the background worker subsystem to stop and not start new jobs.

This commit fixes this by upgrading `RowExclusiveLock` to
`ShareRowExclusiveLock` to ensure that not two sessions tries to update
the row at the same time, remove an initial speculative lock
that are taken when a job status row can be added, and also keeps the
lock until the end of the transaction to prevent other sessions to
update. Since these updating transactions are short, it should not
cause other threads to block long.

Fixes #4293