### PR TITLE
Use PG 14.4 in update test

### DIFF
--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        pg: ["12.11", "13.7", "14.3"]
+        pg: ["12.11", "13.7", "14.4"]
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}
@@ -44,7 +44,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        pg: ["12.11", "13.7", "14.3"]
+        pg: ["12.11", "13.7", "14.4"]
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}


### PR DESCRIPTION
Switch update/downgrade test to use 14.4. This has been split off
the CI PR switching the rest of CI to 14.4 because it usually takes
more then a week for the upstream docker images to become available.