### PR TITLE
Fix empty bytea handlng with distributed tables

### DIFF
--- a/tsl/src/remote/tuplefactory.c
+++ b/tsl/src/remote/tuplefactory.c
@@ -272,8 +272,8 @@ tuplefactory_make_virtual_tuple(TupleFactory *tf, PGresult *res, int row, int fo
 		char *valstr = NULL;
 
 		const int len = PQgetlength(res, row, j);
-		/* we assume that value is NULL is length is 0 */
-		if (len == 0)
+		/* check via PGgetisnull to see if the attr is null */
+		if (PQgetisnull(res, row, j))
 			valstr = NULL;
 		else
 		{

--- a/tsl/test/shared/expected/dist_fetcher_type.out
+++ b/tsl/test/shared/expected/dist_fetcher_type.out
@@ -131,3 +131,43 @@ QUERY PLAN
    Remote SQL: SELECT "time", txn_id, val, info FROM public.disttable_with_ct WHERE _timescaledb_internal.chunks_in(public.disttable_with_ct.*, ARRAY[..])
 (6 rows)
 
+-- Row by row fetcher with bytea data
+set timescaledb.remote_data_fetcher = 'rowbyrow';
+explain (analyze, verbose, costs off, timing off, summary off)
+select * from disttable_with_bytea;
+QUERY PLAN
+ Custom Scan (DataNodeScan) on public.disttable_with_bytea (actual rows=2 loops=1)
+   Output: disttable_with_bytea."time", disttable_with_bytea.bdata
+   Data node: data_node_3
+   Fetcher Type: Row by row
+   Chunks: _dist_hyper_X_X_chunk
+   Remote SQL: SELECT "time", bdata FROM public.disttable_with_bytea WHERE _timescaledb_internal.chunks_in(public.disttable_with_bytea.*, ARRAY[..])
+(6 rows)
+
+select * from disttable_with_bytea;
+ time | bdata 
+------+-------
+ 1001 | \x
+ 1001 | 
+(2 rows)
+
+-- Cursor fetcher with bytea data
+set timescaledb.remote_data_fetcher = 'cursor';
+explain (analyze, verbose, costs off, timing off, summary off)
+select * from disttable_with_bytea;
+QUERY PLAN
+ Custom Scan (DataNodeScan) on public.disttable_with_bytea (actual rows=2 loops=1)
+   Output: disttable_with_bytea."time", disttable_with_bytea.bdata
+   Data node: data_node_3
+   Fetcher Type: Cursor
+   Chunks: _dist_hyper_X_X_chunk
+   Remote SQL: SELECT "time", bdata FROM public.disttable_with_bytea WHERE _timescaledb_internal.chunks_in(public.disttable_with_bytea.*, ARRAY[..])
+(6 rows)
+
+select * from disttable_with_bytea;
+ time | bdata 
+------+-------
+ 1001 | \x
+ 1001 | 
+(2 rows)
+

--- a/tsl/test/shared/sql/dist_fetcher_type.sql
+++ b/tsl/test/shared/sql/dist_fetcher_type.sql
@@ -81,3 +81,17 @@ set timescaledb.remote_data_fetcher = 'auto';
 
 explain (analyze, verbose, costs off, timing off, summary off)
 select * from disttable_with_ct;
+
+-- Row by row fetcher with bytea data
+set timescaledb.remote_data_fetcher = 'rowbyrow';
+
+explain (analyze, verbose, costs off, timing off, summary off)
+select * from disttable_with_bytea;
+select * from disttable_with_bytea;
+
+-- Cursor fetcher with bytea data
+set timescaledb.remote_data_fetcher = 'cursor';
+
+explain (analyze, verbose, costs off, timing off, summary off)
+select * from disttable_with_bytea;
+select * from disttable_with_bytea;

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -287,6 +287,12 @@ INSERT INTO disttable_with_ct VALUES
     ('2019-01-01 01:01', 'ts-1-10-20-30', 1.1, 'a'),
     ('2019-01-01 01:02', 'ts-1-11-20-30', 2.0, repeat('abc', 1000000)); -- TOAST
 
+-- Distributed table with bytea type and insert "empty" and "NULL" values in it
+CREATE TABLE disttable_with_bytea(time bigint NOT NULL, bdata bytea);
+SELECT create_distributed_hypertable('disttable_with_bytea', 'time', chunk_time_interval => 1000000);
+INSERT INTO disttable_with_bytea(time, bdata) VALUES (1001, E'\\x');
+INSERT INTO disttable_with_bytea(time, bdata) VALUES (1001, NULL);
+
 -- Createt table to test fix for https://github.com/timescale/timescaledb/issues/4339
 CREATE TABLE matches (
   day INT NOT NULL,


### PR DESCRIPTION
The "empty" bytea value in a column of a distributed table when
selected was being returned as "null". The actual value on the
datanodes was being stored appropriately but just the return code path
was converting it into "null" on the AN. This has been handled via the
use of PQgetisnull() function now.

Fixes #3455