### PR TITLE
Block drop chunk if chunk is in frozen state

### DIFF
--- a/sql/chunk.sql
+++ b/sql/chunk.sql
@@ -85,6 +85,10 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.freeze_chunk(
    chunk REGCLASS)
 RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_chunk_freeze_chunk' LANGUAGE C VOLATILE;
 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.unfreeze_chunk(
+   chunk REGCLASS)
+RETURNS BOOL AS '@MODULE_PATHNAME@', 'ts_chunk_unfreeze_chunk' LANGUAGE C VOLATILE;
+
 --wrapper for ts_chunk_drop
 --drops the chunk table and its entry in the chunk catalog
 CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_chunk(

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -17,4 +17,4 @@ AS '@MODULE_PATHNAME@', 'ts_data_node_detach' LANGUAGE C VOLATILE;
 
 DROP FUNCTION _timescaledb_internal.attach_osm_table_chunk( hypertable REGCLASS, chunk REGCLASS);
 DROP FUNCTION _timescaledb_internal.alter_job_set_hypertable_id( job_id INTEGER, hypertable REGCLASS );
-
+DROP FUNCTION _timescaledb_internal.unfreeze_chunk( chunk REGCLASS);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -71,6 +71,7 @@ TS_FUNCTION_INFO_V1(ts_chunk_drop_chunks);
 TS_FUNCTION_INFO_V1(ts_chunk_drop_single_chunk);
 TS_FUNCTION_INFO_V1(ts_chunk_attach_osm_table_chunk);
 TS_FUNCTION_INFO_V1(ts_chunk_freeze_chunk);
+TS_FUNCTION_INFO_V1(ts_chunk_unfreeze_chunk);
 TS_FUNCTION_INFO_V1(ts_chunks_in);
 TS_FUNCTION_INFO_V1(ts_chunk_id_from_relid);
 TS_FUNCTION_INFO_V1(ts_chunk_show);
@@ -78,6 +79,9 @@ TS_FUNCTION_INFO_V1(ts_chunk_create);
 TS_FUNCTION_INFO_V1(ts_chunk_status);
 
 static bool ts_chunk_add_status(Chunk *chunk, int32 status);
+#if PG14_GE
+static bool ts_chunk_clear_status(Chunk *chunk, int32 status);
+#endif
 
 static const char *
 DatumGetNameString(Datum datum)
@@ -166,7 +170,7 @@ static Chunk *chunk_resurrect(const Hypertable *ht, int chunk_id);
 #define CHUNK_STATUS_COMPRESSED_UNORDERED 2
 /*
  * A chunk is in frozen state (i.e no inserts/updates/deletes into this chunk are
- * permitted.
+ * permitted. Other chunk level operations like dropping chunk etc. are also blocked.
  *
  */
 #define CHUNK_STATUS_FROZEN 4
@@ -3431,6 +3435,42 @@ ts_chunk_set_frozen(Chunk *chunk)
 #endif
 }
 
+bool
+ts_chunk_unset_frozen(Chunk *chunk)
+{
+#if PG14_GE
+	return ts_chunk_clear_status(chunk, CHUNK_STATUS_FROZEN);
+#else
+	elog(ERROR, "freeze chunk supported only for PG14 or greater");
+	return false;
+#endif
+}
+
+#if PG14_GE
+/* only caller is ts_chunk_unset_frozen. This code is in PG14 block as we run into
+ * defined but unsed error in CI/CD builds for PG < 14.
+ */
+static bool
+ts_chunk_clear_status(Chunk *chunk, int32 status)
+{
+	/* only frozen status can be cleared for a frozen chunk */
+	if (status != CHUNK_STATUS_FROZEN && ts_flags_are_set_32(chunk->fd.status, CHUNK_STATUS_FROZEN))
+	{
+		/* chunk in frozen state cannot be modified */
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("cannot modify frozen chunk status"),
+				 errdetail("chunk id = %d attempt to clear status %d , current status %x ",
+						   chunk->fd.id,
+						   status,
+						   chunk->fd.status)));
+	}
+	uint32 mstatus = ts_clear_flags_32(chunk->fd.status, status);
+	chunk->fd.status = mstatus;
+	return chunk_update_status(&chunk->fd);
+}
+#endif
+
 static bool
 ts_chunk_add_status(Chunk *chunk, int32 status)
 {
@@ -3830,6 +3870,13 @@ ts_chunk_do_drop_chunks(Hypertable *ht, int64 older_than, int64 newer_than, int3
 
 		ASSERT_IS_VALID_CHUNK(&chunks[i]);
 
+		/* frozen chunks are skipped. Not dropped. */
+		if (!ts_chunk_validate_chunk_status_for_operation(chunks[i].table_id,
+														  chunks[i].fd.status,
+														  CHUNK_DROP,
+														  false /*throw_error */))
+			continue;
+
 		/* store chunk name for output */
 		schema_name = quote_identifier(chunks[i].fd.schema_name.data);
 		table_name = quote_identifier(chunks[i].fd.table_name.data);
@@ -4004,6 +4051,29 @@ ts_chunk_freeze_chunk(PG_FUNCTION_ARGS)
 }
 
 Datum
+ts_chunk_unfreeze_chunk(PG_FUNCTION_ARGS)
+{
+	Oid chunk_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+	TS_PREVENT_FUNC_IF_READ_ONLY();
+	Chunk *chunk = ts_chunk_get_by_relid(chunk_relid, true);
+	Assert(chunk != NULL);
+	if (chunk->relkind == RELKIND_FOREIGN_TABLE)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("operation not supported on distributed chunk or foreign table \"%s\"",
+						get_rel_name(chunk_relid))));
+	}
+	if (!ts_flags_are_set_32(chunk->fd.status, CHUNK_STATUS_FROZEN))
+		PG_RETURN_BOOL(true);
+	/* This is a previously frozen chunk. Only selects are permitted on this chunk.
+	 * This changes the status in the catalog to allow previously blocked operations.
+	 */
+	bool ret = ts_chunk_unset_frozen(chunk);
+	PG_RETURN_BOOL(ret);
+}
+
+Datum
 ts_chunk_drop_single_chunk(PG_FUNCTION_ARGS)
 {
 	Oid chunk_relid = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
@@ -4015,6 +4085,10 @@ ts_chunk_drop_single_chunk(PG_FUNCTION_ARGS)
 															   CurrentMemoryContext,
 															   true);
 	Assert(ch != NULL);
+	ts_chunk_validate_chunk_status_for_operation(chunk_relid,
+												 ch->fd.status,
+												 CHUNK_DROP,
+												 true /*throw_error */);
 	/* do not drop any chunk dependencies */
 	ts_chunk_drop(ch, DROP_RESTRICT, LOG);
 	PG_RETURN_BOOL(true);
@@ -4248,9 +4322,9 @@ get_chunk_operation_str(ChunkOperation cmd)
 	}
 }
 
-void
+bool
 ts_chunk_validate_chunk_status_for_operation(Oid chunk_relid, int32 chunk_status,
-											 ChunkOperation cmd)
+											 ChunkOperation cmd, bool throw_error)
 {
 	if (ts_flags_are_set_32(chunk_status, CHUNK_STATUS_FROZEN))
 	{
@@ -4262,17 +4336,21 @@ ts_chunk_validate_chunk_status_for_operation(Oid chunk_relid, int32 chunk_status
 			case CHUNK_UPDATE:
 			case CHUNK_COMPRESS:
 			case CHUNK_DECOMPRESS:
+			case CHUNK_DROP:
 			{
-				elog(ERROR,
-					 "%s not permitted on frozen chunk \"%s\" ",
-					 get_chunk_operation_str(cmd),
-					 get_rel_name(chunk_relid));
+				if (throw_error)
+					elog(ERROR,
+						 "%s not permitted on frozen chunk \"%s\" ",
+						 get_chunk_operation_str(cmd),
+						 get_rel_name(chunk_relid));
+				return false;
 				break;
 			}
 			default:
 				break; /*supported operations */
 		}
 	}
+	return true;
 }
 
 Datum
@@ -4290,11 +4368,13 @@ ts_chunk_create(PG_FUNCTION_ARGS)
 /**
  * Get the chunk status.
  *
- * Values returned are documented above and is a bitwise or of the values.
+ * Values returned are documented above and is a bitwise or of the
+ * CHUNK_STATUS_XXX values.
  *
  * @see CHUNK_STATUS_DEFAULT
  * @see CHUNK_STATUS_COMPRESSED
  * @see CHUNK_STATUS_COMPRESSED_UNORDERED
+ * @see CHUNK_STATUS_FROZEN
  */
 Datum
 ts_chunk_status(PG_FUNCTION_ARGS)

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -45,7 +45,7 @@ typedef enum ChunkOperation
 	CHUNK_DELETE,
 	CHUNK_SELECT,
 	CHUNK_COMPRESS,
-	CHUNK_DECOMPRESS
+	CHUNK_DECOMPRESS,
 } ChunkOperation;
 
 typedef struct Hypercube Hypercube;
@@ -186,6 +186,7 @@ extern void ts_chunks_rename_schema_name(char *old_schema, char *new_schema);
 
 extern TSDLLEXPORT bool ts_chunk_set_unordered(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_frozen(Chunk *chunk);
+extern TSDLLEXPORT bool ts_chunk_unset_frozen(Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_set_compressed_chunk(Chunk *chunk, int32 compressed_chunk_id);
 extern TSDLLEXPORT bool ts_chunk_clear_compressed_chunk(Chunk *chunk);
 extern TSDLLEXPORT void ts_chunk_drop(const Chunk *chunk, DropBehavior behavior, int32 log_level);
@@ -200,9 +201,10 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(const Chunk *chun
 extern TSDLLEXPORT bool ts_chunk_is_unordered(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_compressed(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_uncompressed_or_unordered(const Chunk *chunk);
-extern TSDLLEXPORT void ts_chunk_validate_chunk_status_for_operation(Oid chunk_relid,
+extern TSDLLEXPORT bool ts_chunk_validate_chunk_status_for_operation(Oid chunk_relid,
 																	 int32 chunk_status,
-																	 ChunkOperation cmd);
+																	 ChunkOperation cmd,
+																	 bool throw_error);
 
 extern TSDLLEXPORT bool ts_chunk_contains_compressed_data(const Chunk *chunk);
 extern TSDLLEXPORT ChunkCompressionStatus ts_chunk_get_compression_status(int32 chunk_id);

--- a/src/nodes/chunk_insert_state.c
+++ b/src/nodes/chunk_insert_state.c
@@ -597,7 +597,10 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 	if (chunk->relkind != RELKIND_RELATION && chunk->relkind != RELKIND_FOREIGN_TABLE)
 		elog(ERROR, "insert is not on a table");
 
-	ts_chunk_validate_chunk_status_for_operation(chunk->table_id, chunk->fd.status, CHUNK_INSERT);
+	ts_chunk_validate_chunk_status_for_operation(chunk->table_id,
+												 chunk->fd.status,
+												 CHUNK_INSERT,
+												 true);
 	if (has_compressed_chunk &&
 		(onconflict_action != ONCONFLICT_NONE || ts_chunk_dispatch_has_returning(dispatch)))
 		ereport(ERROR,

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1147,7 +1147,8 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 															 root->parse->commandType ==
 																	 CMD_UPDATE ?
 																 CHUNK_UPDATE :
-																 CHUNK_DELETE);
+																 CHUNK_DELETE,
+															 true);
 			}
 			/* Check for UPDATE/DELETE (DML) on compressed chunks */
 			if (IS_UPDL_CMD(root->parse) && dml_involves_hypertable(root, ht, rti))

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -150,7 +150,8 @@ compresschunkcxt_init(CompressChunkCxt *cxt, Cache *hcache, Oid hypertable_relid
 	srcchunk = ts_chunk_get_by_relid(chunk_relid, true);
 	ts_chunk_validate_chunk_status_for_operation(srcchunk->table_id,
 												 srcchunk->fd.status,
-												 CHUNK_COMPRESS);
+												 CHUNK_COMPRESS,
+												 true);
 	cxt->srcht = srcht;
 	cxt->compress_ht = compress_ht;
 	cxt->srcht_chunk = srcchunk;
@@ -326,7 +327,8 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
 
 	ts_chunk_validate_chunk_status_for_operation(uncompressed_chunk_relid,
 												 uncompressed_chunk->fd.status,
-												 CHUNK_DECOMPRESS);
+												 CHUNK_DECOMPRESS,
+												 true);
 	compressed_chunk = ts_chunk_get_by_id(uncompressed_chunk->fd.compressed_chunk_id, true);
 
 	/* acquire locks on src and compress hypertable and src chunk */

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -33,9 +33,10 @@ ORDER BY chunk_name ;
  _timescaledb_internal | _hyper_1_2_chunk |                  30 |                40
 (2 rows)
 
+----- TESTS for freeze and unfreeze chunk ------------
 --TEST internal api that freezes a chunk
 --freeze one of the chunks
-SELECT chunk_schema || '.' ||  chunk_name as "CHNAME"
+SELECT chunk_schema || '.' ||  chunk_name as "CHNAME", chunk_name as "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'hyper1' and hypertable_schema = 'test1'
 ORDER BY chunk_name LIMIT 1
@@ -53,7 +54,7 @@ SELECT * from test1.hyper1 ORDER BY 1;
    30 |  0.5
 (2 rows)
 
---updates and deletes on frozen chunk should fail
+-- TEST updates and deletes on frozen chunk should fail
 \set ON_ERROR_STOP 0
 UPDATE test1.hyper1 SET temp = 40 WHERE time = 20;
 UPDATE test1.hyper1 SET temp = 40 WHERE temp = 0.5;
@@ -75,9 +76,10 @@ SELECT * from test1.hyper1 ORDER BY 1;
    30 |  0.5
 (2 rows)
 
---inserts into a frozen chunk fails
+-- TEST inserts into a frozen chunk fails
 INSERT INTO test1.hyper1 VALUES ( 11, 11);
 ERROR:  Insert not permitted on frozen chunk "_hyper_1_1_chunk" 
+\set ON_ERROR_STOP 1
 --insert into non-frozen chunk works
 INSERT INTO test1.hyper1 VALUES ( 31, 31);
 SELECT * from test1.hyper1 ORDER BY 1;
@@ -88,7 +90,35 @@ SELECT * from test1.hyper1 ORDER BY 1;
    31 |   31
 (3 rows)
 
-\set ON_ERROR_STOP 1
+-- TEST unfreeze frozen chunk and then drop
+SELECT table_name, status 
+FROM _timescaledb_catalog.chunk WHERE table_name = :'CHUNK_NAME';
+    table_name    | status 
+------------------+--------
+ _hyper_1_1_chunk |      4
+(1 row)
+
+SELECT  _timescaledb_internal.unfreeze_chunk( :'CHNAME');
+ unfreeze_chunk 
+----------------
+ t
+(1 row)
+
+--verify status in catalog
+SELECT table_name, status 
+FROM _timescaledb_catalog.chunk WHERE table_name = :'CHUNK_NAME';
+    table_name    | status 
+------------------+--------
+ _hyper_1_1_chunk |      0
+(1 row)
+
+--unfreezing again works
+SELECT  _timescaledb_internal.unfreeze_chunk( :'CHNAME');
+ unfreeze_chunk 
+----------------
+ t
+(1 row)
+
 SELECT  _timescaledb_internal.drop_chunk( :'CHNAME');
  drop_chunk 
 ------------
@@ -153,6 +183,7 @@ ERROR:  Update not permitted on frozen chunk "_hyper_2_3_chunk"
 --touches only frozen chunk 
 DELETE FROM public.table_to_compress WHERE time < '2020-01-02'; 
 ERROR:  Delete not permitted on frozen chunk "_hyper_2_3_chunk" 
+\set ON_ERROR_STOP 1
 --try to refreeze
 SELECT  _timescaledb_internal.freeze_chunk( :'CHNAME');
  freeze_chunk 
@@ -160,7 +191,6 @@ SELECT  _timescaledb_internal.freeze_chunk( :'CHNAME');
  t
 (1 row)
 
-\set ON_ERROR_STOP 1
 --touches non-frozen chunk 
 SELECT * from public.table_to_compress ORDER BY 1, 3;
     time    | acq_id  | value  
@@ -177,22 +207,35 @@ SELECT * from public.table_to_compress ORDER BY 1, 3;
  01-01-2020 | 1234567 | 777888
 (1 row)
 
---TEST can drop frozen chunk
+--TEST cannot drop frozen chunk, no error is reported.
+-- simply skips
 SELECT drop_chunks('table_to_compress', older_than=> '1 day'::interval);
               drop_chunks               
 ----------------------------------------
- _timescaledb_internal._hyper_2_3_chunk
  _timescaledb_internal._hyper_2_4_chunk
  _timescaledb_internal._hyper_2_5_chunk
-(3 rows)
+(2 rows)
+
+--unfreeze and drop it
+SELECT  _timescaledb_internal.unfreeze_chunk( :'CHNAME');
+ unfreeze_chunk 
+----------------
+ t
+(1 row)
+
+SELECT  _timescaledb_internal.drop_chunk( :'CHNAME');
+ drop_chunk 
+------------
+ t
+(1 row)
 
 --add a new chunk
-INSERT INTO public.table_to_compress VALUES ('2020-01-01', 1234567, 777888);
---TEST now feeeze and try to compress the chunk
-SELECT chunk_schema || '.' ||  chunk_name as "CHNAME"
+INSERT INTO public.table_to_compress VALUES ('2019-01-01', 1234567, 777888);
+--TEST  compress a frozen chunk fails
+SELECT chunk_schema || '.' ||  chunk_name as "CHNAME", chunk_name as "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'table_to_compress' and hypertable_schema = 'public'
-ORDER BY chunk_name LIMIT 1
+ORDER BY chunk_name DESC LIMIT 1
 \gset
 SELECT  _timescaledb_internal.freeze_chunk( :'CHNAME');
  freeze_chunk 
@@ -206,35 +249,12 @@ ERROR:  compress_chunk not permitted on frozen chunk "_hyper_2_7_chunk"
 \set ON_ERROR_STOP 1
 --TEST dropping a frozen chunk
 --DO NOT CHANGE this behavior ---
--- frozen chunks can be dropped.
-SELECT _timescaledb_internal.drop_chunk(:'CHNAME');
- drop_chunk 
-------------
- t
-(1 row)
-
-SELECT count(*) 
-FROM timescaledb_information.chunks
-WHERE hypertable_name = 'table_to_compress' and hypertable_schema = 'public';
- count 
--------
-     0
-(1 row)
-
---TEST error freeze a non-chunk
-CREATE TABLE nochunk_tab( a timestamp, b integer);
+-- frozen chunks cannot be dropped.
 \set ON_ERROR_STOP 0
-SELECT _timescaledb_internal.freeze_chunk('nochunk_tab');
-ERROR:  chunk not found
+SELECT _timescaledb_internal.drop_chunk(:'CHNAME');
+ERROR:  drop_chunk not permitted on frozen chunk "_hyper_2_7_chunk" 
 \set ON_ERROR_STOP 1
---TEST dropping frozen chunk in the presence of caggs
-SELECT * FROM test1.hyper1 ORDER BY 1;
- time | temp 
-------+------
-   30 |  0.5
-   31 |   31
-(2 rows)
-
+--TEST drop_chunk in the presence of caggs. Does not affect cagg data
 CREATE OR REPLACE FUNCTION hyper_dummy_now() RETURNS BIGINT
 LANGUAGE SQL IMMUTABLE AS  'SELECT 100::BIGINT';
 SELECT set_integer_now_func('test1.hyper1', 'hyper_dummy_now');
@@ -253,20 +273,39 @@ SELECT * FROM hyper1_cagg ORDER BY 1;
      30 |     2
 (1 row)
 
---now freeze chunk and drop it
---cagg data is unaffected  
-SELECT chunk_schema || '.' ||  chunk_name as "CHNAME"
+--now freeze chunk and try to  drop it
+SELECT chunk_schema || '.' ||  chunk_name as "CHNAME1", chunk_name as "CHUNK_NAME"
 FROM timescaledb_information.chunks
 WHERE hypertable_name = 'hyper1' and hypertable_schema = 'test1'
 ORDER BY chunk_name LIMIT 1
 \gset
-SELECT  _timescaledb_internal.freeze_chunk( :'CHNAME');
+SELECT  _timescaledb_internal.freeze_chunk( :'CHNAME1');
  freeze_chunk 
 --------------
  t
 (1 row)
 
-SELECT  _timescaledb_internal.drop_chunk( :'CHNAME');
+--cannot drop frozen chunk
+\set ON_ERROR_STOP 0
+SELECT  _timescaledb_internal.drop_chunk( :'CHNAME1');
+ERROR:  drop_chunk not permitted on frozen chunk "_hyper_1_2_chunk" 
+\set ON_ERROR_STOP 1
+-- unfreeze the chunk, then drop the single chunk
+SELECT  _timescaledb_internal.unfreeze_chunk( :'CHNAME1');
+ unfreeze_chunk 
+----------------
+ t
+(1 row)
+
+--drop the single chunk and verify that cagg is unaffected.
+SELECT * FROM test1.hyper1 ORDER BY 1;
+ time | temp 
+------+------
+   30 |  0.5
+   31 |   31
+(2 rows)
+
+SELECT  _timescaledb_internal.drop_chunk( :'CHNAME1');
  drop_chunk 
 ------------
  t
@@ -283,6 +322,15 @@ SELECT * FROM hyper1_cagg ORDER BY 1;
      30 |     2
 (1 row)
 
+--TEST error case (un)freeze a non-chunk
+CREATE TABLE nochunk_tab( a timestamp, b integer);
+\set ON_ERROR_STOP 0
+SELECT _timescaledb_internal.freeze_chunk('nochunk_tab');
+ERROR:  chunk not found
+SELECT _timescaledb_internal.unfreeze_chunk('nochunk_tab');
+ERROR:  chunk not found
+\set ON_ERROR_STOP 1
+----- TESTS for attach_osm_table_chunk ------------
 --TEST for attaching a foreign table as a chunk
 --need superuser access to create foreign data server
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -356,3 +404,42 @@ SELECT _timescaledb_internal.attach_osm_table_chunk('non_ht', 'child_fdw_table')
 ERROR:  "non_ht" is not a hypertable
  
 \set ON_ERROR_STOP 1
+-- TEST error try freeze/unfreeze on dist hypertable
+-- Add distributed hypertables
+\set DN_DBNAME_1 :TEST_DBNAME _1
+\set DN_DBNAME_2 :TEST_DBNAME _2
+\c :TEST_DBNAME :ROLE_SUPERUSER
+SELECT * FROM add_data_node('data_node_1', host => 'localhost', database => :'DN_DBNAME_1');
+  node_name  |   host    | port  |         database          | node_created | database_created | extension_created 
+-------------+-----------+-------+---------------------------+--------------+------------------+-------------------
+ data_node_1 | localhost | 55432 | db_chunk_utils_internal_1 | t            | t                | t
+(1 row)
+
+SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => :'DN_DBNAME_2');
+  node_name  |   host    | port  |         database          | node_created | database_created | extension_created 
+-------------+-----------+-------+---------------------------+--------------+------------------+-------------------
+ data_node_2 | localhost | 55432 | db_chunk_utils_internal_2 | t            | t                | t
+(1 row)
+
+CREATE TABLE disthyper (timec timestamp, device integer);
+SELECT create_distributed_hypertable('disthyper', 'timec', 'device');
+NOTICE:  adding not-null constraint to column "timec"
+ create_distributed_hypertable 
+-------------------------------
+ (6,public,disthyper,t)
+(1 row)
+
+INSERT into disthyper VALUES ('2020-01-01', 10);
+--freeze one of the chunks
+SELECT chunk_schema || '.' ||  chunk_name as "CHNAME3"
+FROM timescaledb_information.chunks
+WHERE hypertable_name = 'disthyper' 
+ORDER BY chunk_name LIMIT 1
+\gset
+\set ON_ERROR_STOP 0
+SELECT  _timescaledb_internal.freeze_chunk( :'CHNAME3');
+ERROR:  operation not supported on distributed chunk or foreign table "_dist_hyper_6_11_chunk"
+SELECT  _timescaledb_internal.unfreeze_chunk( :'CHNAME3');
+ERROR:  operation not supported on distributed chunk or foreign table "_dist_hyper_6_11_chunk"
+\set ON_ERROR_STOP 1
+SET ROLE :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -126,6 +126,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_internal.to_timestamp_without_timezone(bigint)
  _timescaledb_internal.to_unix_microseconds(timestamp with time zone)
  _timescaledb_internal.tsl_loaded()
+ _timescaledb_internal.unfreeze_chunk(regclass)
  _timescaledb_internal.validate_as_data_node()
  _timescaledb_internal.wait_subscription_sync(name,name,integer,numeric)
  add_compression_policy(regclass,"any",boolean,interval)


### PR DESCRIPTION
A chunk in frozen state cannot be dropped.
drop_chunks will skip over frozen chunks without erroring.
Internal api , drop_chunk will error if you attempt to  drop
a chunk without unfreezing it.

This PR also adds a new internal API to unfreeze a chunk.