### PR TITLE
Batch rows on access node for distributed COPY

### DIFF
--- a/src/guc.h
+++ b/src/guc.h
@@ -66,6 +66,15 @@ typedef enum HypertableDistType
 extern TSDLLEXPORT HypertableDistType ts_guc_hypertable_distributed_default;
 extern TSDLLEXPORT int ts_guc_hypertable_replication_factor_default;
 
+typedef enum DistCopyTransferFormat
+{
+	DCTF_Auto,
+	DCTF_Binary,
+	DCTF_Text
+} DistCopyTransferFormat;
+
+extern TSDLLEXPORT DistCopyTransferFormat ts_guc_dist_copy_transfer_format;
+
 #ifdef TS_DEBUG
 extern bool ts_shutdown_bgw;
 extern char *ts_current_timestamp_mock;

--- a/tsl/src/nodes/data_node_copy.c
+++ b/tsl/src/nodes/data_node_copy.c
@@ -288,7 +288,7 @@ data_node_copy_end(CustomScanState *node)
 	DataNodeCopyState *dncs = (DataNodeCopyState *) node;
 
 	ExecEndNode(linitial(node->custom_ps));
-	remote_copy_end(dncs->copy_ctx);
+	remote_copy_end_on_success(dncs->copy_ctx);
 	ts_cache_release(dncs->hcache);
 }
 

--- a/tsl/src/remote/dist_copy.c
+++ b/tsl/src/remote/dist_copy.c
@@ -3,6 +3,8 @@
  * Please see the included NOTICE for copyright information and
  * LICENSE-TIMESCALE for a copy of the license.
  */
+#include "dist_copy.h"
+
 #include <postgres.h>
 #include <access/tupdesc.h>
 #include <catalog/namespace.h>
@@ -15,31 +17,37 @@
 #include <utils/lsyscache.h>
 
 #include "compat/compat.h"
-#include "dist_copy.h"
+#include "chunk.h"
 #include "copy.h"
+#include "data_node.h"
+#include "dimension.h"
+#include "dimension_slice.h"
+#include "guc.h"
+#include "hypercube.h"
+#include "hypertable.h"
 #include "nodes/chunk_dispatch.h"
 #include "nodes/chunk_insert_state.h"
-#include "dimension.h"
-#include "hypertable.h"
 #include "partitioning.h"
-#include "chunk.h"
-#include "ts_catalog/chunk_data_node.h"
-#include "guc.h"
 #include "remote/connection_cache.h"
 #include "remote/dist_txn.h"
-#include "data_node.h"
+#include "ts_catalog/chunk_data_node.h"
 
 #define DEFAULT_PG_DELIMITER '\t'
 #define DEFAULT_PG_NULL_VALUE "\\N"
 
-/* This will maintain a list of connections associated with a given chunk so we don't have to keep
- * looking them up every time.
+/*
+ * Maximum number of rows in batch for insert. Note that arrays of this size are
+ * also allocated on stack.
+ * Don't forget to change the broken recv() tests in dist_remote_error that test
+ * some boundary conditions around this number.
  */
-typedef struct ChunkConnectionList
-{
-	int32 chunk_id;
-	List *connections;
-} ChunkConnectionList;
+#define MAX_BATCH_ROWS 1024
+
+/*
+ * Maximum bytes of COPY data in batch. This is also the default size of the
+ * output copy data buffer.
+ */
+#define MAX_BATCH_BYTES (1 * 1024 * 1024)
 
 /* This contains the information needed to parse a dimension attribute out of a row of text copy
  * data
@@ -54,13 +62,36 @@ typedef struct CopyDimensionInfo
 	int32 atttypmod;
 } CopyDimensionInfo;
 
+typedef struct DataNodeConnection
+{
+	TSConnectionId id;
+	TSConnection *connection;
+} DataNodeConnection;
+
 /* This contains information about connections currently in use by the copy as well as how to create
  * and end the copy command.
  */
 typedef struct CopyConnectionState
 {
-	List *cached_connections;
+	/*
+	 * Cached connections to data nodes.
+	 * Why do we need another layer of caching, when there is dist_txn layer
+	 * already? The API it provides is one function that "does everything
+	 * automatically", namely it's going to stop the COPY each time we request
+	 * the connection. This is not something we want to do for each row when
+	 * we're trying to do bulk copy.
+	 * We can't use the underlying remote_connection_cache directly, because the
+	 * remote chunk creation (chunk_api_create_on_data_nodes) would still use
+	 * the dist_txn layer. Chunks are created interleaved with the actual COPY
+	 * operation, so we would have to somehow maintain these two layers in sync.
+	 */
+	List *data_node_connections;
+
+	/*
+	 * Connections to which we have written something and have to finalize them.
+	 */
 	List *connections_in_use;
+
 	bool using_binary;
 	const char *outgoing_copy_cmd;
 } CopyConnectionState;
@@ -100,8 +131,15 @@ typedef struct RemoteCopyContext
 	bool binary_operation;
 	MemoryContext mctx; /* MemoryContext that holds the RemoteCopyContext */
 
-	/* Data for the current read row */
-	StringInfo row_data;
+	/*
+	 * Incoming rows are batched before creating the chunks and sending them to
+	 * data nodes. The following fields contain the current batch of rows.
+	 */
+	StringInfo *batch_row_data;
+	int batch_row_count;
+	int batch_size_bytes;
+	Point **batch_points;
+	int batch_ordinal;
 } RemoteCopyContext;
 
 /*
@@ -166,14 +204,11 @@ get_copy_dimension_datum(char **fields, CopyDimensionInfo *info)
 	{
 		if (fields[info->corresponding_copy_field] == NULL)
 		{
-			if (info->dim->type == DIMENSION_TYPE_OPEN)
-				ereport(ERROR,
-						(errcode(ERRCODE_NOT_NULL_VIOLATION),
-						 errmsg("NULL value in column \"%s\" violates not-null constraint",
-								NameStr(info->dim->fd.column_name)),
-						 errhint("Columns used for time partitioning cannot be NULL")));
-
-			return 0;
+			ereport(ERROR,
+					(errcode(ERRCODE_NOT_NULL_VIOLATION),
+					 errmsg("NULL value in column \"%s\" violates not-null constraint",
+							NameStr(info->dim->fd.column_name)),
+					 errhint("Columns used for partitioning cannot be NULL")));
 		}
 		d = InputFunctionCall(&info->io_func,
 							  fields[info->corresponding_copy_field],
@@ -230,61 +265,398 @@ calculate_hyperspace_point_from_fields(char **data, CopyDimensionInfo *dimension
 	return p;
 }
 
-static void
-start_remote_copy_on_new_connection(CopyConnectionState *state, TSConnection *connection)
+/*
+ * Look up or set up a COPY connection to the data node.
+ */
+static TSConnection *
+get_copy_connection_to_data_node(RemoteCopyContext *context, TSConnectionId required_id)
 {
-	TSConnectionError err;
-
-	state->connections_in_use = list_append_unique_ptr(state->connections_in_use, connection);
-
-	if (remote_connection_get_status(connection) == CONN_IDLE &&
-		!remote_connection_begin_copy(connection,
-									  state->outgoing_copy_cmd,
-									  state->using_binary,
-									  &err))
-		remote_connection_error_elog(&err, ERROR);
-}
-
-static const ChunkConnectionList *
-create_connection_list_for_chunk(CopyConnectionState *state, int32 chunk_id,
-								 const List *chunk_data_nodes, Oid userid)
-{
-	ChunkConnectionList *chunk_connections;
+	MemoryContext old = MemoryContextSwitchTo(context->mctx);
+	CopyConnectionState *state = &context->connection_state;
+	TSConnection *connection = NULL;
 	ListCell *lc;
-
-	chunk_connections = palloc0(sizeof(ChunkConnectionList));
-	chunk_connections->chunk_id = chunk_id;
-	chunk_connections->connections = NIL;
-
-	foreach (lc, chunk_data_nodes)
+	foreach (lc, state->data_node_connections)
 	{
-		ChunkDataNode *cdn = lfirst(lc);
-		TSConnectionId id = remote_connection_id(cdn->foreign_server_oid, userid);
-		TSConnection *connection = remote_dist_txn_get_connection(id, REMOTE_TXN_NO_PREP_STMT);
-
-		start_remote_copy_on_new_connection(state, connection);
-		chunk_connections->connections = lappend(chunk_connections->connections, connection);
+		DataNodeConnection *entry = (DataNodeConnection *) lfirst(lc);
+		if (required_id.server_id == entry->id.server_id &&
+			required_id.user_id == entry->id.user_id)
+		{
+			connection = entry->connection;
+			break;
+		}
 	}
-	state->cached_connections = lappend(state->cached_connections, chunk_connections);
 
-	return chunk_connections;
+	if (connection == NULL)
+	{
+		/*
+		 * Did not find a cached connection, create a new one and cache it.
+		 * The rest of the code using the connection cache in this process has
+		 * to take care of exiting the COPY subprotocol if it wants to do
+		 * something else like creating a new chunk. Normally this is done under
+		 * the hood by the remote connection layer, and the dist_copy layer also
+		 * uses faster functions that do this for several connections in
+		 * parallel.
+		 */
+		connection = remote_dist_txn_get_connection(required_id, REMOTE_TXN_NO_PREP_STMT);
+
+		DataNodeConnection *entry = palloc(sizeof(DataNodeConnection));
+		entry->connection = connection;
+		entry->id = required_id;
+
+		state->data_node_connections = lappend(state->data_node_connections, entry);
+	}
+
+	/*
+	 * Begin COPY on the connection if needed.
+	 */
+	TSConnectionStatus status = remote_connection_get_status(connection);
+	if (status == CONN_IDLE)
+	{
+		TSConnectionError err;
+		if (!remote_connection_begin_copy(connection,
+										  psprintf("%s /* batch %d conn %p */",
+												   state->outgoing_copy_cmd,
+												   context->batch_ordinal,
+												   remote_connection_get_pg_conn(connection)),
+										  state->using_binary,
+										  &err))
+		{
+			remote_connection_error_elog(&err, ERROR);
+		}
+
+		/*
+		 * Add the connection to the list of active connections to be
+		 * flushed later.
+		 * The normal distributed insert path (not dist_copy, but
+		 * data_node_copy) doesn't reset the connections when it creates
+		 * a new chunk. So the connection status will be idle after we
+		 * created a new chunk, but it will still be in the list of
+		 * active connections. Don't add duplicates.
+		 */
+		if (!list_member(state->connections_in_use, connection))
+		{
+			state->connections_in_use = lappend(state->connections_in_use, connection);
+		}
+	}
+	else if (status == CONN_COPY_IN)
+	{
+		/* Ready to use. */
+		Assert(list_member(state->connections_in_use, connection));
+	}
+	else
+	{
+		elog(ERROR,
+			 "wrong status %d for connection to data node %d when performing "
+			 "distributed COPY\n",
+			 status,
+			 required_id.server_id);
+	}
+
+	MemoryContextSwitchTo(old);
+
+	return connection;
+}
+
+/*
+ * Flush the outgoing buffers on the active data node connections.
+ */
+static void
+flush_active_connections(CopyConnectionState *state)
+{
+	/*
+	 * The connections that we are going to flush on the current iteration.
+	 */
+	List *to_flush = list_copy(state->connections_in_use);
+	/*
+	 * The connections that were busy on the current iteration and that we have
+	 * to wait for.
+	 */
+	List *busy_connections = NIL;
+	for (;;)
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		ListCell *to_flush_cell;
+		foreach (to_flush_cell, to_flush)
+		{
+			TSConnection *conn = lfirst(to_flush_cell);
+			PGconn *pg_conn = remote_connection_get_pg_conn(conn);
+
+			if (remote_connection_get_status(conn) != CONN_COPY_IN)
+			{
+				/*
+				 * This functions only makes sense for connections that are
+				 * currently doing COPY and therefore are in nonblocking mode.
+				 */
+				continue;
+			}
+
+			/*
+			 * This function expects that the COPY processing so far was
+			 * successful, so the data connections should be in nonblocking
+			 * mode.
+			 */
+			Assert(PQisnonblocking(pg_conn) == 1);
+
+			/* Write out all the pending buffers. */
+			int res = PQflush(pg_conn);
+			if (res == -1)
+			{
+				TSConnectionError err;
+				remote_connection_get_error(conn, &err);
+				remote_connection_error_elog(&err, ERROR);
+			}
+			else if (res == 0)
+			{
+				/* Flushed. */
+			}
+			else
+			{
+				/* Busy. */
+				Assert(res == 1);
+				busy_connections = lappend(busy_connections, conn);
+				continue;
+			}
+
+			/* Hooray, done with this connection. */
+		}
+
+		if (list_length(busy_connections) == 0)
+		{
+			/* Flushed everything. */
+			break;
+		}
+
+		/*
+		 * Wait for changes on the busy connections.
+		 * Postgres API doesn't allow to remove a socket from the wait event,
+		 * and it's level-triggered, so we have to recreate the set each time.
+		 */
+		WaitEventSet *set =
+			CreateWaitEventSet(CurrentMemoryContext, list_length(busy_connections) + 1);
+
+		/*
+		 * Postmaster-managed callers must handle postmaster death somehow,
+		 * as stated by the comments in WaitLatchOrSocket.
+		 */
+		(void) AddWaitEventToSet(set, WL_EXIT_ON_PM_DEATH, PGINVALID_SOCKET, NULL, NULL);
+
+		/*
+		 * Add wait events for each busy connection.
+		 */
+		ListCell *busy_cell;
+		foreach (busy_cell, busy_connections)
+		{
+			TSConnection *conn = lfirst(busy_cell);
+			PGconn *pg_conn = remote_connection_get_pg_conn(conn);
+			(void) AddWaitEventToSet(set,
+									 /* events = */ WL_SOCKET_WRITEABLE,
+									 PQsocket(pg_conn),
+									 /* latch = */ NULL,
+									 /* user_data = */ NULL);
+		}
+
+		/* Wait. */
+		WaitEvent occurred[1];
+		int wait_result PG_USED_FOR_ASSERTS_ONLY = WaitEventSetWait(set,
+																	/* timeout = */ 1000,
+																	occurred,
+																	/* nevents = */ 1,
+																	WAIT_EVENT_COPY_FILE_WRITE);
+
+		/*
+		 * The possible results are:
+		 * `0` -- Timeout. Just retry the flush, it will report errors in case
+		 *        there are any.
+		 * `1` -- We have successfully waited for something, we don't care,
+		 *        just continue flushing the rest of the list.
+		 */
+		Assert(wait_result == 0 || wait_result == 1);
+
+		FreeWaitEventSet(set);
+
+		/*
+		 * Repeat the procedure for all the connections that were busy.
+		 */
+		List *tmp = busy_connections;
+		busy_connections = to_flush;
+		to_flush = tmp;
+
+		busy_connections = list_truncate(busy_connections, 0);
+	}
+}
+
+/*
+ * Flush all active data node connections and end COPY simultaneously, instead
+ * of doing this one-by-one in remote_connection_end_copy(). Implies that there
+ * were no errors so far. For error handling, use remote_connection_end_copy().
+ */
+static void
+end_copy_on_success(CopyConnectionState *state)
+{
+	List *to_end_copy = NIL;
+	ListCell *lc;
+	foreach (lc, state->connections_in_use)
+	{
+		TSConnection *conn = lfirst(lc);
+
+		/*
+		 * We expect the connection to be in CONN_COPY_IN status.
+		 * What about other statuses?
+		 * CONN_IDLE:
+		 * The normal distributed insert path (not dist_copy, but
+		 * data_node_copy) doesn't reset the connections when it creates
+		 * a new chunk. So the connection status will be idle after we
+		 * created a new chunk, but it will still be in the list of
+		 * active connections. On the other hand, this function isn't called
+		 * on the normal insert path, so we shouldn't see this state here.
+		 * CONN_PROCESSING:
+		 * Not sure what it would mean, probably an internal program error.
+		 */
+		Assert(remote_connection_get_status(conn) == CONN_COPY_IN);
+
+		PGconn *pg_conn = remote_connection_get_pg_conn(conn);
+
+		/*
+		 * This function expects that the COPY processing so far was
+		 * successful, so the data connections should be in nonblocking
+		 * mode.
+		 */
+		Assert(PQisnonblocking(pg_conn));
+
+		PGresult *res = PQgetResult(pg_conn);
+		if (res == NULL)
+		{
+			/*
+			 * No activity on the connection while we're expecting COPY. This
+			 * is probably an internal program error.
+			 */
+			elog(ERROR,
+				 "the connection is expected to be in PGRES_COPY_IN status, but it has no activity "
+				 "(when flushing data)");
+		}
+
+		if (PQresultStatus(res) != PGRES_COPY_IN)
+		{
+			char *sqlstate = PQresultErrorField(res, PG_DIAG_SQLSTATE);
+			if (sqlstate != NULL && strcmp(sqlstate, "00000") == 0)
+			{
+				/*
+				 * An error has occurred.
+				 */
+				TSConnectionError err;
+				remote_connection_get_result_error(res, &err);
+				remote_connection_error_elog(&err, ERROR);
+			}
+
+			/*
+			 * No erroneous SQLSTATE, but at the same time the connection is
+			 * not in PGRES_COPY_IN status. This must be a logic error.
+			 */
+			elog(ERROR,
+				 "the connection is expected to be in PGRES_COPY_IN status, but instead the status "
+				 "is %d  (when flushing data)",
+				 PQresultStatus(res));
+		}
+
+		/* The connection is in PGRES_COPY_IN status, as expected. */
+		Assert(res != NULL && PQresultStatus(res) == PGRES_COPY_IN);
+
+		to_end_copy = lappend(to_end_copy, conn);
+
+		if (PQputCopyEnd(pg_conn, NULL) != 1)
+		{
+			ereport(ERROR,
+					(errmsg("could not end remote COPY"),
+					 errdetail("%s", PQerrorMessage(pg_conn))));
+		}
+	}
+
+	flush_active_connections(state);
+
+	/*
+	 * Switch the connections back into blocking mode because that's what the
+	 * non-COPY code expects.
+	 */
+	foreach (lc, to_end_copy)
+	{
+		TSConnection *conn = lfirst(lc);
+		PGconn *pg_conn = remote_connection_get_pg_conn(conn);
+
+		if (PQsetnonblocking(pg_conn, 0))
+		{
+			ereport(ERROR,
+					(errmsg("failed to switch the connection into blocking mode"),
+					 errdetail("%s", PQerrorMessage(pg_conn))));
+		}
+	}
+
+	/*
+	 * Verify that the copy has successfully finished on each connection.
+	 */
+	foreach (lc, to_end_copy)
+	{
+		TSConnection *conn = lfirst(lc);
+		PGconn *pg_conn = remote_connection_get_pg_conn(conn);
+		PGresult *res = PQgetResult(pg_conn);
+		if (res == NULL)
+		{
+			ereport(ERROR, (errmsg("unexpected NULL result when ending remote COPY")));
+		}
+
+		if (PQresultStatus(res) != PGRES_COMMAND_OK)
+		{
+			TSConnectionError err;
+			remote_connection_get_result_error(res, &err);
+			remote_connection_error_elog(&err, ERROR);
+		}
+
+		res = PQgetResult(pg_conn);
+		if (res != NULL)
+		{
+			ereport(ERROR,
+					(errmsg("unexpected non-NULL result %d when ending remote COPY",
+							PQresultStatus(res)),
+					 errdetail("%s", PQerrorMessage(pg_conn))));
+		}
+	}
+
+	/*
+	 * Mark the connections as idle. If an error occurs before this, the
+	 * connections are going to be still marked as CONN_COPY_IN, and the
+	 * remote_connection_end_copy() will bring each connection to a valid state.
+	 */
+	foreach (lc, to_end_copy)
+	{
+		TSConnection *conn = (TSConnection *) lfirst(lc);
+		remote_connection_set_status(conn, CONN_IDLE);
+	}
+
+	list_free(to_end_copy);
+	list_free(state->connections_in_use);
+	state->connections_in_use = NIL;
 }
 
 static void
-finish_outstanding_copies(const CopyConnectionState *state)
+end_copy_on_failure(CopyConnectionState *state)
 {
-	ListCell *lc;
-	TSConnectionError err;
+	/* Exit the copy subprotocol. */
+	TSConnectionError err = { 0 };
 	bool failure = false;
-
+	ListCell *lc;
 	foreach (lc, state->connections_in_use)
 	{
 		TSConnection *conn = lfirst(lc);
 
 		if (remote_connection_get_status(conn) == CONN_COPY_IN &&
 			!remote_connection_end_copy(conn, &err))
+		{
 			failure = true;
+		}
 	}
+
+	list_free(state->connections_in_use);
+	state->connections_in_use = NIL;
 
 	if (failure)
 		remote_connection_error_elog(&err, ERROR);
@@ -294,44 +666,17 @@ static const List *
 get_connections_for_chunk(RemoteCopyContext *context, int32 chunk_id, const List *chunk_data_nodes,
 						  Oid userid)
 {
-	CopyConnectionState *state = &context->connection_state;
-	MemoryContext oldmctx;
+	List *conns = NIL;
+
 	ListCell *lc;
-	List *conns;
-
-	foreach (lc, state->cached_connections)
+	foreach (lc, chunk_data_nodes)
 	{
-		ChunkConnectionList *chunkconns = lfirst(lc);
-
-		if (chunkconns->chunk_id == chunk_id)
-		{
-#ifdef USE_ASSERT_CHECKING
-			ListCell *lc2;
-
-			/* Check that connections are in COPY_IN mode */
-			foreach (lc2, chunkconns->connections)
-			{
-				TSConnection *conn = lfirst(lc2);
-
-				Assert(remote_connection_get_status(conn) == CONN_COPY_IN);
-			}
-#endif /* USE_ASSERT_CHECKING */
-			return chunkconns->connections;
-		}
+		ChunkDataNode *cdn = lfirst(lc);
+		TSConnectionId required_id = remote_connection_id(cdn->foreign_server_oid, userid);
+		conns = lappend(conns, get_copy_connection_to_data_node(context, required_id));
 	}
 
-	oldmctx = MemoryContextSwitchTo(context->mctx);
-	conns =
-		create_connection_list_for_chunk(state, chunk_id, chunk_data_nodes, userid)->connections;
-	MemoryContextSwitchTo(oldmctx);
-
 	return conns;
-}
-
-static bool
-copy_should_send_binary()
-{
-	return ts_guc_enable_connection_binary_data;
 }
 
 /*
@@ -442,7 +787,6 @@ deparse_copy_cmd(const CopyStmt *stmt, const Hypertable *ht, bool binary)
 	if (stmt->options != NIL || binary)
 	{
 		bool first = true;
-		appendStringInfo(command, " WITH (");
 		foreach (lc, stmt->options)
 		{
 			DefElem *defel = lfirst_node(DefElem, lc);
@@ -452,32 +796,56 @@ deparse_copy_cmd(const CopyStmt *stmt, const Hypertable *ht, bool binary)
 			if (binary && !is_supported_binary_option(option))
 				continue;
 
-			if (!first)
-				appendStringInfo(command, ", ");
-			else
-				first = false;
+			if (strcmp(option, "delimiter") == 0 || strcmp(option, "encoding") == 0 ||
+				strcmp(option, "escape") == 0 || strcmp(option, "force_not_null") == 0 ||
+				strcmp(option, "force_null") == 0 || strcmp(option, "format") == 0 ||
+				strcmp(option, "header") == 0 || strcmp(option, "null") == 0 ||
+				strcmp(option, "quote") == 0)
+			{
+				/*
+				 * These options are fixed as default for transfer to data nodes
+				 * in text format, regardless of how they are set in the input
+				 * file.
+				 */
+				continue;
+			}
 
-			/* quoted options */
-			if (strcmp(option, "delimiter") == 0 || strcmp(option, "null") == 0 ||
-				strcmp(option, "quote") == 0 || strcmp(option, "escape") == 0 ||
-				strcmp(option, "encoding") == 0)
-				appendStringInfo(command, "%s '%s'", option, def_get_string(defel));
-			/* options that take columns (note force_quote is only for COPY TO) */
-			else if (strcmp(option, "force_not_null") == 0 || strcmp(option, "force_null") == 0)
-				appendStringInfo(command, "%s (%s)", option, def_get_string(defel));
-			/* boolean options don't require an argument to use default setting */
-			else if (defel->arg == NULL &&
-					 (strcmp(option, "oids") == 0 || strcmp(option, "freeze") == 0 ||
-					  strcmp(option, "header") == 0))
-				appendStringInfo(command, "%s", option);
-			/* everything else should pass directly through */
+			if (!first)
+			{
+				appendStringInfo(command, ", ");
+			}
 			else
+			{
+				appendStringInfo(command, " WITH (");
+				first = false;
+			}
+
+			if (defel->arg == NULL &&
+				(strcmp(option, "oids") == 0 || strcmp(option, "freeze") == 0))
+			{
+				/* boolean options don't require an argument to use default setting */
+				appendStringInfo(command, "%s", option);
+			}
+			else
+			{
+				/* everything else should pass directly through */
 				appendStringInfo(command, "%s %s", option, def_get_string(defel));
+			}
 		}
 
 		if (binary)
+		{
+			if (first)
+			{
+				appendStringInfo(command, " WITH (");
+			}
 			appendStringInfo(command, "%sFORMAT binary", first ? "" : ", ");
-		appendStringInfo(command, ")");
+			first = false;
+		}
+		if (!first)
+		{
+			appendStringInfo(command, ")");
+		}
 	}
 
 	return command->data;
@@ -517,7 +885,11 @@ validate_options(List *copy_options, char *delimiter, char **null_string)
 			if (strcmp(fmt, "binary") == 0)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("remote copy does not support binary data")));
+						 errmsg("remote copy does not support binary input in combination with "
+								"text transfer to data nodes"),
+						 errhint("Set timescaledb.enable_connection_binary_data to true and "
+								 "timescaledb.dist_copy_transfer_format to auto to enable "
+								 "binary data transfer.")));
 			else if (strcmp(fmt, "csv") == 0 && !delimiter_found)
 				*delimiter = ',';
 		}
@@ -532,6 +904,46 @@ validate_options(List *copy_options, char *delimiter, char **null_string)
 		else if (strcmp(defel->defname, "null") == 0)
 			*null_string = def_get_string(defel);
 	}
+}
+
+static bool
+copy_should_send_binary(const CopyStmt *stmt)
+{
+	bool input_format_binary = false;
+	ListCell *lc;
+	foreach (lc, stmt->options)
+	{
+		const DefElem *defel = lfirst_node(DefElem, lc);
+		if (strcmp(defel->defname, "format") == 0)
+		{
+			if (strcmp(def_get_string(defel), "binary") == 0)
+			{
+				input_format_binary = true;
+			}
+			break;
+		}
+	}
+
+	if (ts_guc_dist_copy_transfer_format == DCTF_Auto)
+	{
+		return input_format_binary && ts_guc_enable_connection_binary_data;
+	}
+
+	if (ts_guc_dist_copy_transfer_format == DCTF_Binary)
+	{
+		if (!ts_guc_enable_connection_binary_data)
+		{
+			ereport(ERROR,
+					errmsg("the requested binary format for COPY data transfer is disabled by the "
+						   "settings"),
+					errhint("Either enable it by setting timescaledb.enable_connection_binary_data "
+							"to true, or use automatic COPY format detection by setting "
+							"timescaledb.dist_copy_transfer_format to 'auto'."));
+		}
+		return true;
+	}
+
+	return false;
 }
 
 /* Populates the passed in pointer with an array of output functions and returns the array size.
@@ -610,9 +1022,15 @@ remote_copy_begin(const CopyStmt *stmt, Hypertable *ht, ExprContext *per_tuple_c
 	context->mctx = mctx;
 	context->binary_operation = binary_copy;
 	context->connection_state.connections_in_use = NIL;
-	context->connection_state.cached_connections = NIL;
+	context->connection_state.data_node_connections = NIL;
 	context->connection_state.using_binary = binary_copy;
 	context->connection_state.outgoing_copy_cmd = deparse_copy_cmd(stmt, ht, binary_copy);
+
+	context->batch_row_data = palloc0(sizeof(StringInfo) * MAX_BATCH_ROWS);
+	context->batch_points = palloc0(sizeof(Point *) * MAX_BATCH_ROWS);
+	context->batch_row_count = 0;
+	context->batch_size_bytes = 0;
+	context->batch_ordinal = 0;
 
 	if (binary_copy)
 		context->data_context = generate_binary_copy_context(per_tuple_ctx, ht, attnums);
@@ -630,27 +1048,121 @@ remote_copy_get_copycmd(RemoteCopyContext *context)
 	return context->connection_state.outgoing_copy_cmd;
 }
 
+/*
+ * Functions for escaping values for Postgres text format.
+ * See CopyAttributeOutText.
+ */
+static bool
+is_special_character(char c)
+{
+	return (c == '\b' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v' ||
+			c == '\\');
+}
+
+/*
+ * Generate a text row for sending to data nodes, based on text input.
+ *
+ * The input fields are already in text format, so instead of converting to
+ * internal data format and then back to text for output, we simply use the
+ * original text. This saves a lot of CPU by avoiding parsing and re-formatting
+ * the column values. However, we still need to escape any special characters
+ * since the input is unescaped.
+ *
+ * One caveat here is that skipping conversion is only possible under the
+ * assumption that the text encoding used in the client (from which we received
+ * the data) is the same as the destination data node's encoding.
+ */
 static StringInfo
 parse_next_text_row(CopyFromState cstate, List *attnums, TextCopyContext *ctx)
 {
 	StringInfo row_data = makeStringInfo();
-	int i;
 
 	if (!NextCopyFromRawFields(cstate, &ctx->fields, &ctx->nfields))
 		return NULL;
 
-	Assert(ctx->nfields == list_length(attnums));
+	/* check for overflowing/missing fields */
+	if (ctx->nfields != list_length(attnums))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_BAD_COPY_FILE_FORMAT),
+				 errmsg("the number of columns doesn't match")));
+	}
 
-	for (i = 0; i < ctx->nfields - 1; ++i)
-		appendStringInfo(row_data,
-						 "%s%c",
-						 ctx->fields[i] ? ctx->fields[i] : ctx->null_string,
-						 ctx->delimiter);
+	/*
+	 * Format the raw unquoted unescaped fields into the Postgres text format.
+	 * We only have to escape the special characters, mirroring what
+	 * CopyAttributeOutText does. We assume here that the following three
+	 * encodings are the same:
+	 * 1) database encoding on the access node,
+	 * 2) database encoding on the data node,
+	 * 3) client encoding used by the access node to connect to the data node.
+	 * The encoding of the input file is not relevant here, because the raw
+	 * fields are already converted to the server encoding.
+	 * All encoding supported by Postgres embed ASCII, so we can get away with
+	 * single-byte comparisons.
+	 */
+	const int nfields = ctx->nfields;
+	char **restrict fields = ctx->fields;
+	char *restrict output = row_data->data;
+	int len = row_data->len;
+	for (int field = 0; field < nfields; field++)
+	{
+		const char *restrict src = fields[field];
+		/*
+		 * The length of the input we'll have to escape is either the length of
+		 * the input text, or one for null fields which are written as \N.
+		 */
+		const int input_len = (src != NULL) ? strlen(src) : 1;
+		/*
+		 * Calculate how much bytes we might need for output. Each character
+		 * might be replaced with two when escaping, plus the field separator,
+		 * terminating newline and terminating zero.
+		 */
+		const int additional_len = (input_len * 2 + 3);
+		if (row_data->maxlen < len + additional_len)
+		{
+			row_data->len = len;
+			enlargeStringInfo(row_data, additional_len);
+			output = row_data->data;
+		}
 
-	appendStringInfo(row_data,
-					 "%s\n",
-					 ctx->fields[ctx->nfields - 1] ? ctx->fields[ctx->nfields - 1] :
-													 ctx->null_string);
+		/* Add separator. */
+		if (field > 0)
+		{
+			output[len++] = '\t';
+			Assert(len <= row_data->maxlen);
+		}
+
+		if (src == NULL)
+		{
+			/* Null value, encoded as \N */
+			output[len++] = '\\';
+			output[len++] = 'N';
+			Assert(len <= row_data->maxlen);
+			continue;
+		}
+
+		/* The field is not null, replace special characters. */
+		for (int pos = 0; pos < input_len; pos++)
+		{
+			if (unlikely(is_special_character(src[pos])))
+			{
+				output[len++] = '\\';
+				output[len++] = src[pos];
+			}
+			else
+			{
+				output[len++] = src[pos];
+			}
+			Assert(len <= row_data->maxlen);
+		}
+	}
+	/*
+	 * Newline.
+	 */
+	output[len++] = '\n';
+	row_data->len = len;
+	Assert(len <= row_data->maxlen);
 
 	return row_data;
 }
@@ -695,21 +1207,14 @@ generate_binary_copy_data(Datum *values, bool *nulls, List *attnums, FmgrInfo *o
 static StringInfo
 parse_next_binary_row(CopyFromState cstate, List *attnums, BinaryCopyContext *ctx)
 {
-	if (!NextCopyFrom(cstate, ctx->econtext, ctx->values, ctx->nulls))
+	MemoryContext old = MemoryContextSwitchTo(ctx->econtext->ecxt_per_tuple_memory);
+	bool result = NextCopyFrom(cstate, ctx->econtext, ctx->values, ctx->nulls);
+	MemoryContextSwitchTo(old);
+
+	if (!result)
 		return NULL;
 
 	return generate_binary_copy_data(ctx->values, ctx->nulls, attnums, ctx->out_functions);
-}
-
-static bool
-read_next_copy_row(RemoteCopyContext *context, CopyFromState cstate)
-{
-	if (context->binary_operation)
-		context->row_data = parse_next_binary_row(cstate, context->attnums, context->data_context);
-	else
-		context->row_data = parse_next_text_row(cstate, context->attnums, context->data_context);
-
-	return context->row_data != NULL;
 }
 
 static Point *
@@ -750,34 +1255,44 @@ get_current_point_for_binary_copy(BinaryCopyContext *ctx, const Hyperspace *hs)
 	return calculate_hyperspace_point_from_binary(ctx->values, ctx->nulls, hs);
 }
 
-static void
-reset_copy_connection_state(CopyConnectionState *state)
+static bool
+read_next_copy_row(RemoteCopyContext *context, CopyFromState cstate)
 {
-	finish_outstanding_copies(state);
-	list_free(state->cached_connections);
-	list_free(state->connections_in_use);
-	state->cached_connections = NIL;
-	state->connections_in_use = NIL;
-}
+	Point *point = NULL;
+	Hypertable *ht = context->ht;
+	StringInfo row_data;
 
-static Chunk *
-get_target_chunk(Hypertable *ht, Point *p, CopyConnectionState *state)
-{
-	Chunk *chunk = ts_hypertable_find_chunk_for_point(ht, p);
-
-	if (chunk == NULL)
+	if (context->binary_operation)
 	{
-		/*
-		 * Here we might need to create a new chunk. However, any in-progress
-		 * copy operations will be tying up the connection we need to create the
-		 * chunk on a data node.  Since the data nodes for the new chunk aren't
-		 * yet known, just close all in progress COPYs before creating the chunk.
-		 */
-		reset_copy_connection_state(state);
-		chunk = ts_hypertable_create_chunk_for_point(ht, p);
+		row_data = parse_next_binary_row(cstate, context->attnums, context->data_context);
+	}
+	else
+	{
+		row_data = parse_next_text_row(cstate, context->attnums, context->data_context);
 	}
 
-	return chunk;
+	if (row_data == NULL)
+	{
+		return false;
+	}
+
+	if (context->binary_operation)
+	{
+		point = get_current_point_for_binary_copy(context->data_context, ht->space);
+	}
+	else
+	{
+		point = get_current_point_for_text_copy(context->data_context);
+	}
+
+	Assert(context->batch_row_count < MAX_BATCH_ROWS);
+	context->batch_row_data[context->batch_row_count] = row_data;
+	context->batch_points[context->batch_row_count] = point;
+
+	context->batch_row_count++;
+	context->batch_size_bytes += row_data->len;
+
+	return true;
 }
 
 static bool
@@ -797,36 +1312,175 @@ send_copy_data(StringInfo row_data, const List *connections)
 	return true;
 }
 
-static bool
+/*
+ * Rows for sending to a particular data node.
+ */
+typedef struct DataNodeRows
+{
+	int data_node_id;
+	Oid server_oid;
+	TSConnection *connection;
+	int rows_total;
+
+	/* Array of indices into the batch row array. */
+	int *row_indices;
+} DataNodeRows;
+
+static void
 remote_copy_process_and_send_data(RemoteCopyContext *context)
 {
 	Hypertable *ht = context->ht;
-	Chunk *chunk;
-	Point *point;
-	const List *connections;
+	const int n = context->batch_row_count;
+	Assert(n <= MAX_BATCH_ROWS);
 
-	if (context->binary_operation)
-		point = get_current_point_for_binary_copy(context->data_context, ht->space);
-	else
-		point = get_current_point_for_text_copy(context->data_context);
-
-	chunk = get_target_chunk(ht, point, &context->connection_state);
-	connections = get_connections_for_chunk(context, chunk->fd.id, chunk->data_nodes, GetUserId());
-
-	/* for remote copy, we don't use chunk insert states on the AN.
-	 * so we need to explicitly set the chunk as unordered when copies
-	 * are directed to previously compressed chunks
+	/*
+	 * This list tracks the per-batch insert states of the data nodes
+	 * (DataNodeRows).
 	 */
-	if (ts_chunk_is_compressed(chunk) && (!ts_chunk_is_unordered(chunk)))
-		ts_chunk_set_unordered(chunk);
+	List *data_nodes = NIL;
 
-	return send_copy_data(context->row_data, connections);
+	/* For each row, find or create the destination chunk. */
+	bool did_end_copy = false;
+	for (int row_in_batch = 0; row_in_batch < n; row_in_batch++)
+	{
+		Point *point = context->batch_points[row_in_batch];
+
+		Chunk *chunk = ts_hypertable_find_chunk_for_point(ht, point);
+		if (chunk == NULL)
+		{
+			if (!did_end_copy)
+			{
+				/*
+				 * The data node connections have to be flushed and the COPY
+				 * query ended before creating
+				 * a new chunk. They might have outstanding COPY data from the
+				 * previous batch.
+				 */
+				end_copy_on_success(&context->connection_state);
+				did_end_copy = true;
+			}
+			chunk = ts_hypertable_create_chunk_for_point(ht, point);
+		}
+
+		/*
+		 * For remote copy, we don't use chunk insert states on the AN.
+		 * So we need to explicitly set the chunk as unordered when copies
+		 * are directed to previously compressed chunks.
+		 */
+		if (ts_chunk_is_compressed(chunk) && (!ts_chunk_is_unordered(chunk)))
+			ts_chunk_set_unordered(chunk);
+
+		/*
+		 * Schedule the row for sending to the data nodes containing the chunk.
+		 */
+		ListCell *lc;
+		foreach (lc, chunk->data_nodes)
+		{
+			ChunkDataNode *chunk_data_node = lfirst(lc);
+			/* Find the existing insert state for this data node. */
+			DataNodeRows *data_node_rows = NULL;
+			ListCell *lc2;
+			foreach (lc2, data_nodes)
+			{
+				data_node_rows = lfirst(lc2);
+				if (chunk_data_node->foreign_server_oid == data_node_rows->server_oid)
+				{
+					break;
+				}
+			}
+
+			if (lc2 == NULL)
+			{
+				/* No insert state for this data node yet. Create it. */
+				data_node_rows = palloc(sizeof(DataNodeRows));
+				data_node_rows->connection = NULL;
+				data_node_rows->server_oid = chunk_data_node->foreign_server_oid;
+				data_node_rows->rows_total = 0;
+				/*
+				 * Not every tuple in a batch might be sent to every data node,
+				 * but we allocate the maximum possible size to avoid resizing.
+				 */
+				data_node_rows->row_indices = palloc(sizeof(int) * context->batch_row_count);
+				data_nodes = lappend(data_nodes, data_node_rows);
+			}
+
+			Assert(data_node_rows->server_oid == chunk_data_node->foreign_server_oid);
+
+			data_node_rows->row_indices[data_node_rows->rows_total] = row_in_batch;
+			data_node_rows->rows_total++;
+		}
+	}
+
+	/*
+	 * Flush the previous batch to avoid growing the outgoing buffers
+	 * indefinitely if some data node is not keeping up. It would be more
+	 * efficient to check for buffer growth and only flush then, but libpq
+	 * doesn't provide a way to know the outgoing buffer size. It also doesn't
+	 * provide any way to control the outgoing buffer size.
+	 * Don't do it if we have ended the COPY above to create new chunks.
+	 * The number 11 is an arbitrary prime, growing the output buffer to at
+	 * most 11ki rows sounds reasonable.
+	 */
+	if (!did_end_copy && context->batch_ordinal % 11 == 0)
+	{
+		flush_active_connections(&context->connection_state);
+	}
+
+	/*
+	 * Actually send the data to the data nodes. We don't interleave the data
+	 * nodes here, because the batches are relatively small.
+	 */
+	StringInfoData copy_data = { .data = palloc(MAX_BATCH_BYTES), .maxlen = MAX_BATCH_BYTES };
+	ListCell *lc;
+	foreach (lc, data_nodes)
+	{
+		DataNodeRows *dn = lfirst(lc);
+		TSConnectionId required_id = remote_connection_id(dn->server_oid, GetUserId());
+		Assert(dn->connection == NULL);
+		dn->connection = get_copy_connection_to_data_node(context, required_id);
+		PGconn *pg_conn = remote_connection_get_pg_conn(dn->connection);
+
+		resetStringInfo(&copy_data);
+		for (int row = 0; row < dn->rows_total; row++)
+		{
+			StringInfo row_data = context->batch_row_data[dn->row_indices[row]];
+			appendBinaryStringInfo(&copy_data, row_data->data, row_data->len);
+		}
+
+		/*
+		 * Send the copy data to the remote server.
+		 * It can't really return 0 ("would block") until it runs out
+		 * of memory. It just grows the buffer and tries to flush in
+		 * pqPutMsgEnd().
+		 */
+		int res = PQputCopyData(pg_conn, copy_data.data, copy_data.len);
+
+		if (res == -1)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_EXCEPTION),
+					 errmsg("could not send COPY data"),
+					 errdetail("%s", PQerrorMessage(pg_conn))));
+		}
+
+		/*
+		 * We don't have to specially flush the data here, because the flush is
+		 * attempted after finishing each protocol message (pqPutMsgEnd()).
+		 */
+	}
 }
 
+/*
+ * This function is for successfully finishing the COPY: it tries to flush all
+ * the outstanding COPY data to the data nodes. It is sensitive to erroneous
+ * state of connections and is going to fail if they are in a wrong state due to
+ * other errors. Resetting the connections after a known error should be done
+ * with remote_connection_end_copy, not this function.
+ */
 void
-remote_copy_end(RemoteCopyContext *context)
+remote_copy_end_on_success(RemoteCopyContext *context)
 {
-	finish_outstanding_copies(&context->connection_state);
+	end_copy_on_success(&context->connection_state);
 	MemoryContextDelete(context->mctx);
 }
 
@@ -840,34 +1494,59 @@ remote_distributed_copy(const CopyStmt *stmt, CopyChunkState *ccstate, List *att
 												   ht,
 												   GetPerTupleExprContext(estate),
 												   attnums,
-												   copy_should_send_binary());
+												   copy_should_send_binary(stmt));
 	uint64 processed = 0;
+
+	MemoryContext batch_context =
+		AllocSetContextCreate(CurrentMemoryContext, "Remote COPY batch", ALLOCSET_DEFAULT_SIZES);
 
 	PG_TRY();
 	{
+		MemoryContextSwitchTo(batch_context);
 		while (true)
 		{
-			ResetPerTupleExprContext(ccstate->estate);
-			MemoryContextSwitchTo(GetPerTupleMemoryContext(ccstate->estate));
-
 			CHECK_FOR_INTERRUPTS();
 
-			if (!read_next_copy_row(context, ccstate->cstate))
-				break;
+			ResetPerTupleExprContext(ccstate->estate);
 
+			/* Actually process the next row. */
+			bool eof = !read_next_copy_row(context, ccstate->cstate);
+			if (!eof && context->batch_row_count < MAX_BATCH_ROWS &&
+				context->batch_size_bytes < MAX_BATCH_BYTES)
+			{
+				/*
+				 * Accumulate more rows into the current batch.
+				 */
+				continue;
+			}
+
+			/*
+			 * Send out the current batch.
+			 */
 			remote_copy_process_and_send_data(context);
-			++processed;
+
+			processed += context->batch_row_count;
+			context->batch_row_count = 0;
+			context->batch_size_bytes = 0;
+			context->batch_ordinal++;
+			MemoryContextReset(batch_context);
+
+			if (eof)
+			{
+				break;
+			}
 		}
 	}
 	PG_CATCH();
 	{
 		/* If we hit an error, make sure we end our in-progress COPYs */
-		remote_copy_end(context);
+		end_copy_on_failure(&context->connection_state);
+		MemoryContextDelete(context->mctx);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
-	remote_copy_end(context);
+	remote_copy_end_on_success(context);
 	MemoryContextSwitchTo(oldmctx);
 
 	return processed;
@@ -885,6 +1564,7 @@ remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot, const Ch
 {
 	ListCell *lc;
 	bool result;
+	StringInfo row_data;
 
 	/* Pre-materialize all attributes since we will access all of them */
 	slot_getallattrs(slot);
@@ -903,17 +1583,17 @@ remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot, const Ch
 			binctx->values[i] = slot_getattr(slot, attnum, &binctx->nulls[i]);
 		}
 
-		context->row_data = generate_binary_copy_data(binctx->values,
-													  binctx->nulls,
-													  context->attnums,
-													  binctx->out_functions);
+		row_data = generate_binary_copy_data(binctx->values,
+											 binctx->nulls,
+											 context->attnums,
+											 binctx->out_functions);
 	}
 	else
 	{
 		TextCopyContext *textctx = context->data_context;
 		char delim = textctx->delimiter;
 
-		context->row_data = makeStringInfo();
+		row_data = makeStringInfo();
 
 		foreach (lc, context->attnums)
 		{
@@ -927,12 +1607,12 @@ remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot, const Ch
 			value = slot_getattr(slot, attnum, &isnull);
 
 			if (isnull)
-				appendStringInfo(context->row_data, "%s%c", textctx->null_string, delim);
+				appendStringInfo(row_data, "%s%c", textctx->null_string, delim);
 			else
 			{
 				int off = AttrNumberGetAttrOffset(attnum);
 				const char *output = OutputFunctionCall(&textctx->out_functions[off], value);
-				appendStringInfo(context->row_data, "%s%c", output, delim);
+				appendStringInfo(row_data, "%s%c", output, delim);
 			}
 		}
 	}
@@ -945,12 +1625,13 @@ remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot, const Ch
 			get_connections_for_chunk(context, cis->chunk_id, cis->chunk_data_nodes, cis->user_id);
 		Assert(list_length(connections) == list_length(cis->chunk_data_nodes));
 		Assert(list_length(connections) > 0);
-		result = send_copy_data(context->row_data, connections);
+		result = send_copy_data(row_data, connections);
 	}
 	PG_CATCH();
 	{
 		/* If we hit an error, make sure we end our in-progress COPYs */
-		remote_copy_end(context);
+		end_copy_on_failure(&context->connection_state);
+		MemoryContextDelete(context->mctx);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/tsl/src/remote/dist_copy.h
+++ b/tsl/src/remote/dist_copy.h
@@ -18,7 +18,7 @@ extern uint64 remote_distributed_copy(const CopyStmt *stmt, CopyChunkState *ccst
 extern RemoteCopyContext *remote_copy_begin(const CopyStmt *stmt, Hypertable *ht,
 											ExprContext *per_tuple_ctx, List *attnums,
 											bool binary_copy);
-extern void remote_copy_end(RemoteCopyContext *context);
+extern void remote_copy_end_on_success(RemoteCopyContext *context);
 extern bool remote_copy_send_slot(RemoteCopyContext *context, TupleTableSlot *slot,
 								  const ChunkInsertState *cis);
 extern const char *remote_copy_get_copycmd(RemoteCopyContext *context);

--- a/tsl/test/expected/dist_copy_format_long.out
+++ b/tsl/test/expected/dist_copy_format_long.out
@@ -1,0 +1,106 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test distributed COPY with text/binary format for input and for data transfer
+-- to data nodes.
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+\set DN_DBNAME_1 :TEST_DBNAME _1
+\set DN_DBNAME_2 :TEST_DBNAME _2
+\set DN_DBNAME_3 :TEST_DBNAME _3
+SELECT 1 FROM add_data_node('data_node_1', host => 'localhost',
+                            database => :'DN_DBNAME_1');
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT 1 FROM add_data_node('data_node_2', host => 'localhost',
+                            database => :'DN_DBNAME_2');
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT 1 FROM add_data_node('data_node_3', host => 'localhost',
+                            database => :'DN_DBNAME_3');
+ ?column? 
+----------
+        1
+(1 row)
+
+GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
+SET ROLE :ROLE_1;
+-- Aim to about 100 partitions, the data is from 1995 to 2022.
+create table uk_price_paid(price integer, "date" date, postcode1 text, postcode2 text, type smallint, is_new bool, duration smallint, addr1 text, addr2 text, street text, locality text, town text, district text, country text, category smallint);
+select create_distributed_hypertable('uk_price_paid', 'date', 'postcode2',
+    chunk_time_interval => interval '90 day');
+NOTICE:  adding not-null constraint to column "date"
+ create_distributed_hypertable 
+-------------------------------
+ (1,public,uk_price_paid,t)
+(1 row)
+
+-- Populate.
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
+select count(*), sum(price) from uk_price_paid;
+ count  |     sum     
+--------+-------------
+ 100000 | 20759547354
+(1 row)
+
+-- Make binary file.
+\copy (select * from uk_price_paid) to 'prices-100k.pgbinary' with (format binary);
+-- Binary input with binary data transfer.
+set timescaledb.enable_connection_binary_data = true;
+set timescaledb.dist_copy_transfer_format = 'binary';
+create table uk_price_paid_bin(like uk_price_paid);
+select create_distributed_hypertable('uk_price_paid_bin', 'date', 'postcode2',
+    chunk_time_interval => interval '90 day', replication_factor => 2);
+ create_distributed_hypertable  
+--------------------------------
+ (2,public,uk_price_paid_bin,t)
+(1 row)
+
+\copy uk_price_paid_bin from 'prices-100k.pgbinary' with (format binary);
+select count(*), sum(price) from uk_price_paid_bin;
+ count  |     sum     
+--------+-------------
+ 100000 | 20759547354
+(1 row)
+
+-- Text input with explicit format option and binary data transfer.
+truncate uk_price_paid_bin;
+\copy uk_price_paid_bin from program 'zcat < data/prices-100k-random-1.tsv.gz' with (format text);
+select count(*), sum(price) from uk_price_paid_bin;
+ count  |     sum     
+--------+-------------
+ 100000 | 20759547354
+(1 row)
+
+-- Binary input with text data transfer. Doesn't work.
+set timescaledb.dist_copy_transfer_format = 'text';
+\set ON_ERROR_STOP off
+\copy uk_price_paid_bin from 'prices-100k.pgbinary' with (format binary);
+ERROR:  remote copy does not support binary input in combination with text transfer to data nodes
+\set ON_ERROR_STOP on
+-- Text input with text data transfer.
+truncate uk_price_paid_bin;
+\copy uk_price_paid_bin from program 'zcat < data/prices-100k-random-1.tsv.gz';
+select count(*), sum(price) from uk_price_paid_bin;
+ count  |     sum     
+--------+-------------
+ 100000 | 20759547354
+(1 row)
+
+-- Nonsensical settings
+set timescaledb.dist_copy_transfer_format = 'binary';
+set timescaledb.enable_connection_binary_data = false;
+\set ON_ERROR_STOP off
+\copy uk_price_paid_bin from 'prices-100k.pgbinary' with (format binary);
+ERROR:  the requested binary format for COPY data transfer is disabled by the settings
+\set ON_ERROR_STOP on
+-- Teardown
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+DROP DATABASE :DN_DBNAME_1;
+DROP DATABASE :DN_DBNAME_2;
+DROP DATABASE :DN_DBNAME_3;

--- a/tsl/test/expected/dist_copy_long.out
+++ b/tsl/test/expected/dist_copy_long.out
@@ -128,8 +128,71 @@ select count(*) from uk_price_paid;
  200000
 (1 row)
 
-truncate uk_price_paid;
-reset timescaledb.max_open_chunks_per_insert;
+-- Different replication factors
+create table uk_price_paid_r2(like uk_price_paid);
+select create_distributed_hypertable('uk_price_paid_r2', 'date', 'postcode2',
+    chunk_time_interval => interval '90 day', replication_factor => 2);
+ create_distributed_hypertable 
+-------------------------------
+ (4,public,uk_price_paid_r2,t)
+(1 row)
+
+create table uk_price_paid_r3(like uk_price_paid);
+select create_distributed_hypertable('uk_price_paid_r3', 'date', 'postcode2',
+    chunk_time_interval => interval '90 day', replication_factor => 3);
+ create_distributed_hypertable 
+-------------------------------
+ (5,public,uk_price_paid_r3,t)
+(1 row)
+
+select hypertable_name, replication_factor from timescaledb_information.hypertables
+where hypertable_name like 'uk_price_paid%' order by hypertable_name;
+    hypertable_name    | replication_factor 
+-----------------------+--------------------
+ uk_price_paid         |                  1
+ uk_price_paid_r2      |                  2
+ uk_price_paid_r3      |                  3
+ uk_price_paid_space10 |                  1
+ uk_price_paid_space2  |                  1
+(5 rows)
+
+\copy uk_price_paid_r2 from program 'zcat < data/prices-10k-random-1.tsv.gz';
+select count(*) from uk_price_paid_r2;
+ count 
+-------
+ 10000
+(1 row)
+
+\copy uk_price_paid_r3 from program 'zcat < data/prices-10k-random-1.tsv.gz';
+select count(*) from uk_price_paid_r3;
+ count 
+-------
+ 10000
+(1 row)
+
+-- 0, 1, 2 rows
+\copy uk_price_paid from stdin
+select count(*) from uk_price_paid;
+ count  
+--------
+ 200000
+(1 row)
+
+\copy uk_price_paid from program 'zcat < data/prices-10k-random-1.tsv.gz | head -1';
+select count(*) from uk_price_paid;
+ count  
+--------
+ 200001
+(1 row)
+
+\copy uk_price_paid from program 'zcat < data/prices-10k-random-1.tsv.gz | head -2';
+select count(*) from uk_price_paid;
+ count  
+--------
+ 200003
+(1 row)
+
+-- Teardown
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;

--- a/tsl/test/expected/remote_copy-12.out
+++ b/tsl/test/expected/remote_copy-12.out
@@ -19,6 +19,7 @@ FROM (
 (3 rows)
 
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+SET timescaledb.hide_data_node_name_in_errors = 'on';
 -- Start out testing text copy code
 SET timescaledb.enable_connection_binary_data=false;
 SET ROLE :ROLE_1;
@@ -36,6 +37,28 @@ SELECT create_hypertable('"+ri(k33_'')"', 'thyme', partitioning_column=>'pH', nu
  (1,public,"+ri(k33_')",t)
 (1 row)
 
+-- Use local table as an etalon
+create table copy_local(like "+ri(k33_')");
+COPY copy_local FROM STDIN;
+\copy copy_local("pH", "))_", thyme) fROm stdIN deLIMitER '-';
+cOpy copy_local(thYme, "pH", "))_", "flavor") FrOm
+StDiN wiTH dElImITeR ','
+;
+COPY copy_local FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
+select * from copy_local order by 1;
+ thyme  |         ))_          |         flavor         |  pH  | optional 
+--------+----------------------+------------------------+------+----------
+      1 |                   11 | strawberry             |  2.3 | stuff
+     15 |                  403 |                        |    1 | 
+    203 |              3.21321 | something like lemon   |    1 | 
+    208 |                   40 |                        | 0.01 | 
+    315 |                   37 |                        |   10 | 
+    333 |           2309424231 |   _''garbled*(#\)@#$*) |    1 | 
+    342 |                 4324 | "empties"              |    4 | \N
+   4201 | 3.33333333333333e+27 | ""                     |    1 | empties
+ 120321 |     4.43244243242544 |                        |    0 | 
+(9 rows)
+
 -- Run some successful copies
 COPY "+ri(k33_')" FROM STDIN;
 \copy public    .		"+ri(k33_')" ("pH",     "))_"   ,	thyme) fROm stdIN deLIMitER '-';
@@ -43,6 +66,20 @@ cOpy public."+ri(k33_')" (thYme, "pH", "))_", "flavor") FrOm
 StDiN wiTH dElImITeR ','
 ;
 COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
+select * from copy_local order by 1;
+ thyme  |         ))_          |         flavor         |  pH  | optional 
+--------+----------------------+------------------------+------+----------
+      1 |                   11 | strawberry             |  2.3 | stuff
+     15 |                  403 |                        |    1 | 
+    203 |              3.21321 | something like lemon   |    1 | 
+    208 |                   40 |                        | 0.01 | 
+    315 |                   37 |                        |   10 | 
+    333 |           2309424231 |   _''garbled*(#\)@#$*) |    1 | 
+    342 |                 4324 | "empties"              |    4 | \N
+   4201 | 3.33333333333333e+27 | ""                     |    1 | empties
+ 120321 |     4.43244243242544 |                        |    0 | 
+(9 rows)
+
 -- Run some error cases
 \set ON_ERROR_STOP 0
 -- Bad input
@@ -54,9 +91,9 @@ ERROR:  unable to use default value for partitioning column "pH"
 -- Missing required column, these generate a WARNING with a transaction id in them (too flimsy to output)
 SET client_min_messages TO ERROR;
 COPY "+ri(k33_')" (thyme, flavor, "pH") FROM STDIN WITH DELIMITER ',';
-ERROR:  [db_remote_copy_3]: null value in column "))_" violates not-null constraint
+ERROR:  [<hidden node name>]: null value in column "))_" violates not-null constraint
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';
-ERROR:  [db_remote_copy_2]: null value in column "))_" violates not-null constraint
+ERROR:  [<hidden node name>]: null value in column "))_" violates not-null constraint
 SET client_min_messages TO INFO;
 -- Invalid data after new chunk creation, data and chunks should be rolled back
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';
@@ -80,14 +117,14 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
     3420 |                 4324 | "empties"              |    40 | \N
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -104,14 +141,14 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
   6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
   7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
   8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
+  9 |             1 | _timescaledb_internal | _dist_hyper_1_9_chunk  |                     | f       |      0 | f
+ 10 |             1 | _timescaledb_internal | _dist_hyper_1_10_chunk |                     | f       |      0 | f
+ 11 |             1 | _timescaledb_internal | _dist_hyper_1_11_chunk |                     | f       |      0 | f
  12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
  13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
  14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
  15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
  16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
- 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
- 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
- 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
@@ -133,22 +170,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
         7 |             5 | db_remote_copy_2
         8 |             8 | db_remote_copy_1
         8 |             6 | db_remote_copy_2
-       12 |            11 | db_remote_copy_1
-       12 |             8 | db_remote_copy_2
-       13 |            12 | db_remote_copy_1
-       13 |             9 | db_remote_copy_2
-       14 |            13 | db_remote_copy_1
-       14 |            10 | db_remote_copy_2
-       15 |            14 | db_remote_copy_1
-       15 |            11 | db_remote_copy_2
-       16 |            15 | db_remote_copy_1
-       16 |            12 | db_remote_copy_2
-       17 |            16 | db_remote_copy_1
-       17 |            13 | db_remote_copy_2
-       18 |            17 | db_remote_copy_1
-       18 |            14 | db_remote_copy_2
-       19 |            18 | db_remote_copy_1
-       19 |             6 | db_remote_copy_3
+        9 |             9 | db_remote_copy_1
+        9 |             7 | db_remote_copy_2
+       10 |            10 | db_remote_copy_1
+       10 |             8 | db_remote_copy_2
+       11 |            11 | db_remote_copy_1
+       11 |             9 | db_remote_copy_2
+       12 |            12 | db_remote_copy_1
+       12 |            10 | db_remote_copy_2
+       13 |            13 | db_remote_copy_1
+       13 |            11 | db_remote_copy_2
+       14 |            14 | db_remote_copy_1
+       14 |            12 | db_remote_copy_2
+       15 |            15 | db_remote_copy_1
+       15 |            13 | db_remote_copy_2
+       16 |            16 | db_remote_copy_1
+       16 |             3 | db_remote_copy_3
 (32 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
@@ -170,14 +207,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_1
@@ -191,14 +228,14 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
     3420 |                 4324 | "empties"              |    40 | \N
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -215,14 +252,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_2
@@ -234,13 +271,13 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -255,13 +292,13 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
- _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
 (13 rows)
 
 \c :DATA_NODE_3
@@ -278,12 +315,161 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
  _timescaledb_internal._dist_hyper_1_2_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
+ _timescaledb_internal._dist_hyper_1_16_chunk
 (3 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 SET ROLE :ROLE_1;
 DROP TABLE "+ri(k33_')" CASCADE;
+-- Some more test for escaping and quoting
+set timescaledb.enable_connection_binary_data = true;
+set timescaledb.dist_copy_transfer_format = 'text';
+create table escapes(t int, value text);
+select create_distributed_hypertable('escapes', 't', 'value', chunk_time_interval => 100);
+NOTICE:  adding not-null constraint to column "t"
+ create_distributed_hypertable 
+-------------------------------
+ (2,public,escapes,t)
+(1 row)
+
+\copy escapes from stdin
+\copy (select * from escapes order by escapes) to stdout
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Null values not allowed for partitioning columns
+\set ON_ERROR_STOP off
+\copy escapes from stdin
+ERROR:  NULL value in column "value" violates not-null constraint
+\copy escapes from program 'printf "8\n\\.\n"'
+ERROR:  the number of columns doesn't match
+\copy escapes from program 'printf "8\t\n\\.\n"'
+\copy (select * from escapes order by escapes) to stdout
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+\set ON_ERROR_STOP on
+-- Test null values.
+create table null_values(t int, value text);
+select create_distributed_hypertable('null_values', 't', chunk_time_interval => 100);
+NOTICE:  adding not-null constraint to column "t"
+ create_distributed_hypertable 
+-------------------------------
+ (3,public,null_values,t)
+(1 row)
+
+\copy null_values from program 'printf "6\t\\N\n8\t\n\\.\n"'
+\copy (select * from null_values order by null_values) to stdout
+6	\N
+8	
+-- CSV
+\copy (select * from escapes order by escapes) to stdout with (format csv);
+1,"	
+	\"
+2,	
+3,"a
+b"
+4,ddddd
+5,\
+7,\N
+8,""
+9,end
+10,"""'""'"""
+11,"'""'""'"
+12,'
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.tsv';
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv);
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv);
+\copy (select * from escapes order by escapes) to stdout;
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+-- Different delimiter
+\copy (select * from escapes order by escapes) to stdout with (format csv, delimiter '"', quote '''');
+1"'	
+	\'
+2"	
+3"'a
+b'
+4"ddddd
+5"\
+7"\N
+8"''
+9"end
+10"'"''"''"'
+11"'''"''"'''
+12"''''
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+\copy (select * from escapes order by escapes) to stdout;
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+-- Longer values
+truncate table escapes;
+\copy escapes from stdin
+\copy escapes from stdin
+select sum(t), sum(length(value)) from escapes;
+ sum | sum  
+-----+------
+ 276 | 9214
+(1 row)
+
+-- Check different file encoding
+truncate table escapes;
+\copy escapes from stdin
+\copy (select * from escapes order by escapes) to 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select * from escapes order by escapes) to 'remote-copy-utf8.tsv' with (encoding 'UTF8');
+-- Check that output encoding works at all, and the UTF8 and SJIS files are
+-- different. If you set SQL_ASCII as the server encoding, it just silently
+-- ignores the encoding options.
+\set ON_ERROR_STOP 0
+\copy (select  * from escapes order by escapes) to program 'diff -q -- remote-copy-utf8.tsv -' with (encoding 'SJIS');
+Files remote-copy-utf8.tsv and - differ
+diff -q -- remote-copy-utf8.tsv -: child process exited with exit code 1
+\set ON_ERROR_STOP 1
+truncate escapes;
+\copy escapes from 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select  * from escapes order by escapes) to program 'diff -- remote-copy-utf8.tsv -' with (encoding 'UTF8');
+drop table null_values;
+drop table escapes;
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
 SELECT * FROM delete_data_node(:'DATA_NODE_1');
  delete_data_node 

--- a/tsl/test/expected/remote_copy-13.out
+++ b/tsl/test/expected/remote_copy-13.out
@@ -19,6 +19,7 @@ FROM (
 (3 rows)
 
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+SET timescaledb.hide_data_node_name_in_errors = 'on';
 -- Start out testing text copy code
 SET timescaledb.enable_connection_binary_data=false;
 SET ROLE :ROLE_1;
@@ -36,6 +37,28 @@ SELECT create_hypertable('"+ri(k33_'')"', 'thyme', partitioning_column=>'pH', nu
  (1,public,"+ri(k33_')",t)
 (1 row)
 
+-- Use local table as an etalon
+create table copy_local(like "+ri(k33_')");
+COPY copy_local FROM STDIN;
+\copy copy_local("pH", "))_", thyme) fROm stdIN deLIMitER '-';
+cOpy copy_local(thYme, "pH", "))_", "flavor") FrOm
+StDiN wiTH dElImITeR ','
+;
+COPY copy_local FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
+select * from copy_local order by 1;
+ thyme  |         ))_          |         flavor         |  pH  | optional 
+--------+----------------------+------------------------+------+----------
+      1 |                   11 | strawberry             |  2.3 | stuff
+     15 |                  403 |                        |    1 | 
+    203 |              3.21321 | something like lemon   |    1 | 
+    208 |                   40 |                        | 0.01 | 
+    315 |                   37 |                        |   10 | 
+    333 |           2309424231 |   _''garbled*(#\)@#$*) |    1 | 
+    342 |                 4324 | "empties"              |    4 | \N
+   4201 | 3.33333333333333e+27 | ""                     |    1 | empties
+ 120321 |     4.43244243242544 |                        |    0 | 
+(9 rows)
+
 -- Run some successful copies
 COPY "+ri(k33_')" FROM STDIN;
 \copy public    .		"+ri(k33_')" ("pH",     "))_"   ,	thyme) fROm stdIN deLIMitER '-';
@@ -43,6 +66,20 @@ cOpy public."+ri(k33_')" (thYme, "pH", "))_", "flavor") FrOm
 StDiN wiTH dElImITeR ','
 ;
 COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
+select * from copy_local order by 1;
+ thyme  |         ))_          |         flavor         |  pH  | optional 
+--------+----------------------+------------------------+------+----------
+      1 |                   11 | strawberry             |  2.3 | stuff
+     15 |                  403 |                        |    1 | 
+    203 |              3.21321 | something like lemon   |    1 | 
+    208 |                   40 |                        | 0.01 | 
+    315 |                   37 |                        |   10 | 
+    333 |           2309424231 |   _''garbled*(#\)@#$*) |    1 | 
+    342 |                 4324 | "empties"              |    4 | \N
+   4201 | 3.33333333333333e+27 | ""                     |    1 | empties
+ 120321 |     4.43244243242544 |                        |    0 | 
+(9 rows)
+
 -- Run some error cases
 \set ON_ERROR_STOP 0
 -- Bad input
@@ -54,9 +91,9 @@ ERROR:  unable to use default value for partitioning column "pH"
 -- Missing required column, these generate a WARNING with a transaction id in them (too flimsy to output)
 SET client_min_messages TO ERROR;
 COPY "+ri(k33_')" (thyme, flavor, "pH") FROM STDIN WITH DELIMITER ',';
-ERROR:  [db_remote_copy_3]: null value in column "))_" of relation "_dist_hyper_1_1_chunk" violates not-null constraint
+ERROR:  [<hidden node name>]: null value in column "))_" of relation "_dist_hyper_1_1_chunk" violates not-null constraint
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';
-ERROR:  [db_remote_copy_2]: null value in column "))_" of relation "_dist_hyper_1_4_chunk" violates not-null constraint
+ERROR:  [<hidden node name>]: null value in column "))_" of relation "_dist_hyper_1_4_chunk" violates not-null constraint
 SET client_min_messages TO INFO;
 -- Invalid data after new chunk creation, data and chunks should be rolled back
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';
@@ -80,14 +117,14 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
     3420 |                 4324 | "empties"              |    40 | \N
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -104,14 +141,14 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
   6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
   7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
   8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
+  9 |             1 | _timescaledb_internal | _dist_hyper_1_9_chunk  |                     | f       |      0 | f
+ 10 |             1 | _timescaledb_internal | _dist_hyper_1_10_chunk |                     | f       |      0 | f
+ 11 |             1 | _timescaledb_internal | _dist_hyper_1_11_chunk |                     | f       |      0 | f
  12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
  13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
  14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
  15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
  16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
- 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
- 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
- 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
@@ -133,22 +170,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
         7 |             5 | db_remote_copy_2
         8 |             8 | db_remote_copy_1
         8 |             6 | db_remote_copy_2
-       12 |            11 | db_remote_copy_1
-       12 |             8 | db_remote_copy_2
-       13 |            12 | db_remote_copy_1
-       13 |             9 | db_remote_copy_2
-       14 |            13 | db_remote_copy_1
-       14 |            10 | db_remote_copy_2
-       15 |            14 | db_remote_copy_1
-       15 |            11 | db_remote_copy_2
-       16 |            15 | db_remote_copy_1
-       16 |            12 | db_remote_copy_2
-       17 |            16 | db_remote_copy_1
-       17 |            13 | db_remote_copy_2
-       18 |            17 | db_remote_copy_1
-       18 |            14 | db_remote_copy_2
-       19 |            18 | db_remote_copy_1
-       19 |             6 | db_remote_copy_3
+        9 |             9 | db_remote_copy_1
+        9 |             7 | db_remote_copy_2
+       10 |            10 | db_remote_copy_1
+       10 |             8 | db_remote_copy_2
+       11 |            11 | db_remote_copy_1
+       11 |             9 | db_remote_copy_2
+       12 |            12 | db_remote_copy_1
+       12 |            10 | db_remote_copy_2
+       13 |            13 | db_remote_copy_1
+       13 |            11 | db_remote_copy_2
+       14 |            14 | db_remote_copy_1
+       14 |            12 | db_remote_copy_2
+       15 |            15 | db_remote_copy_1
+       15 |            13 | db_remote_copy_2
+       16 |            16 | db_remote_copy_1
+       16 |             3 | db_remote_copy_3
 (32 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
@@ -170,14 +207,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_1
@@ -191,14 +228,14 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
     3420 |                 4324 | "empties"              |    40 | \N
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -215,14 +252,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_2
@@ -234,13 +271,13 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -255,13 +292,13 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
- _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
 (13 rows)
 
 \c :DATA_NODE_3
@@ -278,12 +315,161 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
  _timescaledb_internal._dist_hyper_1_2_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
+ _timescaledb_internal._dist_hyper_1_16_chunk
 (3 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 SET ROLE :ROLE_1;
 DROP TABLE "+ri(k33_')" CASCADE;
+-- Some more test for escaping and quoting
+set timescaledb.enable_connection_binary_data = true;
+set timescaledb.dist_copy_transfer_format = 'text';
+create table escapes(t int, value text);
+select create_distributed_hypertable('escapes', 't', 'value', chunk_time_interval => 100);
+NOTICE:  adding not-null constraint to column "t"
+ create_distributed_hypertable 
+-------------------------------
+ (2,public,escapes,t)
+(1 row)
+
+\copy escapes from stdin
+\copy (select * from escapes order by escapes) to stdout
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Null values not allowed for partitioning columns
+\set ON_ERROR_STOP off
+\copy escapes from stdin
+ERROR:  NULL value in column "value" violates not-null constraint
+\copy escapes from program 'printf "8\n\\.\n"'
+ERROR:  the number of columns doesn't match
+\copy escapes from program 'printf "8\t\n\\.\n"'
+\copy (select * from escapes order by escapes) to stdout
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+\set ON_ERROR_STOP on
+-- Test null values.
+create table null_values(t int, value text);
+select create_distributed_hypertable('null_values', 't', chunk_time_interval => 100);
+NOTICE:  adding not-null constraint to column "t"
+ create_distributed_hypertable 
+-------------------------------
+ (3,public,null_values,t)
+(1 row)
+
+\copy null_values from program 'printf "6\t\\N\n8\t\n\\.\n"'
+\copy (select * from null_values order by null_values) to stdout
+6	\N
+8	
+-- CSV
+\copy (select * from escapes order by escapes) to stdout with (format csv);
+1,"	
+	\"
+2,	
+3,"a
+b"
+4,ddddd
+5,\
+7,\N
+8,""
+9,end
+10,"""'""'"""
+11,"'""'""'"
+12,'
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.tsv';
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv);
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv);
+\copy (select * from escapes order by escapes) to stdout;
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+-- Different delimiter
+\copy (select * from escapes order by escapes) to stdout with (format csv, delimiter '"', quote '''');
+1"'	
+	\'
+2"	
+3"'a
+b'
+4"ddddd
+5"\
+7"\N
+8"''
+9"end
+10"'"''"''"'
+11"'''"''"'''
+12"''''
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+\copy (select * from escapes order by escapes) to stdout;
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+-- Longer values
+truncate table escapes;
+\copy escapes from stdin
+\copy escapes from stdin
+select sum(t), sum(length(value)) from escapes;
+ sum | sum  
+-----+------
+ 276 | 9214
+(1 row)
+
+-- Check different file encoding
+truncate table escapes;
+\copy escapes from stdin
+\copy (select * from escapes order by escapes) to 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select * from escapes order by escapes) to 'remote-copy-utf8.tsv' with (encoding 'UTF8');
+-- Check that output encoding works at all, and the UTF8 and SJIS files are
+-- different. If you set SQL_ASCII as the server encoding, it just silently
+-- ignores the encoding options.
+\set ON_ERROR_STOP 0
+\copy (select  * from escapes order by escapes) to program 'diff -q -- remote-copy-utf8.tsv -' with (encoding 'SJIS');
+Files remote-copy-utf8.tsv and - differ
+diff -q -- remote-copy-utf8.tsv -: child process exited with exit code 1
+\set ON_ERROR_STOP 1
+truncate escapes;
+\copy escapes from 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select  * from escapes order by escapes) to program 'diff -- remote-copy-utf8.tsv -' with (encoding 'UTF8');
+drop table null_values;
+drop table escapes;
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
 SELECT * FROM delete_data_node(:'DATA_NODE_1');
  delete_data_node 

--- a/tsl/test/expected/remote_copy-14.out
+++ b/tsl/test/expected/remote_copy-14.out
@@ -19,6 +19,7 @@ FROM (
 (3 rows)
 
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
+SET timescaledb.hide_data_node_name_in_errors = 'on';
 -- Start out testing text copy code
 SET timescaledb.enable_connection_binary_data=false;
 SET ROLE :ROLE_1;
@@ -36,6 +37,28 @@ SELECT create_hypertable('"+ri(k33_'')"', 'thyme', partitioning_column=>'pH', nu
  (1,public,"+ri(k33_')",t)
 (1 row)
 
+-- Use local table as an etalon
+create table copy_local(like "+ri(k33_')");
+COPY copy_local FROM STDIN;
+\copy copy_local("pH", "))_", thyme) fROm stdIN deLIMitER '-';
+cOpy copy_local(thYme, "pH", "))_", "flavor") FrOm
+StDiN wiTH dElImITeR ','
+;
+COPY copy_local FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
+select * from copy_local order by 1;
+ thyme  |         ))_          |         flavor         |  pH  | optional 
+--------+----------------------+------------------------+------+----------
+      1 |                   11 | strawberry             |  2.3 | stuff
+     15 |                  403 |                        |    1 | 
+    203 |              3.21321 | something like lemon   |    1 | 
+    208 |                   40 |                        | 0.01 | 
+    315 |                   37 |                        |   10 | 
+    333 |           2309424231 |   _''garbled*(#\)@#$*) |    1 | 
+    342 |                 4324 | "empties"              |    4 | \N
+   4201 | 3.33333333333333e+27 | ""                     |    1 | empties
+ 120321 |     4.43244243242544 |                        |    0 | 
+(9 rows)
+
 -- Run some successful copies
 COPY "+ri(k33_')" FROM STDIN;
 \copy public    .		"+ri(k33_')" ("pH",     "))_"   ,	thyme) fROm stdIN deLIMitER '-';
@@ -43,6 +66,20 @@ cOpy public."+ri(k33_')" (thYme, "pH", "))_", "flavor") FrOm
 StDiN wiTH dElImITeR ','
 ;
 COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
+select * from copy_local order by 1;
+ thyme  |         ))_          |         flavor         |  pH  | optional 
+--------+----------------------+------------------------+------+----------
+      1 |                   11 | strawberry             |  2.3 | stuff
+     15 |                  403 |                        |    1 | 
+    203 |              3.21321 | something like lemon   |    1 | 
+    208 |                   40 |                        | 0.01 | 
+    315 |                   37 |                        |   10 | 
+    333 |           2309424231 |   _''garbled*(#\)@#$*) |    1 | 
+    342 |                 4324 | "empties"              |    4 | \N
+   4201 | 3.33333333333333e+27 | ""                     |    1 | empties
+ 120321 |     4.43244243242544 |                        |    0 | 
+(9 rows)
+
 -- Run some error cases
 \set ON_ERROR_STOP 0
 -- Bad input
@@ -54,9 +91,9 @@ ERROR:  unable to use default value for partitioning column "pH"
 -- Missing required column, these generate a WARNING with a transaction id in them (too flimsy to output)
 SET client_min_messages TO ERROR;
 COPY "+ri(k33_')" (thyme, flavor, "pH") FROM STDIN WITH DELIMITER ',';
-ERROR:  [db_remote_copy_3]: null value in column "))_" of relation "_dist_hyper_1_1_chunk" violates not-null constraint
+ERROR:  [<hidden node name>]: null value in column "))_" of relation "_dist_hyper_1_1_chunk" violates not-null constraint
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';
-ERROR:  [db_remote_copy_2]: null value in column "))_" of relation "_dist_hyper_1_4_chunk" violates not-null constraint
+ERROR:  [<hidden node name>]: null value in column "))_" of relation "_dist_hyper_1_4_chunk" violates not-null constraint
 SET client_min_messages TO INFO;
 -- Invalid data after new chunk creation, data and chunks should be rolled back
 COPY "+ri(k33_')" FROM STDIN WITH DELIMITER ',';
@@ -80,14 +117,14 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
     3420 |                 4324 | "empties"              |    40 | \N
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -104,14 +141,14 @@ SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
   6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
   7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
   8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
+  9 |             1 | _timescaledb_internal | _dist_hyper_1_9_chunk  |                     | f       |      0 | f
+ 10 |             1 | _timescaledb_internal | _dist_hyper_1_10_chunk |                     | f       |      0 | f
+ 11 |             1 | _timescaledb_internal | _dist_hyper_1_11_chunk |                     | f       |      0 | f
  12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
  13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
  14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
  15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
  16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
- 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
- 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
- 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
@@ -133,22 +170,22 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;
         7 |             5 | db_remote_copy_2
         8 |             8 | db_remote_copy_1
         8 |             6 | db_remote_copy_2
-       12 |            11 | db_remote_copy_1
-       12 |             8 | db_remote_copy_2
-       13 |            12 | db_remote_copy_1
-       13 |             9 | db_remote_copy_2
-       14 |            13 | db_remote_copy_1
-       14 |            10 | db_remote_copy_2
-       15 |            14 | db_remote_copy_1
-       15 |            11 | db_remote_copy_2
-       16 |            15 | db_remote_copy_1
-       16 |            12 | db_remote_copy_2
-       17 |            16 | db_remote_copy_1
-       17 |            13 | db_remote_copy_2
-       18 |            17 | db_remote_copy_1
-       18 |            14 | db_remote_copy_2
-       19 |            18 | db_remote_copy_1
-       19 |             6 | db_remote_copy_3
+        9 |             9 | db_remote_copy_1
+        9 |             7 | db_remote_copy_2
+       10 |            10 | db_remote_copy_1
+       10 |             8 | db_remote_copy_2
+       11 |            11 | db_remote_copy_1
+       11 |             9 | db_remote_copy_2
+       12 |            12 | db_remote_copy_1
+       12 |            10 | db_remote_copy_2
+       13 |            13 | db_remote_copy_1
+       13 |            11 | db_remote_copy_2
+       14 |            14 | db_remote_copy_1
+       14 |            12 | db_remote_copy_2
+       15 |            15 | db_remote_copy_1
+       15 |            13 | db_remote_copy_2
+       16 |            16 | db_remote_copy_1
+       16 |             3 | db_remote_copy_3
 (32 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node ORDER BY 3;
@@ -170,14 +207,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_1
@@ -191,14 +228,14 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      203 |              3.21321 | something like lemon   |     1 | 
      208 |                   40 | mint                   |  0.01 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
     3420 |                 4324 | "empties"              |    40 | \N
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -215,14 +252,14 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
  _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
 (16 rows)
 
 \c :DATA_NODE_2
@@ -234,13 +271,13 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
      150 |                  403 |                        |    10 | 
      203 |              3.21321 | something like lemon   |     1 | 
      315 |                   37 | mint                   |    10 | 
-     333 |           2309424231 |   _''garbled*(#)@#$*)  |     1 | 
+     333 |           2309424231 |   _''garbled*(#\)@#$*) |     1 | 
      342 |                 4324 | "empties"              |     4 | \N
     2030 |              3.21321 | something like lemon   |    10 | 
     2080 |                   40 | mint                   | 0.001 | 
     3150 |                   37 | mint                   |   100 | 
     3330 |           2309424231 |   _''garbled*(#\)@#$*) |    10 | 
-    4201 | 3.33333333333333e+27 | ""                     |     1 | 
+    4201 | 3.33333333333333e+27 | ""                     |     1 | empties
    42010 | 3.33333333333333e+27 | ""                     |     1 | empties
   120321 |     4.43244243242544 |                        |     0 | 
  1203210 |     4.43244243242544 |                        |     0 | 
@@ -255,13 +292,13 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
  _timescaledb_internal._dist_hyper_1_6_chunk
  _timescaledb_internal._dist_hyper_1_7_chunk
  _timescaledb_internal._dist_hyper_1_8_chunk
+ _timescaledb_internal._dist_hyper_1_9_chunk
+ _timescaledb_internal._dist_hyper_1_10_chunk
+ _timescaledb_internal._dist_hyper_1_11_chunk
  _timescaledb_internal._dist_hyper_1_12_chunk
  _timescaledb_internal._dist_hyper_1_13_chunk
  _timescaledb_internal._dist_hyper_1_14_chunk
  _timescaledb_internal._dist_hyper_1_15_chunk
- _timescaledb_internal._dist_hyper_1_16_chunk
- _timescaledb_internal._dist_hyper_1_17_chunk
- _timescaledb_internal._dist_hyper_1_18_chunk
 (13 rows)
 
 \c :DATA_NODE_3
@@ -278,12 +315,161 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 ----------------------------------------------
  _timescaledb_internal._dist_hyper_1_1_chunk
  _timescaledb_internal._dist_hyper_1_2_chunk
- _timescaledb_internal._dist_hyper_1_19_chunk
+ _timescaledb_internal._dist_hyper_1_16_chunk
 (3 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER;
 SET ROLE :ROLE_1;
 DROP TABLE "+ri(k33_')" CASCADE;
+-- Some more test for escaping and quoting
+set timescaledb.enable_connection_binary_data = true;
+set timescaledb.dist_copy_transfer_format = 'text';
+create table escapes(t int, value text);
+select create_distributed_hypertable('escapes', 't', 'value', chunk_time_interval => 100);
+NOTICE:  adding not-null constraint to column "t"
+ create_distributed_hypertable 
+-------------------------------
+ (2,public,escapes,t)
+(1 row)
+
+\copy escapes from stdin
+\copy (select * from escapes order by escapes) to stdout
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Null values not allowed for partitioning columns
+\set ON_ERROR_STOP off
+\copy escapes from stdin
+ERROR:  NULL value in column "value" violates not-null constraint
+\copy escapes from program 'printf "8\n\\.\n"'
+ERROR:  the number of columns doesn't match
+\copy escapes from program 'printf "8\t\n\\.\n"'
+\copy (select * from escapes order by escapes) to stdout
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+\set ON_ERROR_STOP on
+-- Test null values.
+create table null_values(t int, value text);
+select create_distributed_hypertable('null_values', 't', chunk_time_interval => 100);
+NOTICE:  adding not-null constraint to column "t"
+ create_distributed_hypertable 
+-------------------------------
+ (3,public,null_values,t)
+(1 row)
+
+\copy null_values from program 'printf "6\t\\N\n8\t\n\\.\n"'
+\copy (select * from null_values order by null_values) to stdout
+6	\N
+8	
+-- CSV
+\copy (select * from escapes order by escapes) to stdout with (format csv);
+1,"	
+	\"
+2,	
+3,"a
+b"
+4,ddddd
+5,\
+7,\N
+8,""
+9,end
+10,"""'""'"""
+11,"'""'""'"
+12,'
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.tsv';
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv);
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv);
+\copy (select * from escapes order by escapes) to stdout;
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+-- Different delimiter
+\copy (select * from escapes order by escapes) to stdout with (format csv, delimiter '"', quote '''');
+1"'	
+	\'
+2"	
+3"'a
+b'
+4"ddddd
+5"\
+7"\N
+8"''
+9"end
+10"'"''"''"'
+11"'''"''"'''
+12"''''
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+\copy (select * from escapes order by escapes) to stdout;
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+8	
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+-- Longer values
+truncate table escapes;
+\copy escapes from stdin
+\copy escapes from stdin
+select sum(t), sum(length(value)) from escapes;
+ sum | sum  
+-----+------
+ 276 | 9214
+(1 row)
+
+-- Check different file encoding
+truncate table escapes;
+\copy escapes from stdin
+\copy (select * from escapes order by escapes) to 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select * from escapes order by escapes) to 'remote-copy-utf8.tsv' with (encoding 'UTF8');
+-- Check that output encoding works at all, and the UTF8 and SJIS files are
+-- different. If you set SQL_ASCII as the server encoding, it just silently
+-- ignores the encoding options.
+\set ON_ERROR_STOP 0
+\copy (select  * from escapes order by escapes) to program 'diff -q -- remote-copy-utf8.tsv -' with (encoding 'SJIS');
+Files remote-copy-utf8.tsv and - differ
+diff -q -- remote-copy-utf8.tsv -: child process exited with exit code 1
+\set ON_ERROR_STOP 1
+truncate escapes;
+\copy escapes from 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select  * from escapes order by escapes) to program 'diff -- remote-copy-utf8.tsv -' with (encoding 'UTF8');
+drop table null_values;
+drop table escapes;
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
 SELECT * FROM delete_data_node(:'DATA_NODE_1');
  delete_data_node 

--- a/tsl/test/shared/expected/dist_remote_error.out
+++ b/tsl/test/shared/expected/dist_remote_error.out
@@ -7,6 +7,7 @@
 -- that changed in PG 14.
 set timescaledb.debug_enable_ssl to off;
 set client_min_messages to error;
+SET timescaledb.hide_data_node_name_in_errors = 'on';
 -- A relatively big table on one data node
 create table metrics_dist_remote_error(like metrics_dist);
 select table_name from create_distributed_hypertable('metrics_dist_remote_error', 'time', 'device_id',
@@ -26,22 +27,22 @@ set client_min_messages to ERROR;
 set timescaledb.remote_data_fetcher = 'rowbyrow';
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(0, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 0 rows, 1 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 0 rows, 1 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(1, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 1 rows, 1 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1 rows, 1 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(2, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 2 rows, 2 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 2 rows, 2 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(701, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 701 rows, 701 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 701 rows, 701 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(10000, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 10000 rows, 10000 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 10000 rows, 10000 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(16384, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 16384 rows, 16384 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 16384 rows, 16384 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(10000000, device_id)::int != 0;
 QUERY PLAN
@@ -60,19 +61,19 @@ QUERY PLAN
 set timescaledb.remote_data_fetcher = 'cursor';
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(0, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 0 rows, 1 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 0 rows, 1 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(1, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 1 rows, 1 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1 rows, 1 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(2, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 2 rows, 2 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 2 rows, 2 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(701, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 701 rows, 701 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 701 rows, 701 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(10000, device_id)::int != 0;
-ERROR:  [data_node_1]: debug point: requested to error out after 10000 rows, 10000 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 10000 rows, 10000 rows seen
 explain (analyze, verbose, costs off, timing off, summary off)
 select 1 from metrics_dist_remote_error where ts_debug_shippable_error_after_n_rows(10000000, device_id)::int != 0;
 QUERY PLAN
@@ -99,7 +100,7 @@ insert into metrics_dist_bs
 set timescaledb.enable_connection_binary_data to on;
 explain (analyze, verbose, costs off, timing off, summary off)
 select * from metrics_dist_bs;
-ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
 drop table metrics_dist_bs;
 -- Table with broken receive for a data type.
 create table metrics_dist_br(like metrics_dist);
@@ -110,24 +111,98 @@ select table_name from create_distributed_hypertable('metrics_dist_br',
  metrics_dist_br
 (1 row)
 
+select hypertable_name, replication_factor from timescaledb_information.hypertables
+where hypertable_name = 'metrics_dist_br';
+ hypertable_name | replication_factor 
+-----------------+--------------------
+ metrics_dist_br |                  1
+(1 row)
+
 -- Test that INSERT and COPY fail on data nodes.
 -- Note that we use the text format for the COPY input, so that the access node
 -- doesn't call `recv` and fail by itself. It's going to use binary format for
 -- transfer to data nodes regardless of the input format.
+set timescaledb.dist_copy_transfer_format = 'binary';
 -- First, create the reference.
 \copy (select * from metrics_dist_remote_error) to 'dist_remote_error.text' with (format text);
 -- We have to test various interleavings of COPY and INSERT to check that
 -- one can recover from connection failure states introduced by another.
 \copy metrics_dist_br from 'dist_remote_error.text' with (format text);
-ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
 \copy metrics_dist_br from 'dist_remote_error.text' with (format text);
-ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
 insert into metrics_dist_br select * from metrics_dist_remote_error;
-ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
 insert into metrics_dist_br select * from metrics_dist_remote_error;
-ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
 \copy metrics_dist_br from 'dist_remote_error.text' with (format text);
-ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
+-- Fail at different points
+set timescaledb.debug_broken_sendrecv_throw_after = 1;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1 rows, 1 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 2;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 2 rows, 2 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 1023;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1023 rows, 1023 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 1024;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1024 rows, 1024 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 1025;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1025 rows, 1025 rows seen
+reset timescaledb.debug_broken_sendrecv_throw_after;
+-- Same with different replication factor
+truncate metrics_dist_br;
+select set_replication_factor('metrics_dist_br', 2);
+ set_replication_factor 
+ 
+(1 row)
+
+select hypertable_name, replication_factor from timescaledb_information.hypertables
+where hypertable_name = 'metrics_dist_br';
+ hypertable_name | replication_factor 
+-----------------+--------------------
+ metrics_dist_br |                  2
+(1 row)
+
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
+insert into metrics_dist_br select * from metrics_dist_remote_error;
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
+insert into metrics_dist_br select * from metrics_dist_remote_error;
+ERROR:  [<hidden node name>]: debug point: requested to error out after 7103 rows, 7103 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 1;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1 rows, 1 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 2;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 2 rows, 2 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 1023;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1023 rows, 1023 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 1024;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1024 rows, 1024 rows seen
+set timescaledb.debug_broken_sendrecv_throw_after = 1025;
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [<hidden node name>]: debug point: requested to error out after 1025 rows, 1025 rows seen
+-- Should succeed with text format for data transfer.
+set timescaledb.dist_copy_transfer_format = 'text';
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+-- Final check.
+set timescaledb.enable_connection_binary_data = false;
+select count(*) from metrics_dist_br;
+ count 
+ 20000
+(1 row)
+
+set timescaledb.enable_connection_binary_data = true;
+reset timescaledb.debug_broken_sendrecv_throw_after;
 drop table metrics_dist_br;
 -- Table with sleepy receive for a data type, to improve coverage of the waiting
 -- code on the access node.
@@ -139,6 +214,9 @@ select table_name from create_distributed_hypertable('metrics_dist_bl',
  metrics_dist_bl
 (1 row)
 
+-- We're using sleepy recv function, so need the binary transfer format for it
+-- to be called on the data nodes.
+set timescaledb.dist_copy_transfer_format = 'binary';
 -- Test INSERT and COPY with slow data node.
 \copy metrics_dist_bl from 'dist_remote_error.text' with (format text);
 insert into metrics_dist_bl select * from metrics_dist_remote_error;

--- a/tsl/test/shared/sql/.gitignore
+++ b/tsl/test/shared/sql/.gitignore
@@ -7,5 +7,6 @@
 /generated_columns-*.sql
 /ordered_append-*.sql
 /ordered_append_join-*.sql
+/remote-copy-escapes.*sv
 /space_constraint-*.sql
 /transparent_decompress_chunk-*.sql

--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -1,3 +1,4 @@
+/*.pgbinary
 /cagg_ddl-*.sql
 /cagg_invalidation_dist_ht-*.sql
 /cagg_permissions-*.sql
@@ -11,6 +12,7 @@
 /hypertable_distributed-*.sql
 /jit-*.sql
 /plan_skip_scan-*.sql
+/remote-copy-*sv
 /remote_copy-*.sql
-/transparent_decompression_ordered_index-*.sql
 /transparent_decompression-*.sql
+/transparent_decompression_ordered_index-*.sql

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -69,6 +69,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     dist_api_calls.sql
     dist_commands.sql
     dist_compression.sql
+    dist_copy_format_long.sql
     dist_copy_long.sql
     dist_ddl.sql
     dist_move_chunk.sql

--- a/tsl/test/sql/dist_copy_format_long.sql
+++ b/tsl/test/sql/dist_copy_format_long.sql
@@ -1,0 +1,74 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test distributed COPY with text/binary format for input and for data transfer
+-- to data nodes.
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+
+\set DN_DBNAME_1 :TEST_DBNAME _1
+\set DN_DBNAME_2 :TEST_DBNAME _2
+\set DN_DBNAME_3 :TEST_DBNAME _3
+
+SELECT 1 FROM add_data_node('data_node_1', host => 'localhost',
+                            database => :'DN_DBNAME_1');
+SELECT 1 FROM add_data_node('data_node_2', host => 'localhost',
+                            database => :'DN_DBNAME_2');
+SELECT 1 FROM add_data_node('data_node_3', host => 'localhost',
+                            database => :'DN_DBNAME_3');
+GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
+
+SET ROLE :ROLE_1;
+
+
+-- Aim to about 100 partitions, the data is from 1995 to 2022.
+create table uk_price_paid(price integer, "date" date, postcode1 text, postcode2 text, type smallint, is_new bool, duration smallint, addr1 text, addr2 text, street text, locality text, town text, district text, country text, category smallint);
+select create_distributed_hypertable('uk_price_paid', 'date', 'postcode2',
+    chunk_time_interval => interval '90 day');
+
+-- Populate.
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
+select count(*), sum(price) from uk_price_paid;
+
+-- Make binary file.
+\copy (select * from uk_price_paid) to 'prices-100k.pgbinary' with (format binary);
+
+-- Binary input with binary data transfer.
+set timescaledb.enable_connection_binary_data = true;
+set timescaledb.dist_copy_transfer_format = 'binary';
+create table uk_price_paid_bin(like uk_price_paid);
+select create_distributed_hypertable('uk_price_paid_bin', 'date', 'postcode2',
+    chunk_time_interval => interval '90 day', replication_factor => 2);
+
+\copy uk_price_paid_bin from 'prices-100k.pgbinary' with (format binary);
+select count(*), sum(price) from uk_price_paid_bin;
+
+-- Text input with explicit format option and binary data transfer.
+truncate uk_price_paid_bin;
+\copy uk_price_paid_bin from program 'zcat < data/prices-100k-random-1.tsv.gz' with (format text);
+select count(*), sum(price) from uk_price_paid_bin;
+
+-- Binary input with text data transfer. Doesn't work.
+set timescaledb.dist_copy_transfer_format = 'text';
+\set ON_ERROR_STOP off
+\copy uk_price_paid_bin from 'prices-100k.pgbinary' with (format binary);
+\set ON_ERROR_STOP on
+
+-- Text input with text data transfer.
+truncate uk_price_paid_bin;
+\copy uk_price_paid_bin from program 'zcat < data/prices-100k-random-1.tsv.gz';
+select count(*), sum(price) from uk_price_paid_bin;
+
+-- Nonsensical settings
+set timescaledb.dist_copy_transfer_format = 'binary';
+set timescaledb.enable_connection_binary_data = false;
+\set ON_ERROR_STOP off
+\copy uk_price_paid_bin from 'prices-100k.pgbinary' with (format binary);
+\set ON_ERROR_STOP on
+
+-- Teardown
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
+DROP DATABASE :DN_DBNAME_1;
+DROP DATABASE :DN_DBNAME_2;
+DROP DATABASE :DN_DBNAME_3;

--- a/tsl/test/sql/remote_copy.sql.in
+++ b/tsl/test/sql/remote_copy.sql.in
@@ -16,6 +16,8 @@ FROM (
 ) a;
 GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC;
 
+SET timescaledb.hide_data_node_name_in_errors = 'on';
+
 -- Start out testing text copy code
 SET timescaledb.enable_connection_binary_data=false;
 
@@ -31,6 +33,34 @@ CREATE TABLE "+ri(k33_')" (
 );
 
 SELECT create_hypertable('"+ri(k33_'')"', 'thyme', partitioning_column=>'pH', number_partitions=>4, chunk_time_interval => 100, replication_factor => 2);
+
+-- Use local table as an etalon
+create table copy_local(like "+ri(k33_')");
+
+COPY copy_local FROM STDIN;
+1	11	strawberry	2.3	stuff
+\.
+
+\copy copy_local("pH", "))_", thyme) fROm stdIN deLIMitER '-';
+.01-40-208
+10.-37-315
+\.
+
+cOpy copy_local(thYme, "pH", "))_", "flavor") FrOm
+StDiN wiTH dElImITeR ','
+;
+15,1,403,\N
+203,1.0,3.21321,something like lemon
+333,1.00,2309424231,  _''garbled*(#\\)@#$*)
+\.
+
+COPY copy_local FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FORMAT csv, NULL 'empties', FORCE_NOT_NULL ("pH", "thyme"));
+120321,4.4324424324254352345345,``,0,empties
+4201,3333333333333333333333333333,"",1.0000000000000000000000000000000001,`empties`
+342,4324,"empties",4,\N
+\.
+
+select * from copy_local order by 1;
 
 -- Run some successful copies
 COPY "+ri(k33_')" FROM STDIN;
@@ -55,6 +85,8 @@ COPY "+ri(k33_')" FROM STDIN (FORCE_NULL (flavor, "))_"), QUOTE '`', FREEZE, FOR
 4201,3333333333333333333333333333,"",1.0000000000000000000000000000000001,`empties`
 342,4324,"empties",4,\N
 \.
+
+select * from copy_local order by 1;
 
 -- Run some error cases
 \set ON_ERROR_STOP 0
@@ -133,6 +165,128 @@ select * from show_chunks('"+ri(k33_'')"') ORDER BY 1;
 SET ROLE :ROLE_1;
 
 DROP TABLE "+ri(k33_')" CASCADE;
+
+-- Some more test for escaping and quoting
+set timescaledb.enable_connection_binary_data = true;
+set timescaledb.dist_copy_transfer_format = 'text';
+create table escapes(t int, value text);
+select create_distributed_hypertable('escapes', 't', 'value', chunk_time_interval => 100);
+
+\copy escapes from stdin
+1	\t\b\f\n\r\t\v\\
+2	\t
+3	a\nb
+4	ddddd
+5	\\
+7	\\N
+9	end
+10	"'"'"
+11	'"'"'
+12	'
+\.
+
+\copy (select * from escapes order by escapes) to stdout
+
+-- Null values not allowed for partitioning columns
+\set ON_ERROR_STOP off
+
+\copy escapes from stdin
+6	\N
+\.
+
+\copy escapes from program 'printf "8\n\\.\n"'
+
+\copy escapes from program 'printf "8\t\n\\.\n"'
+
+\copy (select * from escapes order by escapes) to stdout
+
+\set ON_ERROR_STOP on
+
+-- Test null values.
+create table null_values(t int, value text);
+select create_distributed_hypertable('null_values', 't', chunk_time_interval => 100);
+\copy null_values from program 'printf "6\t\\N\n8\t\n\\.\n"'
+\copy (select * from null_values order by null_values) to stdout
+
+-- CSV
+\copy (select * from escapes order by escapes) to stdout with (format csv);
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.tsv';
+
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv);
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv);
+\copy (select * from escapes order by escapes) to stdout;
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+
+-- Different delimiter
+\copy (select * from escapes order by escapes) to stdout with (format csv, delimiter '"', quote '''');
+\copy (select * from escapes order by escapes) to 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+truncate escapes;
+\copy escapes from 'remote-copy-escapes.csv' with (format csv, delimiter '"', quote '''', null ',');
+\copy (select * from escapes order by escapes) to stdout;
+-- Check the result with diff
+\copy (select * from escapes order by escapes) to program 'diff -- remote-copy-escapes.tsv -';
+
+-- Longer values
+truncate table escapes;
+\copy escapes from stdin
+1	a
+2	aa
+3	aaaa
+4	aaaaaaaa
+5	aaaaaaaaaaaaaaaa
+6	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+7	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+8	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+9	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+10	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+11	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+12	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+13	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+\.
+
+\copy escapes from stdin
+14	\t
+15	\t\t
+16	\t\t\t\t
+17	\t\t\t\t\t\t\t\t
+18	\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+19	\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+20	\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+21	\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+22	\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+23	\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+\.
+
+select sum(t), sum(length(value)) from escapes;
+
+-- Check different file encoding
+truncate table escapes;
+\copy escapes from stdin
+1	PostgreSQL（ポストグレス キューエル）は、拡張性とSQL準拠を強調するフリーでオープンソースの関係データベース管理システム（RDBMS）である
+2	Postgresとしても知られている
+4	1996年に、プロジェクトはSQLのサポートを反映してPostgreSQLに改名された
+\.
+
+\copy (select * from escapes order by escapes) to 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select * from escapes order by escapes) to 'remote-copy-utf8.tsv' with (encoding 'UTF8');
+
+-- Check that output encoding works at all, and the UTF8 and SJIS files are
+-- different. If you set SQL_ASCII as the server encoding, it just silently
+-- ignores the encoding options.
+\set ON_ERROR_STOP 0
+\copy (select  * from escapes order by escapes) to program 'diff -q -- remote-copy-utf8.tsv -' with (encoding 'SJIS');
+\set ON_ERROR_STOP 1
+
+truncate escapes;
+
+\copy escapes from 'remote-copy-sjis.tsv' with (encoding 'SJIS');
+\copy (select  * from escapes order by escapes) to program 'diff -- remote-copy-utf8.tsv -' with (encoding 'UTF8');
+
+drop table null_values;
+drop table escapes;
+
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
 SELECT * FROM delete_data_node(:'DATA_NODE_1');
 SELECT * FROM delete_data_node(:'DATA_NODE_2');


### PR DESCRIPTION
Group the incoming rows into batches on access node before COPYing to
data nodes.

This gives 2x-5x speedup on various COPY queries to distributed
hypertables.

Also fix the text format passthrough, and prefer text transfer format for text input to be able to use this passthrough. It saves a lot of CPU on the access node.
Fixes https://github.com/timescale/timescaledb/issues/4761

Part of #4285