### PR TITLE
Synchronize chunk cache sizes

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -263,6 +263,17 @@ TSCopyMultiInsertInfoIsFull(TSCopyMultiInsertInfo *miinfo)
 	if (miinfo->bufferedTuples >= MAX_BUFFERED_TUPLES ||
 		miinfo->bufferedBytes >= MAX_BUFFERED_BYTES)
 		return true;
+
+	if (hash_get_num_entries(miinfo->multiInsertBuffers) >= ts_guc_max_open_chunks_per_insert)
+	{
+		/*
+		 * Flushing each multi-insert buffer will require looking up the
+		 * corresponding chunk insert state in the cache, so don't accumulate
+		 * more inserts than the cache can fit, to avoid thrashing.
+		 */
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
Specifically, flush the chunk multi-insert states when the number of it
reaches the size of the chunk cache. Otherwise, the chunks
corresponding to the multi-insert states go out of cache and have to be
looked up again when the multi-insert state is flushed, which leads to
a performance hit.

Let's see if tsbench shows any improvement.

Part of https://github.com/timescale/timescaledb/pull/4285