### PR TITLE
Add more tests for distributed INSERT and COPY

### DIFF
--- a/tsl/test/shared/expected/dist_remote_error.out
+++ b/tsl/test/shared/expected/dist_remote_error.out
@@ -5,7 +5,6 @@
 \unset ECHO
 -- Disable SSL to get stable error output across versions. SSL adds some output
 -- that changed in PG 14.
-\c -reuse-previous=on sslmode=disable
 set timescaledb.debug_enable_ssl to off;
 set client_min_messages to error;
 -- A relatively big table on one data node
@@ -111,15 +110,42 @@ select table_name from create_distributed_hypertable('metrics_dist_br',
  metrics_dist_br
 (1 row)
 
--- Test that the insert fails on data nodes.
+-- Test that INSERT and COPY fail on data nodes.
+-- Note that we use the text format for the COPY input, so that the access node
+-- doesn't call `recv` and fail by itself. It's going to use binary format for
+-- transfer to data nodes regardless of the input format.
+-- First, create the reference.
+\copy (select * from metrics_dist_remote_error) to 'dist_remote_error.text' with (format text);
+-- We have to test various interleavings of COPY and INSERT to check that
+-- one can recover from connection failure states introduced by another.
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
+\copy metrics_dist_br from 'dist_remote_error.text' with (format text);
+ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
 insert into metrics_dist_br select * from metrics_dist_remote_error;
 ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
--- Also test that the COPY fails on data nodes. Note that we use the text format
--- for the insert, so that the access node doesn't call `recv` and fail by itself.
--- It's going to use binary format for transferring COPY data to data nodes
--- regardless of the input format.
-\copy (select * from metrics_dist_remote_error) to 'dist_remote_error.text' with (format text);
+insert into metrics_dist_br select * from metrics_dist_remote_error;
+ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
 \copy metrics_dist_br from 'dist_remote_error.text' with (format text);
 ERROR:  [data_node_2]: debug point: requested to error out after 7103 rows, 7103 rows seen
 drop table metrics_dist_br;
+-- Table with sleepy receive for a data type, to improve coverage of the waiting
+-- code on the access node.
+create table metrics_dist_bl(like metrics_dist);
+alter table metrics_dist_bl alter column v0 type bl;
+select table_name from create_distributed_hypertable('metrics_dist_bl',
+    'time', 'device_id');
+   table_name    
+ metrics_dist_bl
+(1 row)
+
+-- Test INSERT and COPY with slow data node.
+\copy metrics_dist_bl from 'dist_remote_error.text' with (format text);
+insert into metrics_dist_bl select * from metrics_dist_remote_error;
+select count(*) from metrics_dist_bl;
+ count 
+ 40000
+(1 row)
+
+drop table metrics_dist_bl;
 drop table metrics_dist_remote_error;

--- a/tsl/test/shared/sql/include/dist_remote_error_setup.sql
+++ b/tsl/test/shared/sql/include/dist_remote_error_setup.sql
@@ -42,6 +42,30 @@ create cast (int4 as br) without function as implicit;
 
 create cast (br as int4) without function as implicit;
 
+-- recv that sleeps, optionally (want that only on one data node)
+create type bl;
+
+create or replace function blsend(bl) returns bytea as 'int4send' language internal;
+
+\if :{?sleepy_recv}
+create or replace function blrecv(internal) returns bl
+    as :MODULE_PATHNAME, 'ts_debug_sleepy_int4recv'
+    language c immutable strict parallel safe;
+\else
+create or replace function blrecv(internal) returns bl as 'int4recv' language internal;
+\endif
+
+create or replace function blin(cstring) returns bl as 'int4in' language internal;
+
+create or replace function blout(bl) returns cstring as 'int4out' language internal;
+
+create type bl(input = blin, output = blout, send = blsend, receive = blrecv,
+    internallength = 4, passedbyvalue = true);
+
+create cast (int4 as bl) without function as implicit;
+
+create cast (bl as int4) without function as implicit;
+
 -- Create a function that raises an error every nth row.
 -- It's stable, takes a second argument and returns current number of rows,
 -- so that it is shipped to data nodes and not optimized out.


### PR DESCRIPTION
More interleavings of INSERT/COPY, and test with slow recv() to check
waiting.

Also fix some flakiness while we're at it.

Fixes https://github.com/timescale/timescaledb/issues/4485