### PR TITLE
 Use non-blocking data node connections for COPY

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,7 +131,7 @@ build_script:
 
     # build timescale
 
-     .\bootstrap -DUSE_OPENSSL=0 -DPG_PATH="C:\Program Files\PostgreSQL\12" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CONFIGURATION_TYPES=Debug -DCMAKE_C_FLAGS=/MP
+     .\bootstrap -DCMAKE_VERBOSE_MAKEFILE=ON -DUSE_OPENSSL=0 -DPG_PATH="C:\Program Files\PostgreSQL\12" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CONFIGURATION_TYPES=Debug -DASSERTIONS=ON -DCMAKE_C_FLAGS=/MP
 
     # Filter ssl and local configuration from pg_hba.conf file since
     # we have turned off SSL and local (unix domain socket)


### PR DESCRIPTION
This PR switches the postgres connections to data nodes to non-blocking mode for the duration of the COPY. Other operations on these connections are unaffected.

It serves as a preparation for working with multiple connections simultaneously. No functional changes are introduced, but it's done as a separate PR to simplify review and debugging/bisect in case we introduce an error.

Part of https://github.com/timescale/timescaledb/pull/4285