### PR TITLE
Speed up chunk search by restriction clauses

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -147,6 +147,7 @@ extern void ts_chunk_formdata_fill(FormData_chunk *fd, const TupleInfo *ti);
 extern Chunk *ts_chunk_find_for_point(const Hypertable *ht, const Point *p);
 extern Chunk *ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *schema,
 										const char *prefix);
+List *ts_chunk_id_find_in_subspace(Hypertable *ht, List *dimension_vecs);
 
 extern TSDLLEXPORT Chunk *ts_chunk_create_base(int32 id, int16 num_constraints, const char relkind);
 extern TSDLLEXPORT ChunkStub *ts_chunk_stub_create(int32 id, int16 num_constraints);

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -20,107 +20,6 @@
 #include "ts_catalog/chunk_data_node.h"
 
 /*
- * Find the chunks that match a query.
- *
- * The input is a set of dimension vectors that contain the dimension slices
- * that match a query. Each dimension vector contains all matching dimension
- * slices in one particular dimension.
- *
- * The output is a list of chunks (in the form of partial chunk stubs) whose
- * complete set of dimension slices exist in the given dimension vectors. In
- * other words, we only care about the chunks that match in all dimensions.
- */
-static List *
-scan_stubs_by_constraints(ScanIterator *constr_it, const Hyperspace *hs, const List *dimension_vecs,
-						  MemoryContext per_tuple_mcxt)
-{
-	ListCell *lc;
-	HTAB *htab;
-	struct HASHCTL hctl = {
-		.keysize = sizeof(int32),
-		.entrysize = sizeof(ChunkScanEntry),
-		.hcxt = CurrentMemoryContext,
-	};
-	List *chunk_stubs = NIL;
-
-	htab = hash_create("chunk-stubs-hash", 20, &hctl, HASH_ELEM | HASH_CONTEXT | HASH_BLOBS);
-
-	/*
-	 * Scan for chunk constraints that reference the slices in the dimension
-	 * vectors. Collect the chunk constraints in a hash table keyed on chunk
-	 * ID. After the scan, there will be some chunk IDs in the hash table that
-	 * have a complete set of constraints (one for each dimension). These are
-	 * the chunks that match the query.
-	 */
-	foreach (lc, dimension_vecs)
-	{
-		const DimensionVec *vec = lfirst(lc);
-		int i;
-
-		for (i = 0; i < vec->num_slices; i++)
-		{
-			const DimensionSlice *slice = vec->slices[i];
-			ChunkStub *stub;
-
-			ts_chunk_constraint_scan_iterator_set_slice_id(constr_it, slice->fd.id);
-			ts_scan_iterator_start_or_restart_scan(constr_it);
-
-			while (ts_scan_iterator_next(constr_it) != NULL)
-			{
-				bool isnull, found;
-				TupleInfo *ti = ts_scan_iterator_tuple_info(constr_it);
-				Datum chunk_id_datum;
-				int32 chunk_id;
-				MemoryContext old_mcxt;
-				ChunkScanEntry *entry;
-
-				old_mcxt = MemoryContextSwitchTo(per_tuple_mcxt);
-				MemoryContextReset(per_tuple_mcxt);
-
-				chunk_id_datum = slot_getattr(ti->slot, Anum_chunk_constraint_chunk_id, &isnull);
-				Assert(!isnull);
-				chunk_id = DatumGetInt32(chunk_id_datum);
-
-				if (slot_attisnull(ts_scan_iterator_slot(constr_it),
-								   Anum_chunk_constraint_dimension_slice_id))
-					continue;
-
-				entry = hash_search(htab, &chunk_id, HASH_ENTER, &found);
-				MemoryContextSwitchTo(ti->mctx);
-
-				if (!found)
-				{
-					stub = ts_chunk_stub_create(chunk_id, hs->num_dimensions);
-					stub->cube = ts_hypercube_alloc(hs->num_dimensions);
-					entry->stub = stub;
-				}
-				else
-					stub = entry->stub;
-
-				ts_chunk_constraints_add_from_tuple(stub->constraints, ti);
-				ts_hypercube_add_slice(stub->cube, slice);
-				MemoryContextSwitchTo(old_mcxt);
-
-				/* A stub is complete when we've added constraints for all its
-				 * dimensions */
-				if (chunk_stub_is_complete(stub, hs))
-				{
-					/* The hypercube should also be complete */
-					Assert(stub->cube->num_slices == hs->num_dimensions);
-					/* Slices should be in dimension ID order */
-					ts_hypercube_slice_sort(stub->cube);
-					chunk_stubs = lappend(chunk_stubs, stub);
-				}
-			}
-		}
-	}
-
-	hash_destroy(htab);
-
-	return chunk_stubs;
-}
-
-/*
  * Scan for chunks matching a query.
  *
  * Given a number of dimension slices that match a query (a vector of slices
@@ -136,84 +35,39 @@ scan_stubs_by_constraints(ScanIterator *constr_it, const Hyperspace *hs, const L
  * For performance, try not to interleave scans of different metadata tables
  * in order to maintain data locality while scanning. Also, keep scanned
  * tables and indexes open until all the metadata is scanned for all chunks.
- *
- * NOTE:
- * An OSM chunk has only dummy constraints. Always include an OSM chunk, if
- * it exists, in the set of returned results.
  */
 Chunk **
-ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
-							 LOCKMODE chunk_lockmode, unsigned int *numchunks)
+ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids, unsigned int *num_chunks)
 {
 	MemoryContext work_mcxt =
 		AllocSetContextCreate(CurrentMemoryContext, "chunk-scan-work", ALLOCSET_DEFAULT_SIZES);
 	MemoryContext per_tuple_mcxt =
 		AllocSetContextCreate(work_mcxt, "chunk-scan-per-tuple", ALLOCSET_SMALL_SIZES);
 	MemoryContext orig_mcxt;
-	ScanIterator constr_it;
-	ScanIterator chunk_it;
-	Chunk **chunks = NULL;
+	Chunk **locked_chunks = NULL;
 	Chunk **unlocked_chunks = NULL;
-	unsigned int chunk_count = 0;
+	unsigned int locked_chunk_count = 0;
 	unsigned int unlocked_chunk_count = 0;
-	List *chunk_stubs;
 	ListCell *lc;
 	int remote_chunk_count = 0;
-	int i = 0;
-	bool chunk_sort_needed = false;
-	Oid prev_chunk_oid = InvalidOid;
 
 	Assert(OidIsValid(hs->main_table_relid));
 	orig_mcxt = MemoryContextSwitchTo(work_mcxt);
 
-	int osm_chunk_id = ts_chunk_get_osm_chunk_id(hs->hypertable_id);
 	/*
-	 * Step 1: Scan for chunks that match in all the given dimensions. The
-	 * matching chunks are returned as chunk stubs as they are not yet full
-	 * chunks.
+	 * For each matching chunk, fill in the metadata from the "chunk" table.
+	 * Make sure to filter out "dropped" chunks.
 	 */
-	constr_it = ts_chunk_constraint_scan_iterator_create(orig_mcxt);
-	chunk_stubs = scan_stubs_by_constraints(&constr_it, hs, dimension_vecs, per_tuple_mcxt);
-
-	/*
-	 * If no chunks matched, return early.
-	 */
-	if (list_length(chunk_stubs) == 0)
+	ScanIterator chunk_it = ts_chunk_scan_iterator_create(orig_mcxt);
+	unlocked_chunks = MemoryContextAlloc(work_mcxt, sizeof(Chunk *) * list_length(chunk_ids));
+	foreach (lc, chunk_ids)
 	{
-		ts_scan_iterator_close(&constr_it);
-		MemoryContextSwitchTo(orig_mcxt);
-		MemoryContextDelete(work_mcxt);
-
-		Chunk *osm_chunk = NULL;
-		if (osm_chunk_id != INVALID_CHUNK_ID)
-		{
-			osm_chunk = ts_chunk_get_by_id(osm_chunk_id, true);
-			chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * 1);
-			chunks[0] = osm_chunk;
-		}
-		if (numchunks)
-			*numchunks = osm_chunk ? 1 : 0;
-
-		return chunks;
-	}
-
-	/*
-	 * Step 2: For each matching chunk, fill in the metadata from the "chunk"
-	 * table. Make sure to filter out "dropped" chunks..
-	 */
-	chunk_it = ts_chunk_scan_iterator_create(orig_mcxt);
-	unlocked_chunks = MemoryContextAlloc(work_mcxt, sizeof(Chunk *) * list_length(chunk_stubs));
-
-	bool found_osm_chunk = false;
-	foreach (lc, chunk_stubs)
-	{
-		const ChunkStub *stub = lfirst(lc);
+		int chunk_id = lfirst_int(lc);
 		TupleInfo *ti;
 
 		Assert(CurrentMemoryContext == work_mcxt);
-		Assert(chunk_stub_is_complete(stub, hs));
 
-		ts_chunk_scan_iterator_set_chunk_id(&chunk_it, stub->id);
+		ts_chunk_scan_iterator_set_chunk_id(&chunk_it, chunk_id);
 		ts_scan_iterator_start_or_restart_scan(&chunk_it);
 		ti = ts_scan_iterator_next(&chunk_it);
 
@@ -228,43 +82,18 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 
 			if (!is_dropped)
 			{
-				Chunk *chunk;
-				MemoryContext old_mcxt;
-				Oid schema_oid;
+				Chunk *chunk = MemoryContextAllocZero(orig_mcxt, sizeof(Chunk));
 
-				chunk = MemoryContextAllocZero(ti->mctx, sizeof(Chunk));
-
-				/* The stub constraints only contain dimensional
-				 * constraints. Use them for now and scan for other
-				 * constraints in the next step below. */
-				chunk->constraints = stub->constraints;
-
-				/* Copy the hypercube into the result memory context */
-				old_mcxt = MemoryContextSwitchTo(ti->mctx);
+				MemoryContext old_mcxt = MemoryContextSwitchTo(ti->mctx);
 				ts_chunk_formdata_fill(&chunk->fd, ti);
-				chunk->cube = ts_hypercube_copy(stub->cube);
 				MemoryContextSwitchTo(old_mcxt);
 
-				schema_oid = get_namespace_oid(NameStr(chunk->fd.schema_name), false);
-				chunk->table_id = get_relname_relid(NameStr(chunk->fd.table_name), schema_oid);
+				chunk->constraints = NULL;
+				chunk->cube = NULL;
 				chunk->hypertable_relid = hs->main_table_relid;
-				chunk->relkind = get_rel_relkind(chunk->table_id);
-				Assert(OidIsValid(chunk->table_id));
+
 				unlocked_chunks[unlocked_chunk_count] = chunk;
 				unlocked_chunk_count++;
-
-				if (IS_OSM_CHUNK(chunk))
-					found_osm_chunk = true;
-				/*
-				 * Try to detect when sorting is needed for locking
-				 * purposes. Sometimes, the chunk order resulting from
-				 * scanning will align with the Oid order and no locking is
-				 * needed.
-				 */
-				if (OidIsValid(prev_chunk_oid) && prev_chunk_oid > chunk->table_id)
-					chunk_sort_needed = true;
-
-				prev_chunk_oid = chunk->table_id;
 			}
 
 			MemoryContextSwitchTo(work_mcxt);
@@ -275,92 +104,138 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 
 	ts_scan_iterator_close(&chunk_it);
 
-	Assert(chunks == NULL || chunk_count > 0);
-	Assert(chunk_count <= list_length(chunk_stubs));
+	Assert(unlocked_chunk_count == 0 || unlocked_chunks != NULL);
+	Assert(unlocked_chunk_count <= list_length(chunk_ids));
 	Assert(CurrentMemoryContext == work_mcxt);
-
-	/*
-	 * Lock chunks in Oid order in order to avoid deadlocks. Since we
-	 * sometimes fall back to PG find_inheritance_children() for hypertable
-	 * expansion, we must lock in the same order as in that function to be
-	 * consistent. Make sure to ignore the chunks that were concurrently
-	 * dropped before we could get a lock.
-	 */
-	if (unlocked_chunk_count > 1 && chunk_sort_needed)
-		qsort(unlocked_chunks, unlocked_chunk_count, sizeof(Chunk *), ts_chunk_oid_cmp);
 
 	DEBUG_WAITPOINT("expanded_chunks");
 
-	for (i = 0; i < unlocked_chunk_count; i++)
+	/*
+	 * Batch the lookups to each catalog cache to have more favorable access
+	 * patterns.
+	 * Schema oid isn't likely to change, so cache it.
+	 */
+	char *last_schema_name = NULL;
+	Oid last_schema_oid = InvalidOid;
+	for (int i = 0; i < unlocked_chunk_count; i++)
 	{
 		Chunk *chunk = unlocked_chunks[i];
 
-		if (ts_chunk_lock_if_exists(chunk->table_id, chunk_lockmode))
+		char *current_schema_name = NameStr(chunk->fd.schema_name);
+		if (last_schema_name == NULL || strcmp(last_schema_name, current_schema_name) != 0)
+		{
+			last_schema_name = current_schema_name;
+			last_schema_oid = get_namespace_oid(current_schema_name, false);
+		}
+
+		chunk->table_id = get_relname_relid(NameStr(chunk->fd.table_name), last_schema_oid);
+		Assert(OidIsValid(chunk->table_id));
+	}
+
+	for (int i = 0; i < unlocked_chunk_count; i++)
+	{
+		Chunk *chunk = unlocked_chunks[i];
+		chunk->relkind = get_rel_relkind(chunk->table_id);
+	}
+
+	/*
+	 * Lock the chunks.
+	 */
+	for (int i = 0; i < unlocked_chunk_count; i++)
+	{
+		Chunk *chunk = unlocked_chunks[i];
+
+		if (ts_chunk_lock_if_exists(chunk->table_id, AccessShareLock))
 		{
 			/* Lazy initialize the chunks array */
-			if (NULL == chunks)
-			{
-				int chunks_alloc = unlocked_chunk_count;
-				if (osm_chunk_id != INVALID_CHUNK_ID && !found_osm_chunk)
-					chunks_alloc = unlocked_chunk_count + 1;
-				chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * chunks_alloc);
-			}
-			chunks[chunk_count] = chunk;
+			if (NULL == locked_chunks)
+				locked_chunks =
+					MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * unlocked_chunk_count);
 
-			if (chunk->relkind == RELKIND_FOREIGN_TABLE && !IS_OSM_CHUNK(chunk))
+			locked_chunks[locked_chunk_count] = chunk;
+
+			if (chunk->relkind == RELKIND_FOREIGN_TABLE)
 				remote_chunk_count++;
 
-			chunk_count++;
+			locked_chunk_count++;
 		}
 	}
-	/* get the osm chunk if needed */
-	if (osm_chunk_id != INVALID_CHUNK_ID && !found_osm_chunk)
-	{
-		MemoryContext old_mcxt;
-		old_mcxt = MemoryContextSwitchTo(orig_mcxt);
-		chunks[chunk_count] = ts_chunk_get_by_id(osm_chunk_id, true);
-		MemoryContextSwitchTo(old_mcxt);
-		chunk_count++;
-	}
+
 	/*
-	 * Step 3: The chunk stub scan only contained dimensional
-	 * constraints. Scan the chunk constraints again to get all
-	 * constraints.
+	 * Fetch the chunk constraints.
 	 */
+	ScanIterator constr_it = ts_chunk_constraint_scan_iterator_create(orig_mcxt);
 
-	if (chunk_count > 0)
+	for (int i = 0; i < locked_chunk_count; i++)
 	{
-		/*
-		 * This chunk constraint scan uses a different index, so need to close
-		 * and restart the scan.
-		 */
-		ts_scan_iterator_close(&constr_it);
+		Chunk *chunk = locked_chunks[i];
+		chunk->constraints = ts_chunk_constraints_alloc(/* size_hint = */ 0, orig_mcxt);
 
-		for (i = 0; i < chunk_count; i++)
+		ts_chunk_constraint_scan_iterator_set_chunk_id(&constr_it, chunk->fd.id);
+		ts_scan_iterator_start_or_restart_scan(&constr_it);
+
+		while (ts_scan_iterator_next(&constr_it) != NULL)
 		{
-			Chunk *chunk = chunks[i];
-			int num_constraints_hint = chunk->constraints->num_constraints;
-
-			chunk->constraints = ts_chunk_constraints_alloc(num_constraints_hint, orig_mcxt);
-
-			ts_chunk_constraint_scan_iterator_set_chunk_id(&constr_it, chunk->fd.id);
-			ts_scan_iterator_start_or_restart_scan(&constr_it);
-
-			while (ts_scan_iterator_next(&constr_it) != NULL)
-			{
-				TupleInfo *constr_ti = ts_scan_iterator_tuple_info(&constr_it);
-				MemoryContextSwitchTo(per_tuple_mcxt);
-				ts_chunk_constraints_add_from_tuple(chunk->constraints, constr_ti);
-				MemoryContextSwitchTo(work_mcxt);
-			}
+			TupleInfo *constr_ti = ts_scan_iterator_tuple_info(&constr_it);
+			MemoryContextSwitchTo(per_tuple_mcxt);
+			ts_chunk_constraints_add_from_tuple(chunk->constraints, constr_ti);
+			MemoryContextSwitchTo(work_mcxt);
 		}
 	}
-
 	ts_scan_iterator_close(&constr_it);
+
+	/*
+	 * Build hypercubes for the chunks by finding and combining the dimension
+	 * slices that match the chunk constraints.
+	 */
+	ScanIterator slice_iterator = ts_dimension_slice_scan_iterator_create(NULL, orig_mcxt);
+	for (int chunk_index = 0; chunk_index < locked_chunk_count; chunk_index++)
+	{
+		Chunk *chunk = locked_chunks[chunk_index];
+		ChunkConstraints *constraints = chunk->constraints;
+		MemoryContextSwitchTo(orig_mcxt);
+		Hypercube *cube = ts_hypercube_alloc(constraints->num_dimension_constraints);
+		MemoryContextSwitchTo(work_mcxt);
+		for (int constraint_index = 0; constraint_index < constraints->num_constraints;
+			 constraint_index++)
+		{
+			ChunkConstraint *constraint = &constraints->constraints[constraint_index];
+			if (!is_dimension_constraint(constraint))
+			{
+				continue;
+			}
+
+			/*
+			 * Find the slice by id. Don't have to lock it because the chunk is
+			 * locked.
+			 */
+			const int slice_id = constraint->fd.dimension_slice_id;
+			DimensionSlice *slice_ptr =
+				ts_dimension_slice_scan_iterator_get_by_id(&slice_iterator,
+														   slice_id,
+														   /* tuplock = */ NULL);
+			if (slice_ptr == NULL)
+			{
+				elog(ERROR, "dimension slice %d is not found", slice_id);
+			}
+			MemoryContextSwitchTo(orig_mcxt);
+			DimensionSlice *slice_copy = ts_dimension_slice_create(slice_ptr->fd.dimension_id,
+																   slice_ptr->fd.range_start,
+																   slice_ptr->fd.range_end);
+			slice_copy->fd.id = slice_ptr->fd.id;
+			MemoryContextSwitchTo(work_mcxt);
+			Assert(cube->capacity > cube->num_slices);
+			cube->slices[cube->num_slices++] = slice_copy;
+		}
+		ts_hypercube_slice_sort(cube);
+		chunk->cube = cube;
+	}
+	ts_scan_iterator_close(&slice_iterator);
+
 	Assert(CurrentMemoryContext == work_mcxt);
 
 	/*
-	 * Step 4: Fill in data nodes for remote chunks.
+	 * Fill in data nodes for remote chunks.
 	 *
 	 * Avoid the loop if there are no remote chunks. (Typically, either all
 	 * chunks are remote chunks or none are.)
@@ -369,9 +244,9 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 	{
 		ScanIterator data_node_it = ts_chunk_data_nodes_scan_iterator_create(orig_mcxt);
 
-		for (i = 0; i < chunk_count; i++)
+		for (int i = 0; i < locked_chunk_count; i++)
 		{
-			Chunk *chunk = chunks[i];
+			Chunk *chunk = locked_chunks[i];
 
 			if (chunk->relkind == RELKIND_FOREIGN_TABLE)
 			{
@@ -413,19 +288,18 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 		ts_scan_iterator_close(&data_node_it);
 	}
 
-	if (numchunks)
-		*numchunks = chunk_count;
-
 	MemoryContextSwitchTo(orig_mcxt);
 	MemoryContextDelete(work_mcxt);
 
 #ifdef USE_ASSERT_CHECKING
 	/* Assert that we always return valid chunks */
-	for (i = 0; i < chunk_count; i++)
+	for (int i = 0; i < locked_chunk_count; i++)
 	{
-		ASSERT_IS_VALID_CHUNK(chunks[i]);
+		ASSERT_IS_VALID_CHUNK(locked_chunks[i]);
 	}
 #endif
 
-	return chunks;
+	*num_chunks = locked_chunk_count;
+	Assert(*num_chunks == 0 || locked_chunks != NULL);
+	return locked_chunks;
 }

--- a/src/chunk_scan.h
+++ b/src/chunk_scan.h
@@ -10,7 +10,7 @@
 
 #include "hypertable.h"
 
-extern Chunk **ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
-											LOCKMODE chunk_lockmode, unsigned int *numchunks);
+extern Chunk **ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids,
+										  unsigned int *numchunks);
 
 #endif /* TIMESCALEDB_CHUNK_SCAN_H */

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -4,23 +4,29 @@
  * LICENSE-APACHE for a copy of the license.
  */
 #include <postgres.h>
-#include <utils/typcache.h>
-#include <utils/lsyscache.h>
+
+#include <catalog/pg_inherits.h>
 #include <optimizer/optimizer.h>
 #include <parser/parsetree.h>
 #include <utils/array.h>
 #include <utils/builtins.h>
+#include <utils/lsyscache.h>
+#include <utils/typcache.h>
 
 #include "hypertable_restrict_info.h"
-#include "dimension.h"
-#include "utils.h"
-#include "dimension_slice.h"
+
 #include "chunk.h"
-#include "hypercube.h"
-#include "dimension_vector.h"
-#include "partitioning.h"
 #include "chunk_scan.h"
+#include "dimension.h"
+#include "dimension_slice.h"
+#include "dimension_vector.h"
+#include "hypercube.h"
+#include "partitioning.h"
 #include "scan_iterator.h"
+#include "utils.h"
+
+#include <inttypes.h>
+#include <tcop/tcopprot.h>
 
 typedef struct DimensionRestrictInfo
 {
@@ -84,6 +90,29 @@ dimension_restrict_info_create(const Dimension *d)
 		default:
 			elog(ERROR, "unknown dimension type");
 			return NULL;
+	}
+}
+
+/*
+ * Check if the restriction on this dimension is trivial, that is, the entire
+ * range of the dimension matches.
+ */
+static bool
+dimension_restrict_info_is_trivial(const DimensionRestrictInfo *dri)
+{
+	switch (dri->dimension->type)
+	{
+		case DIMENSION_TYPE_OPEN:
+		{
+			DimensionRestrictInfoOpen *open = (DimensionRestrictInfoOpen *) dri;
+			return open->lower_strategy == InvalidStrategy &&
+				   open->upper_strategy == InvalidStrategy;
+		}
+		case DIMENSION_TYPE_CLOSED:
+			return ((DimensionRestrictInfoClosed *) dri)->strategy == InvalidStrategy;
+		default:
+			Assert(false);
+			return false;
 	}
 }
 
@@ -526,6 +555,25 @@ gather_restriction_dimension_vectors(const HypertableRestrictInfo *hri)
 														   open->lower_strategy,
 														   open->lower_bound);
 
+				/*
+				 * If we have a condition on the second index column
+				 * range_start, use a backward scan direction, so that the index
+				 * is able to use the second column as well to choose the
+				 * starting point for the scan.
+				 * If not, prefer forward direction, because backwards scan is
+				 * slightly slower for some reason.
+				 * Ideally we need some other index type than btree for this,
+				 * because the btree index is not so suited for queries like
+				 * "find an interval that contains a given point", which is what
+				 * we're doing here.
+				 * There is a comment in the Postgres code (_bt_start()) that
+				 * explains the logic of selecting a starting point for a btree
+				 * index scan in more detail.
+				 */
+				it.ctx.scandirection = open->upper_strategy != InvalidStrategy ?
+										   BackwardScanDirection :
+										   ForwardScanDirection;
+
 				dv = scan_and_append_slices(&it, old_nkeys, &dv, false);
 				break;
 			}
@@ -534,36 +582,28 @@ gather_restriction_dimension_vectors(const HypertableRestrictInfo *hri)
 				const DimensionRestrictInfoClosed *closed =
 					(const DimensionRestrictInfoClosed *) dri;
 
-				if (closed->strategy == BTEqualStrategyNumber)
+				/* Shouldn't have trivial restriction infos here. */
+				Assert(closed->strategy == BTEqualStrategyNumber);
+
+				ListCell *cell;
+				foreach (cell, closed->partitions)
 				{
-					/* slice_end >= value && slice_start <= value */
-					ListCell *cell;
+					int32 partition = lfirst_int(cell);
 
-					foreach (cell, closed->partitions)
-					{
-						int32 partition = lfirst_int(cell);
-
-						ts_dimension_slice_scan_iterator_set_range(&it,
-																   dri->dimension->fd.id,
-																   BTLessEqualStrategyNumber,
-																   partition,
-																   BTGreaterEqualStrategyNumber,
-																   partition);
-
-						dv = scan_and_append_slices(&it, old_nkeys, &dv, true);
-					}
-				}
-				else
-				{
+					/*
+					 * slice_end >= value && slice_start <= value.
+					 * See the comment about scan direction above.
+					 */
+					it.ctx.scandirection = BackwardScanDirection;
 					ts_dimension_slice_scan_iterator_set_range(&it,
 															   dri->dimension->fd.id,
-															   InvalidStrategy,
-															   -1,
-															   InvalidStrategy,
-															   -1);
-					dv = scan_and_append_slices(&it, old_nkeys, &dv, false);
-				}
+															   BTLessEqualStrategyNumber,
+															   partition,
+															   BTGreaterEqualStrategyNumber,
+															   partition);
 
+					dv = scan_and_append_slices(&it, old_nkeys, &dv, true);
+				}
 				break;
 			}
 			default:
@@ -597,11 +637,77 @@ gather_restriction_dimension_vectors(const HypertableRestrictInfo *hri)
 
 Chunk **
 ts_hypertable_restrict_info_get_chunks(HypertableRestrictInfo *hri, Hypertable *ht,
-									   LOCKMODE lockmode, unsigned int *num_chunks)
+									   unsigned int *num_chunks)
 {
-	List *dimension_vecs = gather_restriction_dimension_vectors(hri);
-	Assert(hri->num_dimensions == ht->space->num_dimensions);
-	return ts_chunk_scan_by_constraints(ht->space, dimension_vecs, lockmode, num_chunks);
+	/*
+	 * Remove the dimensions for which we don't have a restriction, that is,
+	 * the entire range of the dimension matches. Such dimensions do not
+	 * influence the result set, because their every slice matches, so we can
+	 * just ignore them when searching for the matching chunks.
+	 */
+	const int old_dimensions = hri->num_dimensions;
+	hri->num_dimensions = 0;
+	for (int i = 0; i < old_dimensions; i++)
+	{
+		DimensionRestrictInfo *dri = hri->dimension_restriction[i];
+		if (!dimension_restrict_info_is_trivial(dri))
+		{
+			hri->dimension_restriction[hri->num_dimensions] = dri;
+			hri->num_dimensions++;
+		}
+	}
+
+	List *chunk_ids = NIL;
+	if (hri->num_dimensions == 0)
+	{
+		/*
+		 * No restrictions on hyperspace. Just enumerate all the chunks.
+		 */
+		chunk_ids = ts_chunk_get_chunk_ids_by_hypertable_id(ht->fd.id);
+	}
+	else
+	{
+		/*
+		 * Have some restrictions, enumerate the matching dimension slices.
+		 */
+		List *dimension_vectors = gather_restriction_dimension_vectors(hri);
+		if (list_length(dimension_vectors) == 0)
+		{
+			/*
+			 * No dimension slices match for some dimension for which there is
+			 * a restriction. This means that no chunks match.
+			 */
+			chunk_ids = NIL;
+		}
+		else
+		{
+			/* Find the chunks matching these dimension slices. */
+			chunk_ids = ts_chunk_id_find_in_subspace(ht, dimension_vectors);
+		}
+
+		/*
+		 * Always include the OSM chunk if we have one. It has some virtual
+		 * dimension slices (at the moment, (+inf, +inf) slice for time, but it
+		 * used to be different and might change again.) So sometimes it will
+		 * match and sometimes it won't, so we have to check if it's already
+		 * there not to add a duplicate.
+		 */
+		int32 osm_chunk_id = ts_chunk_get_osm_chunk_id(ht->fd.id);
+		if (osm_chunk_id != 0 && !list_member_int(chunk_ids, osm_chunk_id))
+		{
+			chunk_ids = lappend_int(chunk_ids, osm_chunk_id);
+		}
+	}
+
+	/*
+	 * Sort the ids to have more favorable (closer to sequential) data access
+	 * patterns to our catalog tables and indexes.
+	 * We don't care about the locking order here, because this code uses
+	 * AccessShareLock that doesn't conflict with itself.
+	 */
+	chunk_ids = list_sort_compat(chunk_ids, list_int_cmp_compat);
+
+	return ts_chunk_scan_by_chunk_ids(ht->space, chunk_ids, num_chunks);
 }
 
 /*
@@ -644,8 +750,8 @@ chunk_cmp_reverse(const void *c1, const void *c2)
  */
 Chunk **
 ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri, Hypertable *ht,
-											   Chunk **chunks, LOCKMODE lockmode, bool reverse,
-											   List **nested_oids, unsigned int *num_chunks)
+											   Chunk **chunks, bool reverse, List **nested_oids,
+											   unsigned int *num_chunks)
 {
 	List *slot_chunk_oids = NIL;
 	DimensionSlice *slice = NULL;
@@ -653,7 +759,7 @@ ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri, Hype
 
 	if (chunks == NULL)
 	{
-		chunks = ts_hypertable_restrict_info_get_chunks(hri, ht, lockmode, num_chunks);
+		chunks = ts_hypertable_restrict_info_get_chunks(hri, ht, num_chunks);
 	}
 
 	if (*num_chunks == 0)

--- a/src/hypertable_restrict_info.h
+++ b/src/hypertable_restrict_info.h
@@ -23,12 +23,11 @@ extern bool ts_hypertable_restrict_info_has_restrictions(HypertableRestrictInfo 
 
 /* Get a list of chunk oids for chunks whose constraints match the restriction clauses */
 extern Chunk **ts_hypertable_restrict_info_get_chunks(HypertableRestrictInfo *hri, Hypertable *ht,
-													  LOCKMODE lockmode, unsigned int *num_chunks);
+													  unsigned int *num_chunks);
 
 extern Chunk **ts_hypertable_restrict_info_get_chunks_ordered(HypertableRestrictInfo *hri,
 															  Hypertable *ht, Chunk **chunks,
-															  LOCKMODE lockmode, bool reverse,
-															  List **nested_oids,
+															  bool reverse, List **nested_oids,
 															  unsigned int *num_chunks);
 
 #endif /* TIMESCALEDB_HYPERTABLE_RESTRICT_INFO_H */

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -866,14 +866,13 @@ collect_quals_walker(Node *node, CollectQualCtx *ctx)
 }
 
 static int
-chunk_cmp_chunk_id(const void *c1, const void *c2)
+chunk_cmp_chunk_reloid(const void *c1, const void *c2)
 {
-	return (*(Chunk **) c1)->fd.id - (*(Chunk **) c2)->fd.id;
+	return (*(Chunk **) c1)->table_id - (*(Chunk **) c2)->table_id;
 }
 
 static Chunk **
-find_children_chunks(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockmode,
-					 unsigned int *num_chunks)
+find_children_chunks(HypertableRestrictInfo *hri, Hypertable *ht, unsigned int *num_chunks)
 {
 	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 	{
@@ -881,7 +880,7 @@ find_children_chunks(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockm
 		 * Chunk lookup doesn't work for internal compression tables, have to
 		 * fall back to the regular postgres method.
 		 */
-		List *chunk_oids = find_inheritance_children(ht->main_table_relid, lockmode);
+		List *chunk_oids = find_inheritance_children(ht->main_table_relid, AccessShareLock);
 		if (chunk_oids == NIL)
 		{
 			*num_chunks = 0;
@@ -906,17 +905,14 @@ find_children_chunks(HypertableRestrictInfo *hri, Hypertable *ht, LOCKMODE lockm
 	 * have a trigger blocking inserts on the parent table it cannot contain
 	 * any rows.
 	 */
-	Chunk **chunks = ts_hypertable_restrict_info_get_chunks(hri, ht, lockmode, num_chunks);
+	Chunk **chunks = ts_hypertable_restrict_info_get_chunks(hri, ht, num_chunks);
 
-	if (!ts_hypertable_restrict_info_has_restrictions(hri))
-	{
-		/*
-		 * If we're using all the chunks, sort them by id ascending to roughly
-		 * match the order provided by find_inheritance_children. This is mostly
-		 * needed to avoid test reference changes.
-		 */
-		qsort(chunks, *num_chunks, sizeof(Chunk *), chunk_cmp_chunk_id);
-	}
+	/*
+	 * Sort the chunks by oid ascending to roughly match the order provided
+	 * by find_inheritance_children. This is mostly needed to avoid test
+	 * reference changes.
+	 */
+	qsort(chunks, *num_chunks, sizeof(Chunk *), chunk_cmp_chunk_reloid);
 
 	return chunks;
 }
@@ -948,7 +944,7 @@ should_order_append(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, List *jo
  */
 static Chunk **
 get_explicit_chunks(CollectQualCtx *ctx, PlannerInfo *root, RelOptInfo *rel, Hypertable *ht,
-					LOCKMODE chunk_lockmode, unsigned int *num_chunks)
+					unsigned int *num_chunks)
 {
 	Const *chunks_arg;
 	ArrayIterator chunk_id_iterator;
@@ -1036,7 +1032,7 @@ get_explicit_chunks(CollectQualCtx *ctx, PlannerInfo *root, RelOptInfo *rel, Hyp
 
 	for (i = 0; i < unlocked_chunk_count; i++)
 	{
-		if (ts_chunk_lock_if_exists(unlocked_chunks[i]->table_id, chunk_lockmode))
+		if (ts_chunk_lock_if_exists(unlocked_chunks[i]->table_id, AccessShareLock))
 			chunks[(*num_chunks)++] = unlocked_chunks[i];
 	}
 
@@ -1078,7 +1074,6 @@ get_explicit_chunks(CollectQualCtx *ctx, PlannerInfo *root, RelOptInfo *rel, Hyp
 		return ts_hypertable_restrict_info_get_chunks_ordered(NULL,
 															  ht,
 															  chunks,
-															  chunk_lockmode,
 															  reverse,
 															  nested_oids,
 															  num_chunks);
@@ -1103,11 +1098,10 @@ get_chunks(CollectQualCtx *ctx, PlannerInfo *root, RelOptInfo *rel, Hypertable *
 {
 	bool reverse;
 	int order_attno;
-	LOCKMODE lockmode = AccessShareLock;
 
 	if (ctx->chunk_exclusion_func != NULL)
 	{
-		return get_explicit_chunks(ctx, root, rel, ht, lockmode, num_chunks);
+		return get_explicit_chunks(ctx, root, rel, ht, num_chunks);
 	}
 
 	HypertableRestrictInfo *hri = ts_hypertable_restrict_info_create(rel, ht);
@@ -1144,13 +1138,12 @@ get_chunks(CollectQualCtx *ctx, PlannerInfo *root, RelOptInfo *rel, Hypertable *
 		return ts_hypertable_restrict_info_get_chunks_ordered(hri,
 															  ht,
 															  NULL,
-															  lockmode,
 															  reverse,
 															  nested_oids,
 															  num_chunks);
 	}
 
-	return find_children_chunks(hri, ht, lockmode, num_chunks);
+	return find_children_chunks(hri, ht, num_chunks);
 }
 
 /*


### PR DESCRIPTION
We don't have to look up the dimension slices for dimensions for which
we don't have restrictions.

This also fixes a planning time regression introduced in 2.7. It was introduced in this commit https://github.com/timescale/timescaledb/commit/37190e8a8#diff-e488f45c83647e5d9415d438f2e79eb2780639b7888c7533890b6c577e02d03dL852-L857
We stopped using the fast path for case where there are no restrictions, and the normal path turned out to be slower. This commit speeds it up to the previous level.

The lookup logic this PR introduces is basically the same as the one introduced for `chunk_point_find_chunk_id` by https://github.com/timescale/timescaledb/pull/4390 . The difference is that here the conditions may be underspecified, so multiple chunks match.