### PR TITLE
Segfault when executing IMMUTABLE functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Thanks**
 @nikugogoi for reporting a bug with CTEs and upserts on distributed hypertables
+@jflambert for reporting a bug with IMMUTABLE functions
 
 ## 2.7.0 (2022-05-24)
 

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -562,7 +562,7 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 				ts_data_node_fetcher_scan_type = AutoFetcherType;
 			}
 
-			if (reset_baserel_info)
+			if (reset_baserel_info && ts_baserel_info)
 			{
 				BaserelInfo_destroy(ts_baserel_info);
 				ts_baserel_info = NULL;

--- a/test/expected/ddl-12.out
+++ b/test/expected/ddl-12.out
@@ -555,3 +555,34 @@ SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4);
 NOTICE:  adding not-null constraint to column "time"
 ERROR:  could not find hash function for type tuple
 \set ON_ERROR_STOP 1
+-- immutable functions with sub-transaction (issue #4489)
+CREATE FUNCTION i4489(value TEXT DEFAULT '') RETURNS INTEGER
+AS
+$$
+BEGIN
+  RETURN value::INTEGER;
+EXCEPTION WHEN invalid_text_representation THEN
+  RETURN 0;
+END;
+$$
+LANGUAGE PLPGSQL IMMUTABLE;
+-- should return 1 (one) in both cases
+SELECT i4489('1'), i4489('1');
+ i4489 | i4489 
+-------+-------
+     1 |     1
+(1 row)
+
+-- should return 0 (zero) in all cases handled by the exception
+SELECT i4489(), i4489();
+ i4489 | i4489 
+-------+-------
+     0 |     0
+(1 row)
+
+SELECT i4489('a'), i4489('a');
+ i4489 | i4489 
+-------+-------
+     0 |     0
+(1 row)
+

--- a/test/expected/ddl-13.out
+++ b/test/expected/ddl-13.out
@@ -555,3 +555,34 @@ SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4);
 NOTICE:  adding not-null constraint to column "time"
 ERROR:  could not find hash function for type tuple
 \set ON_ERROR_STOP 1
+-- immutable functions with sub-transaction (issue #4489)
+CREATE FUNCTION i4489(value TEXT DEFAULT '') RETURNS INTEGER
+AS
+$$
+BEGIN
+  RETURN value::INTEGER;
+EXCEPTION WHEN invalid_text_representation THEN
+  RETURN 0;
+END;
+$$
+LANGUAGE PLPGSQL IMMUTABLE;
+-- should return 1 (one) in both cases
+SELECT i4489('1'), i4489('1');
+ i4489 | i4489 
+-------+-------
+     1 |     1
+(1 row)
+
+-- should return 0 (zero) in all cases handled by the exception
+SELECT i4489(), i4489();
+ i4489 | i4489 
+-------+-------
+     0 |     0
+(1 row)
+
+SELECT i4489('a'), i4489('a');
+ i4489 | i4489 
+-------+-------
+     0 |     0
+(1 row)
+

--- a/test/expected/ddl-14.out
+++ b/test/expected/ddl-14.out
@@ -559,3 +559,34 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 \set ON_ERROR_STOP 1
+-- immutable functions with sub-transaction (issue #4489)
+CREATE FUNCTION i4489(value TEXT DEFAULT '') RETURNS INTEGER
+AS
+$$
+BEGIN
+  RETURN value::INTEGER;
+EXCEPTION WHEN invalid_text_representation THEN
+  RETURN 0;
+END;
+$$
+LANGUAGE PLPGSQL IMMUTABLE;
+-- should return 1 (one) in both cases
+SELECT i4489('1'), i4489('1');
+ i4489 | i4489 
+-------+-------
+     1 |     1
+(1 row)
+
+-- should return 0 (zero) in all cases handled by the exception
+SELECT i4489(), i4489();
+ i4489 | i4489 
+-------+-------
+     0 |     0
+(1 row)
+
+SELECT i4489('a'), i4489('a');
+ i4489 | i4489 
+-------+-------
+     0 |     0
+(1 row)
+

--- a/test/sql/ddl.sql.in
+++ b/test/sql/ddl.sql.in
@@ -116,3 +116,21 @@ CREATE TABLE part_custom_dim (time TIMESTAMPTZ, combo TUPLE, device TEXT);
 -- on PG14 custom types are hashable
 SELECT create_hypertable('part_custom_dim', 'time', 'combo', 4);
 \set ON_ERROR_STOP 1
+
+-- immutable functions with sub-transaction (issue #4489)
+CREATE FUNCTION i4489(value TEXT DEFAULT '') RETURNS INTEGER
+AS
+$$
+BEGIN
+  RETURN value::INTEGER;
+EXCEPTION WHEN invalid_text_representation THEN
+  RETURN 0;
+END;
+$$
+LANGUAGE PLPGSQL IMMUTABLE;
+
+-- should return 1 (one) in both cases
+SELECT i4489('1'), i4489('1');
+-- should return 0 (zero) in all cases handled by the exception
+SELECT i4489(), i4489();
+SELECT i4489('a'), i4489('a');


### PR DESCRIPTION
Executing an IMMUTABLE function that has parameters and exception
handling block multiple times in the same transaction causes a null
pointer segfault when try to reset a non-initialized `ts_baserel_info`.

Fixed it by preventing to reset a non-initialized `ts_baserel_info`.

Fixes https://github.com/timescale/timescaledb/issues/4489