### PR TITLE
Handle timescaledb versions aptly in multinode

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -639,12 +639,8 @@ data_node_validate_extension_availability(TSConnection *conn)
 
 	for (i = 0; i < PQntuples(res); i++)
 	{
-		bool old_version = false;
-
 		appendStringInfo(concat_versions, "%s, ", PQgetvalue(res, i, 0));
-		compatible = dist_util_is_compatible_version(PQgetvalue(res, i, 0),
-													 TIMESCALEDB_VERSION,
-													 &old_version);
+		compatible = dist_util_is_compatible_version(PQgetvalue(res, i, 0), TIMESCALEDB_VERSION);
 		if (compatible)
 			break;
 	}

--- a/tsl/src/dist_util.h
+++ b/tsl/src/dist_util.h
@@ -36,7 +36,7 @@ Datum dist_util_remote_compressed_chunk_info(PG_FUNCTION_ARGS);
 Datum dist_util_remote_hypertable_index_info(PG_FUNCTION_ARGS);
 
 void validate_data_node_settings(void);
-bool dist_util_is_compatible_version(const char *data_node_version, const char *access_node_version,
-									 bool *is_old_version);
+bool dist_util_is_compatible_version(const char *data_node_version,
+									 const char *access_node_version);
 
 #endif /* TIMESCALEDB_TSL_DIST_UTIL_H */

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -1015,19 +1015,11 @@ remote_result_query_ok(PGresult *res)
 void
 remote_validate_extension_version(TSConnection *conn, const char *data_node_version)
 {
-	bool old_version;
-
-	if (!dist_util_is_compatible_version(data_node_version, TIMESCALEDB_VERSION, &old_version))
+	if (!dist_util_is_compatible_version(data_node_version, TIMESCALEDB_VERSION))
 		ereport(ERROR,
 				(errcode(ERRCODE_TS_DATA_NODE_INVALID_CONFIG),
 				 errmsg("remote PostgreSQL instance has an incompatible timescaledb extension "
 						"version"),
-				 errdetail_internal("Access node version: %s, remote version: %s.",
-									TIMESCALEDB_VERSION_MOD,
-									data_node_version)));
-	if (old_version)
-		ereport(WARNING,
-				(errmsg("remote PostgreSQL instance has an outdated timescaledb extension version"),
 				 errdetail_internal("Access node version: %s, remote version: %s.",
 									TIMESCALEDB_VERSION_MOD,
 									data_node_version)));

--- a/tsl/test/expected/dist_util.out
+++ b/tsl/test/expected/dist_util.out
@@ -5,55 +5,55 @@
 -- Test version compability function
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 CREATE OR REPLACE FUNCTION compatible_version(version CSTRING, reference CSTRING)
-RETURNS TABLE(is_compatible BOOLEAN, is_old_version BOOLEAN)
+RETURNS BOOLEAN
 AS :TSL_MODULE_PATHNAME, 'ts_test_compatible_version'
 LANGUAGE C VOLATILE;
 SELECT * FROM compatible_version('2.0.0-beta3.19', reference => '2.0.0-beta3.19');
- is_compatible | is_old_version 
----------------+----------------
- t             | f
+ compatible_version 
+--------------------
+ t
 (1 row)
 
 SELECT * FROM compatible_version('2.0.0', reference => '2.0.0');
- is_compatible | is_old_version 
----------------+----------------
- t             | f
+ compatible_version 
+--------------------
+ t
 (1 row)
 
 SELECT * FROM compatible_version('1.9.9', reference => '2.0.0-beta3.19');
- is_compatible | is_old_version 
----------------+----------------
- f             | t
+ compatible_version 
+--------------------
+ f
 (1 row)
 
 SELECT * FROM compatible_version('1.9.9', reference => '2.0.0');
- is_compatible | is_old_version 
----------------+----------------
- f             | t
+ compatible_version 
+--------------------
+ f
 (1 row)
 
 SELECT * FROM compatible_version('2.0.9', reference => '2.0.0-beta3.19');
- is_compatible | is_old_version 
----------------+----------------
- t             | f
+ compatible_version 
+--------------------
+ t
 (1 row)
 
 SELECT * FROM compatible_version('2.0.9', reference => '2.0.0');
- is_compatible | is_old_version 
----------------+----------------
- t             | f
+ compatible_version 
+--------------------
+ t
 (1 row)
 
 SELECT * FROM compatible_version('2.1.9', reference => '2.0.0-beta3.19');
- is_compatible | is_old_version 
----------------+----------------
- f             | f
+ compatible_version 
+--------------------
+ t
 (1 row)
 
 SELECT * FROM compatible_version('2.1.0', reference => '2.1.19-beta3.19');
- is_compatible | is_old_version 
----------------+----------------
- t             | t
+ compatible_version 
+--------------------
+ t
 (1 row)
 
 -- These should not parse and instead generate an error.

--- a/tsl/test/sql/dist_util.sql
+++ b/tsl/test/sql/dist_util.sql
@@ -7,7 +7,7 @@
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 
 CREATE OR REPLACE FUNCTION compatible_version(version CSTRING, reference CSTRING)
-RETURNS TABLE(is_compatible BOOLEAN, is_old_version BOOLEAN)
+RETURNS BOOLEAN
 AS :TSL_MODULE_PATHNAME, 'ts_test_compatible_version'
 LANGUAGE C VOLATILE;
 

--- a/tsl/test/src/test_dist_util.c
+++ b/tsl/test/src/test_dist_util.c
@@ -20,32 +20,12 @@ ts_test_compatible_version(PG_FUNCTION_ARGS)
 {
 	const char *checked_version = PG_GETARG_CSTRING(0);
 	const char *reference_version = PG_GETARG_CSTRING(1);
-
-	TupleDesc tupdesc;
-	HeapTuple tuple;
-	Datum values[2];
-	bool nulls[2] = { false };
-	bool is_old_version;
 	bool is_compatible;
 
 	if (PG_ARGISNULL(1))
 		reference_version = TIMESCALEDB_VERSION;
 
-	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("function returning record called in context "
-						"that cannot accept type record")));
-	}
+	is_compatible = dist_util_is_compatible_version(checked_version, reference_version);
 
-	is_compatible =
-		dist_util_is_compatible_version(checked_version, reference_version, &is_old_version);
-
-	values[0] = BoolGetDatum(is_compatible);
-	values[1] = BoolGetDatum(is_old_version);
-
-	tuple = heap_form_tuple(tupdesc, values, nulls);
-
-	PG_RETURN_DATUM(HeapTupleGetDatum(tuple));
+	PG_RETURN_BOOL(is_compatible);
 }


### PR DESCRIPTION
The current check where we deem a DN incompatible if it's on a newer
version is exactly the opposite of what we want it to be. Fix that and
also add relevant test cases.