### PR TITLE
Support add_dimension() with existing data

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -1489,6 +1489,8 @@ ts_chunk_create_for_point(const Hypertable *ht, const Point *p, const char *sche
 	 */
 	LockRelationOid(ht->main_table_relid, ShareUpdateExclusiveLock);
 
+	DEBUG_WAITPOINT("chunk_create_for_point");
+
 	/*
 	 * Recheck if someone else created the chunk before we got the table
 	 * lock. The returned chunk will have all slices locked so that they

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -46,6 +46,10 @@ extern int ts_chunk_constraint_scan_by_dimension_slice_to_list(const DimensionSl
 extern int ts_chunk_constraint_scan_by_dimension_slice_id(int32 dimension_slice_id,
 														  ChunkConstraints *ccs,
 														  MemoryContext mctx);
+extern ChunkConstraint *ts_chunk_constraints_add(ChunkConstraints *ccs, int32 chunk_id,
+												 int32 dimension_slice_id,
+												 const char *constraint_name,
+												 const char *hypertable_constraint_name);
 extern int ts_chunk_constraints_add_dimension_constraints(ChunkConstraints *ccs, int32 chunk_id,
 														  const Hypercube *cube);
 extern TSDLLEXPORT int ts_chunk_constraints_add_inheritable_constraints(ChunkConstraints *ccs,
@@ -75,6 +79,7 @@ extern int ts_chunk_constraint_adjust_meta(int32 chunk_id, const char *ht_constr
 extern char *
 ts_chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid,
 														const char *hypertable_constraint_name);
+extern void ts_chunk_constraint_insert(ChunkConstraint *constraint);
 extern ChunkConstraint *ts_chunk_constraints_add_from_tuple(ChunkConstraints *ccs,
 															const TupleInfo *ti);
 

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -235,14 +235,169 @@ ERROR:  column "location" is already a dimension
 --adding dimension with both number_partitions and chunk_time_interval should fail
 select add_dimension('test_schema.test_table', 'id2', number_partitions => 2, chunk_time_interval => 1000);
 ERROR:  cannot specify both the number of partitions and an interval
---adding a new dimension on a non-empty table should also fail
-insert into test_schema.test_table values (123456789, 23.8, 'blue', 'type1', 'nyc', 1, 1);
-select add_dimension('test_schema.test_table', 'device_type', 2);
-ERROR:  hypertable "test_table" has data or empty chunks
--- should fail on non-empty table with 'if_not_exists' in case the dimension does not exists
-select add_dimension('test_schema.test_table', 'device_type', 2, if_not_exists => true);
-ERROR:  hypertable "test_table" has data or empty chunks
 \set ON_ERROR_STOP 1
+-- test adding a new dimension on a non-empty table
+CREATE TABLE dim_test(time TIMESTAMPTZ, device int);
+SELECT create_hypertable('dim_test', 'time', chunk_time_interval => INTERVAL '1 day');
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable   
+-----------------------
+ (5,public,dim_test,t)
+(1 row)
+
+CREATE VIEW dim_test_slices AS
+SELECT c.id AS chunk_id, c.hypertable_id, ds.dimension_id, cc.dimension_slice_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.table_name = 'dim_test'
+ORDER BY c.id, ds.dimension_id;
+INSERT INTO dim_test VALUES ('2004-10-10 00:00:00+00', 1);
+INSERT INTO dim_test VALUES ('2004-10-20 00:00:00+00', 2);
+SELECT * FROM dim_test_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |   chunk_table    |   range_start    |    range_end     
+----------+---------------+--------------+--------------------+-----------------------+------------------+------------------+------------------
+        2 |             5 |           12 |                  3 | _timescaledb_internal | _hyper_5_2_chunk | 1097366400000000 | 1097452800000000
+        3 |             5 |           12 |                  4 | _timescaledb_internal | _hyper_5_3_chunk | 1098230400000000 | 1098316800000000
+(2 rows)
+
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_5_2_chunk');
+  Constraint  | Type | Columns | Index |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
+--------------+------+---------+-------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
+ constraint_3 | c    | {time}  | -     | (("time" >= 'Sat Oct 09 17:00:00 2004 PDT'::timestamp with time zone) AND ("time" < 'Sun Oct 10 17:00:00 2004 PDT'::timestamp with time zone)) | f          | f        | t
+(1 row)
+
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_5_3_chunk');
+  Constraint  | Type | Columns | Index |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
+--------------+------+---------+-------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
+ constraint_4 | c    | {time}  | -     | (("time" >= 'Tue Oct 19 17:00:00 2004 PDT'::timestamp with time zone) AND ("time" < 'Wed Oct 20 17:00:00 2004 PDT'::timestamp with time zone)) | f          | f        | t
+(1 row)
+
+-- add dimension to the existing chunks by adding -inf/inf dimension slices
+SELECT add_dimension('dim_test', 'device', 2);
+         add_dimension         
+-------------------------------
+ (13,public,dim_test,device,t)
+(1 row)
+
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_5_2_chunk');
+  Constraint  | Type | Columns | Index |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
+--------------+------+---------+-------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
+ constraint_3 | c    | {time}  | -     | (("time" >= 'Sat Oct 09 17:00:00 2004 PDT'::timestamp with time zone) AND ("time" < 'Sun Oct 10 17:00:00 2004 PDT'::timestamp with time zone)) | f          | f        | t
+(1 row)
+
+SELECT * FROM test.show_constraints('_timescaledb_internal._hyper_5_3_chunk');
+  Constraint  | Type | Columns | Index |                                                                      Expr                                                                      | Deferrable | Deferred | Validated 
+--------------+------+---------+-------+------------------------------------------------------------------------------------------------------------------------------------------------+------------+----------+-----------
+ constraint_4 | c    | {time}  | -     | (("time" >= 'Tue Oct 19 17:00:00 2004 PDT'::timestamp with time zone) AND ("time" < 'Wed Oct 20 17:00:00 2004 PDT'::timestamp with time zone)) | f          | f        | t
+(1 row)
+
+SELECT * FROM dim_test_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |   chunk_table    |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------+----------------------+---------------------
+        2 |             5 |           12 |                  3 | _timescaledb_internal | _hyper_5_2_chunk |     1097366400000000 |    1097452800000000
+        2 |             5 |           13 |                  5 | _timescaledb_internal | _hyper_5_2_chunk | -9223372036854775808 | 9223372036854775807
+        3 |             5 |           12 |                  4 | _timescaledb_internal | _hyper_5_3_chunk |     1098230400000000 |    1098316800000000
+        3 |             5 |           13 |                  5 | _timescaledb_internal | _hyper_5_3_chunk | -9223372036854775808 | 9223372036854775807
+(4 rows)
+
+-- newer chunks have proper dimension slices range
+INSERT INTO dim_test VALUES ('2004-10-30 00:00:00+00', 3);
+SELECT * FROM dim_test_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |   chunk_table    |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------+----------------------+---------------------
+        2 |             5 |           12 |                  3 | _timescaledb_internal | _hyper_5_2_chunk |     1097366400000000 |    1097452800000000
+        2 |             5 |           13 |                  5 | _timescaledb_internal | _hyper_5_2_chunk | -9223372036854775808 | 9223372036854775807
+        3 |             5 |           12 |                  4 | _timescaledb_internal | _hyper_5_3_chunk |     1098230400000000 |    1098316800000000
+        3 |             5 |           13 |                  5 | _timescaledb_internal | _hyper_5_3_chunk | -9223372036854775808 | 9223372036854775807
+        4 |             5 |           12 |                  6 | _timescaledb_internal | _hyper_5_4_chunk |     1099094400000000 |    1099180800000000
+        4 |             5 |           13 |                  7 | _timescaledb_internal | _hyper_5_4_chunk |           1073741823 | 9223372036854775807
+(6 rows)
+
+SELECT * FROM dim_test ORDER BY time;
+             time             | device 
+------------------------------+--------
+ Sat Oct 09 17:00:00 2004 PDT |      1
+ Tue Oct 19 17:00:00 2004 PDT |      2
+ Fri Oct 29 17:00:00 2004 PDT |      3
+(3 rows)
+
+DROP VIEW dim_test_slices;
+DROP TABLE dim_test;
+-- test add_dimension() with existing data on table with space partitioning
+CREATE TABLE dim_test(time TIMESTAMPTZ, device int, data int);
+SELECT create_hypertable('dim_test', 'time', 'device', 2, chunk_time_interval => INTERVAL '1 day');
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable   
+-----------------------
+ (6,public,dim_test,t)
+(1 row)
+
+CREATE VIEW dim_test_slices AS
+SELECT c.id AS chunk_id, c.hypertable_id, ds.dimension_id, cc.dimension_slice_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.table_name = 'dim_test'
+ORDER BY c.id, ds.dimension_id;
+INSERT INTO dim_test VALUES ('2004-10-10 00:00:00+00', 1, 3);
+INSERT INTO dim_test VALUES ('2004-10-20 00:00:00+00', 2, 2);
+SELECT * FROM dim_test_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |   chunk_table    |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------+----------------------+---------------------
+        5 |             6 |           14 |                  8 | _timescaledb_internal | _hyper_6_5_chunk |     1097366400000000 |    1097452800000000
+        5 |             6 |           15 |                  9 | _timescaledb_internal | _hyper_6_5_chunk | -9223372036854775808 |          1073741823
+        6 |             6 |           14 |                 10 | _timescaledb_internal | _hyper_6_6_chunk |     1098230400000000 |    1098316800000000
+        6 |             6 |           15 |                 11 | _timescaledb_internal | _hyper_6_6_chunk |           1073741823 | 9223372036854775807
+(4 rows)
+
+-- new dimension slice will cover full range on existing chunks
+SELECT add_dimension('dim_test', 'data', 1);
+        add_dimension        
+-----------------------------
+ (16,public,dim_test,data,t)
+(1 row)
+
+SELECT * FROM dim_test_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |   chunk_table    |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------+----------------------+---------------------
+        5 |             6 |           14 |                  8 | _timescaledb_internal | _hyper_6_5_chunk |     1097366400000000 |    1097452800000000
+        5 |             6 |           15 |                  9 | _timescaledb_internal | _hyper_6_5_chunk | -9223372036854775808 |          1073741823
+        5 |             6 |           16 |                 12 | _timescaledb_internal | _hyper_6_5_chunk | -9223372036854775808 | 9223372036854775807
+        6 |             6 |           14 |                 10 | _timescaledb_internal | _hyper_6_6_chunk |     1098230400000000 |    1098316800000000
+        6 |             6 |           15 |                 11 | _timescaledb_internal | _hyper_6_6_chunk |           1073741823 | 9223372036854775807
+        6 |             6 |           16 |                 12 | _timescaledb_internal | _hyper_6_6_chunk | -9223372036854775808 | 9223372036854775807
+(6 rows)
+
+INSERT INTO dim_test VALUES ('2004-10-30 00:00:00+00', 3, 1);
+SELECT * FROM dim_test_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |   chunk_table    |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------+----------------------+---------------------
+        5 |             6 |           14 |                  8 | _timescaledb_internal | _hyper_6_5_chunk |     1097366400000000 |    1097452800000000
+        5 |             6 |           15 |                  9 | _timescaledb_internal | _hyper_6_5_chunk | -9223372036854775808 |          1073741823
+        5 |             6 |           16 |                 12 | _timescaledb_internal | _hyper_6_5_chunk | -9223372036854775808 | 9223372036854775807
+        6 |             6 |           14 |                 10 | _timescaledb_internal | _hyper_6_6_chunk |     1098230400000000 |    1098316800000000
+        6 |             6 |           15 |                 11 | _timescaledb_internal | _hyper_6_6_chunk |           1073741823 | 9223372036854775807
+        6 |             6 |           16 |                 12 | _timescaledb_internal | _hyper_6_6_chunk | -9223372036854775808 | 9223372036854775807
+        7 |             6 |           14 |                 13 | _timescaledb_internal | _hyper_6_7_chunk |     1099094400000000 |    1099180800000000
+        7 |             6 |           15 |                 11 | _timescaledb_internal | _hyper_6_7_chunk |           1073741823 | 9223372036854775807
+        7 |             6 |           16 |                 12 | _timescaledb_internal | _hyper_6_7_chunk | -9223372036854775808 | 9223372036854775807
+(9 rows)
+
+SELECT * FROM dim_test ORDER BY time;
+             time             | device | data 
+------------------------------+--------+------
+ Sat Oct 09 17:00:00 2004 PDT |      1 |    3
+ Tue Oct 19 17:00:00 2004 PDT |      2 |    2
+ Fri Oct 29 17:00:00 2004 PDT |      3 |    1
+(3 rows)
+
+DROP VIEW dim_test_slices;
+DROP TABLE dim_test;
 -- should not fail on non-empty table with 'if_not_exists' in case the dimension exists
 select add_dimension('test_schema.test_table', 'location', 2, if_not_exists => true);
 NOTICE:  column "location" is already a dimension, skipping
@@ -251,33 +406,13 @@ NOTICE:  column "location" is already a dimension, skipping
  (5,test_schema,test_table,location,f)
 (1 row)
 
---should fail on empty table that still has chunks --
-\set ON_ERROR_STOP 0
-delete from test_schema.test_table where time is not null;
-select count(*) from test_schema.test_table;
- count 
--------
-     0
-(1 row)
-
-select add_dimension('test_schema.test_table', 'device_type', 2);
-ERROR:  hypertable "test_table" has data or empty chunks
-\set ON_ERROR_STOP 1
---show chunks in the associated schema
-\dt "chunk_schema".*
-                      List of relations
-    Schema    |       Name       | Type  |       Owner       
---------------+------------------+-------+-------------------
- chunk_schema | _hyper_2_2_chunk | table | default_perm_user
-(1 row)
-
 --test partitioning in only time dimension
 create table test_schema.test_1dim(time timestamp, temp float);
 select create_hypertable('test_schema.test_1dim', 'time');
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
- (5,test_schema,test_1dim,t)
+ (7,test_schema,test_1dim,t)
 (1 row)
 
 SELECT * FROM _timescaledb_internal.get_create_command('test_1dim');
@@ -299,7 +434,7 @@ select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true)
 NOTICE:  table "test_1dim" is already a hypertable, skipping
       create_hypertable      
 -----------------------------
- (5,test_schema,test_1dim,f)
+ (7,test_schema,test_1dim,f)
 (1 row)
 
 -- Should error when creating again without if_not_exists set to true
@@ -313,7 +448,7 @@ select create_hypertable('test_schema.test_1dim', 'time', if_not_exists => true)
 NOTICE:  table "test_1dim" is already a hypertable, skipping
       create_hypertable      
 -----------------------------
- (5,test_schema,test_1dim,f)
+ (7,test_schema,test_1dim,f)
 (1 row)
 
 -- Should error when creating again without if_not_exists set to true
@@ -345,7 +480,7 @@ SELECT create_hypertable('test_schema.test_invalid_func', 'time');
 NOTICE:  adding not-null constraint to column "time"
           create_hypertable          
 -------------------------------------
- (6,test_schema,test_invalid_func,t)
+ (8,test_schema,test_invalid_func,t)
 (1 row)
 
 -- should also fail due to invalid signature
@@ -363,7 +498,7 @@ SELECT create_hypertable('test_schema.open_dim_part_func', 'time', time_partitio
 NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
- (7,test_schema,open_dim_part_func,t)
+ (9,test_schema,open_dim_part_func,t)
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -375,7 +510,7 @@ SELECT add_dimension('test_schema.open_dim_part_func', 'event_time', chunk_time_
 NOTICE:  adding not-null constraint to column "event_time"
                   add_dimension                   
 --------------------------------------------------
- (15,test_schema,open_dim_part_func,event_time,t)
+ (20,test_schema,open_dim_part_func,event_time,t)
 (1 row)
 
 --test data migration
@@ -396,27 +531,26 @@ ERROR:  table "test_migrate" is not empty
 select create_hypertable('test_schema.test_migrate', 'time', migrate_data => true);
 NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
-       create_hypertable        
---------------------------------
- (8,test_schema,test_migrate,t)
+        create_hypertable        
+---------------------------------
+ (10,test_schema,test_migrate,t)
 (1 row)
 
 --there should be two new chunks
 select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
  id | schema_name |  table_name  | associated_schema_name | associated_table_prefix | num_dimensions | chunk_sizing_func_schema |  chunk_sizing_func_name  | chunk_target_size | compression_state | compressed_hypertable_id | replication_factor 
 ----+-------------+--------------+------------------------+-------------------------+----------------+--------------------------+--------------------------+-------------------+-------------------+--------------------------+--------------------
-  8 | test_schema | test_migrate | _timescaledb_internal  | _hyper_8                |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
+ 10 | test_schema | test_migrate | _timescaledb_internal  | _hyper_10               |              1 | _timescaledb_internal    | calculate_chunk_interval |                 0 |                 0 |                          |                   
 (1 row)
 
 select * from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0
-  2 |             2 | chunk_schema          | _hyper_2_2_chunk |                     | f       |      0
-  3 |             5 | _timescaledb_internal | _hyper_5_3_chunk |                     | f       |      0
-  4 |             8 | _timescaledb_internal | _hyper_8_4_chunk |                     | f       |      0
-  5 |             8 | _timescaledb_internal | _hyper_8_5_chunk |                     | f       |      0
-(5 rows)
+ id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status 
+----+---------------+-----------------------+--------------------+---------------------+---------+--------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |                     | f       |      0
+  8 |             7 | _timescaledb_internal | _hyper_7_8_chunk   |                     | f       |      0
+  9 |            10 | _timescaledb_internal | _hyper_10_9_chunk  |                     | f       |      0
+ 10 |            10 | _timescaledb_internal | _hyper_10_10_chunk |                     | f       |      0
+(4 rows)
 
 select * from test_schema.test_migrate;
            time           | temp 
@@ -431,13 +565,13 @@ select * from only test_schema.test_migrate;
 ------+------
 (0 rows)
 
-select * from only _timescaledb_internal._hyper_8_4_chunk;
+select * from only _timescaledb_internal._hyper_10_9_chunk;
            time           | temp 
 --------------------------+------
  Tue Oct 19 10:23:54 2004 |    1
 (1 row)
 
-select * from only _timescaledb_internal._hyper_8_5_chunk;
+select * from only _timescaledb_internal._hyper_10_10_chunk;
            time           | temp 
 --------------------------+------
  Sun Dec 19 10:23:54 2004 |    2
@@ -446,9 +580,9 @@ select * from only _timescaledb_internal._hyper_8_5_chunk;
 create table test_schema.test_migrate_empty(time timestamp, temp float);
 select create_hypertable('test_schema.test_migrate_empty', 'time', migrate_data => true);
 NOTICE:  adding not-null constraint to column "time"
-          create_hypertable           
---------------------------------------
- (9,test_schema,test_migrate_empty,t)
+           create_hypertable           
+---------------------------------------
+ (11,test_schema,test_migrate_empty,t)
 (1 row)
 
 CREATE TYPE test_type AS (time timestamp, temp float);
@@ -457,7 +591,7 @@ SELECT create_hypertable('test_table_of_type', 'time');
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
- (10,public,test_table_of_type,t)
+ (12,public,test_table_of_type,t)
 (1 row)
 
 INSERT INTO test_table_of_type VALUES ('2004-10-19 10:23:54+02', 1.0), ('2004-12-19 10:23:54+02', 2.0);
@@ -472,7 +606,7 @@ SELECT create_hypertable('test_table_of_type', 'time');
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
- (11,public,test_table_of_type,t)
+ (13,public,test_table_of_type,t)
 (1 row)
 
 INSERT INTO test_table_of_type VALUES ('2004-10-19 10:23:54+02', 1.0), ('2004-12-19 10:23:54+02', 2.0);
@@ -544,7 +678,7 @@ select create_hypertable('test_schema.test_partfunc', 'time');
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
- (12,test_schema,test_partfunc,t)
+ (14,test_schema,test_partfunc,t)
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -561,7 +695,7 @@ ERROR:  invalid partitioning function
 select add_dimension('test_schema.test_partfunc', 'device', 2, partitioning_func => 'partfunc_valid');
               add_dimension              
 -----------------------------------------
- (21,test_schema,test_partfunc,device,t)
+ (26,test_schema,test_partfunc,device,t)
 (1 row)
 
 -- check get_create_command produces valid command
@@ -570,7 +704,7 @@ SELECT create_hypertable('test_schema.test_sql_cmd','time');
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
- (13,test_schema,test_sql_cmd,t)
+ (15,test_schema,test_sql_cmd,t)
 (1 row)
 
 SELECT * FROM _timescaledb_internal.get_create_command('test_sql_cmd');
@@ -619,7 +753,7 @@ select set_integer_now_func('test_table_int', 'dummy_now');
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
 ----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
- 24 |            15 | time        | bigint      | t       |            |                          |                   |               1 | public                  | dummy_now
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 | public                  | dummy_now
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -641,6 +775,6 @@ ALTER SCHEMA my_user_schema RENAME TO my_new_schema;
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
  id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
 ----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
- 24 |            15 | time        | bigint      | t       |            |                          |                   |               1 | my_new_schema           | dummy_now4
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 | my_new_schema           | dummy_now4
 (1 row)
 

--- a/test/isolation/expected/concurrent_add_dimension.out
+++ b/test/isolation/expected/concurrent_add_dimension.out
@@ -1,0 +1,78 @@
+unused step name: s1_wp_enable
+unused step name: s1_wp_release
+Parsed test spec with 3 sessions
+
+starting permutation: s3_wp_enable s1_add_dimension s2_add_dimension s3_wp_release s3_query
+step s3_wp_enable: SELECT debug_waitpoint_enable('add_dimension_ht_lock');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_add_dimension: SELECT true FROM add_dimension('dim_test', 'device', 2); <waiting ...>
+step s2_add_dimension: SELECT true FROM add_dimension('dim_test', 'device', 1); <waiting ...>
+step s3_wp_release: SELECT debug_waitpoint_release('add_dimension_ht_lock');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_add_dimension: <... completed>
+bool
+----
+t   
+(1 row)
+
+step s2_add_dimension: <... completed>
+ERROR:  column "device" is already a dimension
+step s3_query: 
+	SELECT count(*)
+	FROM _timescaledb_catalog.chunk c
+	INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+	INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+	INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+	INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+	WHERE h.table_name = 'dim_test';
+
+count
+-----
+    2
+(1 row)
+
+
+starting permutation: s3_chunk_wp_enable s1_create_chunk s2_add_dimension2 s3_chunk_wp_release s3_query
+step s3_chunk_wp_enable: SELECT debug_waitpoint_enable('chunk_create_for_point');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_create_chunk: INSERT INTO dim_test VALUES ('2004-10-20 00:00:00+00', 1, 2); <waiting ...>
+step s2_add_dimension2: SELECT true FROM add_dimension('dim_test', 'device2', 1); <waiting ...>
+step s3_chunk_wp_release: SELECT debug_waitpoint_release('chunk_create_for_point');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_create_chunk: <... completed>
+step s2_add_dimension2: <... completed>
+bool
+----
+t   
+(1 row)
+
+step s3_query: 
+	SELECT count(*)
+	FROM _timescaledb_catalog.chunk c
+	INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+	INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+	INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+	INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+	WHERE h.table_name = 'dim_test';
+
+count
+-----
+    4
+(1 row)
+

--- a/test/isolation/specs/CMakeLists.txt
+++ b/test/isolation/specs/CMakeLists.txt
@@ -14,7 +14,7 @@ set(TEST_TEMPLATES)
 
 set(TEST_TEMPLATES_DEBUG
     dropchunks_race.spec.in multi_transaction_indexing.spec.in
-    concurrent_query_and_drop_chunks.spec.in)
+    concurrent_query_and_drop_chunks.spec.in concurrent_add_dimension.spec.in)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_TEMPLATES ${TEST_TEMPLATES_DEBUG})

--- a/test/isolation/specs/concurrent_add_dimension.spec.in
+++ b/test/isolation/specs/concurrent_add_dimension.spec.in
@@ -1,0 +1,54 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and
+# LICENSE-APACHE for a copy of the license.
+
+setup {
+  CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_enable';
+
+  CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+  AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_release';
+
+  DROP TABLE IF EXISTS dim_test;
+  CREATE TABLE dim_test(time TIMESTAMPTZ, device int, device2 int);
+  SELECT true FROM create_hypertable('dim_test', 'time', chunk_time_interval => INTERVAL '1 day');
+  INSERT INTO dim_test VALUES ('2004-10-10 00:00:00+00', 1, 1);
+}
+
+teardown {
+  DROP TABLE dim_test;
+}
+
+session "s1"
+step "s1_wp_enable"        { SELECT debug_waitpoint_enable('add_dimension_ht_lock'); }
+step "s1_wp_release"       { SELECT debug_waitpoint_release('add_dimension_ht_lock'); }
+step "s1_add_dimension"	   { SELECT true FROM add_dimension('dim_test', 'device', 2); }
+step "s1_create_chunk"     { INSERT INTO dim_test VALUES ('2004-10-20 00:00:00+00', 1, 2); }
+
+session "s2"
+step "s2_add_dimension"	   { SELECT true FROM add_dimension('dim_test', 'device', 1); }
+step "s2_add_dimension2"   { SELECT true FROM add_dimension('dim_test', 'device2', 1); }
+
+session "s3"
+step "s3_wp_enable"        { SELECT debug_waitpoint_enable('add_dimension_ht_lock'); }
+step "s3_wp_release"       { SELECT debug_waitpoint_release('add_dimension_ht_lock'); }
+step "s3_chunk_wp_enable"  { SELECT debug_waitpoint_enable('chunk_create_for_point'); }
+step "s3_chunk_wp_release" { SELECT debug_waitpoint_release('chunk_create_for_point'); }
+
+step "s3_query"            {
+	SELECT count(*)
+	FROM _timescaledb_catalog.chunk c
+	INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+	INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+	INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+	INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+	WHERE h.table_name = 'dim_test';
+}
+
+# Test concurrent add_dimension() call with existing data
+#
+permutation "s3_wp_enable" "s1_add_dimension" "s2_add_dimension" "s3_wp_release" "s3_query"
+
+# Test concurrent chunk creation during add_dimension() call
+#
+permutation "s3_chunk_wp_enable" "s1_create_chunk" "s2_add_dimension2" "s3_chunk_wp_release" "s3_query"

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -2232,14 +2232,24 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Create one chunk to block add_dimension
 INSERT INTO dimented_table VALUES('2017-01-01 06:01', 1, '2017-01-01 08:01', 1);
-\set ON_ERROR_STOP 0
--- add_dimension should fail when table has data and a chunk
-SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
-ERROR:  hypertable "dimented_table" has data or empty chunks
-\set ON_ERROR_STOP 1
--- Clear table
-TRUNCATE dimented_table;
--- Now add_dimension should work
+CREATE VIEW dimented_table_slices AS
+SELECT c.id AS chunk_id, c.hypertable_id, ds.dimension_id, cc.dimension_slice_id, c.schema_name AS
+       chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.table_name = 'dimented_table'
+ORDER BY c.id, ds.dimension_id;
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |    range_end     
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 | 1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |        536870911
+(2 rows)
+
+-- add_dimension() with existing data
 SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
 NOTICE:  adding not-null constraint to column "column2"
  dimension_id | schema_name |   table_name   | column_name | created 
@@ -2247,10 +2257,33 @@ NOTICE:  adding not-null constraint to column "column2"
             9 | public      | dimented_table | column2     | t
 (1 row)
 
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+---------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 |    1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |           536870911
+       11 |             5 |            9 |                 10 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+(3 rows)
+
 SELECT * FROM add_dimension('dimented_table', 'column3', 4, partitioning_func => '_timescaledb_internal.get_partition_for_key');
  dimension_id | schema_name |   table_name   | column_name | created 
 --------------+-------------+----------------+-------------+---------
            10 | public      | dimented_table | column3     | t
+(1 row)
+
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+---------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 |    1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |           536870911
+       11 |             5 |            9 |                 10 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+       11 |             5 |           10 |                 11 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+(4 rows)
+
+SELECT * FROM dimented_table ORDER BY time;
+             time             | column1 |           column2            | column3 
+------------------------------+---------+------------------------------+---------
+ Sun Jan 01 06:01:00 2017 PST |       1 | Sun Jan 01 08:01:00 2017 PST |       1
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -2287,7 +2320,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
  10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
 (9 rows)
 
--- Note that this didn't get the add_dimension
+-- ensure data node has new dimensions
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
 SELECT * FROM _timescaledb_catalog.dimension;
 $$);

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -2231,14 +2231,24 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Create one chunk to block add_dimension
 INSERT INTO dimented_table VALUES('2017-01-01 06:01', 1, '2017-01-01 08:01', 1);
-\set ON_ERROR_STOP 0
--- add_dimension should fail when table has data and a chunk
-SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
-ERROR:  hypertable "dimented_table" has data or empty chunks
-\set ON_ERROR_STOP 1
--- Clear table
-TRUNCATE dimented_table;
--- Now add_dimension should work
+CREATE VIEW dimented_table_slices AS
+SELECT c.id AS chunk_id, c.hypertable_id, ds.dimension_id, cc.dimension_slice_id, c.schema_name AS
+       chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.table_name = 'dimented_table'
+ORDER BY c.id, ds.dimension_id;
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |    range_end     
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 | 1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |        536870911
+(2 rows)
+
+-- add_dimension() with existing data
 SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
 NOTICE:  adding not-null constraint to column "column2"
  dimension_id | schema_name |   table_name   | column_name | created 
@@ -2246,10 +2256,33 @@ NOTICE:  adding not-null constraint to column "column2"
             9 | public      | dimented_table | column2     | t
 (1 row)
 
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+---------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 |    1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |           536870911
+       11 |             5 |            9 |                 10 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+(3 rows)
+
 SELECT * FROM add_dimension('dimented_table', 'column3', 4, partitioning_func => '_timescaledb_internal.get_partition_for_key');
  dimension_id | schema_name |   table_name   | column_name | created 
 --------------+-------------+----------------+-------------+---------
            10 | public      | dimented_table | column3     | t
+(1 row)
+
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+---------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 |    1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |           536870911
+       11 |             5 |            9 |                 10 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+       11 |             5 |           10 |                 11 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+(4 rows)
+
+SELECT * FROM dimented_table ORDER BY time;
+             time             | column1 |           column2            | column3 
+------------------------------+---------+------------------------------+---------
+ Sun Jan 01 06:01:00 2017 PST |       1 | Sun Jan 01 08:01:00 2017 PST |       1
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -2286,7 +2319,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
  10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
 (9 rows)
 
--- Note that this didn't get the add_dimension
+-- ensure data node has new dimensions
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
 SELECT * FROM _timescaledb_catalog.dimension;
 $$);

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -2235,14 +2235,24 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Create one chunk to block add_dimension
 INSERT INTO dimented_table VALUES('2017-01-01 06:01', 1, '2017-01-01 08:01', 1);
-\set ON_ERROR_STOP 0
--- add_dimension should fail when table has data and a chunk
-SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
-ERROR:  hypertable "dimented_table" has data or empty chunks
-\set ON_ERROR_STOP 1
--- Clear table
-TRUNCATE dimented_table;
--- Now add_dimension should work
+CREATE VIEW dimented_table_slices AS
+SELECT c.id AS chunk_id, c.hypertable_id, ds.dimension_id, cc.dimension_slice_id, c.schema_name AS
+       chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.table_name = 'dimented_table'
+ORDER BY c.id, ds.dimension_id;
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |    range_end     
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 | 1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |        536870911
+(2 rows)
+
+-- add_dimension() with existing data
 SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
 NOTICE:  adding not-null constraint to column "column2"
  dimension_id | schema_name |   table_name   | column_name | created 
@@ -2250,10 +2260,33 @@ NOTICE:  adding not-null constraint to column "column2"
             9 | public      | dimented_table | column2     | t
 (1 row)
 
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+---------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 |    1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |           536870911
+       11 |             5 |            9 |                 10 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+(3 rows)
+
 SELECT * FROM add_dimension('dimented_table', 'column3', 4, partitioning_func => '_timescaledb_internal.get_partition_for_key');
  dimension_id | schema_name |   table_name   | column_name | created 
 --------------+-------------+----------------+-------------+---------
            10 | public      | dimented_table | column3     | t
+(1 row)
+
+SELECT * FROM dimented_table_slices;
+ chunk_id | hypertable_id | dimension_id | dimension_slice_id |     chunk_schema      |      chunk_table       |     range_start      |      range_end      
+----------+---------------+--------------+--------------------+-----------------------+------------------------+----------------------+---------------------
+       11 |             5 |            7 |                  8 | _timescaledb_internal | _dist_hyper_5_11_chunk |     1482969600000000 |    1483574400000000
+       11 |             5 |            8 |                  9 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 |           536870911
+       11 |             5 |            9 |                 10 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+       11 |             5 |           10 |                 11 | _timescaledb_internal | _dist_hyper_5_11_chunk | -9223372036854775808 | 9223372036854775807
+(4 rows)
+
+SELECT * FROM dimented_table ORDER BY time;
+             time             | column1 |           column2            | column3 
+------------------------------+---------+------------------------------+---------
+ Sun Jan 01 06:01:00 2017 PST |       1 | Sun Jan 01 08:01:00 2017 PST |       1
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
@@ -2290,7 +2323,7 @@ SELECT * FROM _timescaledb_catalog.dimension;
  10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
 (9 rows)
 
--- Note that this didn't get the add_dimension
+-- ensure data node has new dimensions
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
 SELECT * FROM _timescaledb_catalog.dimension;
 $$);

--- a/tsl/test/sql/dist_hypertable.sql.in
+++ b/tsl/test/sql/dist_hypertable.sql.in
@@ -662,22 +662,33 @@ SELECT * FROM create_distributed_hypertable('dimented_table', 'time', partitioni
 -- Create one chunk to block add_dimension
 INSERT INTO dimented_table VALUES('2017-01-01 06:01', 1, '2017-01-01 08:01', 1);
 
-\set ON_ERROR_STOP 0
--- add_dimension should fail when table has data and a chunk
+CREATE VIEW dimented_table_slices AS
+SELECT c.id AS chunk_id, c.hypertable_id, ds.dimension_id, cc.dimension_slice_id, c.schema_name AS
+       chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN _timescaledb_catalog.dimension td ON (h.id = td.hypertable_id)
+INNER JOIN _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = td.id)
+INNER JOIN _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.table_name = 'dimented_table'
+ORDER BY c.id, ds.dimension_id;
+
+SELECT * FROM dimented_table_slices;
+
+-- add_dimension() with existing data
 SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
-\set ON_ERROR_STOP 1
--- Clear table
-TRUNCATE dimented_table;
--- Now add_dimension should work
-SELECT * FROM add_dimension('dimented_table', 'column2', chunk_time_interval => interval '1 week');
+SELECT * FROM dimented_table_slices;
+
 SELECT * FROM add_dimension('dimented_table', 'column3', 4, partitioning_func => '_timescaledb_internal.get_partition_for_key');
+SELECT * FROM dimented_table_slices;
+SELECT * FROM dimented_table ORDER BY time;
 
 SELECT * FROM _timescaledb_catalog.dimension;
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 
 SELECT * FROM _timescaledb_catalog.dimension;
 
--- Note that this didn't get the add_dimension
+-- ensure data node has new dimensions
 SELECT * FROM test.remote_exec(ARRAY[:'DATA_NODE_1', :'DATA_NODE_2', :'DATA_NODE_3'], $$
 SELECT * FROM _timescaledb_catalog.dimension;
 $$);


### PR DESCRIPTION
This change allows to create new dimensions even with
existing chunks.

It does not modify any existing data or do migration,
instead it creates full-range (-inf/inf) dimension slice for
existing chunks in order to be compatible with newly created
dimension.

All new chunks created after this will follow logic of the new
dimension and its partitioning.

Issue: https://github.com/timescale/timescaledb/issues/2818