### PR TITLE
Introduce a stalebot to close issues

### DIFF
--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -1,0 +1,40 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          stale-issue-message: 'This issue has been automatically marked as stale due to lack of activity. You can remove the stale label or comment. Otherwise, this issue will be closed in 30 days. Thank you!'
+          close-issue-message: 'We are closing this issue due to lack of activity. Feel free to reopen it if you can provide more information. Thank you!'
+       
+          # Don't process PRs 
+          days-before-stale: -1
+
+          # Process only issues
+          days-before-issue-stale: 60
+          days-before-issue-close: 30
+          
+          # Add this label after 'days-before-issue-stale' days to mark it as stale
+          stale-issue-label: 'no-activity'
+
+          # Process only issues that contain the label 'need-more-info'
+          only-labels: 'need-more-info'
+          
+          # Stale only issues with one of these labels
+          any-of-issue-labels: 'bug,enhancement'
+          
+          # Exclude issues with the 'in-progress' label
+          exempt-issue-labels: 'in-progress'
+
+          # Exclude assigned issues         
+          exempt-all-assignees: true
+ 
+          # Dry run
+          debug-only: true
+


### PR DESCRIPTION
This PR introduces a configuration for the 'actions/stale' stalebot,
which is used to automatically flag and close stale issues after
a few days of inactivity.

Note: The configuration runs in dry-mode to test the behavior of the
     bot on our repository first.