### PR TITLE
Add chunks to baserel cache on chunk exclusion

### DIFF
--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -25,6 +25,7 @@
 #define PLANNER_LOCATION_MAGIC -29811
 
 typedef struct Chunk Chunk;
+typedef struct Hypertable Hypertable;
 typedef struct TsFdwRelInfo TsFdwRelInfo;
 typedef struct TimescaleDBPrivate
 {
@@ -104,5 +105,8 @@ extern void ts_plan_expand_timebucket_annotate(PlannerInfo *root, RelOptInfo *re
 extern Node *ts_constify_now(PlannerInfo *root, List *rtable, Node *node);
 extern void ts_planner_constraint_cleanup(PlannerInfo *root, RelOptInfo *rel);
 extern Node *ts_add_space_constraints(PlannerInfo *root, List *rtable, Node *node);
+
+extern void add_baserel_cache_entry_for_chunk(Oid chunk_reloid, uint32 chunk_status,
+											  Hypertable *hypertable, TsRelType chunk_reltype);
 
 #endif /* TIMESCALEDB_PLANNER_H */


### PR DESCRIPTION
This speeds up the planning by avoiding the repeated lookup of the
chunk metadata.

Gives about 10% speedup on planning-only queries like `explain select * from my_hypertable`.