### PR TITLE
Fix assertion hit in row_by_row_fetcher_close

### DIFF
--- a/tsl/src/remote/row_by_row_fetcher.c
+++ b/tsl/src/remote/row_by_row_fetcher.c
@@ -547,9 +547,11 @@ row_by_row_fetcher_close(DataFetcher *df)
 {
 	RowByRowFetcher *fetcher = cast_fetcher(RowByRowFetcher, df);
 
-	Assert(fetcher->state.open);
-
-	if (fetcher->state.data_req != NULL)
+	/*
+	 * The fetcher state might not be open if the fetcher got initialized but
+	 * never executed due to executor constraints.
+	 */
+	if (fetcher->state.open && fetcher->state.data_req != NULL)
 	{
 		int end_res = PQendcopy(remote_connection_get_pg_conn(fetcher->state.conn));
 		if (end_res != 0)

--- a/tsl/test/shared/expected/dist_fetcher_type.out
+++ b/tsl/test/shared/expected/dist_fetcher_type.out
@@ -171,3 +171,23 @@ select * from disttable_with_bytea;
  1001 | 
 (2 rows)
 
+-- #4515 test for assertion failure in row_by_row_fetcher_close
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
+SELECT *
+FROM
+  conditions ref_0
+WHERE EXISTS (
+  SELECT FROM
+    distinct_on_distributed,
+    LATERAL (
+      SELECT *
+      FROM pg_class,
+      LATERAL (
+        SELECT ref_0.device FROM pg_class WHERE false LIMIT 1) as lat_1
+      ) as lat_2
+  WHERE (SELECT 1 FROM pg_class LIMIT 1) >= ref_0.device
+);
+ time | device | value 
+------+--------+-------
+(0 rows)
+

--- a/tsl/test/shared/sql/dist_fetcher_type.sql
+++ b/tsl/test/shared/sql/dist_fetcher_type.sql
@@ -95,3 +95,21 @@ set timescaledb.remote_data_fetcher = 'cursor';
 explain (analyze, verbose, costs off, timing off, summary off)
 select * from disttable_with_bytea;
 select * from disttable_with_bytea;
+
+-- #4515 test for assertion failure in row_by_row_fetcher_close
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
+SELECT *
+FROM
+  conditions ref_0
+WHERE EXISTS (
+  SELECT FROM
+    distinct_on_distributed,
+    LATERAL (
+      SELECT *
+      FROM pg_class,
+      LATERAL (
+        SELECT ref_0.device FROM pg_class WHERE false LIMIT 1) as lat_1
+      ) as lat_2
+  WHERE (SELECT 1 FROM pg_class LIMIT 1) >= ref_0.device
+);
+


### PR DESCRIPTION
When executing multinode queries that initialize row-by-row fetcher
but never execute it the node cleanup code would hit an assertion
checking the state of the fetcher. Found by sqlsmith.

Fixes #4515 