### PR TITLE
Throw better error message on incompatible row fetcher settings

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -515,20 +515,29 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 			{
 				reset_fetcher_type = true;
 
-				if (ts_guc_remote_data_fetcher == AutoFetcherType)
+				if (context.num_distributed_tables >= 2)
 				{
-					if (context.num_distributed_tables >= 2)
+					if (ts_guc_remote_data_fetcher == RowByRowFetcherType)
 					{
-						ts_data_node_fetcher_scan_type = CursorFetcherType;
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("row-by-row fetcher not supported"),
+								 errhint("Row-by-row fetching of data is not supported in "
+										 "queries with multiple distributed hypertables."
+										 " Use cursor fetcher instead.")));
 					}
-					else
-					{
-						ts_data_node_fetcher_scan_type = RowByRowFetcherType;
-					}
+					ts_data_node_fetcher_scan_type = CursorFetcherType;
 				}
 				else
 				{
-					ts_data_node_fetcher_scan_type = ts_guc_remote_data_fetcher;
+					if (ts_guc_remote_data_fetcher == AutoFetcherType)
+					{
+						ts_data_node_fetcher_scan_type = RowByRowFetcherType;
+					}
+					else
+					{
+						ts_data_node_fetcher_scan_type = ts_guc_remote_data_fetcher;
+					}
 				}
 			}
 

--- a/tsl/test/expected/dist_query.out
+++ b/tsl/test/expected/dist_query.out
@@ -21,7 +21,6 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_REFER
 -- Use a small fetch size to make sure that result are fetched across
 -- multiple fetches.
 --ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fetch_size '500');
-SET timescaledb.remote_data_fetcher = 'rowbyrow';
 SET client_min_messages TO notice;
 -- Load the data
 \ir :TEST_LOAD_NAME

--- a/tsl/test/shared/expected/dist_fetcher_type.out
+++ b/tsl/test/shared/expected/dist_fetcher_type.out
@@ -72,7 +72,7 @@ set timescaledb.remote_data_fetcher = 'rowbyrow';
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
 where t1.id = t2.id + 1
 limit 1;
-ERROR:  could not set single-row mode on connection to "data_node_1"
+ERROR:  row-by-row fetcher not supported
 -- Check once again that 'auto' is used after 'rowbyrow'.
 set timescaledb.remote_data_fetcher = 'auto';
 select 1 x from distinct_on_distributed t1, distinct_on_distributed t2
@@ -190,4 +190,34 @@ WHERE EXISTS (
  time | device | value 
 ------+--------+-------
 (0 rows)
+
+-- #4518
+-- test error handling for queries with multiple distributed hypertables
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
+SELECT * FROM
+  conditions_dist1 ref_0
+WHERE EXISTS (
+  SELECT FROM
+    distinct_on_distributed as ref_1,
+    LATERAL (select * from metrics as ref_2) as subq_3
+  WHERE
+    (SELECT device_id FROM metrics_compressed limit 1 offset 3) >= ref_0.device
+);
+ERROR:  row-by-row fetcher not supported
+SET timescaledb.remote_data_fetcher = 'auto';
+SELECT * FROM
+  conditions_dist1 ref_0
+WHERE EXISTS (
+  SELECT FROM
+    distinct_on_distributed as ref_1,
+    LATERAL (select * from metrics as ref_2) as subq_3
+  WHERE
+    (SELECT device_id FROM metrics_compressed limit 1 offset 3) >= ref_0.device
+)
+ORDER BY 1,2;
+             time             | device | value 
+------------------------------+--------+-------
+ Sun Jan 01 06:01:00 2017 PST |      1 |   1.2
+ Sun Jan 01 08:01:00 2017 PST |      1 |   7.3
+(2 rows)
 

--- a/tsl/test/shared/sql/dist_fetcher_type.sql
+++ b/tsl/test/shared/sql/dist_fetcher_type.sql
@@ -113,3 +113,26 @@ WHERE EXISTS (
   WHERE (SELECT 1 FROM pg_class LIMIT 1) >= ref_0.device
 );
 
+-- #4518
+-- test error handling for queries with multiple distributed hypertables
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
+SELECT * FROM
+  conditions_dist1 ref_0
+WHERE EXISTS (
+  SELECT FROM
+    distinct_on_distributed as ref_1,
+    LATERAL (select * from metrics as ref_2) as subq_3
+  WHERE
+    (SELECT device_id FROM metrics_compressed limit 1 offset 3) >= ref_0.device
+);
+SET timescaledb.remote_data_fetcher = 'auto';
+SELECT * FROM
+  conditions_dist1 ref_0
+WHERE EXISTS (
+  SELECT FROM
+    distinct_on_distributed as ref_1,
+    LATERAL (select * from metrics as ref_2) as subq_3
+  WHERE
+    (SELECT device_id FROM metrics_compressed limit 1 offset 3) >= ref_0.device
+)
+ORDER BY 1,2;

--- a/tsl/test/sql/dist_query.sql
+++ b/tsl/test/sql/dist_query.sql
@@ -25,7 +25,6 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_UNOPTIMIZED', :'TEST_RESULTS_REFER
 -- Use a small fetch size to make sure that result are fetched across
 -- multiple fetches.
 --ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fetch_size '500');
-SET timescaledb.remote_data_fetcher = 'rowbyrow';
 SET client_min_messages TO notice;
 
 -- Load the data


### PR DESCRIPTION
When a query has multiple distributed hypertables the row-by-by
fetcher cannot be used. This patch adjusts the fetcher type
selection to always use cursor fetcher when multiple distributed
hypertables are involved.

Fixes #4518