### PR TITLE
Activate a stalebot to close issues

### DIFF
--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -35,6 +35,3 @@ jobs:
           # Exclude assigned issues         
           exempt-all-assignees: true
  
-          # Dry run
-          debug-only: true
-


### PR DESCRIPTION
In #4499, a stalebot configuration was introduced. According to the
configuration, the stalebot runs in dry mode. The [output](https://github.com/timescale/timescaledb/runs/7383402365?check_suite_focus=true) of a dry
mode run was analyzed and issues with an outdated  "need-more-info"
label have been cleaned up. So, the stalebot can now be activated.