### PR TITLE
Fix gapfill group comparison for toasted values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #4482 Ensure (de-)compression is not performed twice on the same chunk
+* #4517 Fix prepared statement param handling in ChunkAppend
+* #4526 Fix gapfill group comparison for TOASTed values
 
 **Thanks**
 

--- a/tsl/src/nodes/gapfill/exec.h
+++ b/tsl/src/nodes/gapfill/exec.h
@@ -83,6 +83,8 @@ typedef struct GapFillGroupColumnState
 	GapFillColumnState base;
 	Datum value;
 	bool isnull;
+	Oid collation;
+	FmgrInfo eq_func;
 } GapFillGroupColumnState;
 
 typedef struct GapFillState

--- a/tsl/test/shared/expected/gapfill-12.out
+++ b/tsl/test/shared/expected/gapfill-12.out
@@ -3160,3 +3160,33 @@ GROUP BY 1;
  Tue Nov 05 02:30:00 2019 PST | 20266.958984375 | 20266.959547
 (11 rows)
 
+-- check gapfill group change detection with TOASTed values
+CREATE TABLE gapfill_group_toast(time timestamptz NOT NULL, device text, value float);
+SELECT table_name FROM create_hypertable('gapfill_group_toast', 'time');
+     table_name      
+ gapfill_group_toast
+(1 row)
+
+INSERT INTO gapfill_group_toast
+SELECT
+  generate_series('2022-06-01'::timestamptz, '2022-06-03'::timestamptz, '1min'::interval),
+  '4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43',
+  random();
+ALTER TABLE gapfill_group_toast SET(timescaledb.compress, timescaledb.compress_segmentby = 'device');
+SELECT count(compress_chunk(c)) FROM show_chunks('gapfill_group_toast') c;
+ count 
+     2
+(1 row)
+
+SELECT
+  time_bucket_gapfill('1 day', time), device
+FROM gapfill_group_toast
+WHERE time >= '2022-06-01' AND time <= '2022-06-02'
+GROUP BY 1,2;
+     time_bucket_gapfill      |                              device                              
+------------------------------+------------------------------------------------------------------
+ Tue May 31 17:00:00 2022 PDT | 4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43
+ Wed Jun 01 17:00:00 2022 PDT | 4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43
+(2 rows)
+
+DROP TABLE gapfill_group_toast;

--- a/tsl/test/shared/expected/gapfill-13.out
+++ b/tsl/test/shared/expected/gapfill-13.out
@@ -3167,3 +3167,33 @@ GROUP BY 1;
  Tue Nov 05 02:30:00 2019 PST | 20266.958984375 | 20266.959547
 (11 rows)
 
+-- check gapfill group change detection with TOASTed values
+CREATE TABLE gapfill_group_toast(time timestamptz NOT NULL, device text, value float);
+SELECT table_name FROM create_hypertable('gapfill_group_toast', 'time');
+     table_name      
+ gapfill_group_toast
+(1 row)
+
+INSERT INTO gapfill_group_toast
+SELECT
+  generate_series('2022-06-01'::timestamptz, '2022-06-03'::timestamptz, '1min'::interval),
+  '4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43',
+  random();
+ALTER TABLE gapfill_group_toast SET(timescaledb.compress, timescaledb.compress_segmentby = 'device');
+SELECT count(compress_chunk(c)) FROM show_chunks('gapfill_group_toast') c;
+ count 
+     2
+(1 row)
+
+SELECT
+  time_bucket_gapfill('1 day', time), device
+FROM gapfill_group_toast
+WHERE time >= '2022-06-01' AND time <= '2022-06-02'
+GROUP BY 1,2;
+     time_bucket_gapfill      |                              device                              
+------------------------------+------------------------------------------------------------------
+ Tue May 31 17:00:00 2022 PDT | 4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43
+ Wed Jun 01 17:00:00 2022 PDT | 4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43
+(2 rows)
+
+DROP TABLE gapfill_group_toast;

--- a/tsl/test/shared/expected/gapfill-14.out
+++ b/tsl/test/shared/expected/gapfill-14.out
@@ -3167,3 +3167,33 @@ GROUP BY 1;
  Tue Nov 05 02:30:00 2019 PST | 20266.958984375 | 20266.959547
 (11 rows)
 
+-- check gapfill group change detection with TOASTed values
+CREATE TABLE gapfill_group_toast(time timestamptz NOT NULL, device text, value float);
+SELECT table_name FROM create_hypertable('gapfill_group_toast', 'time');
+     table_name      
+ gapfill_group_toast
+(1 row)
+
+INSERT INTO gapfill_group_toast
+SELECT
+  generate_series('2022-06-01'::timestamptz, '2022-06-03'::timestamptz, '1min'::interval),
+  '4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43',
+  random();
+ALTER TABLE gapfill_group_toast SET(timescaledb.compress, timescaledb.compress_segmentby = 'device');
+SELECT count(compress_chunk(c)) FROM show_chunks('gapfill_group_toast') c;
+ count 
+     2
+(1 row)
+
+SELECT
+  time_bucket_gapfill('1 day', time), device
+FROM gapfill_group_toast
+WHERE time >= '2022-06-01' AND time <= '2022-06-02'
+GROUP BY 1,2;
+     time_bucket_gapfill      |                              device                              
+------------------------------+------------------------------------------------------------------
+ Tue May 31 17:00:00 2022 PDT | 4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43
+ Wed Jun 01 17:00:00 2022 PDT | 4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43
+(2 rows)
+
+DROP TABLE gapfill_group_toast;

--- a/tsl/test/shared/sql/gapfill.sql.in
+++ b/tsl/test/shared/sql/gapfill.sql.in
@@ -1452,3 +1452,23 @@ SELECT
 FROM (VALUES ('2019-11-05 2:20'), ('2019-11-05 2:30')) v (ts)
 GROUP BY 1;
 
+-- check gapfill group change detection with TOASTed values
+CREATE TABLE gapfill_group_toast(time timestamptz NOT NULL, device text, value float);
+SELECT table_name FROM create_hypertable('gapfill_group_toast', 'time');
+
+INSERT INTO gapfill_group_toast
+SELECT
+  generate_series('2022-06-01'::timestamptz, '2022-06-03'::timestamptz, '1min'::interval),
+  '4e0ee04cc6a94fd40497b8dbaac2fe434e0ee04cc6a94fd40497b8dbaac2fe43',
+  random();
+
+ALTER TABLE gapfill_group_toast SET(timescaledb.compress, timescaledb.compress_segmentby = 'device');
+SELECT count(compress_chunk(c)) FROM show_chunks('gapfill_group_toast') c;
+
+SELECT
+  time_bucket_gapfill('1 day', time), device
+FROM gapfill_group_toast
+WHERE time >= '2022-06-01' AND time <= '2022-06-02'
+GROUP BY 1,2;
+
+DROP TABLE gapfill_group_toast;


### PR DESCRIPTION
The gapfill mechanism to detect an aggregation group change was
using datumIsEqual to compare the group values. datumIsEqual does
not detoast values so when one value is toasted and the other value
is not it will not return the correct result. This patch changes
the gapfill code to use the correct equal operator for the type
of the group column instead of datumIsEqual.