### PR TITLE
Handle stats properly for range types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ accidentally triggering the load of a previous DB version.**
 * #4482 Ensure (de-)compression is not performed twice on the same chunk
 * #4517 Fix prepared statement param handling in ChunkAppend
 * #4526 Fix gapfill group comparison for TOASTed values
+* #4527 Handle stats properly for range types
 
 **Thanks**
 

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -733,8 +733,9 @@ collect_colstat_slots(const HeapTuple tuple, const Form_pg_statistic formdata, D
 		ATTSTATSSLOT_NUMBERS,						/* CORRELATION */
 		ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS, /* MCELEM */
 		ATTSTATSSLOT_NUMBERS,						/* DECHIST */
-		ATTSTATSSLOT_VALUES | ATTSTATSSLOT_NUMBERS, /* RANGE_LENGTH_HISTOGRAM */
-		ATTSTATSSLOT_VALUES							/* BOUNDS_HISTOGRAM */
+		/* ATTSTATSSLOT_VALUES is not always present for all HISTOGRAM operators.. */
+		ATTSTATSSLOT_NUMBERS, /* RANGE_LENGTH_HISTOGRAM */
+		ATTSTATSSLOT_VALUES   /* BOUNDS_HISTOGRAM */
 	};
 
 	int i;
@@ -772,8 +773,12 @@ collect_colstat_slots(const HeapTuple tuple, const Form_pg_statistic formdata, D
 			continue;
 		}
 
-		convert_op_oid_to_strings(slot_op, op_strings + nopstrings);
-		nopstrings += STRINGS_PER_OP_OID;
+		/* slot_op can be invalid for some "kinds" like STATISTIC_KIND_BOUNDS_HISTOGRAM */
+		if (OidIsValid(slot_op))
+		{
+			convert_op_oid_to_strings(slot_op, op_strings + nopstrings);
+			nopstrings += STRINGS_PER_OP_OID;
+		}
 
 		if (kind > STATISTIC_KIND_BOUNDS_HISTOGRAM)
 			ereport(ERROR,

--- a/tsl/test/expected/chunk_api.out
+++ b/tsl/test/expected/chunk_api.out
@@ -22,7 +22,8 @@ LANGUAGE C;
 GRANT CREATE ON DATABASE :"TEST_DBNAME" TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE SCHEMA "ChunkSchema";
-CREATE TABLE chunkapi (time timestamptz, device int, temp float);
+-- Use range types as well for columns
+CREATE TABLE chunkapi (time timestamptz, device int, temp float, rng int8range);
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
@@ -30,7 +31,7 @@ NOTICE:  adding not-null constraint to column "time"
              1 | public      | chunkapi   | t
 (1 row)
 
-INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4, int8range(4, 10));
 SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
 FROM show_chunks('chunkapi')
 ORDER BY chunk_id;
@@ -238,12 +239,13 @@ SELECT * FROM _timescaledb_internal.get_chunk_relstats('chunkapi');
 (2 rows)
 
 SELECT * FROM _timescaledb_internal.get_chunk_colstats('chunkapi');
- chunk_id | hypertable_id | att_num | nullfrac | width | distinctval |  slotkind   | slotopstrings | slotcollations | slot1numbers | slot2numbers | slot3numbers | slot4numbers | slot5numbers | slotvaluetypetrings | slot1values | slot2values | slot3values | slot4values | slot5values 
-----------+---------------+---------+----------+-------+-------------+-------------+---------------+----------------+--------------+--------------+--------------+--------------+--------------+---------------------+-------------+-------------+-------------+-------------+-------------
-        1 |             1 |       1 |        0 |     8 |          -1 | {0,0,0,0,0} | {}            | {0,0,0,0,0}    |              |              |              |              |              | {}                  |             |             |             |             | 
-        1 |             1 |       2 |        0 |     4 |          -1 | {0,0,0,0,0} | {}            | {0,0,0,0,0}    |              |              |              |              |              | {}                  |             |             |             |             | 
-        1 |             1 |       3 |        0 |     8 |          -1 | {0,0,0,0,0} | {}            | {0,0,0,0,0}    |              |              |              |              |              | {}                  |             |             |             |             | 
-(3 rows)
+ chunk_id | hypertable_id | att_num | nullfrac | width | distinctval |  slotkind   |                   slotopstrings                    | slotcollations | slot1numbers | slot2numbers | slot3numbers | slot4numbers | slot5numbers | slotvaluetypetrings | slot1values | slot2values | slot3values | slot4values | slot5values 
+----------+---------------+---------+----------+-------+-------------+-------------+----------------------------------------------------+----------------+--------------+--------------+--------------+--------------+--------------+---------------------+-------------+-------------+-------------+-------------+-------------
+        1 |             1 |       1 |        0 |     8 |          -1 | {0,0,0,0,0} | {}                                                 | {0,0,0,0,0}    |              |              |              |              |              | {}                  |             |             |             |             | 
+        1 |             1 |       2 |        0 |     4 |          -1 | {0,0,0,0,0} | {}                                                 | {0,0,0,0,0}    |              |              |              |              |              | {}                  |             |             |             |             | 
+        1 |             1 |       3 |        0 |     8 |          -1 | {0,0,0,0,0} | {}                                                 | {0,0,0,0,0}    |              |              |              |              |              | {}                  |             |             |             |             | 
+        1 |             1 |       4 |        0 |    22 |          -1 | {6,0,0,0,0} | {<,pg_catalog,float8,pg_catalog,float8,pg_catalog} | {0,0,0,0,0}    | {0}          |              |              |              |              | {}                  |             |             |             |             | 
+(4 rows)
 
 SELECT relname, reltuples, relpages, relallvisible FROM pg_class WHERE relname IN
 (SELECT (_timescaledb_internal.show_chunk(show_chunks)).table_name
@@ -263,9 +265,10 @@ ORDER BY tablename, attname;
     tablename     | attname | inherited | null_frac | avg_width | n_distinct 
 ------------------+---------+-----------+-----------+-----------+------------
  _hyper_1_1_chunk | device  | f         |         0 |         4 |         -1
+ _hyper_1_1_chunk | rng     | f         |         0 |        22 |         -1
  _hyper_1_1_chunk | temp    | f         |         0 |         8 |         -1
  _hyper_1_1_chunk | time    | f         |         0 |         8 |         -1
-(3 rows)
+(4 rows)
 
 -- Test getting chunk stats on a distribute hypertable
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
@@ -566,9 +569,9 @@ DROP DATABASE :DN_DBNAME_2;
 -- Test create_chunk_table to recreate the chunk table and show dimension slices
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 SELECT * FROM chunkapi ORDER BY time;
-             time             | device | temp 
-------------------------------+--------+------
- Mon Jan 01 05:00:00 2018 PST |      1 | 23.4
+             time             | device | temp |  rng   
+------------------------------+--------+------+--------
+ Mon Jan 01 05:00:00 2018 PST |      1 | 23.4 | [4,10)
 (1 row)
 
 SELECT chunk_schema AS "CHUNK_SCHEMA", chunk_name AS "CHUNK_NAME"

--- a/tsl/test/sql/chunk_api.sql
+++ b/tsl/test/sql/chunk_api.sql
@@ -11,11 +11,12 @@ GRANT CREATE ON DATABASE :"TEST_DBNAME" TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
 CREATE SCHEMA "ChunkSchema";
-CREATE TABLE chunkapi (time timestamptz, device int, temp float);
+-- Use range types as well for columns
+CREATE TABLE chunkapi (time timestamptz, device int, temp float, rng int8range);
 
 SELECT * FROM create_hypertable('chunkapi', 'time', 'device', 2);
 
-INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4);
+INSERT INTO chunkapi VALUES ('2018-01-01 05:00:00-8', 1, 23.4, int8range(4, 10));
 
 SELECT (_timescaledb_internal.show_chunk(show_chunks)).*
 FROM show_chunks('chunkapi')


### PR DESCRIPTION
For range types, the operator entry in statistics table is invalid.
Also, certain range types don't have "VALUES" but only have "NUMBERS"
entries.