### PR TITLE
Fix memory leak in function telemetry

### DIFF
--- a/src/telemetry/functions.c
+++ b/src/telemetry/functions.c
@@ -265,9 +265,12 @@ function_telemetry_increment(Oid func_id, HTAB **local_counts)
 		HASHCTL hash_info = {
 			.keysize = sizeof(Oid),
 			.entrysize = sizeof(FnTelemetryEntry),
+			.hcxt = CurrentMemoryContext,
 		};
-		*local_counts =
-			hash_create("fn telemetry local function hash", 10, &hash_info, HASH_ELEM | HASH_BLOBS);
+		*local_counts = hash_create("fn telemetry local function hash",
+									10,
+									&hash_info,
+									HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 	}
 
 	entry = hash_search(*local_counts, &func_id, HASH_ENTER, &found);


### PR DESCRIPTION
hash_create will create the hash table in TopMemoryContext unless
explicitly requested to create in different memory context. The
function telemetry code did not explicitly request a different
context leading to a memory leak.

Fixes #4507