### PR TITLE
Remove CODEOWNERS file to activate pull-review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @timescale/database-eng


### PR DESCRIPTION
In #4525 a workflow was introduced for running pull-review to
automate reviewer assignment based on code ownership. However
the CODEOWNERS file was not removed.  As reviewers will be assigned
based on it if it exists, it prevents the pull-review workflow
from taking effect. This commit removes CODEOWNERS to allow
pull-review to do the reviewer assignment.