### PR TITLE
Use explicit memory context with hash_create

### DIFF
--- a/src/func_cache.c
+++ b/src/func_cache.c
@@ -464,7 +464,10 @@ initialize_func_info()
 	Relation rel;
 	int i;
 
-	func_hash = hash_create("func_cache", _MAX_CACHE_FUNCTIONS, &hashctl, HASH_ELEM | HASH_BLOBS);
+	func_hash = hash_create("func_cache",
+							_MAX_CACHE_FUNCTIONS,
+							&hashctl,
+							HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
 	rel = table_open(ProcedureRelationId, AccessShareLock);
 

--- a/tsl/src/continuous_aggs/insert.c
+++ b/tsl/src/continuous_aggs/insert.c
@@ -103,7 +103,7 @@ cache_inval_init()
 	continuous_aggs_cache_inval_htab = hash_create("TS Continuous Aggs Cache Inval",
 												   CA_CACHE_INVAL_INIT_HTAB_SIZE,
 												   &ctl,
-												   HASH_ELEM | HASH_BLOBS);
+												   HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 };
 
 static int64


### PR DESCRIPTION
This changes the hash_create calls in the function cache and in the
cagg code to use explicit memory context. Without this hash_create
will create the hash table in TopMemoryContext potentially leading
to memory leaks.