### PR TITLE
Release 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,25 @@ accidentally triggering the load of a previous DB version.**
 * #4393 Support intervals with day component when constifying now()
 * #4397 Support intervals with month component when constifying now()
 
+## 2.7.2 (2022-07-26)
+
+This release is a patch release. We recommend that you upgrade at the
+next available opportunity.
+Among other things this release fixes several memory leaks, handling
+of TOASTed values in GapFill and parameter handling in prepared statements.
+
 **Bugfixes**
-* #4482 Ensure (de-)compression is not performed twice on the same chunk
 * #4517 Fix prepared statement param handling in ChunkAppend
+* #4522 Fix ANALYZE on dist hypertable for a set of nodes
 * #4526 Fix gapfill group comparison for TOASTed values
 * #4527 Handle stats properly for range types
-* #4522 Fix ANALYZE on dist hypertable for a set of nodes
+* #4532 Fix memory leak in function telemetry
+* #4534 Use explicit memory context with hash_create
+* #4538 Fix chunk creation on hypertables with non-default statistics
 
 **Thanks**
-
+* @3a6u9ka, @bgemmill, @hongquan, @stl-leonid-kalmaev and @victor-sudakov for reporting a memory leak
+* @hleung2021 and @laocaixw  for reporting an issue with parameter handling in prepared statements
 
 ## 2.7.1 (2022-07-07)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -36,7 +36,8 @@ set(MOD_FILES
     updates/2.5.2--2.6.0.sql
     updates/2.6.0--2.6.1.sql
     updates/2.6.1--2.7.0.sql
-    updates/2.7.0--2.7.1.sql)
+    updates/2.7.0--2.7.1.sql
+    updates/2.7.1--2.7.2.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.8.0-dev
-update_from_version = 2.7.1
+update_from_version = 2.7.2
 downgrade_to_version = 2.7.1


### PR DESCRIPTION
This release is a patch release. We recommend that you upgrade at the
next available opportunity.
Among other things this release fixes several memory leaks, handling
of TOASTed values in GapFill and parameter handling in prepared statements.

**Bugfixes**
* #4517 Fix prepared statement param handling in ChunkAppend
* #4522 Fix ANALYZE on dist hypertable for a set of nodes
* #4526 Fix gapfill group comparison for TOASTed values
* #4527 Handle stats properly for range types
* #4532 Fix memory leak in function telemetry
* #4534 Use explicit memory context with hash_create
* #4538 Fix chunk creation on hypertables with non-default statistics

**Thanks**

* @3a6u9ka, @bgemmill , @hongquan, @stl-leonid-kalmaev and @victor-sudakov for reporting a memory leak
* @hleung2021 and @laocaixw  for reporting an issue with parameter handling in prepared statements
