### PR TITLE
Bump macOS version used in CI to 11

### DIFF
--- a/scripts/gh_matrix_builder.py
+++ b/scripts/gh_matrix_builder.py
@@ -103,7 +103,7 @@ def build_apache_config(overrides):
 def macos_config(overrides):
   base_config = dict({
     "pg": PG12_LATEST,
-    "os": "macos-10.15",
+    "os": "macos-11",
     "cc": "clang",
     "cxx": "clang++",
     "clang": "clang",


### PR DESCRIPTION
macOS 10.15 is deprecated as github action environment and will
be unsupported by end of august. This PR switches our CI to use
macOS 11 environment instead.

https://github.com/actions/virtual-environments/issues/5583