### PR TITLE
Fix chunk creation on hypertables with non-default statistics

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -890,6 +890,12 @@ ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tabl
 		 */
 		create_toast_table(&stmt.base, objaddr.objectId);
 
+		/*
+		 * Some options require being table owner to set for example statistics
+		 * so we have to set them before restoring security context
+		 */
+		set_attoptions(rel, objaddr.objectId);
+
 		if (uid != saved_uid)
 			SetUserIdAndSecContext(saved_uid, sec_ctx);
 	}
@@ -915,6 +921,12 @@ ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tabl
 		CreateForeignTable(&stmt, objaddr.objectId);
 
 		/*
+		 * Some options require being table owner to set for example statistics
+		 * so we have to set them before restoring security context
+		 */
+		set_attoptions(rel, objaddr.objectId);
+
+		/*
 		 * Need to restore security context to execute remote commands as the
 		 * original user
 		 */
@@ -929,8 +941,6 @@ ts_chunk_create_table(const Chunk *chunk, const Hypertable *ht, const char *tabl
 	}
 	else
 		elog(ERROR, "invalid relkind \"%c\" when creating chunk", chunk->relkind);
-
-	set_attoptions(rel, objaddr.objectId);
 
 	table_close(rel, AccessShareLock);
 

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -769,3 +769,23 @@ CREATE VIEW v1 AS SELECT random();
 ALTER VIEW v1 SET (autovacuum_enabled = false);
 ERROR:  unrecognized parameter "autovacuum_enabled"
 \set ON_ERROR_STOP 1
+-- issue 4474
+-- test hypertable with non-default statistics target
+-- and chunk creation triggered by non-owner
+CREATE ROLE role_4474;
+CREATE TABLE i4474(time timestamptz NOT NULL);
+SELECT table_name FROM public.create_hypertable( 'i4474', 'time');
+ table_name 
+------------
+ i4474
+(1 row)
+
+GRANT SELECT, INSERT on i4474 TO role_4474;
+-- create chunk as owner
+INSERT INTO i4474 SELECT '2020-01-01';
+-- set statistics
+ALTER TABLE i4474 ALTER COLUMN time SET statistics 10;
+-- create chunk as non-owner
+SET ROLE role_4474;
+INSERT INTO i4474 SELECT '2021-01-01';
+RESET ROLE;


### PR DESCRIPTION
When triggering chunk creation on a hypertable with non-default
statistics targets by a user different from the hypertable owner
the chunk creation will fail with a permission error. This patch
changes the chunk table creation to run the attribute modification
as the table owner.

Fixes #4474