### PR TITLE
Fix dist_copy_long test on macOS

### DIFF
--- a/tsl/test/expected/dist_copy_long.out
+++ b/tsl/test/expected/dist_copy_long.out
@@ -53,28 +53,28 @@ select create_distributed_hypertable('uk_price_paid_space10', 'date', 'postcode2
  (3,public,uk_price_paid_space10,t)
 (1 row)
 
-\copy uk_price_paid_space2 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space2 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space2;
  count 
 -------
  10000
 (1 row)
 
-\copy uk_price_paid_space2 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space2 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space2;
  count 
 -------
  20000
 (1 row)
 
-\copy uk_price_paid_space10 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space10 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space10;
  count 
 -------
  10000
 (1 row)
 
-\copy uk_price_paid_space10 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space10 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space10;
  count 
 -------
@@ -82,14 +82,14 @@ select count(*) from uk_price_paid_space10;
 (1 row)
 
 set timescaledb.max_open_chunks_per_insert = 1;
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
  count  
 --------
  100000
 (1 row)
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
  count  
 --------
@@ -98,14 +98,14 @@ select count(*) from uk_price_paid;
 
 truncate uk_price_paid;
 set timescaledb.max_open_chunks_per_insert = 2;
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
  count  
 --------
  100000
 (1 row)
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
  count  
 --------
@@ -114,14 +114,14 @@ select count(*) from uk_price_paid;
 
 truncate uk_price_paid;
 set timescaledb.max_open_chunks_per_insert = 1117;
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
  count  
 --------
  100000
 (1 row)
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
  count  
 --------

--- a/tsl/test/sql/dist_copy_long.sql
+++ b/tsl/test/sql/dist_copy_long.sql
@@ -32,23 +32,23 @@ create table uk_price_paid_space10(like uk_price_paid);
 select create_distributed_hypertable('uk_price_paid_space10', 'date', 'postcode2', 10, chunk_time_interval => interval '90 day');
 
 
-\copy uk_price_paid_space2 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space2 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space2;
-\copy uk_price_paid_space2 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space2 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space2;
 
-\copy uk_price_paid_space10 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space10 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space10;
-\copy uk_price_paid_space10 from program 'zcat data/prices-10k-random-1.tsv.gz';
+\copy uk_price_paid_space10 from program 'zcat < data/prices-10k-random-1.tsv.gz';
 select count(*) from uk_price_paid_space10;
 
 
 set timescaledb.max_open_chunks_per_insert = 1;
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
 
 truncate uk_price_paid;
@@ -56,10 +56,10 @@ truncate uk_price_paid;
 
 set timescaledb.max_open_chunks_per_insert = 2;
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
 
 truncate uk_price_paid;
@@ -67,10 +67,10 @@ truncate uk_price_paid;
 
 set timescaledb.max_open_chunks_per_insert = 1117;
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
 
-\copy uk_price_paid from program 'zcat data/prices-100k-random-1.tsv.gz';
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
 
 truncate uk_price_paid;


### PR DESCRIPTION
On macOS zcat expects the file to end in .Z appending that extension
when the supplied filename does not have it. Leading to the following
error for the dist_copy_long test:

zcat: can't stat: data/prices-10k-random-1.tsv.gz
(data/prices-10k-random-1.tsv.gz.Z): No such file or directory

This patch changes the dist_copy_long test to use the shell to read
the file instead and use input redirection so zcat never sees the
filename.