### PR TITLE
Remove unused function and macro

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -227,7 +227,6 @@ extern ScanIterator ts_chunk_scan_iterator_create(MemoryContext result_mcxt);
 extern void ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id);
 extern bool ts_chunk_lock_if_exists(Oid chunk_oid, LOCKMODE chunk_lockmode);
 extern int ts_chunk_oid_cmp(const void *p1, const void *p2);
-extern void ts_chunk_add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht);
 
 #define chunk_get_by_name(schema_name, table_name, fail_if_not_found)                              \
 	ts_chunk_get_by_name_with_memory_context(schema_name,                                          \
@@ -243,7 +242,5 @@ extern void ts_chunk_add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht
 	 ((chunk)->relkind == RELKIND_RELATION || ((chunk)->relkind == RELKIND_FOREIGN_TABLE)))
 
 #define ASSERT_IS_VALID_CHUNK(chunk) Assert(IS_VALID_CHUNK(chunk))
-
-#define ASSERT_IS_NULL_OR_VALID_CHUNK(chunk) Assert(chunk == NULL || IS_VALID_CHUNK(chunk))
 
 #endif /* TIMESCALEDB_CHUNK_H */


### PR DESCRIPTION
This patch removes ts_chunk_add_foreign_table_as_chunk function
never had an implementation added and the ASSERT_IS_NULL_OR_VALID_CHUNK
macro which has no user.