### PR TITLE
Add hypertable distributed argument and defaults 

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -20,8 +20,9 @@
 -- chunk_target_size - (Optional) The target size for chunks (e.g., '1000MB', 'estimate', or 'off')
 -- chunk_sizing_func - (Optional) A function to calculate the chunk time interval for new chunks
 -- time_partitioning_func - (Optional) The partitioning function to use for "time" partitioning
--- replication_factor - (Optional) A value of 1 or greater makes this hypertable distributed
+-- replication_factor - (Optional) Set replication_factor to use with the new hypertable
 -- data_nodes - (Optional) The specific data nodes to distribute this hypertable across
+-- distributed - (Optional) Create distributed hypertable
 CREATE OR REPLACE FUNCTION @extschema@.create_hypertable(
     relation                REGCLASS,
     time_column_name        NAME,
@@ -38,10 +39,10 @@ CREATE OR REPLACE FUNCTION @extschema@.create_hypertable(
     chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc,
     time_partitioning_func  REGPROC = NULL,
     replication_factor      INTEGER = NULL,
-    data_nodes              NAME[] = NULL
+    data_nodes              NAME[] = NULL,
+    distributed             BOOLEAN = NULL
 ) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create' LANGUAGE C VOLATILE;
 
--- Same functionality as create_hypertable, only must have a replication factor > 0 (defaults to 1)
 CREATE OR REPLACE FUNCTION @extschema@.create_distributed_hypertable(
     relation                REGCLASS,
     time_column_name        NAME,
@@ -57,7 +58,7 @@ CREATE OR REPLACE FUNCTION @extschema@.create_distributed_hypertable(
     chunk_target_size       TEXT = NULL,
     chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc,
     time_partitioning_func  REGPROC = NULL,
-    replication_factor      INTEGER = 1,
+    replication_factor      INTEGER = NULL,
     data_nodes              NAME[] = NULL
 ) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_distributed_create' LANGUAGE C VOLATILE;
 

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -268,3 +268,44 @@ ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_agg_migra
 DROP TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step;
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_agg_migrate_plan;
 DROP TABLE _timescaledb_catalog.continuous_agg_migrate_plan;
+
+DROP FUNCTION IF EXISTS @extschema@.create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc,integer,name[],boolean);
+DROP FUNCTION IF EXISTS @extschema@.create_distributed_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc,integer,name[]);
+
+CREATE FUNCTION @extschema@.create_hypertable(
+    relation                REGCLASS,
+    time_column_name        NAME,
+    partitioning_column     NAME = NULL,
+    number_partitions       INTEGER = NULL,
+    associated_schema_name  NAME = NULL,
+    associated_table_prefix NAME = NULL,
+    chunk_time_interval     ANYELEMENT = NULL::bigint,
+    create_default_indexes  BOOLEAN = TRUE,
+    if_not_exists           BOOLEAN = FALSE,
+    partitioning_func       REGPROC = NULL,
+    migrate_data            BOOLEAN = FALSE,
+    chunk_target_size       TEXT = NULL,
+    chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc,
+    time_partitioning_func  REGPROC = NULL,
+    replication_factor      INTEGER = NULL,
+    data_nodes              NAME[] = NULL
+) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_create' LANGUAGE C VOLATILE;
+
+CREATE FUNCTION @extschema@.create_distributed_hypertable(
+    relation                REGCLASS,
+    time_column_name        NAME,
+    partitioning_column     NAME = NULL,
+    number_partitions       INTEGER = NULL,
+    associated_schema_name  NAME = NULL,
+    associated_table_prefix NAME = NULL,
+    chunk_time_interval     ANYELEMENT = NULL::bigint,
+    create_default_indexes  BOOLEAN = TRUE,
+    if_not_exists           BOOLEAN = FALSE,
+    partitioning_func       REGPROC = NULL,
+    migrate_data            BOOLEAN = FALSE,
+    chunk_target_size       TEXT = NULL,
+    chunk_sizing_func       REGPROC = '_timescaledb_internal.calculate_chunk_interval'::regproc,
+    time_partitioning_func  REGPROC = NULL,
+    replication_factor      INTEGER = 1,
+    data_nodes              NAME[] = NULL
+) RETURNS TABLE(hypertable_id INT, schema_name NAME, table_name NAME, created BOOL) AS '@MODULE_PATHNAME@', 'ts_hypertable_distributed_create' LANGUAGE C VOLATILE;

--- a/src/guc.c
+++ b/src/guc.c
@@ -55,6 +55,13 @@ static const struct config_enum_entry remote_data_fetchers[] = {
 	{ NULL, 0, false }
 };
 
+static const struct config_enum_entry hypertable_distributed_types[] = {
+	{ "auto", HYPERTABLE_DIST_AUTO, false },
+	{ "local", HYPERTABLE_DIST_LOCAL, false },
+	{ "distributed", HYPERTABLE_DIST_DISTRIBUTED, false },
+	{ NULL, 0, false }
+};
+
 bool ts_guc_enable_optimizations = true;
 bool ts_guc_restoring = false;
 bool ts_guc_enable_constraint_aware_append = true;
@@ -88,6 +95,8 @@ TSDLLEXPORT char *ts_guc_ssl_dir = NULL;
 TSDLLEXPORT char *ts_guc_passfile = NULL;
 TSDLLEXPORT bool ts_guc_enable_remote_explain = false;
 TSDLLEXPORT DataFetcherType ts_guc_remote_data_fetcher = AutoFetcherType;
+TSDLLEXPORT HypertableDistType ts_guc_hypertable_distributed_default = HYPERTABLE_DIST_AUTO;
+TSDLLEXPORT int ts_guc_hypertable_replication_factor_default = 1;
 
 #ifdef TS_DEBUG
 bool ts_shutdown_bgw = false;
@@ -486,6 +495,33 @@ _guc_init(void)
 							   /* assign_hook= */ NULL,
 							   /* show_hook= */ NULL);
 #endif
+
+	DefineCustomEnumVariable("timescaledb.hypertable_distributed_default",
+							 "Set distributed hypertables default creation policy",
+							 "Set default policy to create local or distributed hypertables "
+							 "(auto, local or distributed)",
+							 (int *) &ts_guc_hypertable_distributed_default,
+							 HYPERTABLE_DIST_AUTO,
+							 hypertable_distributed_types,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomIntVariable("timescaledb.hypertable_replication_factor_default",
+							"Default replication factor value to use with a hypertables",
+							"Global default value for replication factor to use with hypertables "
+							"when the `replication_factor` argument is not provided",
+							&ts_guc_hypertable_replication_factor_default,
+							1,
+							1,
+							65536,
+							PGC_USERSET,
+							0,
+							NULL,
+							NULL,
+							NULL);
 }
 
 void

--- a/src/guc.h
+++ b/src/guc.h
@@ -56,6 +56,16 @@ typedef enum DataFetcherType
 
 extern TSDLLEXPORT DataFetcherType ts_guc_remote_data_fetcher;
 
+typedef enum HypertableDistType
+{
+	HYPERTABLE_DIST_AUTO,
+	HYPERTABLE_DIST_LOCAL,
+	HYPERTABLE_DIST_DISTRIBUTED
+} HypertableDistType;
+
+extern TSDLLEXPORT HypertableDistType ts_guc_hypertable_distributed_default;
+extern TSDLLEXPORT int ts_guc_hypertable_replication_factor_default;
+
 #ifdef TS_DEBUG
 extern bool ts_shutdown_bgw;
 extern char *ts_current_timestamp_mock;

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -162,9 +162,6 @@ extern TSDLLEXPORT List *ts_hypertable_get_available_data_node_server_oids(const
 extern TSDLLEXPORT HypertableType ts_hypertable_get_type(const Hypertable *ht);
 extern TSDLLEXPORT void ts_hypertable_func_call_on_data_nodes(const Hypertable *ht,
 															  FunctionCallInfo fcinfo);
-extern TSDLLEXPORT int16 ts_validate_replication_factor(int32 replication_factor, bool is_null,
-														bool is_dist_call, int num_data_nodes,
-														const char *hypertable_name);
 extern TSDLLEXPORT Datum ts_hypertable_get_open_dim_max_value(const Hypertable *ht,
 															  int dimension_index, bool *isnull);
 
@@ -173,6 +170,9 @@ extern TSDLLEXPORT void ts_hypertable_formdata_fill(FormData_hypertable *fd, con
 extern TSDLLEXPORT void ts_hypertable_scan_by_name(ScanIterator *iterator, const char *schema,
 												   const char *name);
 extern TSDLLEXPORT bool ts_hypertable_update_dimension_partitions(const Hypertable *ht);
+extern TSDLLEXPORT int16 ts_validate_replication_factor(const char *hypertable_name,
+														int32 replication_factor,
+														int num_data_nodes);
 
 #define hypertable_scan(schema, table, tuple_found, data, lockmode, tuplock)                       \
 	ts_hypertable_scan_with_memory_context(schema,                                                 \

--- a/tsl/src/hypertable.c
+++ b/tsl/src/hypertable.c
@@ -230,11 +230,9 @@ static void
 update_replication_factor(Hypertable *const ht, const int32 replication_factor_in)
 {
 	const int16 replication_factor =
-		ts_validate_replication_factor(replication_factor_in,
-									   false,
-									   true,
-									   list_length(ht->data_nodes),
-									   get_rel_name(ht->main_table_relid));
+		ts_validate_replication_factor(get_rel_name(ht->main_table_relid),
+									   replication_factor_in,
+									   list_length(ht->data_nodes));
 
 	ht->fd.replication_factor = replication_factor;
 	ts_hypertable_update(ht);

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -2544,6 +2544,246 @@ NOTICE:  adding not-null constraint to column "time"
 INSERT INTO hyper SELECT t, ceil((random() * 5))::int, random() * 80
 FROM generate_series('2019-01-01'::timestamptz, '2019-01-05'::timestamptz, '1 minute') as t;
 ANALYZE hyper;
+--
+-- Test hypertable distributed defaults
+--
+SHOW timescaledb.hypertable_distributed_default;
+ timescaledb.hypertable_distributed_default 
+--------------------------------------------
+ auto
+(1 row)
+
+SHOW timescaledb.hypertable_replication_factor_default;
+ timescaledb.hypertable_replication_factor_default 
+---------------------------------------------------
+ 1
+(1 row)
+
+/* CASE1: create_hypertable(distributed, replication_factor) */
+-- defaults are not applied
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('drf_test', 'time', distributed=>false, replication_factor=>1);
+ERROR:  local hypertables cannot set replication_factor
+\set ON_ERROR_STOP 1
+SELECT create_hypertable('drf_test', 'time', distributed=>true, replication_factor=>1);
+   create_hypertable    
+------------------------
+ (21,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  1
+(1 row)
+
+DROP TABLE drf_test;
+/* CASE2: create_hypertable(distributed) */
+-- auto
+SET timescaledb.hypertable_distributed_default TO 'auto';
+-- create regular hypertable by default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>false);
+   create_hypertable    
+------------------------
+ (22,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ f              |                   
+(1 row)
+
+DROP TABLE drf_test;
+-- create distributed hypertable using replication factor default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>true);
+   create_hypertable    
+------------------------
+ (23,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  1
+(1 row)
+
+DROP TABLE drf_test;
+-- distributed (same as auto)
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+-- create regular hypertable by default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>false);
+   create_hypertable    
+------------------------
+ (24,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ f              |                   
+(1 row)
+
+DROP TABLE drf_test;
+-- create distributed hypertable using replication factor default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>true);
+   create_hypertable    
+------------------------
+ (25,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  1
+(1 row)
+
+DROP TABLE drf_test;
+-- local
+SET timescaledb.hypertable_distributed_default TO 'local';
+-- unsupported
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>false);
+ERROR:  local hypertables cannot set replication_factor
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+-- create distributed hypertable using replication factor default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>true);
+   create_hypertable    
+------------------------
+ (26,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  1
+(1 row)
+
+DROP TABLE drf_test;
+/* CASE3: create_hypertable(replication_factor) */
+-- auto
+SET timescaledb.hypertable_distributed_default TO 'auto';
+-- create distributed hypertable when replication_factor > 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=>2);
+   create_hypertable    
+------------------------
+ (27,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  2
+(1 row)
+
+DROP TABLE drf_test;
+-- distributed
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+-- create distributed hypertable
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=>2);
+   create_hypertable    
+------------------------
+ (28,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  2
+(1 row)
+
+DROP TABLE drf_test;
+-- local
+SET timescaledb.hypertable_distributed_default TO 'local';
+-- unsupported
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=>2);
+ERROR:  local hypertables cannot set replication_factor
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+-- distributed hypertable member: replication_factor=>-1
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=> -1);
+ERROR:  local hypertables cannot set replication_factor
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+/* CASE4: create_hypertable() */
+-- auto
+SET timescaledb.hypertable_distributed_default TO 'auto';
+-- regular by default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time');
+   create_hypertable    
+------------------------
+ (29,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ f              |                   
+(1 row)
+
+DROP TABLE drf_test;
+-- distributed
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+-- distributed hypertable with using default replication factor
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time');
+   create_hypertable    
+------------------------
+ (30,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  1
+(1 row)
+
+DROP TABLE drf_test;
+-- local
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+-- unsupported
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time');
+   create_hypertable    
+------------------------
+ (31,public,drf_test,t)
+(1 row)
+
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+/* CASE5: create_distributed_hypertable() default replication factor */
+SET timescaledb.hypertable_distributed_default TO 'auto';
+SET timescaledb.hypertable_replication_factor_default TO 3;
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_distributed_hypertable('drf_test', 'time');
+ create_distributed_hypertable 
+-------------------------------
+ (32,public,drf_test,t)
+(1 row)
+
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+ is_distributed | replication_factor 
+----------------+--------------------
+ t              |                  3
+(1 row)
+
+DROP TABLE drf_test;
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :MY_DB1;

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -162,7 +162,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  compress_chunk(regclass,boolean)
  create_distributed_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc,integer,name[])
  create_distributed_restore_point(text)
- create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc,integer,name[])
+ create_hypertable(regclass,name,name,integer,name,name,anyelement,boolean,boolean,regproc,boolean,text,regproc,regproc,integer,name[],boolean)
  decompress_chunk(regclass,boolean)
  delete_data_node(name,boolean,boolean,boolean,boolean)
  delete_job(integer)

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -728,6 +728,147 @@ INSERT INTO hyper SELECT t, ceil((random() * 5))::int, random() * 80
 FROM generate_series('2019-01-01'::timestamptz, '2019-01-05'::timestamptz, '1 minute') as t;
 ANALYZE hyper;
 
+--
+-- Test hypertable distributed defaults
+--
+SHOW timescaledb.hypertable_distributed_default;
+SHOW timescaledb.hypertable_replication_factor_default;
+
+/* CASE1: create_hypertable(distributed, replication_factor) */
+
+-- defaults are not applied
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+\set ON_ERROR_STOP 0
+SELECT create_hypertable('drf_test', 'time', distributed=>false, replication_factor=>1);
+\set ON_ERROR_STOP 1
+SELECT create_hypertable('drf_test', 'time', distributed=>true, replication_factor=>1);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+/* CASE2: create_hypertable(distributed) */
+
+-- auto
+SET timescaledb.hypertable_distributed_default TO 'auto';
+
+-- create regular hypertable by default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>false);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- create distributed hypertable using replication factor default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>true);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- distributed (same as auto)
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+
+-- create regular hypertable by default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>false);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- create distributed hypertable using replication factor default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>true);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- local
+SET timescaledb.hypertable_distributed_default TO 'local';
+
+-- unsupported
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>false);
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+
+-- create distributed hypertable using replication factor default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', distributed=>true);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+/* CASE3: create_hypertable(replication_factor) */
+
+-- auto
+SET timescaledb.hypertable_distributed_default TO 'auto';
+
+-- create distributed hypertable when replication_factor > 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=>2);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- distributed
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+
+-- create distributed hypertable
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=>2);
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- local
+SET timescaledb.hypertable_distributed_default TO 'local';
+
+-- unsupported
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=>2);
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+
+-- distributed hypertable member: replication_factor=>-1
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time', replication_factor=> -1);
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+
+/* CASE4: create_hypertable() */
+
+-- auto
+SET timescaledb.hypertable_distributed_default TO 'auto';
+
+-- regular by default
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time');
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- distributed
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+
+-- distributed hypertable with using default replication factor
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time');
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
+-- local
+SET timescaledb.hypertable_distributed_default TO 'distributed';
+
+-- unsupported
+\set ON_ERROR_STOP 0
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_hypertable('drf_test', 'time');
+DROP TABLE drf_test;
+\set ON_ERROR_STOP 1
+
+/* CASE5: create_distributed_hypertable() default replication factor */
+SET timescaledb.hypertable_distributed_default TO 'auto';
+SET timescaledb.hypertable_replication_factor_default TO 3;
+
+CREATE TABLE drf_test(time TIMESTAMPTZ NOT NULL);
+SELECT create_distributed_hypertable('drf_test', 'time');
+SELECT is_distributed, replication_factor FROM timescaledb_information.hypertables WHERE hypertable_name = 'drf_test';
+DROP TABLE drf_test;
+
 -- cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :MY_DB1;


### PR DESCRIPTION
This PR introduces a new `distributed` argument to the
create_hypertable() function as well as two new GUC's to
control its default behaviour: timescaledb.hypertable_distributed_default
and timescaledb.hypertable_replication_factor_default.

The main idea of this change is to allow automatic creation
of the distributed hypertables by default.