### PR TITLE
Trigger bug board assignment on issue comment

### DIFF
--- a/.github/workflows/procedural.yaml
+++ b/.github/workflows/procedural.yaml
@@ -3,6 +3,8 @@ name: Add bugs to bugs project
 on:
   issues:
     types: [ opened, labeled ]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   add-to-project:


### PR DESCRIPTION
So far, issues were added to the bug board when they are labeled;
issues that are not on the board and receive a response were not
automatically added. This patch extends the workflow trigger; all
bug issues that receive a response are also assigned to the board.