### PR TITLE
Add a generic memory leak test to CI

### DIFF
--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -54,9 +54,13 @@ jobs:
         sudo systemctl start postgresql@${{ matrix.pg }}-main.service
         sudo -u postgres psql -X -c "CREATE USER runner SUPERUSER LOGIN;"
 
-    - name: Run memory test
+    - name: Run insert memory test
       run: |
         sudo -u postgres python ./scripts/test_memory_spikes.py & sleep 5 && psql -d postgres -v ECHO=all -X -f scripts/out_of_order_random_direct.sql
+
+    - name: Run generic memory test
+      run: |
+        sudo -u postgres python ./scripts/test_memory_spikes.py & sleep 5 && psql -d postgres -v ECHO=all -X -f scripts/memory_leaks.sql
 
     - name: Postgres log
       if: always()

--- a/scripts/memory_leaks.sql
+++ b/scripts/memory_leaks.sql
@@ -1,0 +1,33 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+DROP DATABASE IF EXISTS test;
+CREATE DATABASE test;
+\c test
+\timing
+
+DROP EXTENSION IF EXISTS timescaledb CASCADE;
+CREATE EXTENSION timescaledb;
+
+SELECT pg_backend_pid();
+SELECT pg_sleep(5);
+
+CREATE TABLE metrics(time timestamptz, device text, value float);
+SELECT create_hypertable('metrics', 'time');
+
+INSERT INTO metrics SELECT '2020-01-01'::timestamptz + format('%ss',time)::interval, format('Device %s',time%10), random() FROM generate_series(1,1000000) g(time);
+
+
+\o /dev/null
+\set ECHO none
+\timing off
+\echo Starting 1 million SELECT queries
+SELECT format($$SELECT * FROM metrics WHERE device = 'Device %s' ORDER BY time DESC LIMIT 1;$$,time % 10) FROM generate_series(1,1000000) g(time) \gexec
+
+\echo Starting 10k UPDATE queries
+SELECT format($$UPDATE metrics SET value = %s WHERE time < '2020-01-02' AND device = 'Device %s';$$,time,time % 10) FROM generate_series(1,10000) g(time) \gexec
+
+\echo Starting 50k INSERTs with batches of 1000
+SELECT format($$INSERT INTO metrics SELECT '2021-01-01'::timestamptz + '%ss'::interval + format('%%s', time)::interval, format('Device %%s',time %% 10), random() FROM generate_series(1,1000) g(time);$$,time) FROM generate_series(1,50000) g(time) \gexec
+

--- a/scripts/test_memory_spikes.py
+++ b/scripts/test_memory_spikes.py
@@ -4,8 +4,7 @@
 #  Please see the included NOTICE for copyright information and
 #  LICENSE-APACHE for a copy of the license.
 
-# Python script to check if there are memory spikes when running
-# out of order random inserts to TimescaleDB database
+# Python script to check if there are memory spikes when running queries
 import psutil
 import time
 import sys
@@ -13,7 +12,7 @@ from datetime import datetime
 
 DEFAULT_MEMCAP = 300 # in MB
 THRESHOLD_RATIO = 1.5 # ratio above which considered memory spike
-WAIT_TO_STABILIZE = 30 # wait in seconds before considering memory stable
+WAIT_TO_STABILIZE = 15 # wait in seconds before considering memory stable
 CHECK_INTERVAL = 15
 DEBUG = False
 
@@ -63,7 +62,7 @@ def find_new_process():
     process_count = len(base_process)
 
     print("Waiting {} seconds for process running inserts to start".format(WAIT_TO_STABILIZE), flush=True)
-    time.sleep(WAIT_TO_STABILIZE) # wait 30 seconds to get process that runs the inserts
+    time.sleep(WAIT_TO_STABILIZE) # wait WAIT_TO_STABILIZE seconds to get process that runs the inserts
 
     # continuously check for creation of new postgres process
     timeout = time.time() + 60
@@ -95,7 +94,7 @@ def main():
     pid = find_new_process()
     p = psutil.Process(pid)
     print('*** Check this pid is the same as "pg_backend_pid" from SQL command ***')
-    print('New process running random inserts:', pid)
+    print('New process backend process:', pid)
 
     print('Waiting {} seconds for memory consumption to stabilize'.format(WAIT_TO_STABILIZE), flush=True)
     time.sleep(WAIT_TO_STABILIZE)
@@ -138,7 +137,7 @@ def main():
             sys.exit(4)
         time.sleep(CHECK_INTERVAL)
 
-    print('No memory errors detected with out of order random inserts', flush=True)
+    print('No memory leaks detected', flush=True)
     sys.exit(0) # success
 
 if __name__ == '__main__':


### PR DESCRIPTION
Unlike the existing memory leak test which tests a single INSERT
of 100.000.000 rows in a single transaction, this runs 1000000
SELECT, 10K UPDATE and 10K INSERT queries in the same backend.