### PR TITLE
Fix dump_meta_data for windows

### DIFF
--- a/scripts/dump_meta_data.sql
+++ b/scripts/dump_meta_data.sql
@@ -12,7 +12,7 @@
 \echo '<exclude_from_test>'
 \echo 'Date, git commit, and extension version can change without it being an error.'
 \echo 'Adding this tag allows us to run regression tests on this script file.'
-\echo `date`
+select now();
 \echo 'Postgres version'
 select version();
 


### PR DESCRIPTION
The dump_meta_data sql script used an external call to date to get
the current data which does not work on windows. This patch changes
the script to use now() instead to get the current time and date.

Fixes #3674