### PR TITLE
Fix timescaledb_post_restore GUC handling

### DIFF
--- a/sql/restoring.sql
+++ b/sql/restoring.sql
@@ -26,7 +26,8 @@ DECLARE
 BEGIN
     SELECT current_database() INTO db;
     EXECUTE format($$ALTER DATABASE %I RESET timescaledb.restoring $$, db);
-    RESET timescaledb.restoring;
+    -- we cannot use reset here because the reset_val might not be off
+    SET timescaledb.restoring TO off;
     PERFORM _timescaledb_internal.restart_background_workers();
 
     --try to restore the backed up uuid, if the restore did not set one

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -297,6 +297,14 @@ SHOW timescaledb.restoring;
  on
 (1 row)
 
+-- reconnect and check GUC value in new session
+\c
+SHOW timescaledb.restoring;
+ timescaledb.restoring 
+-----------------------
+ on
+(1 row)
+
 \! utils/pg_dump_aux_restore.sh dump/pg_dump.sql
 -- Inserting with restoring ON in current session causes tuples to be
 -- inserted on main table, but this should be protected by the insert

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -100,6 +100,9 @@ UPDATE _timescaledb_config.bgw_job SET scheduled = false;
 RESET client_min_messages;
 SELECT timescaledb_pre_restore();
 SHOW timescaledb.restoring;
+-- reconnect and check GUC value in new session
+\c
+SHOW timescaledb.restoring;
 
 \! utils/pg_dump_aux_restore.sh dump/pg_dump.sql
 


### PR DESCRIPTION
In the session timescaledb_post_restore() was called the value for
timescaledb.restoring might not be changed because the reset_val
for the GUC was still on. We have to use explicit SET in this
session to adjust the GUC.

Fixes #4267 