### PR TITLE
Add runtime exclusion for ANY using subselect

### DIFF
--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -114,10 +114,25 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 		{
 			ListCell *lc_var;
 
-			/*
-			 * check the param references a partitioning column of the hypertable
-			 * otherwise we skip runtime exclusion
+			/* We have two types of exclusion:
+			 *
+			 * Parent exclusion fires if the entire hypertable can be excluded.
+			 * This happens if doing things like joining against a parameter
+			 * value that is an empty array or NULL. It doesn't happen often,
+			 * but when it does, it speeds up the query immensely. It's also cheap
+			 * to check for this condition as you check this once per hypertable
+			 * at runtime.
+			 *
+			 * Child exclusion works by seeing if there is a contradiction between
+			 * the chunks constraints and the expression on parameter values. For example,
+			 * it can evaluate whether a time parameter from a subquery falls outside
+			 * the range of the chunk. It is more widely applicable than the parent
+			 * exclusion but is also more expensive to evaluate since you have to perform
+			 * the check on every chunk. Child exclusion can only apply if one of the quals
+			 * involves a partitioning column.
+			 *
 			 */
+			path->runtime_exclusion_parent = true;
 			foreach (lc_var, pull_var_clause((Node *) rinfo->clause, 0))
 			{
 				Var *var = lfirst(lc_var);
@@ -130,12 +145,22 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 				if (var->varno == rel->relid && var->varattno > 0 &&
 					ts_is_partitioning_column(ht, var->varattno))
 				{
-					path->runtime_exclusion = true;
+					path->runtime_exclusion_children = true;
 					break;
 				}
 			}
 		}
 	}
+	/*
+	 * Our strategy is to use child exclusion if possible (if a partitioning
+	 * column is used) and fall back to parent exclusion if we can't use child
+	 * exclusion. Please note: there is no point to using both child and parent
+	 * exclusion at the same time since child exclusion would always exclude
+	 * the same chunks that parent exclusion would.
+	 */
+
+	if (path->runtime_exclusion_parent && path->runtime_exclusion_children)
+		path->runtime_exclusion_parent = false;
 
 	/*
 	 * Make sure our subpath is either an Append or MergeAppend node
@@ -253,7 +278,8 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 		if (!has_scan_childs)
 		{
 			path->startup_exclusion = false;
-			path->runtime_exclusion = false;
+			path->runtime_exclusion_parent = false;
+			path->runtime_exclusion_children = false;
 		}
 
 		path->cpath.custom_paths = nested_children;

--- a/src/nodes/chunk_append/chunk_append.h
+++ b/src/nodes/chunk_append/chunk_append.h
@@ -15,7 +15,8 @@ typedef struct ChunkAppendPath
 {
 	CustomPath cpath;
 	bool startup_exclusion;
-	bool runtime_exclusion;
+	bool runtime_exclusion_parent;
+	bool runtime_exclusion_children;
 	bool pushdown_limit;
 	int limit_tuples;
 	int first_partial_path;

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -52,7 +52,8 @@ typedef struct ChunkAppendState
 
 	Oid ht_reloid;
 	bool startup_exclusion;
-	bool runtime_exclusion;
+	bool runtime_exclusion_parent;
+	bool runtime_exclusion_children;
 	bool runtime_initialized;
 	uint32 limit;
 
@@ -62,6 +63,8 @@ typedef struct ChunkAppendState
 	List *initial_constraints;
 	/* list of restrictinfo clauses indexed like initial_subplans */
 	List *initial_ri_clauses;
+	/* List of restrictinfo clauses on the parent hypertable */
+	List *initial_parent_clauses;
 
 	/* list of subplans after startup exclusion */
 	List *filtered_subplans;
@@ -79,7 +82,8 @@ typedef struct ChunkAppendState
 
 	/* number of loops and exclusions for EXPLAIN */
 	int runtime_number_loops;
-	int runtime_number_exclusions;
+	int runtime_number_exclusions_parent;
+	int runtime_number_exclusions_children;
 
 	LWLock *lock;
 	ParallelContext *pcxt;
@@ -140,11 +144,13 @@ ts_chunk_append_state_create(CustomScan *cscan)
 	state->initial_subplans = cscan->custom_plans;
 	state->initial_ri_clauses = lsecond(cscan->custom_private);
 	state->sort_options = lfourth(cscan->custom_private);
+	state->initial_parent_clauses = lfirst(list_nth_cell(cscan->custom_private, 4));
 
 	state->startup_exclusion = (bool) linitial_int(settings);
-	state->runtime_exclusion = (bool) lsecond_int(settings);
-	state->limit = lthird_int(settings);
-	state->first_partial_plan = lfourth_int(settings);
+	state->runtime_exclusion_parent = (bool) lsecond_int(settings);
+	state->runtime_exclusion_children = (bool) lthird_int(settings);
+	state->limit = lfourth_int(settings);
+	state->first_partial_plan = lfirst_int(list_nth_cell(settings, 4));
 
 	state->filtered_subplans = state->initial_subplans;
 	state->filtered_ri_clauses = state->initial_ri_clauses;
@@ -225,10 +231,10 @@ do_startup_exclusion(ChunkAppendState *state)
 			}
 
 			/*
-			 * if this node does runtime exclusion we keep the constified
+			 * if this node does runtime exclusion on the children we keep the constified
 			 * expressions to save us some work during runtime exclusion
 			 */
-			if (state->runtime_exclusion)
+			if (state->runtime_exclusion_children)
 			{
 				List *const_ri_clauses = NIL;
 				foreach (lc, restrictinfos)
@@ -319,7 +325,7 @@ chunk_append_begin(CustomScanState *node, EState *estate, int eflags)
 		i++;
 	}
 
-	if (state->runtime_exclusion)
+	if (state->runtime_exclusion_parent || state->runtime_exclusion_children)
 	{
 		state->params = state->subplanstates[0]->plan->allParam;
 		/*
@@ -327,6 +333,30 @@ chunk_append_begin(CustomScanState *node, EState *estate, int eflags)
 		 */
 		node->ss.ps.chgParam = bms_copy(state->subplanstates[0]->plan->allParam);
 	}
+}
+
+static bool
+can_exclude_constraints_using_clauses(ChunkAppendState *state, List *constraints, List *clauses,
+									  PlannerInfo root, PlanState *ps)
+{
+	bool can_exclude;
+	ListCell *lc;
+	MemoryContext old = MemoryContextSwitchTo(state->exclusion_ctx);
+	List *restrictinfos = NIL;
+
+	foreach (lc, clauses)
+	{
+		RestrictInfo *ri = makeNode(RestrictInfo);
+		ri->clause = lfirst(lc);
+		restrictinfos = lappend(restrictinfos, ri);
+	}
+	restrictinfos = constify_restrictinfo_params(&root, ps->state, restrictinfos);
+
+	can_exclude = can_exclude_chunk(constraints, restrictinfos);
+
+	MemoryContextReset(state->exclusion_ctx);
+	MemoryContextSwitchTo(old);
+	return can_exclude;
 }
 
 /*
@@ -345,18 +375,47 @@ initialize_runtime_exclusion(ChunkAppendState *state)
 		.glob = &glob,
 	};
 
+	state->runtime_initialized = true;
+
+	if (state->num_subplans == 0)
+	{
+		return;
+	}
+
+	state->runtime_number_loops++;
+
+	if (state->runtime_exclusion_parent)
+	{
+		/* try to exclude all the chunks using the parents clauses.
+		 * here, all constraints are true but exclusion can still
+		 * happen because of things like ANY(empty set), and NULL
+		 * inference
+		 */
+		if (can_exclude_constraints_using_clauses(state,
+												  list_make1(makeBoolConst(true, false)),
+												  state->initial_parent_clauses,
+												  root,
+												  &state->csstate.ss.ps))
+		{
+			state->runtime_number_exclusions_parent++;
+			return;
+		}
+	}
+
+	if (!state->runtime_exclusion_children)
+	{
+		for (i = 0; i < state->num_subplans; i++)
+		{
+			state->valid_subplans = bms_add_member(state->valid_subplans, i);
+		}
+		return;
+	}
+
 	Assert(state->num_subplans == list_length(state->filtered_ri_clauses));
 
 	lc_clauses = list_head(state->filtered_ri_clauses);
 	lc_constraints = list_head(state->filtered_constraints);
 
-	if (state->num_subplans == 0)
-	{
-		state->runtime_initialized = true;
-		return;
-	}
-
-	state->runtime_number_loops++;
 	/*
 	 * mark subplans as active/inactive in valid_subplans
 	 */
@@ -364,8 +423,6 @@ initialize_runtime_exclusion(ChunkAppendState *state)
 	{
 		PlanState *ps = state->subplanstates[i];
 		Scan *scan = ts_chunk_append_get_scan_plan(ps->plan);
-		List *restrictinfos = NIL;
-		ListCell *lc;
 
 		if (scan == NULL || scan->scanrelid == 0)
 		{
@@ -373,33 +430,21 @@ initialize_runtime_exclusion(ChunkAppendState *state)
 		}
 		else
 		{
-			bool can_exclude;
-			MemoryContext old = MemoryContextSwitchTo(state->exclusion_ctx);
-
-			foreach (lc, lfirst(lc_clauses))
-			{
-				RestrictInfo *ri = makeNode(RestrictInfo);
-				ri->clause = lfirst(lc);
-				restrictinfos = lappend(restrictinfos, ri);
-			}
-			restrictinfos = constify_restrictinfo_params(&root, ps->state, restrictinfos);
-
-			can_exclude = can_exclude_chunk(lfirst(lc_constraints), restrictinfos);
-
-			MemoryContextReset(state->exclusion_ctx);
-			MemoryContextSwitchTo(old);
+			bool can_exclude = can_exclude_constraints_using_clauses(state,
+																	 lfirst(lc_constraints),
+																	 lfirst(lc_clauses),
+																	 root,
+																	 ps);
 
 			if (!can_exclude)
 				state->valid_subplans = bms_add_member(state->valid_subplans, i);
 			else
-				state->runtime_number_exclusions++;
+				state->runtime_number_exclusions_children++;
 		}
 
 		lc_clauses = lnext_compat(state->filtered_ri_clauses, lc_clauses);
 		lc_constraints = lnext_compat(state->filtered_constraints, lc_constraints);
 	}
-
-	state->runtime_initialized = true;
 }
 
 /*
@@ -464,7 +509,7 @@ get_next_subplan(ChunkAppendState *state, int last_plan)
 	if (last_plan == NO_MATCHING_SUBPLANS)
 		return NO_MATCHING_SUBPLANS;
 
-	if (state->runtime_exclusion)
+	if (state->runtime_exclusion_parent || state->runtime_exclusion_children)
 	{
 		if (!state->runtime_initialized)
 			initialize_runtime_exclusion(state);
@@ -611,7 +656,8 @@ chunk_append_rescan(CustomScanState *node)
 	/*
 	 * detect changed params and reset runtime exclusion state
 	 */
-	if (state->runtime_exclusion && bms_overlap(node->ss.ps.chgParam, state->params))
+	if ((state->runtime_exclusion_parent || state->runtime_exclusion_children) &&
+		bms_overlap(node->ss.ps.chgParam, state->params))
 	{
 		bms_free(state->valid_subplans);
 		state->valid_subplans = NULL;
@@ -786,6 +832,8 @@ constify_param_mutator(Node *node, void *context)
 			{
 				ExprContext *econtext = GetPerTupleExprContext(estate);
 				ExecSetParamPlan(prm.execPlan, econtext);
+				// reload prm as it may have been changed by ExecSetParamPlan call above.
+				prm = estate->es_param_exec_vals[param->paramid];
 			}
 
 			if (prm.execPlan == NULL)
@@ -1010,7 +1058,9 @@ chunk_append_explain(CustomScanState *node, List *ancestors, ExplainState *es)
 		ExplainPropertyBool("Startup Exclusion", state->startup_exclusion, es);
 
 	if (es->verbose || es->format != EXPLAIN_FORMAT_TEXT)
-		ExplainPropertyBool("Runtime Exclusion", state->runtime_exclusion, es);
+		ExplainPropertyBool("Runtime Exclusion",
+							(state->runtime_exclusion_parent || state->runtime_exclusion_children),
+							es);
 
 	if (state->startup_exclusion)
 		ExplainPropertyInteger("Chunks excluded during startup",
@@ -1018,9 +1068,15 @@ chunk_append_explain(CustomScanState *node, List *ancestors, ExplainState *es)
 							   list_length(state->initial_subplans) - list_length(node->custom_ps),
 							   es);
 
-	if (state->runtime_exclusion && state->runtime_number_loops > 0)
+	if (state->runtime_exclusion_parent && state->runtime_number_loops > 0)
 	{
-		int avg_excluded = state->runtime_number_exclusions / state->runtime_number_loops;
+		int avg_excluded = state->runtime_number_exclusions_parent / state->runtime_number_loops;
+		ExplainPropertyInteger("Hypertables excluded during runtime", NULL, avg_excluded, es);
+	}
+
+	if (state->runtime_exclusion_children && state->runtime_number_loops > 0)
+	{
+		int avg_excluded = state->runtime_number_exclusions_children / state->runtime_number_loops;
 		ExplainPropertyInteger("Chunks excluded during runtime", NULL, avg_excluded, es);
 	}
 }

--- a/test/expected/append-12.out
+++ b/test/expected/append-12.out
@@ -48,7 +48,7 @@ BEGIN
     RETURN '2017-08-22T10:00:00'::timestamptz;
 END;
 $BODY$;
-CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
+CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
 psql:include/append_load.sql:35: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
@@ -57,11 +57,11 @@ psql:include/append_load.sql:35: NOTICE:  adding not-null constraint to column "
 (1 row)
 
 -- create three chunks
-INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
-                               ('2017-03-22T09:18:23', 21.5, 1),
-                               ('2017-05-22T09:18:22', 36.2, 2),
-                               ('2017-05-22T09:18:23', 15.2, 2),
-                               ('2017-08-22T09:18:22', 34.1, 3);
+INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-03-22T09:18:23', 21.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
+                               ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
+                               ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
@@ -74,6 +74,11 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+-- Create another table to join with which is not a hypertable.
+CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
+INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
+                             ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
+                             ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
@@ -1753,6 +1758,7 @@ ORDER BY time DESC, device_id;
          ->  Limit (actual rows=1 loops=1)
                ->  Custom Scan (ChunkAppend) on join_test j (actual rows=1 loops=1)
                      Order: j."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1 (actual rows=0 loops=1)
                            Filter: (a.colorid = colorid)
                            Rows Removed by Filter: 1
@@ -1761,7 +1767,7 @@ ORDER BY time DESC, device_id;
                            Rows Removed by Filter: 1
                      ->  Index Scan using _hyper_2_4_chunk_join_test_time_idx on _hyper_2_4_chunk j_3 (actual rows=1 loops=1)
                            Filter: (a.colorid = colorid)
-(18 rows)
+(19 rows)
 
 -- test runtime exclusion with LATERAL and generate_series
 :PREFIX SELECT g.time FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g(time) LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m WHERE m.time=g.time LIMIT 1) m ON true;
@@ -2259,6 +2265,123 @@ ANALYZE i3030;
 
 DROP TABLE i3030;
 RESET enable_seqscan;
+--parent runtime exclusion tests:
+--optimization works with ANY (array)
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT coalesce(array_agg(attr), array[]::jsonb[]) FROM join_test_plain WHERE temp > 100)::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Aggregate (actual rows=1 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> ANY ($0))
+(13 rows)
+
+--optimization does not work for ANY subquery (does not force an initplan)
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT attr FROM join_test_plain WHERE temp > 100));
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Nested Loop Semi Join (actual rows=0 loops=1)
+   Join Filter: (a.attr @> join_test_plain.attr)
+   ->  Append (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk a (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk a_1 (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_1_3_chunk a_2 (actual rows=1 loops=1)
+   ->  Materialize (actual rows=0 loops=5)
+         ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+               Filter: (temp > '100'::double precision)
+               Rows Removed by Filter: 3
+(10 rows)
+
+--works on any strict operator without ANY
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> (SELECT attr FROM join_test_plain WHERE temp > 100 limit 1);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=0 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> $0)
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> $0)
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> $0)
+(13 rows)
+
+--optimization works with function calls
+CREATE OR REPLACE FUNCTION select_tag(_min_temp int)
+ RETURNS jsonb[]
+ LANGUAGE sql
+ STABLE PARALLEL SAFE
+AS $function$
+   SELECT coalesce(array_agg(attr), array[]::jsonb[])
+  FROM join_test_plain
+  WHERE temp > _min_temp
+$function$;
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT select_tag(100))::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> ANY ($0))
+(10 rows)
+
+--optimization does not work when result is null
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT array_agg(attr) FROM join_test_plain WHERE temp > 100)::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 0
+   InitPlan 1 (returns $0)
+     ->  Aggregate (actual rows=1 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 2
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 2
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 1
+(16 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results
@@ -2282,4 +2405,4 @@ RESET enable_seqscan;
 + timescaledb.enable_chunk_append  | off
  (2 rows)
  
-  time | temp | colorid 
+  time | temp | colorid | attr 

--- a/test/expected/append-13.out
+++ b/test/expected/append-13.out
@@ -48,7 +48,7 @@ BEGIN
     RETURN '2017-08-22T10:00:00'::timestamptz;
 END;
 $BODY$;
-CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
+CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
 psql:include/append_load.sql:35: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
@@ -57,11 +57,11 @@ psql:include/append_load.sql:35: NOTICE:  adding not-null constraint to column "
 (1 row)
 
 -- create three chunks
-INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
-                               ('2017-03-22T09:18:23', 21.5, 1),
-                               ('2017-05-22T09:18:22', 36.2, 2),
-                               ('2017-05-22T09:18:23', 15.2, 2),
-                               ('2017-08-22T09:18:22', 34.1, 3);
+INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-03-22T09:18:23', 21.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
+                               ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
+                               ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
@@ -74,6 +74,11 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+-- Create another table to join with which is not a hypertable.
+CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
+INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
+                             ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
+                             ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
@@ -1754,6 +1759,7 @@ ORDER BY time DESC, device_id;
          ->  Limit (actual rows=1 loops=1)
                ->  Custom Scan (ChunkAppend) on join_test j (actual rows=1 loops=1)
                      Order: j."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1 (actual rows=0 loops=1)
                            Filter: (a.colorid = colorid)
                            Rows Removed by Filter: 1
@@ -1762,7 +1768,7 @@ ORDER BY time DESC, device_id;
                            Rows Removed by Filter: 1
                      ->  Index Scan using _hyper_2_4_chunk_join_test_time_idx on _hyper_2_4_chunk j_3 (actual rows=1 loops=1)
                            Filter: (a.colorid = colorid)
-(18 rows)
+(19 rows)
 
 -- test runtime exclusion with LATERAL and generate_series
 :PREFIX SELECT g.time FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g(time) LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m WHERE m.time=g.time LIMIT 1) m ON true;
@@ -2260,6 +2266,123 @@ ANALYZE i3030;
 
 DROP TABLE i3030;
 RESET enable_seqscan;
+--parent runtime exclusion tests:
+--optimization works with ANY (array)
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT coalesce(array_agg(attr), array[]::jsonb[]) FROM join_test_plain WHERE temp > 100)::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Aggregate (actual rows=1 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> ANY ($0))
+(13 rows)
+
+--optimization does not work for ANY subquery (does not force an initplan)
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT attr FROM join_test_plain WHERE temp > 100));
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Nested Loop Semi Join (actual rows=0 loops=1)
+   Join Filter: (a_1.attr @> join_test_plain.attr)
+   ->  Append (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk a_1 (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk a_2 (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_1_3_chunk a_3 (actual rows=1 loops=1)
+   ->  Materialize (actual rows=0 loops=5)
+         ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+               Filter: (temp > '100'::double precision)
+               Rows Removed by Filter: 3
+(10 rows)
+
+--works on any strict operator without ANY
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> (SELECT attr FROM join_test_plain WHERE temp > 100 limit 1);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=0 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> $0)
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> $0)
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> $0)
+(13 rows)
+
+--optimization works with function calls
+CREATE OR REPLACE FUNCTION select_tag(_min_temp int)
+ RETURNS jsonb[]
+ LANGUAGE sql
+ STABLE PARALLEL SAFE
+AS $function$
+   SELECT coalesce(array_agg(attr), array[]::jsonb[])
+  FROM join_test_plain
+  WHERE temp > _min_temp
+$function$;
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT select_tag(100))::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> ANY ($0))
+(10 rows)
+
+--optimization does not work when result is null
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT array_agg(attr) FROM join_test_plain WHERE temp > 100)::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 0
+   InitPlan 1 (returns $0)
+     ->  Aggregate (actual rows=1 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 2
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 2
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 1
+(16 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results
@@ -2283,4 +2406,4 @@ RESET enable_seqscan;
 + timescaledb.enable_chunk_append  | off
  (2 rows)
  
-  time | temp | colorid 
+  time | temp | colorid | attr 

--- a/test/expected/append-14.out
+++ b/test/expected/append-14.out
@@ -48,7 +48,7 @@ BEGIN
     RETURN '2017-08-22T10:00:00'::timestamptz;
 END;
 $BODY$;
-CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
+CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
 psql:include/append_load.sql:35: NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
@@ -57,11 +57,11 @@ psql:include/append_load.sql:35: NOTICE:  adding not-null constraint to column "
 (1 row)
 
 -- create three chunks
-INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
-                               ('2017-03-22T09:18:23', 21.5, 1),
-                               ('2017-05-22T09:18:22', 36.2, 2),
-                               ('2017-05-22T09:18:23', 15.2, 2),
-                               ('2017-08-22T09:18:22', 34.1, 3);
+INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-03-22T09:18:23', 21.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
+                               ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
+                               ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
 SELECT create_hypertable('join_test', 'time', chunk_time_interval => 2628000000000);
@@ -74,6 +74,11 @@ psql:include/append_load.sql:46: NOTICE:  adding not-null constraint to column "
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+-- Create another table to join with which is not a hypertable.
+CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
+INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
+                             ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
+                             ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
 SELECT create_hypertable('metrics_date','time');
@@ -1754,6 +1759,7 @@ ORDER BY time DESC, device_id;
          ->  Limit (actual rows=1 loops=1)
                ->  Custom Scan (ChunkAppend) on join_test j (actual rows=1 loops=1)
                      Order: j."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Index Scan using _hyper_2_6_chunk_join_test_time_idx on _hyper_2_6_chunk j_1 (actual rows=0 loops=1)
                            Filter: (a.colorid = colorid)
                            Rows Removed by Filter: 1
@@ -1762,7 +1768,7 @@ ORDER BY time DESC, device_id;
                            Rows Removed by Filter: 1
                      ->  Index Scan using _hyper_2_4_chunk_join_test_time_idx on _hyper_2_4_chunk j_3 (actual rows=1 loops=1)
                            Filter: (a.colorid = colorid)
-(18 rows)
+(19 rows)
 
 -- test runtime exclusion with LATERAL and generate_series
 :PREFIX SELECT g.time FROM generate_series('2000-01-01'::timestamptz, '2000-02-01'::timestamptz, '1d'::interval) g(time) LEFT JOIN LATERAL(SELECT time FROM metrics_timestamptz m WHERE m.time=g.time LIMIT 1) m ON true;
@@ -2260,6 +2266,123 @@ ANALYZE i3030;
 
 DROP TABLE i3030;
 RESET enable_seqscan;
+--parent runtime exclusion tests:
+--optimization works with ANY (array)
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT coalesce(array_agg(attr), array[]::jsonb[]) FROM join_test_plain WHERE temp > 100)::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Aggregate (actual rows=1 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> ANY ($0))
+(13 rows)
+
+--optimization does not work for ANY subquery (does not force an initplan)
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT attr FROM join_test_plain WHERE temp > 100));
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Nested Loop Semi Join (actual rows=0 loops=1)
+   Join Filter: (a_1.attr @> join_test_plain.attr)
+   ->  Append (actual rows=5 loops=1)
+         ->  Seq Scan on _hyper_1_1_chunk a_1 (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_1_2_chunk a_2 (actual rows=2 loops=1)
+         ->  Seq Scan on _hyper_1_3_chunk a_3 (actual rows=1 loops=1)
+   ->  Materialize (actual rows=0 loops=5)
+         ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+               Filter: (temp > '100'::double precision)
+               Rows Removed by Filter: 3
+(10 rows)
+
+--works on any strict operator without ANY
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> (SELECT attr FROM join_test_plain WHERE temp > 100 limit 1);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Limit (actual rows=0 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> $0)
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> $0)
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> $0)
+(13 rows)
+
+--optimization works with function calls
+CREATE OR REPLACE FUNCTION select_tag(_min_temp int)
+ RETURNS jsonb[]
+ LANGUAGE sql
+ STABLE PARALLEL SAFE
+AS $function$
+   SELECT coalesce(array_agg(attr), array[]::jsonb[])
+  FROM join_test_plain
+  WHERE temp > _min_temp
+$function$;
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT select_tag(100))::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 1
+   InitPlan 1 (returns $0)
+     ->  Result (actual rows=1 loops=1)
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (never executed)
+         Filter: (attr @> ANY ($0))
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (never executed)
+         Filter: (attr @> ANY ($0))
+(10 rows)
+
+--optimization does not work when result is null
+:PREFIX
+SELECT *
+FROM append_test a
+WHERE a.attr @> ANY((SELECT array_agg(attr) FROM join_test_plain WHERE temp > 100)::jsonb[]);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on append_test a (actual rows=0 loops=1)
+   Hypertables excluded during runtime: 0
+   InitPlan 1 (returns $0)
+     ->  Aggregate (actual rows=1 loops=1)
+           ->  Seq Scan on join_test_plain (actual rows=0 loops=1)
+                 Filter: (temp > '100'::double precision)
+                 Rows Removed by Filter: 3
+   ->  Seq Scan on _hyper_1_1_chunk a_1 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 2
+   ->  Seq Scan on _hyper_1_2_chunk a_2 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 2
+   ->  Seq Scan on _hyper_1_3_chunk a_3 (actual rows=0 loops=1)
+         Filter: (attr @> ANY ($0))
+         Rows Removed by Filter: 1
+(16 rows)
+
 --generate the results into two different files
 \set ECHO errors
 --- Unoptimized results
@@ -2283,4 +2406,4 @@ RESET enable_seqscan;
 + timescaledb.enable_chunk_append  | off
  (2 rows)
  
-  time | temp | colorid 
+  time | temp | colorid | attr 

--- a/test/sql/include/append_load.sql
+++ b/test/sql/include/append_load.sql
@@ -31,15 +31,15 @@ BEGIN
 END;
 $BODY$;
 
-CREATE TABLE append_test(time timestamptz, temp float, colorid integer);
+CREATE TABLE append_test(time timestamptz, temp float, colorid integer, attr jsonb);
 SELECT create_hypertable('append_test', 'time', chunk_time_interval => 2628000000000);
 
 -- create three chunks
-INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1),
-                               ('2017-03-22T09:18:23', 21.5, 1),
-                               ('2017-05-22T09:18:22', 36.2, 2),
-                               ('2017-05-22T09:18:23', 15.2, 2),
-                               ('2017-08-22T09:18:22', 34.1, 3);
+INSERT INTO append_test VALUES ('2017-03-22T09:18:22', 23.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-03-22T09:18:23', 21.5, 1, '{"a": 1, "b": 2}'),
+                               ('2017-05-22T09:18:22', 36.2, 2, '{"c": 3, "b": 2}'),
+                               ('2017-05-22T09:18:23', 15.2, 2, '{"c": 3}'),
+                               ('2017-08-22T09:18:22', 34.1, 3, '{"c": 4}');
 
 -- Create another hypertable to join with
 CREATE TABLE join_test(time timestamptz, temp float, colorid integer);
@@ -48,6 +48,13 @@ SELECT create_hypertable('join_test', 'time', chunk_time_interval => 26280000000
 INSERT INTO join_test VALUES ('2017-01-22T09:18:22', 15.2, 1),
                              ('2017-02-22T09:18:22', 24.5, 2),
                              ('2017-08-22T09:18:22', 23.1, 3);
+
+-- Create another table to join with which is not a hypertable.
+CREATE TABLE join_test_plain(time timestamptz, temp float, colorid integer, attr jsonb);
+
+INSERT INTO join_test_plain VALUES ('2017-01-22T09:18:22', 15.2, 1, '{"a": 1}'),
+                             ('2017-02-22T09:18:22', 24.5, 2, '{"b": 2}'),
+                             ('2017-08-22T09:18:22', 23.1, 3, '{"c": 3}');
 
 -- create hypertable with DATE time dimension
 CREATE TABLE metrics_date(time DATE NOT NULL);
@@ -93,5 +100,4 @@ SELECT create_hypertable('i2661', 'timestamp');
 
 INSERT INTO i2661 SELECT 1, 'speed', generate_series('2019-12-31 00:00:00', '2020-01-10 00:00:00', '2m'::interval), 0;
 ANALYZE i2661;
-
 

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -6852,6 +6852,7 @@ ORDER BY c.id;
          ->  Limit (actual rows=0 loops=6840)
                ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
@@ -6873,7 +6874,7 @@ ORDER BY c.id;
                                  ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-(34 rows)
+(35 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -8122,6 +8122,7 @@ ORDER BY c.id;
          ->  Limit (actual rows=0 loops=6840)
                ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
@@ -8143,7 +8144,7 @@ ORDER BY c.id;
                                  ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-(34 rows)
+(35 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -8122,6 +8122,7 @@ ORDER BY c.id;
          ->  Limit (actual rows=0 loops=6840)
                ->  Custom Scan (ChunkAppend) on metrics_ordered m (actual rows=0 loops=6840)
                      Order: m."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
                            ->  Sort (actual rows=0 loops=6840)
                                  Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
@@ -8143,7 +8144,7 @@ ORDER BY c.id;
                                  ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
                                        Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                                        Rows Removed by Filter: 5
-(34 rows)
+(35 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -182,10 +182,11 @@ ORDER BY c.id;
          ->  Limit (actual rows=1 loops=4291)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
                      Order: m_1."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=1 loops=4291)
                            ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=1 loops=4291)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(11 rows)
+(12 rows)
 
 SET enable_seqscan = FALSE;
 \ir include/transparent_decompression_ordered_index.sql
@@ -326,6 +327,7 @@ WHERE extract(minute FROM d.time) = 0;
                ->  Limit (actual rows=0 loops=389)
                      ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                            Order: m_1."time" DESC
+                           Hypertables excluded during runtime: 0
                            ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
                                  ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
@@ -341,7 +343,7 @@ WHERE extract(minute FROM d.time) = 0;
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
                                  ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(47 rows)
+(48 rows)
 
 :PREFIX
 SELECT d.device_id,
@@ -386,6 +388,7 @@ WHERE extract(minute FROM d.time) = 0;
          ->  Limit (actual rows=0 loops=389)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                      Order: m_1."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
                            ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
@@ -401,7 +404,7 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
                            ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(43 rows)
+(44 rows)
 
 --github issue 1558
 SET enable_seqscan = FALSE;

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -182,10 +182,11 @@ ORDER BY c.id;
          ->  Limit (actual rows=1 loops=4291)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
                      Order: m_1."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=1 loops=4291)
                            ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=1 loops=4291)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(11 rows)
+(12 rows)
 
 SET enable_seqscan = FALSE;
 \ir include/transparent_decompression_ordered_index.sql
@@ -326,6 +327,7 @@ WHERE extract(minute FROM d.time) = 0;
                ->  Limit (actual rows=0 loops=389)
                      ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                            Order: m_1."time" DESC
+                           Hypertables excluded during runtime: 0
                            ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
                                  ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
@@ -341,7 +343,7 @@ WHERE extract(minute FROM d.time) = 0;
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
                                  ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(47 rows)
+(48 rows)
 
 :PREFIX
 SELECT d.device_id,
@@ -386,6 +388,7 @@ WHERE extract(minute FROM d.time) = 0;
          ->  Limit (actual rows=0 loops=389)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                      Order: m_1."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
                            ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
@@ -401,7 +404,7 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
                            ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(43 rows)
+(44 rows)
 
 --github issue 1558
 SET enable_seqscan = FALSE;

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -182,10 +182,11 @@ ORDER BY c.id;
          ->  Limit (actual rows=1 loops=4291)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx2 m_1 (actual rows=1 loops=4291)
                      Order: m_1."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_3_11_chunk m_2 (actual rows=1 loops=4291)
                            ->  Index Scan Backward using compress_hyper_4_12_chunk__compressed_hypertable_4_device_id_de on compress_hyper_4_12_chunk compress_hyper_4_12_chunk_1 (actual rows=1 loops=4291)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(11 rows)
+(12 rows)
 
 SET enable_seqscan = FALSE;
 \ir include/transparent_decompression_ordered_index.sql
@@ -326,6 +327,7 @@ WHERE extract(minute FROM d.time) = 0;
                ->  Limit (actual rows=0 loops=389)
                      ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                            Order: m_1."time" DESC
+                           Hypertables excluded during runtime: 0
                            ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
                                  ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
@@ -341,7 +343,7 @@ WHERE extract(minute FROM d.time) = 0;
                            ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
                                  ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
                                        Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(47 rows)
+(48 rows)
 
 :PREFIX
 SELECT d.device_id,
@@ -386,6 +388,7 @@ WHERE extract(minute FROM d.time) = 0;
          ->  Limit (actual rows=0 loops=389)
                ->  Custom Scan (ChunkAppend) on metrics_ordered_idx m_1 (actual rows=0 loops=389)
                      Order: m_1."time" DESC
+                     Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_2 (actual rows=0 loops=389)
                            ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=0 loops=389)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
@@ -401,7 +404,7 @@ WHERE extract(minute FROM d.time) = 0;
                      ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_6 (actual rows=0 loops=305)
                            ->  Index Scan Backward using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=0 loops=305)
                                  Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
-(43 rows)
+(44 rows)
 
 --github issue 1558
 SET enable_seqscan = FALSE;

--- a/tsl/test/shared/expected/ordered_append-12.out
+++ b/tsl/test/shared/expected/ordered_append-12.out
@@ -2787,7 +2787,7 @@ WHERE time = (
 ORDER BY time;
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=5 loops=1)
-   Chunks excluded during runtime: 1
+   Chunks excluded during runtime: 2
    InitPlan 1 (returns $0)
      ->  Aggregate (actual rows=1 loops=1)
            ->  Append (actual rows=68370 loops=1)
@@ -2797,11 +2797,10 @@ QUERY PLAN
                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=25190 loops=1)
                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $0)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                Filter: ((_ts_meta_min_1 <= $0) AND (_ts_meta_max_1 >= $0))
-               Rows Removed by Filter: 20
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $0)
          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2812,7 +2811,7 @@ QUERY PLAN
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
                Filter: ((_ts_meta_min_1 <= $0) AND (_ts_meta_max_1 >= $0))
                Rows Removed by Filter: 25
-(26 rows)
+(25 rows)
 
 -- test ordered append with limit expression
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-13.out
+++ b/tsl/test/shared/expected/ordered_append-13.out
@@ -2790,7 +2790,7 @@ WHERE time = (
 ORDER BY time;
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=5 loops=1)
-   Chunks excluded during runtime: 1
+   Chunks excluded during runtime: 2
    InitPlan 1 (returns $0)
      ->  Aggregate (actual rows=1 loops=1)
            ->  Append (actual rows=68370 loops=1)
@@ -2800,11 +2800,10 @@ QUERY PLAN
                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=25190 loops=1)
                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $0)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                Filter: ((_ts_meta_min_1 <= $0) AND (_ts_meta_max_1 >= $0))
-               Rows Removed by Filter: 20
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $0)
          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2815,7 +2814,7 @@ QUERY PLAN
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
                Filter: ((_ts_meta_min_1 <= $0) AND (_ts_meta_max_1 >= $0))
                Rows Removed by Filter: 25
-(26 rows)
+(25 rows)
 
 -- test ordered append with limit expression
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -2790,7 +2790,7 @@ WHERE time = (
 ORDER BY time;
 QUERY PLAN
  Custom Scan (ChunkAppend) on metrics_compressed (actual rows=5 loops=1)
-   Chunks excluded during runtime: 1
+   Chunks excluded during runtime: 2
    InitPlan 1 (returns $0)
      ->  Aggregate (actual rows=1 loops=1)
            ->  Append (actual rows=68370 loops=1)
@@ -2800,11 +2800,10 @@ QUERY PLAN
                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
                  ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk _hyper_X_X_chunk_1 (actual rows=25190 loops=1)
                        ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $0)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
                Filter: ((_ts_meta_min_1 <= $0) AND (_ts_meta_max_1 >= $0))
-               Rows Removed by Filter: 20
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
          Filter: ("time" = $0)
          ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
@@ -2815,7 +2814,7 @@ QUERY PLAN
          ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
                Filter: ((_ts_meta_min_1 <= $0) AND (_ts_meta_max_1 >= $0))
                Rows Removed by Filter: 25
-(26 rows)
+(25 rows)
 
 -- test ordered append with limit expression
 :PREFIX


### PR DESCRIPTION
Add runtime exclusion for statements such as :

   WHERE col @> ANY(subselect)

In this case, if the subselect returns no rows, the
result is always false. This is independent of whether
or not the partitioning columns is referenced.

Also fix a bug (or missed optimization) if the subselect
hasn't been executed by the time the runtime exclusion
executes.