### PR TITLE
Fix ABI test git errors

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -41,7 +41,8 @@ jobs:
         fi
 
         docker run -i --rm -v $(pwd):/mnt ${BUILDER_IMAGE} bash <<"EOF"
-          apk add cmake gcc make build-base krb5-dev openssl-dev > /dev/null
+          apk add cmake gcc make build-base krb5-dev openssl-dev git > /dev/null
+          git config --global --add safe.directory /mnt
           cd /mnt
           BUILD_DIR=build_abi BUILD_FORCE_REMOVE=true ./bootstrap
           make -C build_abi install


### PR DESCRIPTION
The most recent versions of the postgres docker image no longer
contain git by default. The version available also contains a fix
for the git vulnerability that changed the git behaviour to check
file ownership.
Since we bind mount the source checkout into the build container
the user of the checkout is unlikely to match the user inside the
container. This patch configures git to skip the owner check for
the bind-mounted directory.

https://github.blog/2022-04-12-git-security-vulnerability-announced/