### PR TITLE
Exponentially backoff when out of background workers

### DIFF
--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -36,6 +36,7 @@ extern TSDLLEXPORT void ts_bgw_job_stat_upsert_next_start(int32 bgw_job_id, Time
 
 extern bool ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
 
-extern TimestampTz ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job);
+extern TimestampTz ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job,
+											  int32 consecutive_failed_starts);
 
 #endif /* BGW_JOB_STAT_H */

--- a/tsl/test/expected/bgw_db_scheduler.out
+++ b/tsl/test/expected/bgw_db_scheduler.out
@@ -1077,14 +1077,15 @@ ORDER BY job_id;
    1012 | t                |          1 |               1 |              0 |             0 |                   0
 (7 rows)
 
---but after the first batch finishes and 1 second (START_RETRY_MS) passes, the last job will run.
-SELECT ts_bgw_params_reset_time(1000000, true); --set to second 1
+--but after the first batch finishes and 1 second (START_RETRY_MS) plus 2 seconds
+-- backoff pass, the last job will run.
+SELECT ts_bgw_params_reset_time(3000000, true); --set to second 3
  ts_bgw_params_reset_time 
 --------------------------
  
 (1 row)
 
-SELECT wait_for_timer_to_run(1000000);
+SELECT wait_for_timer_to_run(3000000);
  wait_for_timer_to_run 
 -----------------------
  t
@@ -1124,20 +1125,20 @@ ORDER BY job_id;
    1013 | t                |          1 |               1 |              0 |             0 |                   0
 (8 rows)
 
-SELECT * FROM bgw_log WHERE application_name = 'DB Scheduler' ORDER BY mock_time, application_name, msg_no;
- msg_no | mock_time | application_name |                                   msg                                    
---------+-----------+------------------+--------------------------------------------------------------------------
-      0 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      1 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      2 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      3 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      4 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      5 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      6 |         0 | DB Scheduler     | [TESTING] Registered new background worker
-      7 |         0 | DB Scheduler     | failed to launch job 1013 "test_job_3_long_8": out of background workers
-      8 |         0 | DB Scheduler     | [TESTING] Wait until 1000000, started at 0
-      9 |   1000000 | DB Scheduler     | [TESTING] Registered new background worker
-     10 |   1000000 | DB Scheduler     | [TESTING] Wait until 5000000, started at 1000000
+SELECT * FROM sorted_bgw_log WHERE application_name = 'DB Scheduler' ORDER BY application_name, msg_no;
+ msg_no | application_name |                                   msg                                    
+--------+------------------+--------------------------------------------------------------------------
+      0 | DB Scheduler     | [TESTING] Registered new background worker
+      1 | DB Scheduler     | [TESTING] Registered new background worker
+      2 | DB Scheduler     | [TESTING] Registered new background worker
+      3 | DB Scheduler     | [TESTING] Registered new background worker
+      4 | DB Scheduler     | [TESTING] Registered new background worker
+      5 | DB Scheduler     | [TESTING] Registered new background worker
+      6 | DB Scheduler     | [TESTING] Registered new background worker
+      7 | DB Scheduler     | failed to launch job 1013 "test_job_3_long_8": out of background workers
+      8 | DB Scheduler     | [TESTING] Wait until (RANDOM), started at (RANDOM)
+      9 | DB Scheduler     | [TESTING] Registered new background worker
+     10 | DB Scheduler     | [TESTING] Wait until (RANDOM), started at (RANDOM)
 (11 rows)
 
 SELECT ts_bgw_params_destroy();

--- a/tsl/test/sql/bgw_db_scheduler.sql
+++ b/tsl/test/sql/bgw_db_scheduler.sql
@@ -456,9 +456,10 @@ SELECT job_id, last_run_success, total_runs, total_successes, total_failures, to
 FROM _timescaledb_internal.bgw_job_stat
 ORDER BY job_id;
 
---but after the first batch finishes and 1 second (START_RETRY_MS) passes, the last job will run.
-SELECT ts_bgw_params_reset_time(1000000, true); --set to second 1
-SELECT wait_for_timer_to_run(1000000);
+--but after the first batch finishes and 1 second (START_RETRY_MS) plus 2 seconds
+-- backoff pass, the last job will run.
+SELECT ts_bgw_params_reset_time(3000000, true); --set to second 3
+SELECT wait_for_timer_to_run(3000000);
 SELECT wait_for_job_3_to_finish(8);
 
 SELECT ts_bgw_params_reset_time(30000000, true); --set to second 30, which causes a quit.
@@ -469,7 +470,7 @@ SELECT job_id, last_run_success, total_runs, total_successes, total_failures, to
 FROM _timescaledb_internal.bgw_job_stat
 ORDER BY job_id;
 
-SELECT * FROM bgw_log WHERE application_name = 'DB Scheduler' ORDER BY mock_time, application_name, msg_no;
+SELECT * FROM sorted_bgw_log WHERE application_name = 'DB Scheduler' ORDER BY application_name, msg_no;
 
 SELECT ts_bgw_params_destroy();
 


### PR DESCRIPTION
The scheduler detects the following three types of job failures:

1.Jobs that fail to launch (due to shortage of background workers)
2.Jobs that throw a runtime error
3.Jobs that crash due to a process crashing

In cases 2 and 3, additive backoff is applied in calculating the next
start time of a failed job.
In case 1 we previously retried to launch all jobs that failed to launch
simultaneously.

This commit introduces exponential backoff in case 1,
randomly selecting a wait time in [2, 2 + 2^f] seconds at microsecond granularity.
The aim is to reduce the collision probability for jobs that compete
for a background worker. The maximum backoff value is 1 minute.
It does not change the behavior for cases 2 and 3.

Fixes #4562