### PR TITLE
Dont run isolation tests on PG 12.0 and 13.2

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DREQUIRE_ALL_TESTS=ON -DLINTER_STRICT=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }} -DLINTER_STRICT=ON
         make -j $MAKE_JOBS -C build
         make -C build install
 


### PR DESCRIPTION
The output format of the isolation tester got changed by pg upstream
and backported to earlier versions. This means PG versions before
the backport have different output format then latest PG version.
We used to add all the isolation tests to the IGNORE list for those
PG versions but that is error prone and often forgotten when new
isolation tests are added. This patch skips the isolation test on
PG versions with incompatible output format.