### PR TITLE
Ensure osm chunks are not excluded by chunk exclusion logic

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -185,6 +185,7 @@ CREATE TABLE _timescaledb_catalog.chunk (
   compressed_chunk_id integer ,
   dropped boolean NOT NULL DEFAULT FALSE,
   status integer NOT NULL DEFAULT 0,
+  osm_chunk boolean NOT NULL DEFAULT FALSE,
   -- table constraints
   CONSTRAINT chunk_pkey PRIMARY KEY (id),
   CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name),
@@ -194,8 +195,8 @@ CREATE TABLE _timescaledb_catalog.chunk (
 ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
 
 CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
-
 CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk ( osm_chunk  );
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -196,7 +196,11 @@ ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.c
 
 CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
 CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
-CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk ( osm_chunk  );
+--we could use a partial index (where osm_chunk is true). However, the catalog code
+--does not work with partial/functional indexes. So we instead have a full index here.
+--Another option would be to use the status field to identify a OSM chunk. However bit
+--operations only work on varbit datatype and not integer datatype. 
+CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk (osm_chunk, hypertable_id);
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -10,3 +10,14 @@ CREATE TABLE _timescaledb_catalog.dimension_partition (
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension_partition', '');
 GRANT SELECT ON _timescaledb_catalog.dimension_partition TO PUBLIC;
 DROP FUNCTION IF EXISTS @extschema@.remove_continuous_aggregate_policy(REGCLASS, BOOL);
+
+-- add a new column to chunk catalog table 
+ALTER TABLE _timescaledb_catalog.chunk ADD COLUMN  osm_chunk boolean ;
+UPDATE _timescaledb_catalog.chunk SET osm_chunk = FALSE;
+
+ALTER TABLE _timescaledb_catalog.chunk
+  ALTER COLUMN  osm_chunk SET NOT NULL;
+ALTER TABLE _timescaledb_catalog.chunk 
+  ALTER COLUMN  osm_chunk SET DEFAULT FALSE;
+
+CREATE INDEX chunk_osm_chunk_idx ON _timescaledb_catalog.chunk (osm_chunk, hypertable_id);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -22,6 +22,7 @@ DROP FUNCTION _timescaledb_internal.unfreeze_chunk( chunk REGCLASS);
 -- Drop dimension partition metadata table
 ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.dimension_partition;
 DROP TABLE IF EXISTS _timescaledb_catalog.dimension_partition;
+
 DROP FUNCTION IF EXISTS timescaledb_experimental.add_policies;
 DROP FUNCTION IF EXISTS timescaledb_experimental.remove_policies;
 DROP FUNCTION IF EXISTS timescaledb_experimental.remove_all_policies;
@@ -34,4 +35,120 @@ AS '@MODULE_PATHNAME@', 'ts_policy_refresh_cagg_remove'
 LANGUAGE C VOLATILE STRICT;
 
 DROP VIEW IF EXISTS timescaledb_experimental.policies;
+
+--
+-- Rebuild the catalog table `_timescaledb_catalog.chunk`
+--
+-- We need to recreate the catalog from scratch because when we drop a column
+-- Postgres marks `pg_attribute.attisdropped=TRUE` instead of removing it from
+-- the `pg_catalog.pg_attribute` table.
+--
+-- If we downgrade and upgrade the extension without rebuilding the catalog table it
+-- will mess up `pg_attribute.attnum` and we will end up with issues when trying
+-- to update data in those catalog tables.
+
+-- Recreate _timescaledb_catalog.chunk table --
+CREATE TABLE _timescaledb_internal.chunk_tmp
+AS SELECT * from _timescaledb_catalog.chunk;
+
+CREATE TABLE _timescaledb_internal.tmp_chunk_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.chunk_id_seq;
+
+--drop foreign keys on chunk table
+ALTER TABLE _timescaledb_catalog.chunk_constraint DROP CONSTRAINT 
+chunk_constraint_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_index DROP CONSTRAINT 
+chunk_index_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_data_node DROP CONSTRAINT 
+chunk_data_node_chunk_id_fkey;
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats DROP CONSTRAINT 
+bgw_policy_chunk_stats_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT 
+compression_chunk_size_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT 
+compression_chunk_size_compressed_chunk_id_fkey;
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation DROP CONSTRAINT
+chunk_copy_operation_chunk_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.hypertables;
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS _timescaledb_internal.hypertable_chunk_local_size;
+DROP VIEW IF EXISTS _timescaledb_internal.compressed_chunk_stats;
+DROP VIEW IF EXISTS timescaledb_experimental.chunk_replication_status;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.chunk;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.chunk_id_seq;
+DROP TABLE _timescaledb_catalog.chunk;
+
+CREATE SEQUENCE _timescaledb_catalog.chunk_id_seq MINVALUE 1;
+
+-- now create table without self referential foreign key
+CREATE TABLE _timescaledb_catalog.chunk (
+  id integer NOT NULL DEFAULT nextval('_timescaledb_catalog.chunk_id_seq'),
+  hypertable_id int NOT NULL,
+  schema_name name NOT NULL,
+  table_name name NOT NULL,
+  compressed_chunk_id integer ,
+  dropped boolean NOT NULL DEFAULT FALSE,
+  status integer NOT NULL DEFAULT 0,
+  -- table constraints
+  CONSTRAINT chunk_pkey PRIMARY KEY (id),
+  CONSTRAINT chunk_schema_name_table_name_key UNIQUE (schema_name, table_name)
+);
+
+INSERT INTO _timescaledb_catalog.chunk
+( id, hypertable_id, schema_name, table_name,
+  compressed_chunk_id, dropped, status)
+SELECT id, hypertable_id, schema_name, table_name,
+  compressed_chunk_id, dropped, status
+FROM _timescaledb_internal.chunk_tmp;
+
+--add indexes to the chunk table
+CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
+CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+
+ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.chunk.id;
+SELECT setval('_timescaledb_catalog.chunk_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_chunk_seq_value;
+
+-- add self referential foreign key
+ALTER TABLE _timescaledb_catalog.chunk ADD CONSTRAINT chunk_compressed_chunk_id_fkey FOREIGN KEY ( compressed_chunk_id )
+ REFERENCES _timescaledb_catalog.chunk( id );
+
+--add foreign key constraint 
+ALTER TABLE _timescaledb_catalog.chunk 
+      ADD CONSTRAINT chunk_hypertable_id_fkey 
+      FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.chunk_constraint ADD CONSTRAINT 
+chunk_constraint_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id); 
+ALTER TABLE _timescaledb_catalog.chunk_index ADD CONSTRAINT
+chunk_index_chunk_id_fkey FOREIGN KEY (chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE;
+ALTER TABLE _timescaledb_catalog.chunk_data_node ADD CONSTRAINT
+chunk_data_node_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk(id);  
+ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats ADD CONSTRAINT
+bgw_policy_chunk_stats_chunk_id_fkey FOREIGN KEY (chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_chunk_id_fkey FOREIGN KEY (chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT
+compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) 
+REFERENCES _timescaledb_catalog.chunk(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.chunk_copy_operation ADD CONSTRAINT
+chunk_copy_operation_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.chunk_tmp;
+DROP TABLE _timescaledb_internal.tmp_chunk_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.chunk_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.chunk TO PUBLIC;
+
+-- end recreate _timescaledb_catalog.chunk table --
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -19,6 +19,7 @@
 #include "export.h"
 
 #define INVALID_CHUNK_ID 0
+#define IS_OSM_CHUNK(chunk) ((chunk)->fd.osm_chunk == true)
 
 /* Should match definitions in ddl_api.sql */
 #define DROP_CHUNKS_FUNCNAME "drop_chunks"
@@ -227,6 +228,7 @@ extern ScanIterator ts_chunk_scan_iterator_create(MemoryContext result_mcxt);
 extern void ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id);
 extern bool ts_chunk_lock_if_exists(Oid chunk_oid, LOCKMODE chunk_lockmode);
 extern int ts_chunk_oid_cmp(const void *p1, const void *p2);
+int ts_chunk_get_osm_chunk_id(int hypertable_id);
 
 #define chunk_get_by_name(schema_name, table_name, fail_if_not_found)                              \
 	ts_chunk_get_by_name_with_memory_context(schema_name,                                          \

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -136,6 +136,10 @@ scan_stubs_by_constraints(ScanIterator *constr_it, const Hyperspace *hs, const L
  * For performance, try not to interleave scans of different metadata tables
  * in order to maintain data locality while scanning. Also, keep scanned
  * tables and indexes open until all the metadata is scanned for all chunks.
+ *
+ * NOTE:
+ * An OSM chunk has only dummy constraints. Always include an OSM chunk, if
+ * it exists, in the set of returned results.
  */
 Chunk **
 ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
@@ -162,6 +166,7 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 	Assert(OidIsValid(hs->main_table_relid));
 	orig_mcxt = MemoryContextSwitchTo(work_mcxt);
 
+	int osm_chunk_id = ts_chunk_get_osm_chunk_id(hs->hypertable_id);
 	/*
 	 * Step 1: Scan for chunks that match in all the given dimensions. The
 	 * matching chunks are returned as chunk stubs as they are not yet full
@@ -179,10 +184,17 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 		MemoryContextSwitchTo(orig_mcxt);
 		MemoryContextDelete(work_mcxt);
 
+		Chunk *osm_chunk = NULL;
+		if (osm_chunk_id != INVALID_CHUNK_ID)
+		{
+			osm_chunk = ts_chunk_get_by_id(osm_chunk_id, true);
+			chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * 1);
+			chunks[0] = osm_chunk;
+		}
 		if (numchunks)
-			*numchunks = 0;
+			*numchunks = osm_chunk ? 1 : 0;
 
-		return NULL;
+		return chunks;
 	}
 
 	/*
@@ -192,6 +204,7 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 	chunk_it = ts_chunk_scan_iterator_create(orig_mcxt);
 	unlocked_chunks = MemoryContextAlloc(work_mcxt, sizeof(Chunk *) * list_length(chunk_stubs));
 
+	bool found_osm_chunk = false;
 	foreach (lc, chunk_stubs)
 	{
 		const ChunkStub *stub = lfirst(lc);
@@ -240,6 +253,8 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 				unlocked_chunks[unlocked_chunk_count] = chunk;
 				unlocked_chunk_count++;
 
+				if (IS_OSM_CHUNK(chunk))
+					found_osm_chunk = true;
 				/*
 				 * Try to detect when sorting is needed for locking
 				 * purposes. Sometimes, the chunk order resulting from
@@ -284,17 +299,29 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 		{
 			/* Lazy initialize the chunks array */
 			if (NULL == chunks)
-				chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * unlocked_chunk_count);
-
+			{
+				int chunks_alloc = unlocked_chunk_count;
+				if (osm_chunk_id != INVALID_CHUNK_ID && !found_osm_chunk)
+					chunks_alloc = unlocked_chunk_count + 1;
+				chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * chunks_alloc);
+			}
 			chunks[chunk_count] = chunk;
 
-			if (chunk->relkind == RELKIND_FOREIGN_TABLE)
+			if (chunk->relkind == RELKIND_FOREIGN_TABLE && !IS_OSM_CHUNK(chunk))
 				remote_chunk_count++;
 
 			chunk_count++;
 		}
 	}
-
+	/* get the osm chunk if needed */
+	if (osm_chunk_id != INVALID_CHUNK_ID && !found_osm_chunk)
+	{
+		MemoryContext old_mcxt;
+		old_mcxt = MemoryContextSwitchTo(orig_mcxt);
+		chunks[chunk_count] = ts_chunk_get_by_id(osm_chunk_id, true);
+		MemoryContextSwitchTo(old_mcxt);
+		chunk_count++;
+	}
 	/*
 	 * Step 3: The chunk stub scan only contained dimensional
 	 * constraints. Scan the chunk constraints again to get all

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -494,6 +494,8 @@ scan_and_append_slices(ScanIterator *it, int old_nkeys, DimensionVec **dv, bool 
 	return *dv;
 }
 
+/* search dimension_slice catalog table for slices that meet hri restriction
+ */
 static List *
 gather_restriction_dimension_vectors(const HypertableRestrictInfo *hri)
 {

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -164,6 +164,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 			[CHUNK_HYPERTABLE_ID_INDEX] = "chunk_hypertable_id_idx",
 			[CHUNK_SCHEMA_NAME_INDEX] = "chunk_schema_name_table_name_key",
 			[CHUNK_COMPRESSED_CHUNK_ID_INDEX] = "chunk_compressed_chunk_id_idx",
+			[CHUNK_OSM_CHUNK_INDEX] = "chunk_osm_chunk_idx",
 		},
 	},
 	[CHUNK_CONSTRAINT] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -407,6 +407,7 @@ enum Anum_chunk
 	Anum_chunk_compressed_chunk_id,
 	Anum_chunk_dropped,
 	Anum_chunk_status,
+	Anum_chunk_osm_chunk,
 	_Anum_chunk_max,
 };
 
@@ -421,6 +422,7 @@ typedef struct FormData_chunk
 	int32 compressed_chunk_id;
 	bool dropped;
 	int32 status;
+	bool osm_chunk;
 } FormData_chunk;
 
 typedef FormData_chunk *Form_chunk;
@@ -431,6 +433,7 @@ enum
 	CHUNK_HYPERTABLE_ID_INDEX,
 	CHUNK_SCHEMA_NAME_INDEX,
 	CHUNK_COMPRESSED_CHUNK_ID_INDEX,
+	CHUNK_OSM_CHUNK_INDEX,
 	_MAX_CHUNK_INDEX,
 };
 
@@ -453,6 +456,11 @@ enum Anum_chunk_schema_name_idx
 {
 	Anum_chunk_schema_name_idx_schema_name = 1,
 	Anum_chunk_schema_name_idx_table_name,
+};
+
+enum Anum_chunk_osm_chunk_idx
+{
+	Anum_chunk_osm_chunk_idx_osm_chunk = 1,
 };
 
 /************************************

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -461,6 +461,7 @@ enum Anum_chunk_schema_name_idx
 enum Anum_chunk_osm_chunk_idx
 {
 	Anum_chunk_osm_chunk_idx_osm_chunk = 1,
+	Anum_chunk_osm_chunk_idx_hypertable_id,
 };
 
 /************************************

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -185,25 +185,25 @@ SELECT relname, reloptions FROM pg_class WHERE relname IN ('_hyper_2_3_chunk','_
 -- Need superuser to ALTER chunks in _timescaledb_internal schema
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
 (1 row)
 
 -- Rename chunk
 ALTER TABLE _timescaledb_internal._hyper_2_2_chunk RENAME TO new_chunk_name;
 SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id |      schema_name      |   table_name   | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+----------------+---------------------+---------+--------
-  2 |             2 | _timescaledb_internal | new_chunk_name |                     | f       |      0
+ id | hypertable_id |      schema_name      |   table_name   | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+----------------+---------------------+---------+--------+-----------
+  2 |             2 | _timescaledb_internal | new_chunk_name |                     | f       |      0 | f
 (1 row)
 
 -- Set schema
 ALTER TABLE _timescaledb_internal.new_chunk_name SET SCHEMA public;
 SELECT * FROM _timescaledb_catalog.chunk WHERE id = 2;
- id | hypertable_id | schema_name |   table_name   | compressed_chunk_id | dropped | status 
-----+---------------+-------------+----------------+---------------------+---------+--------
-  2 |             2 | public      | new_chunk_name |                     | f       |      0
+ id | hypertable_id | schema_name |   table_name   | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+----------------+---------------------+---------+--------+-----------
+  2 |             2 | public      | new_chunk_name |                     | f       |      0 | f
 (1 row)
 
 -- Test that we cannot rename chunk columns
@@ -679,10 +679,10 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+--------------------+---------------------+---------+--------
- 24 |            12 | new_associated_schema | _hyper_12_24_chunk |                     | f       |      0
- 25 |            12 | new_associated_schema | _hyper_12_25_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
+ 24 |            12 | new_associated_schema | _hyper_12_24_chunk |                     | f       |      0 | f
+ 25 |            12 | new_associated_schema | _hyper_12_25_chunk |                     | f       |      0 | f
 (2 rows)
 
 DROP TABLE my_table;

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -544,12 +544,12 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_migrate';
 (1 row)
 
 select * from _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+--------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |                     | f       |      0
-  8 |             7 | _timescaledb_internal | _hyper_7_8_chunk   |                     | f       |      0
-  9 |            10 | _timescaledb_internal | _hyper_10_9_chunk  |                     | f       |      0
- 10 |            10 | _timescaledb_internal | _hyper_10_10_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk   |                     | f       |      0 | f
+  8 |             7 | _timescaledb_internal | _hyper_7_8_chunk   |                     | f       |      0 | f
+  9 |            10 | _timescaledb_internal | _hyper_10_9_chunk  |                     | f       |      0 | f
+ 10 |            10 | _timescaledb_internal | _hyper_10_10_chunk |                     | f       |      0 | f
 (4 rows)
 
 select * from test_schema.test_migrate;

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -32,10 +32,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
 (2 rows)
 
 DROP OWNED BY :ROLE_DEFAULT_PERM_USER;
@@ -46,9 +46,9 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  2 |             2 | _timescaledb_internal | _hyper_2_2_chunk |                     | f       |      0 | f
 (1 row)
 
 DROP TABLE  hypertable_schema.superuser;
@@ -59,8 +59,8 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -37,10 +37,10 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+---------------+------------------+---------------------+---------+--------
-  1 |             1 | chunk_schema1 | _hyper_1_1_chunk |                     | f       |      0
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f       |      0
+ id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+---------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | chunk_schema1 | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f       |      0 | f
 (2 rows)
 
 RESET ROLE;
@@ -60,18 +60,18 @@ SELECT * FROM _timescaledb_catalog.hypertable ORDER BY id;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+---------------+------------------+---------------------+---------+--------
-  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f       |      0
+ id | hypertable_id |  schema_name  |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+---------------+------------------+---------------------+---------+--------+-----------
+  2 |             2 | chunk_schema2 | _hyper_2_2_chunk |                     | f       |      0 | f
 (1 row)
 
 --new chunk should be created in the internal associated schema
 INSERT INTO hypertable_schema.test1 VALUES ('2001-01-01 01:01:01', 23.3, 1);
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  2 |             2 | chunk_schema2         | _hyper_2_2_chunk |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  2 |             2 | chunk_schema2         | _hyper_2_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
 (2 rows)
 
 RESET ROLE;
@@ -91,8 +91,8 @@ SELECT * FROM _timescaledb_catalog.hypertable GROUP BY id;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -157,12 +157,12 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
 (28 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
 (4 rows)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/expected/insert-13.out
+++ b/test/expected/insert-13.out
@@ -157,12 +157,12 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
 (28 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
 (4 rows)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/expected/insert-14.out
+++ b/test/expected/insert-14.out
@@ -157,12 +157,12 @@ SELECT * FROM test.show_indexesp('_timescaledb_internal._hyper%');
 (28 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
 (4 rows)
 
 SELECT * FROM "two_Partitions" ORDER BY "timeCustom", device_id, series_0, series_1;

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -242,22 +242,22 @@ SELECT * FROM "1dim_neg";
 (7 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name     | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+-------------------+---------------------+---------+--------
-  1 |             1 | one_Partition         | _hyper_1_1_chunk  |                     | f       |      0
-  2 |             1 | one_Partition         | _hyper_1_2_chunk  |                     | f       |      0
-  3 |             1 | one_Partition         | _hyper_1_3_chunk  |                     | f       |      0
-  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk  |                     | f       |      0
-  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk  |                     | f       |      0
-  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk  |                     | f       |      0
-  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk  |                     | f       |      0
-  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk  |                     | f       |      0
- 10 |             5 | _timescaledb_internal | _hyper_5_10_chunk |                     | f       |      0
- 11 |             6 | _timescaledb_internal | _hyper_6_11_chunk |                     | f       |      0
- 12 |             6 | _timescaledb_internal | _hyper_6_12_chunk |                     | f       |      0
- 13 |             6 | _timescaledb_internal | _hyper_6_13_chunk |                     | f       |      0
- 14 |             6 | _timescaledb_internal | _hyper_6_14_chunk |                     | f       |      0
- 15 |             6 | _timescaledb_internal | _hyper_6_15_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name     | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+-------------------+---------------------+---------+--------+-----------
+  1 |             1 | one_Partition         | _hyper_1_1_chunk  |                     | f       |      0 | f
+  2 |             1 | one_Partition         | _hyper_1_2_chunk  |                     | f       |      0 | f
+  3 |             1 | one_Partition         | _hyper_1_3_chunk  |                     | f       |      0 | f
+  4 |             2 | _timescaledb_internal | _hyper_2_4_chunk  |                     | f       |      0 | f
+  5 |             3 | _timescaledb_internal | _hyper_3_5_chunk  |                     | f       |      0 | f
+  6 |             3 | _timescaledb_internal | _hyper_3_6_chunk  |                     | f       |      0 | f
+  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk  |                     | f       |      0 | f
+  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk  |                     | f       |      0 | f
+ 10 |             5 | _timescaledb_internal | _hyper_5_10_chunk |                     | f       |      0 | f
+ 11 |             6 | _timescaledb_internal | _hyper_6_11_chunk |                     | f       |      0 | f
+ 12 |             6 | _timescaledb_internal | _hyper_6_12_chunk |                     | f       |      0 | f
+ 13 |             6 | _timescaledb_internal | _hyper_6_13_chunk |                     | f       |      0 | f
+ 14 |             6 | _timescaledb_internal | _hyper_6_14_chunk |                     | f       |      0 | f
+ 15 |             6 | _timescaledb_internal | _hyper_6_15_chunk |                     | f       |      0 | f
 (14 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -41,12 +41,12 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0
-  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
 (4 rows)
 
 SELECT * FROM test.show_subtables('"two_Partitions"');
@@ -84,8 +84,8 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 -- should be empty
@@ -105,11 +105,11 @@ INSERT INTO public."two_Partitions"("timeCustom", device_id, series_0, series_1)
 (1257894000000000000, 'dev2', 1.5, 1),
 (1257894002000000000, 'dev1', 2.5, 3);
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------+---------------------+---------+--------
-  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0
-  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f       |      0
-  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f
+  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f       |      0 | f
+  7 |             1 | _timescaledb_internal | _hyper_1_7_chunk |                     | f       |      0 | f
 (3 rows)
 
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_5_chunk;

--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -633,11 +633,11 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 --we see the chunks row with the dropped flags set;
 SELECT * FROM _timescaledb_catalog.chunk where dropped;
- id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+--------------------+---------------------+---------+--------
- 13 |            10 | _timescaledb_internal | _hyper_10_13_chunk |                     | t       |      0
- 14 |            10 | _timescaledb_internal | _hyper_10_14_chunk |                     | t       |      0
- 15 |            10 | _timescaledb_internal | _hyper_10_15_chunk |                     | t       |      0
+ id | hypertable_id |      schema_name      |     table_name     | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+--------------------+---------------------+---------+--------+-----------
+ 13 |            10 | _timescaledb_internal | _hyper_10_13_chunk |                     | t       |      0 | f
+ 14 |            10 | _timescaledb_internal | _hyper_10_14_chunk |                     | t       |      0 | f
+ 15 |            10 | _timescaledb_internal | _hyper_10_15_chunk |                     | t       |      0 | f
 (3 rows)
 
 --still see data in the view

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -665,11 +665,11 @@ SELECT * FROM drop_chunks_table ORDER BY time ASC limit 1;
 
 --we see the chunks row with the dropped flags set;
 SELECT * FROM _timescaledb_catalog.chunk where dropped;
- id | hypertable_id |      schema_name      |       table_name        | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+-------------------------+---------------------+---------+--------
- 13 |            10 | _timescaledb_internal | _dist_hyper_10_13_chunk |                     | t       |      0
- 14 |            10 | _timescaledb_internal | _dist_hyper_10_14_chunk |                     | t       |      0
- 15 |            10 | _timescaledb_internal | _dist_hyper_10_15_chunk |                     | t       |      0
+ id | hypertable_id |      schema_name      |       table_name        | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+-------------------------+---------------------+---------+--------+-----------
+ 13 |            10 | _timescaledb_internal | _dist_hyper_10_13_chunk |                     | t       |      0 | f
+ 14 |            10 | _timescaledb_internal | _dist_hyper_10_14_chunk |                     | t       |      0 | f
+ 15 |            10 | _timescaledb_internal | _dist_hyper_10_15_chunk |                     | t       |      0 | f
 (3 rows)
 
 --still see data in the view

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -363,7 +363,7 @@ SELECT create_hypertable('ht_try', 'timec', chunk_time_interval => interval '1 d
  (5,public,ht_try,t)
 (1 row)
 
-INSERT INTO ht_try VALUES ('2020-05-05 01:00', 222, 222);
+INSERT INTO ht_try VALUES ('2022-05-05 01:00', 222, 222);
 SELECT * FROM child_fdw_table;
             timec             | acq_id | value 
 ------------------------------+--------+-------
@@ -381,7 +381,7 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'ht_try' ORDER BY 1;
     chunk_name    |           range_start           |            range_end            
 ------------------+---------------------------------+---------------------------------
- _hyper_5_9_chunk | Mon May 04 17:00:00 2020 PDT    | Tue May 05 17:00:00 2020 PDT
+ _hyper_5_9_chunk | Wed May 04 17:00:00 2022 PDT    | Thu May 05 17:00:00 2022 PDT
  child_fdw_table  | Tue Nov 23 16:00:00 4684 PST BC | Wed Nov 24 16:00:00 4684 PST BC
 (2 rows)
 
@@ -389,7 +389,7 @@ SELECT * FROM ht_try ORDER BY 1;
             timec             | acq_id | value 
 ------------------------------+--------+-------
  Wed Jan 01 01:00:00 2020 PST |    100 |  1000
- Tue May 05 01:00:00 2020 PDT |    222 |   222
+ Thu May 05 01:00:00 2022 PDT |    222 |   222
 (2 rows)
 
 SELECT relname, relowner::regrole FROM pg_class
@@ -408,6 +408,38 @@ FROM pg_inherits WHERE inhparent = 'ht_try'::regclass ORDER BY 1;
  child_fdw_table
  _timescaledb_internal._hyper_5_9_chunk
 (2 rows)
+
+--TEST chunk exclusion code does not filter out OSM chunk
+SELECT * from ht_try ORDER BY 1;
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+ Thu May 05 01:00:00 2022 PDT |    222 |   222
+(2 rows)
+
+SELECT * from ht_try WHERE timec < '2022-01-01 01:00' ORDER BY 1; 
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
+SELECT * from ht_try WHERE timec = '2020-01-01 01:00' ORDER BY 1; 
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
+SELECT * from ht_try WHERE  timec > '2000-01-01 01:00' and timec < '2022-01-01 01:00' ORDER BY 1;
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
+SELECT * from ht_try WHERE timec > '2020-01-01 01:00' ORDER BY 1; 
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Thu May 05 01:00:00 2022 PDT |    222 |   222
+(1 row)
 
 -- TEST error have to be hypertable owner to attach a chunk to it
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -71,12 +71,12 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
- id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+--------------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   4 | f       |      1
-  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |                     | f       |      0
-  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |        table_name        | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+--------------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk         |                   4 | f       |      1 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk         |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk         |                     | f       |      0 | f
+  4 |             2 | _timescaledb_internal | compress_hyper_2_4_chunk |                     | f       |      0 | f
 (4 rows)
 
 -- TEST 4 --

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -433,11 +433,11 @@ SELECT * FROM test.show_subtables('disttable');
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+-----------------------+---------------------+---------+--------
-  2 |             3 | _timescaledb_internal | _dist_hyper_3_2_chunk |                     | f       |      0
-  3 |             3 | _timescaledb_internal | _dist_hyper_3_3_chunk |                     | f       |      0
-  4 |             3 | _timescaledb_internal | _dist_hyper_3_4_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
+  2 |             3 | _timescaledb_internal | _dist_hyper_3_2_chunk |                     | f       |      0 | f
+  3 |             3 | _timescaledb_internal | _dist_hyper_3_3_chunk |                     | f       |      0 | f
+  4 |             3 | _timescaledb_internal | _dist_hyper_3_4_chunk |                     | f       |      0 | f
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
@@ -586,10 +586,10 @@ ORDER BY foreign_table_name;
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+-----------------------+---------------------+---------+--------
-  3 |             3 | _timescaledb_internal | _dist_hyper_3_3_chunk |                     | f       |      0
-  4 |             3 | _timescaledb_internal | _dist_hyper_3_4_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
+  3 |             3 | _timescaledb_internal | _dist_hyper_3_3_chunk |                     | f       |      0 | f
+  4 |             3 | _timescaledb_internal | _dist_hyper_3_4_chunk |                     | f       |      0 | f
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;
@@ -636,8 +636,8 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 -- Attach data node should now succeed
@@ -828,8 +828,8 @@ SELECT * FROM _timescaledb_catalog.chunk_data_node;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 \set ON_ERROR_STOP 0
@@ -898,11 +898,11 @@ SELECT * FROM test.show_subtables('disttable');
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+-----------------------+---------------------+---------+--------
-  5 |             5 | _timescaledb_internal | _dist_hyper_5_5_chunk |                     | f       |      0
-  6 |             5 | _timescaledb_internal | _dist_hyper_5_6_chunk |                     | f       |      0
-  7 |             5 | _timescaledb_internal | _dist_hyper_5_7_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
+  5 |             5 | _timescaledb_internal | _dist_hyper_5_5_chunk |                     | f       |      0 | f
+  6 |             5 | _timescaledb_internal | _dist_hyper_5_6_chunk |                     | f       |      0 | f
+  7 |             5 | _timescaledb_internal | _dist_hyper_5_7_chunk |                     | f       |      0 | f
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.hypertable_data_node;

--- a/tsl/test/expected/dist_compression.out
+++ b/tsl/test/expected/dist_compression.out
@@ -287,36 +287,36 @@ $$);
 NOTICE:  [db_dist_compression_1]: 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_1]:
-id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status
---+-------------+---------------------+------------------------+-------------------+-------+------
- 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  5|f      |     1
- 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  6|f      |     1
- 5|            2|_timescaledb_internal|compress_hyper_2_5_chunk|                   |f      |     0
- 6|            2|_timescaledb_internal|compress_hyper_2_6_chunk|                   |f      |     0
+id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+---------------------+------------------------+-------------------+-------+------+---------
+ 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  5|f      |     1|f        
+ 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  6|f      |     1|f        
+ 5|            2|_timescaledb_internal|compress_hyper_2_5_chunk|                   |f      |     0|f        
+ 6|            2|_timescaledb_internal|compress_hyper_2_6_chunk|                   |f      |     0|f        
 (4 rows)
 
 
 NOTICE:  [db_dist_compression_2]: 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_2]:
-id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status
---+-------------+---------------------+------------------------+-------------------+-------+------
- 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  5|f      |     1
- 2|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  6|f      |     1
- 5|            2|_timescaledb_internal|compress_hyper_2_5_chunk|                   |f      |     0
- 6|            2|_timescaledb_internal|compress_hyper_2_6_chunk|                   |f      |     0
+id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+---------------------+------------------------+-------------------+-------+------+---------
+ 1|            1|_timescaledb_internal|_dist_hyper_1_1_chunk   |                  5|f      |     1|f        
+ 2|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  6|f      |     1|f        
+ 5|            2|_timescaledb_internal|compress_hyper_2_5_chunk|                   |f      |     0|f        
+ 6|            2|_timescaledb_internal|compress_hyper_2_6_chunk|                   |f      |     0|f        
 (4 rows)
 
 
 NOTICE:  [db_dist_compression_3]: 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY id
 NOTICE:  [db_dist_compression_3]:
-id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status
---+-------------+---------------------+------------------------+-------------------+-------+------
- 1|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  4|f      |     1
- 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  3|f      |     1
- 3|            2|_timescaledb_internal|compress_hyper_2_3_chunk|                   |f      |     0
- 4|            2|_timescaledb_internal|compress_hyper_2_4_chunk|                   |f      |     0
+id|hypertable_id|schema_name          |table_name              |compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+---------------------+------------------------+-------------------+-------+------+---------
+ 1|            1|_timescaledb_internal|_dist_hyper_1_2_chunk   |                  4|f      |     1|f        
+ 2|            1|_timescaledb_internal|_dist_hyper_1_3_chunk   |                  3|f      |     1|f        
+ 3|            2|_timescaledb_internal|compress_hyper_2_3_chunk|                   |f      |     0|f        
+ 4|            2|_timescaledb_internal|compress_hyper_2_4_chunk|                   |f      |     0|f        
 (4 rows)
 
 
@@ -694,11 +694,11 @@ from chunk_compression_stats('conditions') where compression_status like 'Compre
 (2 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY id;
- id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+-----------------------+---------------------+---------+--------
-  6 |             2 | _timescaledb_internal | _dist_hyper_2_6_chunk |                     | f       |      1
-  7 |             2 | _timescaledb_internal | _dist_hyper_2_7_chunk |                     | f       |      0
-  8 |             2 | _timescaledb_internal | _dist_hyper_2_8_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |      table_name       | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+-----------------------+---------------------+---------+--------+-----------
+  6 |             2 | _timescaledb_internal | _dist_hyper_2_6_chunk |                     | f       |      1 | f
+  7 |             2 | _timescaledb_internal | _dist_hyper_2_7_chunk |                     | f       |      0 | f
+  8 |             2 | _timescaledb_internal | _dist_hyper_2_8_chunk |                     | f       |      0 | f
 (3 rows)
 
 -- TEST 4 --

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -1667,8 +1667,8 @@ SELECT * FROM disttable;
 
 -- Metadata and tables cleaned up
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 SELECT * FROM show_chunks('disttable');
@@ -1685,8 +1685,8 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 
@@ -1709,8 +1709,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 
@@ -1733,8 +1733,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -1666,8 +1666,8 @@ SELECT * FROM disttable;
 
 -- Metadata and tables cleaned up
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 SELECT * FROM show_chunks('disttable');
@@ -1684,8 +1684,8 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 
@@ -1708,8 +1708,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 
@@ -1732,8 +1732,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -1670,8 +1670,8 @@ SELECT * FROM disttable;
 
 -- Metadata and tables cleaned up
 SELECT * FROM _timescaledb_catalog.chunk;
- id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status 
-----+---------------+-------------+------------+---------------------+---------+--------
+ id | hypertable_id | schema_name | table_name | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-------------+------------+---------------------+---------+--------+-----------
 (0 rows)
 
 SELECT * FROM show_chunks('disttable');
@@ -1688,8 +1688,8 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 
@@ -1712,8 +1712,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 
@@ -1736,8 +1736,8 @@ time|device|temp|Color
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.chunk
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status
---+-------------+-----------+----------+-------------------+-------+------
+id|hypertable_id|schema_name|table_name|compressed_chunk_id|dropped|status|osm_chunk
+--+-------------+-----------+----------+-------------------+-------+------+---------
 (0 rows)
 
 

--- a/tsl/test/expected/remote_copy-12.out
+++ b/tsl/test/expected/remote_copy-12.out
@@ -100,24 +100,24 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
 (18 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
- id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0
-  2 |             1 | _timescaledb_internal | _dist_hyper_1_2_chunk  |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _dist_hyper_1_3_chunk  |                     | f       |      0
-  4 |             1 | _timescaledb_internal | _dist_hyper_1_4_chunk  |                     | f       |      0
-  5 |             1 | _timescaledb_internal | _dist_hyper_1_5_chunk  |                     | f       |      0
-  6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0
-  7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0
-  8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0
- 12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0
- 13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0
- 14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0
- 15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0
- 16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0
- 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0
- 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0
- 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _dist_hyper_1_2_chunk  |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _dist_hyper_1_3_chunk  |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _dist_hyper_1_4_chunk  |                     | f       |      0 | f
+  5 |             1 | _timescaledb_internal | _dist_hyper_1_5_chunk  |                     | f       |      0 | f
+  6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
+  7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
+  8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
+ 12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
+ 13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
+ 14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
+ 15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
+ 16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
+ 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
+ 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
+ 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;

--- a/tsl/test/expected/remote_copy-13.out
+++ b/tsl/test/expected/remote_copy-13.out
@@ -100,24 +100,24 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
 (18 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
- id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0
-  2 |             1 | _timescaledb_internal | _dist_hyper_1_2_chunk  |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _dist_hyper_1_3_chunk  |                     | f       |      0
-  4 |             1 | _timescaledb_internal | _dist_hyper_1_4_chunk  |                     | f       |      0
-  5 |             1 | _timescaledb_internal | _dist_hyper_1_5_chunk  |                     | f       |      0
-  6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0
-  7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0
-  8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0
- 12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0
- 13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0
- 14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0
- 15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0
- 16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0
- 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0
- 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0
- 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _dist_hyper_1_2_chunk  |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _dist_hyper_1_3_chunk  |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _dist_hyper_1_4_chunk  |                     | f       |      0 | f
+  5 |             1 | _timescaledb_internal | _dist_hyper_1_5_chunk  |                     | f       |      0 | f
+  6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
+  7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
+  8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
+ 12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
+ 13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
+ 14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
+ 15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
+ 16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
+ 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
+ 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
+ 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;

--- a/tsl/test/expected/remote_copy-14.out
+++ b/tsl/test/expected/remote_copy-14.out
@@ -100,24 +100,24 @@ SELECT * FROM "+ri(k33_')" ORDER BY 1;
 (18 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk ORDER BY 1;
- id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status 
-----+---------------+-----------------------+------------------------+---------------------+---------+--------
-  1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0
-  2 |             1 | _timescaledb_internal | _dist_hyper_1_2_chunk  |                     | f       |      0
-  3 |             1 | _timescaledb_internal | _dist_hyper_1_3_chunk  |                     | f       |      0
-  4 |             1 | _timescaledb_internal | _dist_hyper_1_4_chunk  |                     | f       |      0
-  5 |             1 | _timescaledb_internal | _dist_hyper_1_5_chunk  |                     | f       |      0
-  6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0
-  7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0
-  8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0
- 12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0
- 13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0
- 14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0
- 15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0
- 16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0
- 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0
- 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0
- 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0
+ id | hypertable_id |      schema_name      |       table_name       | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _dist_hyper_1_1_chunk  |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _dist_hyper_1_2_chunk  |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _dist_hyper_1_3_chunk  |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _dist_hyper_1_4_chunk  |                     | f       |      0 | f
+  5 |             1 | _timescaledb_internal | _dist_hyper_1_5_chunk  |                     | f       |      0 | f
+  6 |             1 | _timescaledb_internal | _dist_hyper_1_6_chunk  |                     | f       |      0 | f
+  7 |             1 | _timescaledb_internal | _dist_hyper_1_7_chunk  |                     | f       |      0 | f
+  8 |             1 | _timescaledb_internal | _dist_hyper_1_8_chunk  |                     | f       |      0 | f
+ 12 |             1 | _timescaledb_internal | _dist_hyper_1_12_chunk |                     | f       |      0 | f
+ 13 |             1 | _timescaledb_internal | _dist_hyper_1_13_chunk |                     | f       |      0 | f
+ 14 |             1 | _timescaledb_internal | _dist_hyper_1_14_chunk |                     | f       |      0 | f
+ 15 |             1 | _timescaledb_internal | _dist_hyper_1_15_chunk |                     | f       |      0 | f
+ 16 |             1 | _timescaledb_internal | _dist_hyper_1_16_chunk |                     | f       |      0 | f
+ 17 |             1 | _timescaledb_internal | _dist_hyper_1_17_chunk |                     | f       |      0 | f
+ 18 |             1 | _timescaledb_internal | _dist_hyper_1_18_chunk |                     | f       |      0 | f
+ 19 |             1 | _timescaledb_internal | _dist_hyper_1_19_chunk |                     | f       |      0 | f
 (16 rows)
 
 SELECT * FROM _timescaledb_catalog.chunk_data_node ORDER BY 1, 3;

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -224,7 +224,7 @@ CREATE FOREIGN TABLE child_fdw_table
 --now attach foreign table as a chunk of the hypertable.
 CREATE TABLE ht_try(timec timestamptz NOT NULL, acq_id bigint, value bigint);
 SELECT create_hypertable('ht_try', 'timec', chunk_time_interval => interval '1 day');
-INSERT INTO ht_try VALUES ('2020-05-05 01:00', 222, 222);
+INSERT INTO ht_try VALUES ('2022-05-05 01:00', 222, 222);
 
 SELECT * FROM child_fdw_table;
 
@@ -243,6 +243,13 @@ WHERE relname in ( select chunk_name FROM timescaledb_information.chunks
 SELECT inhrelid::regclass
 FROM pg_inherits WHERE inhparent = 'ht_try'::regclass ORDER BY 1;
 
+--TEST chunk exclusion code does not filter out OSM chunk
+SELECT * from ht_try ORDER BY 1;
+SELECT * from ht_try WHERE timec < '2022-01-01 01:00' ORDER BY 1; 
+SELECT * from ht_try WHERE timec = '2020-01-01 01:00' ORDER BY 1; 
+SELECT * from ht_try WHERE  timec > '2000-01-01 01:00' and timec < '2022-01-01 01:00' ORDER BY 1;
+
+SELECT * from ht_try WHERE timec > '2020-01-01 01:00' ORDER BY 1; 
 -- TEST error have to be hypertable owner to attach a chunk to it
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
The chunk exclusion code examines the dimension_slice catalog table to filter out chunks.
OSM chunks do not register their actual dimension ranges with the catalogs. This metadata is managed by OSM. So an OSM chunk, if it exists, should not be excluded.
We add a new column, osm_chunk, to the chunk catalog table to mark an OSM chunk.

To Reviewers:
Most of the file changes are due to the addition of the new catalog column.


Disable-check: commit-count