### PR TITLE
Fix assertion in GRANT .. ON ALL TABLES IN SCHEMA

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1592,7 +1592,8 @@ process_grant_and_revoke(ProcessUtilityArgs *args)
 				/* Execute command right away, to check any permission errors before propagating
 				 * it to the distributed DDL */
 				result = DDL_DONE;
-				prev_ProcessUtility(args);
+				if (stmt->objects != NIL)
+					prev_ProcessUtility(args);
 
 				/* Restore ALL IN SCHEMA command type and it's objects */
 				if (was_schema_op)

--- a/test/expected/grant_hypertable.out
+++ b/test/expected/grant_hypertable.out
@@ -388,3 +388,7 @@ REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER_2;
  public | _hyper_2_9_chunk  | table | super_user=arwdDxt/super_user |                   | 
 (3 rows)
 
+-- GRANT/REVOKE in an empty schema (Issue #4581)
+CREATE SCHEMA test_grant;
+GRANT ALL ON ALL TABLES IN SCHEMA test_grant TO :ROLE_DEFAULT_PERM_USER_2;
+REVOKE ALL ON ALL TABLES IN SCHEMA test_grant FROM :ROLE_DEFAULT_PERM_USER_2;

--- a/test/sql/grant_hypertable.sql
+++ b/test/sql/grant_hypertable.sql
@@ -111,3 +111,8 @@ REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER_2;
 \z measurements
 \z conditions
 \z public.*chunk
+
+-- GRANT/REVOKE in an empty schema (Issue #4581)
+CREATE SCHEMA test_grant;
+GRANT ALL ON ALL TABLES IN SCHEMA test_grant TO :ROLE_DEFAULT_PERM_USER_2;
+REVOKE ALL ON ALL TABLES IN SCHEMA test_grant FROM :ROLE_DEFAULT_PERM_USER_2;


### PR DESCRIPTION
When working on a fix for #4555 discovered that executing
`{GRANT|REVOKE} .. ON ALL TABLES IN SCHEMA` in an empty schema lead to
an assertion because we change the way that command is executed by
collecting all objects involved and processing one by one.

Fixed it by executing the previous process utility hook just when the
list of target objects is not empty.

Fixes #4581