### PR TITLE
Fix partitioning functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #4486 Adding boolean column with default value doesn't work on compressed table
+* #4575 Fix use of `get_partition_hash` and `get_partition_for_key` inside an IMMUTABLE function
 
 **Thanks**
 @janko for reporting
+@AlmiS for reporting error on `get_partition_hash` executed inside an IMMUTABLE function
 
 ## 2.7.2 (2022-07-26)
 

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -317,6 +317,9 @@ resolve_function_argtype(FunctionCallInfo fcinfo)
 			/* Argument is function, so our input is its result type */
 			argtype = ((FuncExpr *) node)->funcresulttype;
 			break;
+		case T_Param:
+			argtype = ((Param *) node)->paramtype;
+			break;
 		default:
 			elog(ERROR, "unsupported expression argument node type %u", nodeTag(node));
 	}

--- a/test/expected/hash.out
+++ b/test/expected/hash.out
@@ -302,3 +302,22 @@ SELECT _timescaledb_internal.get_partition_hash('08002b:010203'::macaddr);
           294987870
 (1 row)
 
+-- Test inside IMMUTABLE function (Issue #4575)
+CREATE FUNCTION my_get_partition_hash(INTEGER) RETURNS INTEGER
+AS 'SELECT _timescaledb_internal.get_partition_hash($1);'
+LANGUAGE SQL IMMUTABLE;
+CREATE FUNCTION my_get_partition_for_key(INTEGER) RETURNS INTEGER
+AS 'SELECT _timescaledb_internal.get_partition_for_key($1);'
+LANGUAGE SQL IMMUTABLE;
+SELECT my_get_partition_hash(1);
+ my_get_partition_hash 
+-----------------------
+             242423622
+(1 row)
+
+SELECT my_get_partition_for_key(1);
+ my_get_partition_for_key 
+--------------------------
+               1516350201
+(1 row)
+

--- a/test/sql/hash.sql
+++ b/test/sql/hash.sql
@@ -76,3 +76,15 @@ SELECT _timescaledb_internal.get_partition_for_key(187::numeric);
 SELECT _timescaledb_internal.get_partition_for_key(187::double precision);
 SELECT _timescaledb_internal.get_partition_for_key(int4range(10, 20));
 SELECT _timescaledb_internal.get_partition_hash('08002b:010203'::macaddr);
+
+-- Test inside IMMUTABLE function (Issue #4575)
+CREATE FUNCTION my_get_partition_hash(INTEGER) RETURNS INTEGER
+AS 'SELECT _timescaledb_internal.get_partition_hash($1);'
+LANGUAGE SQL IMMUTABLE;
+
+CREATE FUNCTION my_get_partition_for_key(INTEGER) RETURNS INTEGER
+AS 'SELECT _timescaledb_internal.get_partition_for_key($1);'
+LANGUAGE SQL IMMUTABLE;
+
+SELECT my_get_partition_hash(1);
+SELECT my_get_partition_for_key(1);


### PR DESCRIPTION
When executing `get_partition_{hash|for_key}` inside an IMMUTABLE
function we're getting the following error:

`ERROR: unsupported expression argument node type 112`

This error is because the underlying `resolve_function_argtype` was not
dealing with `T_Param` node type.

Fixed it by dealing properly with `T_Param` node type returning the
`paramtype` for the argument type.

Fixes #4575