### PR TITLE
Fix rename for distributed hypertable

### DIFF
--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -454,13 +454,46 @@ TRUNCATE non_disttable1, non_disttable2;
 TRUNCATE disttable;
 -- RENAME TO
 ALTER TABLE disttable RENAME TO disttable2;
+SELECT true FROM pg_tables WHERE tablename = 'disttable2';
+ bool 
+------
+ t
+(1 row)
+
+\c :MY_DB1
+SELECT true FROM pg_tables WHERE tablename = 'disttable2';
+ bool 
+------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SET ROLE :ROLE_1;
 ALTER TABLE disttable2 RENAME TO disttable;
+SELECT true FROM pg_tables WHERE tablename = 'disttable';
+ bool 
+------
+ t
+(1 row)
+
+\c :MY_DB1
+SELECT true FROM pg_tables WHERE tablename = 'disttable';
+ bool 
+------
+ t
+(1 row)
+
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SET ROLE :ROLE_1;
 -- SET SCHEMA
-ALTER TABLE disttable SET SCHEMA some_schema;
-ALTER TABLE some_schema.disttable SET SCHEMA public;
 \set ON_ERROR_STOP 0
 ALTER TABLE disttable SET SCHEMA some_unexist_schema;
 ERROR:  schema "some_unexist_schema" does not exist
+\set ON_ERROR_STOP 1
+-- some_schema was not created on data nodes
+\set ON_ERROR_STOP 0
+ALTER TABLE disttable SET SCHEMA some_schema;
+ERROR:  [data_node_1]: schema "some_schema" does not exist
 \set ON_ERROR_STOP 1
 -- OWNER TO
 RESET ROLE;

--- a/tsl/test/sql/dist_ddl.sql
+++ b/tsl/test/sql/dist_ddl.sql
@@ -102,13 +102,27 @@ TRUNCATE disttable;
 
 -- RENAME TO
 ALTER TABLE disttable RENAME TO disttable2;
+
+SELECT true FROM pg_tables WHERE tablename = 'disttable2';
+\c :MY_DB1
+SELECT true FROM pg_tables WHERE tablename = 'disttable2';
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SET ROLE :ROLE_1;
 ALTER TABLE disttable2 RENAME TO disttable;
+SELECT true FROM pg_tables WHERE tablename = 'disttable';
+\c :MY_DB1
+SELECT true FROM pg_tables WHERE tablename = 'disttable';
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SET ROLE :ROLE_1;
 
 -- SET SCHEMA
-ALTER TABLE disttable SET SCHEMA some_schema;
-ALTER TABLE some_schema.disttable SET SCHEMA public;
 \set ON_ERROR_STOP 0
 ALTER TABLE disttable SET SCHEMA some_unexist_schema;
+\set ON_ERROR_STOP 1
+
+-- some_schema was not created on data nodes
+\set ON_ERROR_STOP 0
+ALTER TABLE disttable SET SCHEMA some_schema;
 \set ON_ERROR_STOP 1
 
 -- OWNER TO


### PR DESCRIPTION
Fix ALTER TABLE RENAME TO command execution on a distributed
hypertable, make sure data node list is set and command is
executed on the data nodes.

Fix #4491