### PR TITLE
Modify chunk exclusion to include OSM chunks  (draft)

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -196,6 +196,7 @@ ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq OWNED BY _timescaledb_catalog.c
 CREATE INDEX chunk_hypertable_id_idx ON _timescaledb_catalog.chunk (hypertable_id);
 
 CREATE INDEX chunk_compressed_chunk_id_idx ON _timescaledb_catalog.chunk (compressed_chunk_id);
+CREATE INDEX chunk_status_hypertable_id_idx ON _timescaledb_catalog.chunk (status, hypertable_id);
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk', '');
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_id_seq', '');

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -10,3 +10,6 @@ CREATE TABLE _timescaledb_catalog.dimension_partition (
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension_partition', '');
 GRANT SELECT ON _timescaledb_catalog.dimension_partition TO PUBLIC;
 DROP FUNCTION IF EXISTS @extschema@.remove_continuous_aggregate_policy(REGCLASS, BOOL);
+
+--Add new index on chunk catalog table
+CREATE INDEX chunk_status_hypertable_id_idx ON _timescaledb_catalog.chunk (status, hypertable_id);

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -35,3 +35,5 @@ LANGUAGE C VOLATILE STRICT;
 
 DROP VIEW IF EXISTS timescaledb_experimental.policies;
 
+--drop new index on chunk table
+DROP INDEX _timescaledb_catalog.chunk_status_hypertable_id_idx;

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -201,6 +201,7 @@ extern TSDLLEXPORT Chunk *ts_chunk_get_compressed_chunk_parent(const Chunk *chun
 extern TSDLLEXPORT bool ts_chunk_is_unordered(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_compressed(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_is_uncompressed_or_unordered(const Chunk *chunk);
+extern TSDLLEXPORT bool ts_chunk_is_osm_chunk(const Chunk *chunk);
 extern TSDLLEXPORT bool ts_chunk_validate_chunk_status_for_operation(Oid chunk_relid,
 																	 int32 chunk_status,
 																	 ChunkOperation cmd,
@@ -227,6 +228,7 @@ extern ScanIterator ts_chunk_scan_iterator_create(MemoryContext result_mcxt);
 extern void ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id);
 extern bool ts_chunk_lock_if_exists(Oid chunk_oid, LOCKMODE chunk_lockmode);
 extern int ts_chunk_oid_cmp(const void *p1, const void *p2);
+int ts_chunk_get_osm_chunk_id(int hypertable_id);
 
 #define chunk_get_by_name(schema_name, table_name, fail_if_not_found)                              \
 	ts_chunk_get_by_name_with_memory_context(schema_name,                                          \

--- a/src/chunk_scan.c
+++ b/src/chunk_scan.c
@@ -136,6 +136,10 @@ scan_stubs_by_constraints(ScanIterator *constr_it, const Hyperspace *hs, const L
  * For performance, try not to interleave scans of different metadata tables
  * in order to maintain data locality while scanning. Also, keep scanned
  * tables and indexes open until all the metadata is scanned for all chunks.
+ *
+ * NOTE:
+ * An OSM chunk has only dummy constraints. Always include an OSM chunk, if
+ * it exists, in the set of returned results.
  */
 Chunk **
 ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
@@ -162,6 +166,7 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 	Assert(OidIsValid(hs->main_table_relid));
 	orig_mcxt = MemoryContextSwitchTo(work_mcxt);
 
+	int osm_chunk_id = ts_chunk_get_osm_chunk_id(hs->hypertable_id);
 	/*
 	 * Step 1: Scan for chunks that match in all the given dimensions. The
 	 * matching chunks are returned as chunk stubs as they are not yet full
@@ -179,10 +184,17 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 		MemoryContextSwitchTo(orig_mcxt);
 		MemoryContextDelete(work_mcxt);
 
+		Chunk *osm_chunk = NULL;
+		if (osm_chunk_id != INVALID_CHUNK_ID)
+		{
+			osm_chunk = ts_chunk_get_by_id(osm_chunk_id, true);
+			chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * 1);
+			chunks[0] = osm_chunk;
+		}
 		if (numchunks)
-			*numchunks = 0;
+			*numchunks = osm_chunk ? 1 : 0;
 
-		return NULL;
+		return chunks;
 	}
 
 	/*
@@ -192,6 +204,7 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 	chunk_it = ts_chunk_scan_iterator_create(orig_mcxt);
 	unlocked_chunks = MemoryContextAlloc(work_mcxt, sizeof(Chunk *) * list_length(chunk_stubs));
 
+	bool found_osm_chunk = false;
 	foreach (lc, chunk_stubs)
 	{
 		const ChunkStub *stub = lfirst(lc);
@@ -240,6 +253,8 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 				unlocked_chunks[unlocked_chunk_count] = chunk;
 				unlocked_chunk_count++;
 
+				if (ts_chunk_is_osm_chunk(chunk))
+					found_osm_chunk = true;
 				/*
 				 * Try to detect when sorting is needed for locking
 				 * purposes. Sometimes, the chunk order resulting from
@@ -284,17 +299,29 @@ ts_chunk_scan_by_constraints(const Hyperspace *hs, const List *dimension_vecs,
 		{
 			/* Lazy initialize the chunks array */
 			if (NULL == chunks)
-				chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * unlocked_chunk_count);
-
+			{
+				int chunks_alloc = unlocked_chunk_count;
+				if (osm_chunk_id != INVALID_CHUNK_ID && !found_osm_chunk)
+					chunks_alloc = unlocked_chunk_count + 1;
+				chunks = MemoryContextAlloc(orig_mcxt, sizeof(Chunk *) * chunks_alloc);
+			}
 			chunks[chunk_count] = chunk;
 
-			if (chunk->relkind == RELKIND_FOREIGN_TABLE)
+			if (chunk->relkind == RELKIND_FOREIGN_TABLE && !ts_chunk_is_osm_chunk(chunk))
 				remote_chunk_count++;
 
 			chunk_count++;
 		}
 	}
-
+	/* get the osm chunk if needed */
+	if (osm_chunk_id != INVALID_CHUNK_ID && !found_osm_chunk)
+	{
+		MemoryContext old_mcxt;
+		old_mcxt = MemoryContextSwitchTo(orig_mcxt);
+		chunks[chunk_count] = ts_chunk_get_by_id(osm_chunk_id, true);
+		MemoryContextSwitchTo(old_mcxt);
+		chunk_count++;
+	}
 	/*
 	 * Step 3: The chunk stub scan only contained dimensional
 	 * constraints. Scan the chunk constraints again to get all

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -164,6 +164,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 			[CHUNK_HYPERTABLE_ID_INDEX] = "chunk_hypertable_id_idx",
 			[CHUNK_SCHEMA_NAME_INDEX] = "chunk_schema_name_table_name_key",
 			[CHUNK_COMPRESSED_CHUNK_ID_INDEX] = "chunk_compressed_chunk_id_idx",
+			[CHUNK_STATUS_HYPERTABLE_ID_INDEX] = "chunk_status_hypertable_id_idx",
 		},
 	},
 	[CHUNK_CONSTRAINT] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -431,6 +431,7 @@ enum
 	CHUNK_HYPERTABLE_ID_INDEX,
 	CHUNK_SCHEMA_NAME_INDEX,
 	CHUNK_COMPRESSED_CHUNK_ID_INDEX,
+	CHUNK_STATUS_HYPERTABLE_ID_INDEX,
 	_MAX_CHUNK_INDEX,
 };
 
@@ -453,6 +454,12 @@ enum Anum_chunk_schema_name_idx
 {
 	Anum_chunk_schema_name_idx_schema_name = 1,
 	Anum_chunk_schema_name_idx_table_name,
+};
+
+enum Anum_chunk_status_hypertable_id_idx
+{
+	Anum_chunk_status_hypertable_id_idx_status = 1,
+	Anum_chunk_status_hypertable_id_idx_hypertable_id,
 };
 
 /************************************

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -363,7 +363,7 @@ SELECT create_hypertable('ht_try', 'timec', chunk_time_interval => interval '1 d
  (5,public,ht_try,t)
 (1 row)
 
-INSERT INTO ht_try VALUES ('2020-05-05 01:00', 222, 222);
+INSERT INTO ht_try VALUES ('2022-05-05 01:00', 222, 222);
 SELECT * FROM child_fdw_table;
             timec             | acq_id | value 
 ------------------------------+--------+-------
@@ -381,7 +381,7 @@ FROM timescaledb_information.chunks
 WHERE hypertable_name = 'ht_try' ORDER BY 1;
     chunk_name    |           range_start           |            range_end            
 ------------------+---------------------------------+---------------------------------
- _hyper_5_9_chunk | Mon May 04 17:00:00 2020 PDT    | Tue May 05 17:00:00 2020 PDT
+ _hyper_5_9_chunk | Wed May 04 17:00:00 2022 PDT    | Thu May 05 17:00:00 2022 PDT
  child_fdw_table  | Tue Nov 23 16:00:00 4684 PST BC | Wed Nov 24 16:00:00 4684 PST BC
 (2 rows)
 
@@ -389,7 +389,7 @@ SELECT * FROM ht_try ORDER BY 1;
             timec             | acq_id | value 
 ------------------------------+--------+-------
  Wed Jan 01 01:00:00 2020 PST |    100 |  1000
- Tue May 05 01:00:00 2020 PDT |    222 |   222
+ Thu May 05 01:00:00 2022 PDT |    222 |   222
 (2 rows)
 
 SELECT relname, relowner FROM pg_class
@@ -408,6 +408,38 @@ FROM pg_inherits WHERE inhparent = 'ht_try'::regclass ORDER BY 1;
  child_fdw_table
  _timescaledb_internal._hyper_5_9_chunk
 (2 rows)
+
+--TEST chunk exclusion code does not filter out OSM chunk
+SELECT * from ht_try ORDER BY 1;
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+ Thu May 05 01:00:00 2022 PDT |    222 |   222
+(2 rows)
+
+SELECT * from ht_try WHERE timec < '2022-01-01 01:00' ORDER BY 1; 
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
+SELECT * from ht_try WHERE timec = '2020-01-01 01:00' ORDER BY 1; 
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
+SELECT * from ht_try WHERE  timec > '2000-01-01 01:00' and timec < '2022-01-01 01:00' ORDER BY 1;
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Wed Jan 01 01:00:00 2020 PST |    100 |  1000
+(1 row)
+
+SELECT * from ht_try WHERE timec > '2020-01-01 01:00' ORDER BY 1; 
+            timec             | acq_id | value 
+------------------------------+--------+-------
+ Thu May 05 01:00:00 2022 PDT |    222 |   222
+(1 row)
 
 -- TEST error have to be hypertable owner to attach a chunk to it
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -224,7 +224,7 @@ CREATE FOREIGN TABLE child_fdw_table
 --now attach foreign table as a chunk of the hypertable.
 CREATE TABLE ht_try(timec timestamptz NOT NULL, acq_id bigint, value bigint);
 SELECT create_hypertable('ht_try', 'timec', chunk_time_interval => interval '1 day');
-INSERT INTO ht_try VALUES ('2020-05-05 01:00', 222, 222);
+INSERT INTO ht_try VALUES ('2022-05-05 01:00', 222, 222);
 
 SELECT * FROM child_fdw_table;
 
@@ -243,6 +243,13 @@ WHERE relname in ( select chunk_name FROM timescaledb_information.chunks
 SELECT inhrelid::regclass
 FROM pg_inherits WHERE inhparent = 'ht_try'::regclass ORDER BY 1;
 
+--TEST chunk exclusion code does not filter out OSM chunk
+SELECT * from ht_try ORDER BY 1;
+SELECT * from ht_try WHERE timec < '2022-01-01 01:00' ORDER BY 1; 
+SELECT * from ht_try WHERE timec = '2020-01-01 01:00' ORDER BY 1; 
+SELECT * from ht_try WHERE  timec > '2000-01-01 01:00' and timec < '2022-01-01 01:00' ORDER BY 1;
+
+SELECT * from ht_try WHERE timec > '2020-01-01 01:00' ORDER BY 1; 
 -- TEST error have to be hypertable owner to attach a chunk to it
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
The chunk exclusion code examines the dimension_slice catalog
table to filter out chunks. OSM chunks do not register their
actual dimension ranges with the catalogs. This metadata is
managed by OSM. So an OSM chunk, if it exists, should not
be excluded.