### PR TITLE
Centralize CI settings

### DIFF
--- a/.github/ci_settings.py
+++ b/.github/ci_settings.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+#  This file and its contents are licensed under the Apache License 2.0.
+#  Please see the included NOTICE for copyright information and
+#  LICENSE-APACHE for a copy of the license.
+
+# Common settings for our CI jobs
+
+PG12_EARLIEST = "12.0"
+PG12_LATEST = "12.12"
+PG13_EARLIEST = "13.2"
+PG13_LATEST = "13.8"
+PG14_EARLIEST = "14.0"
+PG14_LATEST = "14.5"
+
+PG_LATEST = [PG12_LATEST, PG13_LATEST, PG14_LATEST]

--- a/.github/gh_config_reader.py
+++ b/.github/gh_config_reader.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+#  This file and its contents are licensed under the Apache License 2.0.
+#  Please see the included NOTICE for copyright information and
+#  LICENSE-APACHE for a copy of the license.
+
+import json
+import ci_settings
+
+# generate commands to set github action variables
+for key in dir(ci_settings):
+    if not key.startswith("__"):
+        value = getattr(ci_settings, key)
+        print(str.format("::set-output name={0}::{1}", key, json.dumps(value)))

--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -17,16 +17,10 @@
 
 import json
 import sys
+from ci_settings import PG12_EARLIEST, PG12_LATEST, PG13_EARLIEST, PG13_LATEST, PG14_EARLIEST, PG14_LATEST
 
 # github event type which is either push, pull_request or schedule
 event_type = sys.argv[1]
-
-PG12_EARLIEST = "12.0"
-PG12_LATEST = "12.12"
-PG13_EARLIEST = "13.2"
-PG13_LATEST = "13.8"
-PG14_EARLIEST = "14.0"
-PG14_LATEST = "14.5"
 
 m = {"include": [],}
 

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -15,13 +15,25 @@ on:
     branches:
       - prerelease_test
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
+      id: setter
+      run: python .github/gh_config_reader.py
+
   abi_test:
     name: ABI Test ${{ matrix.type}} PG${{ matrix.pg }}
     runs-on: ubuntu-latest
+    needs: config
     strategy:
       fail-fast: false
       matrix:
-        pg: ["12.8","13.4","14.0"]
+        pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
         type: ["min","max"]
 
     steps:

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -7,13 +7,25 @@ on:
     branches:
       - coverity_scan
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
+      id: setter
+      run: python .github/gh_config_reader.py
+
   coverity:
     name: Coverity ${{ matrix.pg }}
     runs-on: ${{ matrix.os }}
+    needs: config
     strategy:
       fail-fast: false
       matrix:
-        pg: ["12.12", "13.8", "14.5"]
+        pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
         os: [ubuntu-20.04]
     env:
       PG_SRC_DIR: pgbuild

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -8,9 +8,21 @@ on:
       - prerelease_test
   pull_request:
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
+      id: setter
+      run: python .github/gh_config_reader.py
+
   regress_linux_32bit:
     name: PG${{ matrix.pg }} ${{ matrix.build_type }} linux-i386
     runs-on: ubuntu-latest
+    needs: config
     container:
       image: i386/debian:buster-slim
       options: --privileged --ulimit core=-1
@@ -20,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: ["12.12","13.8","14.5"]
+        pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
         build_type: [ Debug ]
 
     steps:

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Build matrix
       id: set-matrix
-      run: python scripts/gh_matrix_builder.py ${{ github.event_name }}
+      run: python .github/gh_matrix_builder.py ${{ github.event_name }}
 
   regress:
     name: PG${{ matrix.pg }}${{ matrix.snapshot }} ${{ matrix.name }} ${{ matrix.os }}

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -36,15 +36,27 @@ env:
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_leak.txt print_suppressions=0 log_path=${{ github.workspace }}/sanitizer.log log_exe_name=true print_suppressions=false exitcode=27 external_symbolizer_path=/usr/lib/llvm-10/bin/llvm-symbolizer
   UBSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_ub.txt print_stacktrace=1 halt_on_error=1 log_path=${{ github.workspace }}/sanitizer.log log_exe_name=true print_suppressions=false exitcode=27 external_symbolizer_path=/usr/lib/llvm-10/bin/llvm-symbolizer
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
+      id: setter
+      run: python .github/gh_config_reader.py
+
   sanitizer:
     name: PG${{ matrix.pg }} Sanitizer ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: config
     strategy:
       fail-fast: false
       matrix:
         # "os" has to be in the matrix due to a bug in "env": https://github.community/t/how-to-use-env-context/16975
         os: ["ubuntu-20.04"]
-        pg: ["12.12","13.8","14.5"]
+        pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
     steps:
     - name: Install Linux Dependencies
       run: |

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -8,13 +8,25 @@ on:
     branches:
       - sqlsmith
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg14_latest: ${{ steps.setter.outputs.PG14_LATEST }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
+      id: setter
+      run: python .github/gh_config_reader.py
+
   regress:
     name: SQLsmith PG${{ matrix.pg }}
     runs-on: ${{ matrix.os }}
+    needs: config
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
-        pg: ["14.5"]
+        pg: [ "${{ fromJson(needs.config.outputs.pg14_latest) }}" ]
         cc: ["gcc"]
         build_type: ["Debug"]
       fail-fast: false

--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -12,26 +12,26 @@ jobs:
         with:
           stale-issue-message: 'This issue has been automatically marked as stale due to lack of activity. You can remove the stale label or comment. Otherwise, this issue will be closed in 30 days. Thank you!'
           close-issue-message: 'We are closing this issue due to lack of activity. Feel free to add a comment to this issue if you can provide more information and we will re-open it. Thank you!'
-       
-          # Don't process PRs 
+
+          # Don't process PRs
           days-before-stale: -1
 
           # Process only issues
           days-before-issue-stale: 60
           days-before-issue-close: 30
-          
+
           # Add this label after 'days-before-issue-stale' days to mark it as stale
           stale-issue-label: 'no-activity'
 
           # Process only issues that contain the label 'need-more-info'
           only-labels: 'need-more-info'
-          
+
           # Stale only issues with one of these labels
           any-of-issue-labels: 'bug,enhancement'
-          
+
           # Exclude issues with the 'in-progress' label
           exempt-issue-labels: 'in-progress'
 
-          # Exclude assigned issues         
+          # Exclude assigned issues
           exempt-all-assignees: true
- 
+

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -8,12 +8,24 @@ on:
       - prerelease_test
   pull_request:
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
+      id: setter
+      run: python .github/gh_config_reader.py
+
   update_test:
     name: Update test PG${{ matrix.pg }}
     runs-on: 'ubuntu-latest'
+    needs: config
     strategy:
       matrix:
-        pg: ["12.12", "13.8", "14.5"]
+        pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}
@@ -42,9 +54,10 @@ jobs:
   downgrade_test:
     name: Downgrade test PG${{ matrix.pg }}
     runs-on: 'ubuntu-latest'
+    needs: config
     strategy:
       matrix:
-        pg: ["12.12", "13.8", "14.5"]
+        pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
       fail-fast: false
     env:
       PG_VERSION: ${{ matrix.pg }}


### PR DESCRIPTION
This patch adds a new settings file for common github action settings.
Instead of repeating latest pg versions in every github workflow we
can read the settings from this central file.