### PR TITLE
Reset compression sequence when group resets

### DIFF
--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -897,6 +897,15 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 	row_compressor->rowcnt_pre_compression += row_compressor->rows_compressed_into_current_value;
 	row_compressor->num_compressed_rows++;
 	row_compressor->rows_compressed_into_current_value = 0;
+
+	/*
+	 * The sequence number of the compressed tuple is per segment by grouping
+	 * and should be reset when the grouping changes to prevent overflows with
+	 * many segmentby columns.
+	 */
+	if (changed_groups)
+		row_compressor->sequence_num = SEQUENCE_NUM_GAP;
+
 	MemoryContextReset(row_compressor->per_row_ctx);
 }
 

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -349,11 +349,11 @@ SELECT sum(_ts_meta_count) from :COMPRESSED_CHUNK_NAME;
   42
 (1 row)
 
-SELECT _ts_meta_sequence_num from :COMPRESSED_CHUNK_NAME;
- _ts_meta_sequence_num 
------------------------
-                    10
-                    20
+SELECT location, _ts_meta_sequence_num from :COMPRESSED_CHUNK_NAME ORDER BY 1,2;
+ location | _ts_meta_sequence_num 
+----------+-----------------------
+ NYC      |                    10
+ POR      |                    10
 (2 rows)
 
 \x
@@ -1586,4 +1586,53 @@ SELECT count(*) FROM metrics;
 -------
  12961
 (1 row)
+
+-- test sequence number is local to segment by
+CREATE TABLE local_seq(time timestamptz, device int);
+SELECT table_name FROM create_hypertable('local_seq','time');
+NOTICE:  adding not-null constraint to column "time"
+ table_name 
+------------
+ local_seq
+(1 row)
+
+ALTER TABLE local_seq SET(timescaledb.compress,timescaledb.compress_segmentby='device');
+INSERT INTO local_seq SELECT '2000-01-01',1 FROM generate_series(1,3000);
+INSERT INTO local_seq SELECT '2000-01-01',2 FROM generate_series(1,3500);
+INSERT INTO local_seq SELECT '2000-01-01',3 FROM generate_series(1,3000);
+INSERT INTO local_seq SELECT '2000-01-01',4 FROM generate_series(1,3000);
+INSERT INTO local_seq SELECT '2000-01-01', generate_series(5,8);
+SELECT compress_chunk(c) FROM show_chunks('local_seq') c;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_33_66_chunk
+(1 row)
+
+SELECT
+	format('%s.%s',chunk.schema_name,chunk.table_name) AS "COMP_CHUNK"
+FROM _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable ht_comp ON ht_comp.id = ht.compressed_hypertable_id
+  INNER JOIN _timescaledb_catalog.chunk ON chunk.hypertable_id = ht_comp.id
+WHERE ht.table_name = 'local_seq' \gset
+SELECT device, _ts_meta_sequence_num, _ts_meta_count FROM :COMP_CHUNK ORDER BY 1,2;
+ device | _ts_meta_sequence_num | _ts_meta_count 
+--------+-----------------------+----------------
+      1 |                    10 |           1000
+      1 |                    20 |           1000
+      1 |                    30 |           1000
+      2 |                    10 |           1000
+      2 |                    20 |           1000
+      2 |                    30 |           1000
+      2 |                    40 |            500
+      3 |                    10 |           1000
+      3 |                    20 |           1000
+      3 |                    30 |           1000
+      4 |                    10 |           1000
+      4 |                    20 |           1000
+      4 |                    30 |           1000
+      5 |                    10 |              1
+      6 |                    10 |              1
+      7 |                    10 |              1
+      8 |                    10 |              1
+(17 rows)
 

--- a/tsl/test/expected/dist_move_chunk.out
+++ b/tsl/test/expected/dist_move_chunk.out
@@ -422,7 +422,7 @@ SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk;
                            time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
 ----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
  BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
- BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    20 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
+ BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
 (2 rows)
 
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
@@ -466,7 +466,7 @@ SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk;
                            time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
 ----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
  BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
- BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    20 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
+ BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
 (2 rows)
 
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;
@@ -586,7 +586,7 @@ SELECT * FROM _timescaledb_internal.compress_hyper_3_6_chunk;
                            time                           | device |                                                                       temp                                                                       | _ts_meta_count | _ts_meta_sequence_num |      _ts_meta_min_1      |      _ts_meta_max_1      
 ----------------------------------------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+----------------+-----------------------+--------------------------+--------------------------
  BAAAAgna9rUEAAACCdr2tQQAAAAAAQAAAAEAAAAAAAAADgAEE7XtaggA |      1 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 01:00:00 2018 | Thu Mar 08 01:00:00 2018
- BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    20 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
+ BAAAAgnaICFgAAACCdogIWAAAAAAAQAAAAEAAAAAAAAADgAEE7RAQsAA |     10 | AwA/uZmZmZmZmgAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEGAAAAAAAAAAIAAAABAAAAAQAAAAAAAAAGAAAAAAAAAD0AAAABPR/czMzMzMzN |              1 |                    10 | Thu Mar 08 00:00:00 2018 | Thu Mar 08 00:00:00 2018
 (2 rows)
 
 SELECT * FROM _timescaledb_internal._dist_hyper_3_12_chunk ORDER BY time;

--- a/tsl/test/sql/compression.sql
+++ b/tsl/test/sql/compression.sql
@@ -155,7 +155,7 @@ where uncompressed.compressed_chunk_id = compressed.id AND uncompressed.id = :'C
 SELECT count(*) from :CHUNK_NAME;
 SELECT count(*) from :COMPRESSED_CHUNK_NAME;
 SELECT sum(_ts_meta_count) from :COMPRESSED_CHUNK_NAME;
-SELECT _ts_meta_sequence_num from :COMPRESSED_CHUNK_NAME;
+SELECT location, _ts_meta_sequence_num from :COMPRESSED_CHUNK_NAME ORDER BY 1,2;
 
 \x
 SELECT chunk_id, numrows_pre_compression, numrows_post_compression
@@ -688,3 +688,26 @@ WHERE h.id = c.hypertable_id and h.table_name = 'metrics'
 ORDER BY 1;
 
 SELECT count(*) FROM metrics;
+
+-- test sequence number is local to segment by
+CREATE TABLE local_seq(time timestamptz, device int);
+SELECT table_name FROM create_hypertable('local_seq','time');
+ALTER TABLE local_seq SET(timescaledb.compress,timescaledb.compress_segmentby='device');
+
+INSERT INTO local_seq SELECT '2000-01-01',1 FROM generate_series(1,3000);
+INSERT INTO local_seq SELECT '2000-01-01',2 FROM generate_series(1,3500);
+INSERT INTO local_seq SELECT '2000-01-01',3 FROM generate_series(1,3000);
+INSERT INTO local_seq SELECT '2000-01-01',4 FROM generate_series(1,3000);
+INSERT INTO local_seq SELECT '2000-01-01', generate_series(5,8);
+
+SELECT compress_chunk(c) FROM show_chunks('local_seq') c;
+
+SELECT
+	format('%s.%s',chunk.schema_name,chunk.table_name) AS "COMP_CHUNK"
+FROM _timescaledb_catalog.hypertable ht
+  INNER JOIN _timescaledb_catalog.hypertable ht_comp ON ht_comp.id = ht.compressed_hypertable_id
+  INNER JOIN _timescaledb_catalog.chunk ON chunk.hypertable_id = ht_comp.id
+WHERE ht.table_name = 'local_seq' \gset
+
+SELECT device, _ts_meta_sequence_num, _ts_meta_count FROM :COMP_CHUNK ORDER BY 1,2;
+


### PR DESCRIPTION
The sequence number of the compressed tuple is per segment by grouping
and should be reset when the grouping changes to prevent overflows with
many segmentby columns.