### PR TITLE
Fix telemetry BGW memory leak

### DIFF
--- a/src/telemetry/functions.c
+++ b/src/telemetry/functions.c
@@ -57,9 +57,12 @@ allowed_extension_functions(const char **visible_extensions, int num_visible_ext
 	HASHCTL hash_info = {
 		.keysize = sizeof(Oid),
 		.entrysize = sizeof(AllowedFnHashEntry),
+		.hcxt = CurrentMemoryContext,
 	};
-	HTAB *allowed_fns =
-		hash_create("fn telemetry allowed_functions", 1000, &hash_info, HASH_ELEM | HASH_BLOBS);
+	HTAB *allowed_fns = hash_create("fn telemetry allowed_functions",
+									1000,
+									&hash_info,
+									HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 
 	Relation depRel = table_open(DependRelationId, AccessShareLock);
 


### PR DESCRIPTION
Applies the same fix as PR #4534 to the hash table created in the telemetry background worker.
(unlikely to cause a serious memory leak b/c apparently BGWs don't live long, but it's needed for code-quality anyway)