### PR TITLE
Fix coccinelle hash_create script

### DIFF
--- a/coccinelle/hash_create.cocci
+++ b/coccinelle/hash_create.cocci
@@ -5,34 +5,35 @@
 // to be explicit about the memory context our hash tables live in so we enforce
 // usage of the flag.
 @ hash_create @
-expression res;
 position p;
 @@
 
-res@p = hash_create(...);
+hash_create@p(...)
 
 @safelist@
-expression res;
 expression arg1, arg2, arg3;
 expression w1, w2;
-expression flags;
 position hash_create.p;
 @@
 (
-res@p = hash_create(arg1,arg2,arg3, w1 | HASH_CONTEXT | w2);
+hash_create@p(arg1,arg2,arg3, w1 | HASH_CONTEXT | w2)
 |
-res@p = hash_create(arg1,arg2,arg3, w1 | HASH_CONTEXT);
+hash_create@p(arg1,arg2,arg3, w1 | HASH_CONTEXT)
 |
-res@p = hash_create(arg1,arg2,arg3, HASH_CONTEXT | w2 );
-|
-Assert(flags & HASH_CONTEXT);
-res@p = hash_create(arg1,arg2,arg3, flags);
+hash_create@p(arg1,arg2,arg3, HASH_CONTEXT | w2 )
 )
-@ depends on !safelist @
+@safelist2@
 expression res;
+expression arg1, arg2, arg3;
+expression flags;
+position hash_create.p;
+@@
+Assert(flags & HASH_CONTEXT);
+res = hash_create@p(arg1,arg2,arg3, flags);
+@ depends on !safelist && !safelist2 @
 position hash_create.p;
 @@
 
 + /* hash_create without HASH_CONTEXT flag */
-  res@p = hash_create(...);
+  hash_create@p(...)
 

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -293,12 +293,14 @@ register_entrypoint_for_db(Oid db_id, VirtualTransactionId vxid, BackgroundWorke
 static HTAB *
 init_database_htab(void)
 {
-	HASHCTL info = { .keysize = sizeof(Oid), .entrysize = sizeof(DbHashEntry) };
+	HASHCTL info = { .keysize = sizeof(Oid),
+					 .entrysize = sizeof(DbHashEntry),
+					 .hcxt = TopMemoryContext };
 
 	return hash_create("launcher_db_htab",
 					   ts_guc_max_background_workers,
 					   &info,
-					   HASH_BLOBS | HASH_ELEM);
+					   HASH_BLOBS | HASH_CONTEXT | HASH_ELEM);
 }
 
 /* Insert a scheduler entry into the hash table. Correctly set entry values. */


### PR DESCRIPTION
Previously the hash_create coccinelle script would not detect
hash_create calls that declared the return variable in the same
statement or that used the return value of hash_create as return
value.

Disable-check: commit-count
