### PR TITLE
Disable local line in pg_hba.conf on Windows

### DIFF
--- a/test/pg_hba.conf.in
+++ b/test/pg_hba.conf.in
@@ -1,8 +1,8 @@
 # TYPE  DATABASE        USER                                ADDRESS                 METHOD
 
 # "local" is for Unix domain socket connections only
-local   all             all                                                         trust
-local   replication     all                                                         trust
+@TEST_HBA_LOCAL@   all             all                                                         trust
+@TEST_HBA_LOCAL@   replication     all                                                         trust
 # IPv4 local connections:
 hostssl  all             @TEST_ROLE_CLUSTER_SUPERUSER@  127.0.0.1/32           cert clientcert=verify-full
 hostssl  all             @TEST_ROLE_1@                  127.0.0.1/32           cert clientcert=verify-full

--- a/test/test-defs.cmake
+++ b/test/test-defs.cmake
@@ -42,6 +42,13 @@ set(TEST_SCHEDULE_SHARED
 set(ISOLATION_TEST_SCHEDULE ${CMAKE_CURRENT_BINARY_DIR}/isolation_test_schedule)
 set(TEST_PASSFILE ${TEST_OUTPUT_DIR}/pgpass.conf)
 
+# Windows does not support local connections (unix domain sockets)
+if(WIN32)
+  set(TEST_HBA_LOCAL "#local")
+else()
+  set(TEST_HBA_LOCAL "local")
+endif()
+
 configure_file(${PRIMARY_TEST_DIR}/pg_hba.conf.in pg_hba.conf)
 set(TEST_PG_HBA_FILE ${TEST_OUTPUT_DIR}/pg_hba.conf)
 


### PR DESCRIPTION
Windows does not support unix domain socket connections so we comment
out `local` lines in pg_hba.conf. On PG12 on Windows this will prevent
server start otherwise.