### PR TITLE
Remove unused header file

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -51,7 +51,6 @@
 #include <utils/rel.h>
 #include <utils/builtins.h>
 #include <utils/catcache.h>
-#include <utils/int8.h>
 #include <utils/regproc.h>
 #include <utils/ruleutils.h>
 #include <utils/syscache.h>

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -11,7 +11,6 @@
 #include <nodes/makefuncs.h>
 #include <optimizer/optimizer.h>
 #include <rewrite/rewriteManip.h>
-#include <utils/int8.h>
 #include <utils/builtins.h>
 
 #include "options.h"


### PR DESCRIPTION
The Postgres header utils/int8.h is not necessary and it was removed in
version 15 by commit postgres/postgres@cfc7191dfea330dd7a71e940d59de78129bb6175