### PR TITLE
Change usage of scanint8 to pg_strtoint64

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -535,8 +535,6 @@ get_reindex_options(ReindexStmt *stmt)
 	make_new_heap(tableOid, tableSpace, relpersistence, ExclusiveLock)
 #endif
 
-#endif /* TIMESCALEDB_COMPAT_H */
-
 /*
  * PostgreSQL < 14 does not have F_TIMESTAMPTZ_GT macro but instead has
  * the oid of that function as F_TIMESTAMP_GT even though the signature
@@ -547,3 +545,25 @@ get_reindex_options(ReindexStmt *stmt)
 #define F_TIMESTAMPTZ_GE F_TIMESTAMP_GE
 #define F_TIMESTAMPTZ_GT F_TIMESTAMP_GT
 #endif
+
+/*
+ * PostgreSQL 15 removed "utils/int8.h" header and change the "scanint8"
+ * function to "pg_strtoint64" in "utils/builtins.h".
+ *
+ * https://github.com/postgres/postgres/commit/cfc7191dfea330dd7a71e940d59de78129bb6175
+ */
+#if PG15_LT
+#include <utils/int8.h>
+static inline int64
+pg_strtoint64(const char *str)
+{
+	int64 result;
+	scanint8(str, false, &result);
+
+	return result;
+}
+#else
+#include <utils/builtins.h>
+#endif
+
+#endif /* TIMESCALEDB_COMPAT_H */

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -5,7 +5,6 @@
  */
 #include <postgres.h>
 #include <utils/builtins.h>
-#include <utils/int8.h>
 #include <utils/memutils.h>
 #include <utils/palloc.h>
 #include <utils/snapmgr.h>
@@ -29,6 +28,7 @@
 #include <time_bucket.h>
 #include <hypertable_cache.h>
 
+#include "compat/compat.h"
 #include "remote/dist_commands.h"
 #include "ts_catalog/catalog.h"
 #include "ts_catalog/continuous_agg.h"
@@ -1452,8 +1452,8 @@ remote_invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertab
 				Assert(PQgetisnull(result, 0, 1));
 				continue;
 			}
-			scanint8(PQgetvalue(result, 0, 0), false, &start_time);
-			scanint8(PQgetvalue(result, 0, 1), false, &end_time);
+			start_time = pg_strtoint64(PQgetvalue(result, 0, 0));
+			end_time = pg_strtoint64(PQgetvalue(result, 0, 1));
 			elog(DEBUG1,
 				 "merged invalidations for refresh on [" INT64_FORMAT ", " INT64_FORMAT "] from %s",
 				 start_time,


### PR DESCRIPTION
PostgreSQL 15 changed `scanint8` to `pg_strtoint64`, so added it to the
compatibility layer and use just of pg_strtoint64 in source code.

postgres/postgres@cfc7191dfea330dd7a71e940d59de78129bb6175