### PR TITLE
Fix telemetry initialization

### DIFF
--- a/src/telemetry/functions.c
+++ b/src/telemetry/functions.c
@@ -187,8 +187,17 @@ ts_function_telemetry_read(const char **visible_extensions, int num_visible_exte
 	fn_telemetry_entry_vec *all_entries;
 	HTAB *allowed_ext_fns;
 
-	if (!function_counts)
-		return NULL;
+	if (function_counts == NULL)
+	{
+		FnTelemetryRendezvous **rendezvous =
+			(FnTelemetryRendezvous **) find_rendezvous_variable(RENDEZVOUS_FUNCTION_TELEMENTRY);
+
+		if (*rendezvous == NULL)
+			return NULL;
+
+		function_counts = (*rendezvous)->function_counts;
+		function_counts_lock = (*rendezvous)->lock;
+	}
 
 	all_entries = read_shared_map();
 	entries_to_send =


### PR DESCRIPTION
We cannot rely on the planner initializing the shared hashmap reference since there's no guarantee we'll actually run SPI code in the BGW before we marshal the request. This commit adds initialization checking to `ts_function_telemetry_read()` itself to ensure it will always read from an initialized state if possible. As this code run very infrequently, it currently checks every time and does not skip if it once saw a lack of entries. This is unlikely to matter.

It would be nice to test this more explicitly, but that will likely have to wait until we have better reporting about BGW internals. For now I've relied on manual testing. Look at the telemetry report for the DB with UUID `d412018f-a435-492f-9ab6-b09d480ab1c1` received at timestamp `2022-08-16 18:56:53+00` for an example.