### PR TITLE
Add missing gitignore entry

### DIFF
--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -1,4 +1,5 @@
 /cagg_ddl-*.sql
+/cagg_invalidation_dist_ht-*.sql
 /cagg_permissions-*.sql
 /cagg_query-*.sql
 /cagg_union_view-*.sql


### PR DESCRIPTION
Pull request #4416 introduced a new template SQL test file but missed
to add the properly gitgnore entry to ignore generated test files.