### PR TITLE
Enable Windows workflow in nightly CI run

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -1,6 +1,9 @@
 # Test building the extension on Windows
 name: Regression Windows
 on:
+  schedule:
+    # run daily 20:00 on main branch
+    - cron: '0 20 * * *'
   push:
     branches:
       - prerelease_test
@@ -9,11 +12,19 @@ jobs:
   config:
     runs-on: ubuntu-latest
     outputs:
-      build_type: ${{ steps.config.outputs.build_type }}
+      build_type: ${{ steps.build_type.outputs.build_type }}
+      pg12_latest: ${{ steps.config.outputs.pg12_latest }}
+      pg13_latest: ${{ steps.config.outputs.pg13_latest }}
+      pg14_latest: ${{ steps.config.outputs.pg14_latest }}
 
     steps:
-    - name: Build matrix
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
       id: config
+      run: python .github/gh_config_reader.py
+    - name: Set build_type
+      id: build_type
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "::set-output name=build_type::['Debug']"
@@ -31,18 +42,18 @@ jobs:
         pg: [ 12, 13, 14 ]
         os: [ windows-2022 ]
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
+        ignores: ["chunk_adaptive metadata"]
         tsl_ignores: ["compression_algos dist_partial_agg remote_connection"]
-        tsl_skips: ["bgw_db_scheduler build_info cagg_ddl_dist_ht data_fetcher dist_remote_error remote_txn"]
+        tsl_skips: ["bgw_db_scheduler cagg_ddl_dist_ht data_fetcher dist_compression dist_move_chunk dist_remote_error remote_txn"]
+        pg_config: ["-cfsync=off -cstatement_timeout=60s"]
         include:
           - pg: 12
-            pkg_version: 12.12.1
+            pkg_version: ${{ fromJson(needs.config.outputs.pg12_latest) }}.1
           - pg: 13
-            pkg_version: 13.8.1
-            ignores_version: chunk_adaptive metadata
-            tsl_skips_version: dist_grant-13 dist_move_chunk build_info
+            pkg_version: ${{ fromJson(needs.config.outputs.pg13_latest) }}.1
+            tsl_skips_version: dist_grant-13
           - pg: 14
-            pkg_version: 14.5.1
-            shared_ignores_version: dist_distinct_pushdown ordered_append_join-14
+            pkg_version: ${{ fromJson(needs.config.outputs.pg14_latest) }}.1
     env:
       # PostgreSQL configuration
       PGPORT: 55432
@@ -96,7 +107,8 @@ jobs:
         icacls ${{ env.TABLESPACE2 }} /grant runneradmin:F /T
         copy build_win/test/postgresql.conf ${{ env.PGDATA }}
         copy build_win/test/pg_hba.conf ${{ env.PGDATA }}
-        ~/PostgreSQL/${{ matrix.pg }}/bin/pg_ctl start -o "-cfsync=off"
+        ~/PostgreSQL/${{ matrix.pg }}/bin/pg_ctl start -o "${{ matrix.pg_config }}"
+        ~/PostgreSQL/${{ matrix.pg }}/bin/pg_isready -U postgres -d postgres
         ~/PostgreSQL/${{ matrix.pg }}/bin/psql -U postgres -d postgres -c 'CREATE USER root SUPERUSER LOGIN;'
         ~/PostgreSQL/${{ matrix.pg }}/bin/psql -U postgres -d postgres -c 'SHOW log_filename;SHOW data_directory;SELECT version();'
 
@@ -132,17 +144,19 @@ jobs:
           make -C build_wsl isolationchecklocal
         fi
 
-        make -C build_wsl regresschecklocal IGNORES="${{ matrix.ignores_version }}"
+        make -C build_wsl regresschecklocal IGNORES="${{ matrix.ignores }}"
 
     - name: Setup postgres cluster for TSL tests
       if: matrix.pg != '12'
       run: |
         ~/PostgreSQL/${{ matrix.pg }}/bin/pg_ctl stop
+        timeout 10
         Remove-Item -Recurse ${{ env.PGDATA }}
         ~/PostgreSQL/${{ matrix.pg }}/bin/initdb -U postgres -A trust --locale=us --encoding=UTF8
         copy build_win/tsl/test/postgresql.conf ${{ env.PGDATA }}
         copy build_win/tsl/test/pg_hba.conf ${{ env.PGDATA }}
-        ~/PostgreSQL/${{ matrix.pg }}/bin/pg_ctl start -o "-cfsync=off -clog_filename=postgres.log"
+        ~/PostgreSQL/${{ matrix.pg }}/bin/pg_ctl start -o "${{ matrix.pg_config }}"
+        ~/PostgreSQL/${{ matrix.pg }}/bin/pg_isready -U postgres -d postgres
         ~/PostgreSQL/${{ matrix.pg }}/bin/psql -U postgres -d postgres -c 'CREATE USER root SUPERUSER LOGIN;'
 
     - name: Run TSL tests
@@ -151,7 +165,6 @@ jobs:
       run: |
         export TEST_TABLESPACE1_PREFIX='${{ env.TABLESPACE1 }}'
         export TEST_TABLESPACE2_PREFIX='${{ env.TABLESPACE2 }}'
-        cmake -B build_wsl -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DTEST_PGPORT_LOCAL=${{ env.PGPORT }}
 
         # isolationtester is only packaged with pg14+ so we would have to build our own postgres
         # to get it for earlier versions so we skip it for < 14.
@@ -160,10 +173,6 @@ jobs:
         fi
 
         make -C build_wsl -k regresschecklocal-t IGNORES="${{ matrix.tsl_ignores }}" SKIPS="${{ matrix.tsl_skips }} ${{ matrix.tsl_skips_version }}"
-
-        if [[ "${{ matrix.pg }}" == "14" ]]; then
-          make -C build_wsl -k regresschecklocal-shared IGNORES="${{ matrix.shared_ignores_version }}"
-        fi
 
     - name: Show regression diffs
       if: always() && matrix.pg != '12'


### PR DESCRIPTION
Enable the Windows CI workflow in nightly runs. In nightly runs
the CI run will also test release configuration in addition to
the debug configuration run on PRs.