### PR TITLE
Modify OSM chunk constraint info in chunk catalog

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4454,7 +4454,7 @@ fill_hypercube_for_foreign_table_chunk(Hyperspace *hs)
 		const Dimension *dim = &hs->dimensions[i];
 		Assert(dim->type == DIMENSION_TYPE_OPEN);
 		Oid dimtype = ts_dimension_get_partition_type(dim);
-		Datum val = Int64GetDatum(ts_time_get_min(dimtype));
+		Datum val = ts_time_datum_get_max(dimtype);
 		p->coordinates[p->num_coords++] = ts_time_value_to_internal(val, dimtype);
 		cube->slices[i] = ts_dimension_calculate_default_slice(dim, p->coordinates[i]);
 		cube->num_slices++;

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -854,6 +854,11 @@ should_chunk_append(Hypertable *ht, PlannerInfo *root, RelOptInfo *rel, Path *pa
 				if (!ordered || path->pathkeys == NIL || list_length(merge->subpaths) == 0)
 					return false;
 
+				/* cannot support ordered append with OSM chunks. OSM chunk
+				 * ranges are not recorded with the catalog
+				 */
+				if (ht && ts_chunk_get_osm_chunk_id(ht->fd.id) != INVALID_CHUNK_ID)
+					return false;
 				pk = linitial_node(PathKey, path->pathkeys);
 
 				/*

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -405,10 +405,10 @@ SELECT chunk_name, range_start, range_end
 FROM chunk_view
 WHERE hypertable_name = 'ht_try'
 ORDER BY chunk_name;
-    chunk_name    |           range_start           |            range_end            
-------------------+---------------------------------+---------------------------------
- _hyper_5_9_chunk | Wed May 04 17:00:00 2022 PDT    | Thu May 05 17:00:00 2022 PDT
- child_fdw_table  | Tue Nov 23 16:00:00 4684 PST BC | Wed Nov 24 16:00:00 4684 PST BC
+    chunk_name    |          range_start           |          range_end           
+------------------+--------------------------------+------------------------------
+ _hyper_5_9_chunk | Wed May 04 17:00:00 2022 PDT   | Thu May 05 17:00:00 2022 PDT
+ child_fdw_table  | Thu Dec 31 16:00:00 294246 PST | infinity
 (2 rows)
 
 SELECT * FROM ht_try ORDER BY 1;
@@ -588,6 +588,26 @@ where conrelid = 'child_hyper_constr'::regclass ORDER BY 1;
          conname         
 -------------------------
  hyper_constr_temp_check
+(1 row)
+
+--TEST policy is not applied on OSM chunk
+CREATE OR REPLACE FUNCTION dummy_now_smallint() RETURNS BIGINT LANGUAGE SQL IMMUTABLE as  'SELECT 500::bigint' ;
+SELECT set_integer_now_func('hyper_constr', 'dummy_now_smallint');
+ set_integer_now_func 
+----------------------
+ 
+(1 row)
+
+SELECT add_retention_policy('hyper_constr', 100::int) AS deljob_id \gset
+CALL run_job(:deljob_id);
+CALL run_job(:deljob_id);
+SELECT chunk_name, range_start, range_end
+FROM chunk_view
+WHERE hypertable_name = 'hyper_constr'
+ORDER BY chunk_name;
+     chunk_name     |             range_start             | range_end 
+--------------------+-------------------------------------+-----------
+ child_hyper_constr | Sat Jan 09 20:00:54.7758 294247 PST | infinity
 (1 row)
 
 -- clean up databases created


### PR DESCRIPTION
The OSM chunk registers a dummy primary dimension range in the TimescaleDB catalog. Use the max interval of the dimension instead of the min interval i.e
    use range like [Dec 31 294246 PST, infinity).
Otherwise, policies can try to apply the policy on an OSM chunk.
    
Add test with policies for OSM chunks
