### PR TITLE
Improve windows package test

### DIFF
--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -10,14 +10,51 @@ on:
     branches:
     - release_test
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      pg12_earliest: ${{ steps.config.outputs.pg12_abi_min }}
+      pg13_earliest: ${{ steps.config.outputs.pg13_abi_min }}
+      pg14_earliest: ${{ steps.config.outputs.pg14_abi_min }}
+      pg12_latest: ${{ steps.config.outputs.pg12_latest }}
+      pg13_latest: ${{ steps.config.outputs.pg13_latest }}
+      pg14_latest: ${{ steps.config.outputs.pg14_latest }}
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Read configuration
+      id: config
+      run: python .github/gh_config_reader.py
+
   build:
-    name: Windows package PG${{ matrix.pg }}
+    name: Windows package PG${{ matrix.test }}
     runs-on: ${{ matrix.os }}
+    needs: config
     strategy:
       fail-fast: false
       matrix:
-        pg: [ 12, 13, 14 ]
+        test: [ "12min", "12max", "13min", "13max", "14min", "14max" ]
         os: [ windows-2019 ]
+        include:
+          - test: 12min
+            pg: 12
+            pkg_version: ${{ fromJson(needs.config.outputs.pg12_earliest) }}
+          - test: 12max
+            pg: 12
+            pkg_version: ${{ fromJson(needs.config.outputs.pg12_latest) }}.1
+          - test: 13min
+            pg: 13
+            pkg_version: ${{ fromJson(needs.config.outputs.pg13_earliest) }}.1
+          - test: 13max
+            pg: 13
+            pkg_version: ${{ fromJson(needs.config.outputs.pg13_latest) }}.1
+          - test: 14min
+            pg: 14
+            pkg_version: ${{ fromJson(needs.config.outputs.pg14_earliest) }}.1
+          - test: 14max
+            pg: 14
+            pkg_version: ${{ fromJson(needs.config.outputs.pg14_latest) }}.1
     env:
       # PostgreSQL configuration
       PGPORT: 6543
@@ -44,7 +81,7 @@ jobs:
       run: |
         choco feature disable --name=usePackageExitCodes
         choco feature disable --name=showDownloadProgress
-        choco install postgresql${{ matrix.pg }} --force -y --install-args="'--prefix $HOME/PostgreSQL/${{ matrix.pg }} --extract-only yes'"
+        choco install postgresql${{ matrix.pg }} --version ${{ matrix.pkg_version }} --force -y --install-args="'--prefix $HOME/PostgreSQL/${{ matrix.pg }} --extract-only yes'"
         choco install wget
 
     - name: Install TimescaleDB


### PR DESCRIPTION
Change the windows package test to use explicit postgres versions
and test both minimum and maximum supported postgres minor version.