### PR TITLE
Schema-qualify function telemetry

### DIFF
--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -442,7 +442,8 @@ add_function_call_telemetry(JsonbParseState *state)
 		for (uint32 i = 0; i < functions->num_elements; i++)
 		{
 			FnTelemetryEntry *entry = fn_telemetry_entry_vec_at(functions, i);
-			ts_jsonb_add_int64(state, format_procedure(entry->fn), entry->count);
+			char *proc_sig = format_procedure_qualified(entry->fn);
+			ts_jsonb_add_int64(state, proc_sig, entry->count);
 		}
 	}
 

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -550,16 +550,16 @@ EXECUTE record_from_prepared;
 
 DEALLOCATE record_from_prepared;
 SELECT get_telemetry_report()->'functions_used';
-                                                                                                        ?column?                                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"abs(integer)": 1, "min(integer)": 1, "sum(integer)": 1, "get_telemetry_report()": 1, "int4eq(integer,integer)": 1, "int4mi(integer,integer)": 11, "int4pl(integer,integer)": 3, "jsonb_object_field(jsonb,text)": 1}
+                                                                                                                                                             ?column?                                                                                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"pg_catalog.abs(integer)": 1, "pg_catalog.min(integer)": 1, "pg_catalog.sum(integer)": 1, "public.get_telemetry_report()": 1, "pg_catalog.int4eq(integer,integer)": 1, "pg_catalog.int4mi(integer,integer)": 11, "pg_catalog.int4pl(integer,integer)": 3, "pg_catalog.jsonb_object_field(pg_catalog.jsonb,pg_catalog.text)": 1}
 (1 row)
 
 -- check the report again to see if resetting works
 SELECT get_telemetry_report()->'functions_used';
-                              ?column?                              
---------------------------------------------------------------------
- {"get_telemetry_report()": 1, "jsonb_object_field(jsonb,text)": 1}
+                                                  ?column?                                                  
+------------------------------------------------------------------------------------------------------------
+ {"public.get_telemetry_report()": 1, "pg_catalog.jsonb_object_field(pg_catalog.jsonb,pg_catalog.text)": 1}
 (1 row)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER


### PR DESCRIPTION
This commit unconditionally schema-qualifies the function telemetry. In the default setting `format_procedure()` only schema-qualifies things that aren't on the search path. This could cause to much variation across users. Further, it'd be nice to tell if functions in-use are from an experimental schema or a main one.