### PR TITLE
Fix time_bucket_ng origin handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,20 @@ accidentally triggering the load of a previous DB version.**
 * #4641 Allow bucketing by month in time_bucket
 
 **Bugfixes**
+* #4416 Handle TRUNCATE TABLE on chunks
 * #4486 Adding boolean column with default value doesn't work on compressed table
 * #4555 Handle properly default privileges on Continuous Aggregates
 * #4575 Fix use of `get_partition_hash` and `get_partition_for_key` inside an IMMUTABLE function
-* #4416 Handle TRUNCATE TABLE on chunks
 * #4611 Fix a potential OOM when loading large data sets into a hypertable
+* #4646 Fix time_bucket_ng origin handling
 
 **Thanks**
-@janko for reporting an issue when adding bool column with default value to compressed hypertable
 @AlmiS for reporting error on `get_partition_hash` executed inside an IMMUTABLE function
-@michaelkitson for reporting permission errors using default privileges on Continuous Aggregates
+@janko for reporting an issue when adding bool column with default value to compressed hypertable
 @jayadevanm for reporting error of TRUNCATE TABLE on compressed chunk
+@michaelkitson for reporting permission errors using default privileges on Continuous Aggregates
 @ninjaltd and @mrksngl for reporting a potential OOM when loading large data sets into a hypertable
+@ssmoss for reporting an issue with time_bucket_ng origin handling
 
 ## 2.7.2 (2022-07-26)
 

--- a/src/time_bucket.c
+++ b/src/time_bucket.c
@@ -526,20 +526,13 @@ ts_time_bucket_ng_date(PG_FUNCTION_ARGS)
 		/* Handle months and years */
 
 		j2date(date + POSTGRES_EPOCH_JDATE, &year, &month, &day);
+		int32 result;
+		int32 offset = origin_year * 12 + origin_month - 1;
+		int32 timestamp = year * 12 + month - 1;
+		TIME_BUCKET(interval->month, timestamp, offset, PG_INT32_MIN, PG_INT32_MAX, result);
 
-		if ((year < origin_year) || ((year == origin_year) && (month < origin_month)))
-		{
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("origin must be before the given date")));
-		}
-
-		delta = (year * 12 + month) - (origin_year * 12 + origin_month);
-		bucket_number = delta / interval->month;
-		year = origin_year + (origin_month - 1 + bucket_number * interval->month) / 12;
-		month =
-			(((origin_year * 12 + (origin_month - 1)) + (bucket_number * interval->month)) % 12) +
-			1;
+		year = result / 12;
+		month = (result % 12) + 1;
 		day = 1;
 
 		date = date2j(year, month, day) - POSTGRES_EPOCH_JDATE;

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -1298,7 +1298,11 @@ SELECT timescaledb_experimental.time_bucket_ng('1 month', '2001-02-03' :: date, 
 ERROR:  origin must be the first day of the month
 HINT:  When using timestamptz-version of the function, 'origin' is converted to provided 'timezone'.
 SELECT timescaledb_experimental.time_bucket_ng('1 month', '2000-01-02' :: date, origin => '2001-01-01') AS result;
-ERROR:  origin must be before the given date
+   result   
+------------
+ 01-01-2000
+(1 row)
+
 SELECT timescaledb_experimental.time_bucket_ng('1 day', '2000-01-02' :: date, origin => '2001-01-01') AS result;
 ERROR:  origin must be before the given date
 SELECT timescaledb_experimental.time_bucket_ng('1 month 3 hours', '2021-11-22' :: timestamp) AS result;


### PR DESCRIPTION
This patch makes time_bucket_ng work correctly with origin values
that are after the timestamp value to be bucketed.

Fixes #4117
