### PR TITLE
Show warnings during create_hypertable().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ argument or resolve the type ambiguity by casting to the intended type.
 
 **Features**
 * #4670 Add timezone support to time_bucket_gapfill
+* #4650 Show warnings when not following best practices
 
 **Bugfixes**
 * #4619 Improve handling enum columns in compressed hypertables

--- a/test/expected/agg_bookends-12.out
+++ b/test/expected/agg_bookends-12.out
@@ -16,6 +16,8 @@ SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized resul
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE btest(time timestamp NOT NULL, time_alt timestamp, gp INTEGER, temp float, strid TEXT DEFAULT 'testing');
 SELECT schema_name, table_name, created FROM create_hypertable('btest', 'time');
+psql:include/agg_bookends_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/agg_bookends_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time_alt" does not follow best practices
  schema_name | table_name | created 
 -------------+------------+---------
  public      | btest      | t
@@ -30,6 +32,7 @@ INSERT INTO btest VALUES('2017-01-20T09:00:21', '2017-01-20T09:00:56', 2, 30.2);
 INSERT INTO btest VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1, repeat('xyz', 1000000) );
 CREATE TABLE btest_numeric (time timestamp NOT NULL, quantity numeric);
 SELECT schema_name, table_name, created FROM create_hypertable('btest_numeric', 'time');
+psql:include/agg_bookends_load.sql:16: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  schema_name |  table_name   | created 
 -------------+---------------+---------
  public      | btest_numeric | t

--- a/test/expected/agg_bookends-13.out
+++ b/test/expected/agg_bookends-13.out
@@ -16,6 +16,8 @@ SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized resul
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE btest(time timestamp NOT NULL, time_alt timestamp, gp INTEGER, temp float, strid TEXT DEFAULT 'testing');
 SELECT schema_name, table_name, created FROM create_hypertable('btest', 'time');
+psql:include/agg_bookends_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/agg_bookends_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time_alt" does not follow best practices
  schema_name | table_name | created 
 -------------+------------+---------
  public      | btest      | t
@@ -30,6 +32,7 @@ INSERT INTO btest VALUES('2017-01-20T09:00:21', '2017-01-20T09:00:56', 2, 30.2);
 INSERT INTO btest VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1, repeat('xyz', 1000000) );
 CREATE TABLE btest_numeric (time timestamp NOT NULL, quantity numeric);
 SELECT schema_name, table_name, created FROM create_hypertable('btest_numeric', 'time');
+psql:include/agg_bookends_load.sql:16: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  schema_name |  table_name   | created 
 -------------+---------------+---------
  public      | btest_numeric | t

--- a/test/expected/agg_bookends-14.out
+++ b/test/expected/agg_bookends-14.out
@@ -16,6 +16,8 @@ SELECT format('\! diff -u  --label "Unoptimized result" --label "Optimized resul
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE btest(time timestamp NOT NULL, time_alt timestamp, gp INTEGER, temp float, strid TEXT DEFAULT 'testing');
 SELECT schema_name, table_name, created FROM create_hypertable('btest', 'time');
+psql:include/agg_bookends_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+psql:include/agg_bookends_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time_alt" does not follow best practices
  schema_name | table_name | created 
 -------------+------------+---------
  public      | btest      | t
@@ -30,6 +32,7 @@ INSERT INTO btest VALUES('2017-01-20T09:00:21', '2017-01-20T09:00:56', 2, 30.2);
 INSERT INTO btest VALUES('2017-01-20T09:00:43', '2017-01-20T09:01:55', 2, 20.1, repeat('xyz', 1000000) );
 CREATE TABLE btest_numeric (time timestamp NOT NULL, quantity numeric);
 SELECT schema_name, table_name, created FROM create_hypertable('btest_numeric', 'time');
+psql:include/agg_bookends_load.sql:16: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  schema_name |  table_name   | created 
 -------------+---------------+---------
  public      | btest_numeric | t

--- a/test/expected/alter.out
+++ b/test/expected/alter.out
@@ -13,6 +13,7 @@ ALTER TABLE alter_before ALTER COLUMN colorid RESET (n_distinct);
 ALTER TABLE alter_before ALTER COLUMN temp SET STATISTICS 100;
 ALTER TABLE alter_before ALTER COLUMN notes SET STORAGE EXTERNAL;
 SELECT create_hypertable('alter_before', 'time', chunk_time_interval => 2628000000000);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
@@ -51,6 +52,7 @@ ORDER BY c.relname, a.attnum;
 -- DROP a table's column after making it a hypertable and having data
 CREATE TABLE alter_after(id serial, time timestamp, temp float, colorid integer, notes text, notes_2 text);
 SELECT create_hypertable('alter_after', 'time', chunk_time_interval => 2628000000000);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------

--- a/test/expected/alternate_users.out
+++ b/test/expected/alternate_users.out
@@ -78,6 +78,7 @@ ERROR:  must be owner of hypertable "one_Partition"
 \set ON_ERROR_STOP 1
 CREATE TABLE "1dim"(time timestamp, temp float);
 SELECT create_hypertable('"1dim"', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
@@ -441,6 +442,7 @@ ALTER TABLE PUBLIC."Hypertable_1" ADD COLUMN sensor_4 BIGINT NOT NULL DEFAULT 13
 CREATE TABLE plain_table_su (time timestamp, temp float);
 CREATE TABLE hypertable_su (time timestamp, temp float);
 SELECT create_hypertable('hypertable_su', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
@@ -453,6 +455,7 @@ INSERT INTO hypertable_su VALUES('2017-01-20T09:00:01', 22.5);
 --all of the following should produce errors
 \set ON_ERROR_STOP 0
 SELECT create_hypertable('plain_table_su', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 ERROR:  must be owner of hypertable "plain_table_su"
 CREATE INDEX ON plain_table_su (time, temp);
 ERROR:  must be owner of table plain_table_su

--- a/test/expected/append-12.out
+++ b/test/expected/append-12.out
@@ -92,6 +92,7 @@ ANALYZE metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
+psql:include/append_load.sql:67: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -134,6 +135,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
+psql:include/append_load.sql:99: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)

--- a/test/expected/append-13.out
+++ b/test/expected/append-13.out
@@ -92,6 +92,7 @@ ANALYZE metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
+psql:include/append_load.sql:67: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -134,6 +135,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
+psql:include/append_load.sql:99: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)

--- a/test/expected/append-14.out
+++ b/test/expected/append-14.out
@@ -92,6 +92,7 @@ ANALYZE metrics_date;
 -- create hypertable with TIMESTAMP time dimension
 CREATE TABLE metrics_timestamp(time TIMESTAMP NOT NULL);
 SELECT create_hypertable('metrics_timestamp','time');
+psql:include/append_load.sql:67: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
        create_hypertable        
 --------------------------------
  (4,public,metrics_timestamp,t)
@@ -134,6 +135,7 @@ CREATE TABLE i2661 (
   "first" float4 NULL
 );
 SELECT create_hypertable('i2661', 'timestamp');
+psql:include/append_load.sql:99: WARNING:  column type "character varying" used for "name" does not follow best practices
  create_hypertable  
 --------------------
  (7,public,i2661,t)

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -780,6 +780,7 @@ SELECT drop_chunks(format('%1$I.%2$I', schema_name, table_name)::regclass, older
 
 CREATE TABLE PUBLIC.drop_chunk_test_ts(time timestamp, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_ts', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------

--- a/test/expected/cluster-12.out
+++ b/test/expected/cluster-12.out
@@ -153,6 +153,7 @@ ERROR:  there is no previously clustered index for table "_hyper_1_1_chunk"
 CREATE TABLE cluster_alter(time timestamp, id text, val int);
 CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
 SELECT table_name FROM create_hypertable('cluster_alter', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
   table_name   
 ---------------

--- a/test/expected/cluster-13.out
+++ b/test/expected/cluster-13.out
@@ -153,6 +153,7 @@ ERROR:  there is no previously clustered index for table "_hyper_1_1_chunk"
 CREATE TABLE cluster_alter(time timestamp, id text, val int);
 CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
 SELECT table_name FROM create_hypertable('cluster_alter', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
   table_name   
 ---------------

--- a/test/expected/cluster-14.out
+++ b/test/expected/cluster-14.out
@@ -153,6 +153,7 @@ ERROR:  there is no previously clustered index for table "_hyper_1_1_chunk"
 CREATE TABLE cluster_alter(time timestamp, id text, val int);
 CREATE INDEX idstuff ON cluster_alter USING btree (id ASC NULLS LAST, time);
 SELECT table_name FROM create_hypertable('cluster_alter', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
   table_name   
 ---------------

--- a/test/expected/constraint-12.out
+++ b/test/expected/constraint-12.out
@@ -786,6 +786,7 @@ ALTER TABLE hyper_unique DROP CONSTRAINT hyper_unique_time_key;
 -- test for constraint validation crash, see #1183
 CREATE TABLE test_validate(time timestamp NOT NULL, a TEXT, b TEXT);
 SELECT * FROM create_hypertable('test_validate', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  hypertable_id | schema_name |  table_name   | created 
 ---------------+-------------+---------------+---------
             14 | public      | test_validate | t
@@ -813,6 +814,7 @@ id int,
 time timestamp,
 CONSTRAINT pk PRIMARY KEY (time, id) USING INDEX TABLESPACE tablespace1);
 SELECT create_hypertable('tbl', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_hypertable 
 -------------------
  (15,public,tbl,t)

--- a/test/expected/constraint-13.out
+++ b/test/expected/constraint-13.out
@@ -786,6 +786,7 @@ ALTER TABLE hyper_unique DROP CONSTRAINT hyper_unique_time_key;
 -- test for constraint validation crash, see #1183
 CREATE TABLE test_validate(time timestamp NOT NULL, a TEXT, b TEXT);
 SELECT * FROM create_hypertable('test_validate', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  hypertable_id | schema_name |  table_name   | created 
 ---------------+-------------+---------------+---------
             14 | public      | test_validate | t
@@ -813,6 +814,7 @@ id int,
 time timestamp,
 CONSTRAINT pk PRIMARY KEY (time, id) USING INDEX TABLESPACE tablespace1);
 SELECT create_hypertable('tbl', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_hypertable 
 -------------------
  (15,public,tbl,t)

--- a/test/expected/constraint-14.out
+++ b/test/expected/constraint-14.out
@@ -786,6 +786,7 @@ ALTER TABLE hyper_unique DROP CONSTRAINT hyper_unique_time_key;
 -- test for constraint validation crash, see #1183
 CREATE TABLE test_validate(time timestamp NOT NULL, a TEXT, b TEXT);
 SELECT * FROM create_hypertable('test_validate', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  hypertable_id | schema_name |  table_name   | created 
 ---------------+-------------+---------------+---------
             14 | public      | test_validate | t
@@ -813,6 +814,7 @@ id int,
 time timestamp,
 CONSTRAINT pk PRIMARY KEY (time, id) USING INDEX TABLESPACE tablespace1);
 SELECT create_hypertable('tbl', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_hypertable 
 -------------------
  (15,public,tbl,t)

--- a/test/expected/copy-12.out
+++ b/test/expected/copy-12.out
@@ -335,6 +335,7 @@ SELECT COUNT(*) FROM hyper_copy_large;
 -- Migrate data to chunks by using copy
 SELECT create_hypertable('hyper_copy_large', 'time',
    chunk_time_interval => INTERVAL '1 hour', migrate_data => 'true');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  migrating data to chunks
        create_hypertable       
 -------------------------------

--- a/test/expected/copy-13.out
+++ b/test/expected/copy-13.out
@@ -335,6 +335,7 @@ SELECT COUNT(*) FROM hyper_copy_large;
 -- Migrate data to chunks by using copy
 SELECT create_hypertable('hyper_copy_large', 'time',
    chunk_time_interval => INTERVAL '1 hour', migrate_data => 'true');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  migrating data to chunks
        create_hypertable       
 -------------------------------

--- a/test/expected/copy-14.out
+++ b/test/expected/copy-14.out
@@ -335,6 +335,7 @@ SELECT COUNT(*) FROM hyper_copy_large;
 -- Migrate data to chunks by using copy
 SELECT create_hypertable('hyper_copy_large', 'time',
    chunk_time_interval => INTERVAL '1 hour', migrate_data => 'true');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  migrating data to chunks
        create_hypertable       
 -------------------------------

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -409,6 +409,7 @@ NOTICE:  column "location" is already a dimension, skipping
 --test partitioning in only time dimension
 create table test_schema.test_1dim(time timestamp, temp float);
 select create_hypertable('test_schema.test_1dim', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
@@ -526,9 +527,11 @@ select * from only test_schema.test_migrate;
 \set ON_ERROR_STOP 0
 --should fail without migrate_data => true
 select create_hypertable('test_schema.test_migrate', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 ERROR:  table "test_migrate" is not empty
 \set ON_ERROR_STOP 1
 select create_hypertable('test_schema.test_migrate', 'time', migrate_data => true);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
 NOTICE:  migrating data to chunks
         create_hypertable        
@@ -579,6 +582,7 @@ select * from only _timescaledb_internal._hyper_10_10_chunk;
 
 create table test_schema.test_migrate_empty(time timestamp, temp float);
 select create_hypertable('test_schema.test_migrate_empty', 'time', migrate_data => true);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
@@ -588,6 +592,7 @@ NOTICE:  adding not-null constraint to column "time"
 CREATE TYPE test_type AS (time timestamp, temp float);
 CREATE TABLE test_table_of_type OF test_type;
 SELECT create_hypertable('test_table_of_type', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
@@ -603,6 +608,7 @@ DROP TYPE test_type CASCADE;
 NOTICE:  drop cascades to 3 other objects
 CREATE TABLE test_table_of_type (time timestamp, temp float);
 SELECT create_hypertable('test_table_of_type', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------
@@ -778,3 +784,21 @@ select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_I
  29 |            17 | time        | bigint      | t       |            |                          |                   |               1 | my_new_schema           | dummy_now4
 (1 row)
 
+-- github issue #4650
+CREATE TABLE sample_table (
+       cpu double precision null,
+       time TIMESTAMP WITH TIME ZONE NOT NULL,
+       sensor_id INTEGER NOT NULL,
+       name varchar(100) default 'this is a default string value',
+       UNIQUE(sensor_id, time)
+);
+ALTER TABLE sample_table DROP COLUMN name;
+-- below creation should not report any warnings.
+SELECT * FROM create_hypertable('sample_table', 'time');
+ hypertable_id | schema_name |  table_name  | created 
+---------------+-------------+--------------+---------
+            18 | public      | sample_table | t
+(1 row)
+
+-- cleanup
+DROP TABLE sample_table CASCADE;

--- a/test/expected/ddl-12.out
+++ b/test/expected/ddl-12.out
@@ -386,6 +386,7 @@ SELECT * FROM PUBLIC."Hypertable_1";
 CREATE TABLE alter_test(time timestamptz, temp float, color varchar(10));
 -- create hypertable with two chunks
 SELECT create_hypertable('alter_test', 'time', 'color', 2, chunk_time_interval => 2628000000000);
+WARNING:  column type "character varying" used for "color" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
@@ -531,6 +532,7 @@ ERROR:  cannot drop column named in partition key
 -- test expression index creation where physical layout of chunks differs from hypertable
 CREATE TABLE i2504(time timestamp NOT NULL, a int, b int, c int, d int);
 select create_hypertable('i2504', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
   create_hypertable  
 ---------------------
  (11,public,i2504,t)

--- a/test/expected/ddl-13.out
+++ b/test/expected/ddl-13.out
@@ -386,6 +386,7 @@ SELECT * FROM PUBLIC."Hypertable_1";
 CREATE TABLE alter_test(time timestamptz, temp float, color varchar(10));
 -- create hypertable with two chunks
 SELECT create_hypertable('alter_test', 'time', 'color', 2, chunk_time_interval => 2628000000000);
+WARNING:  column type "character varying" used for "color" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
@@ -531,6 +532,7 @@ ERROR:  cannot drop column named in partition key
 -- test expression index creation where physical layout of chunks differs from hypertable
 CREATE TABLE i2504(time timestamp NOT NULL, a int, b int, c int, d int);
 select create_hypertable('i2504', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
   create_hypertable  
 ---------------------
  (11,public,i2504,t)

--- a/test/expected/ddl-14.out
+++ b/test/expected/ddl-14.out
@@ -386,6 +386,7 @@ SELECT * FROM PUBLIC."Hypertable_1";
 CREATE TABLE alter_test(time timestamptz, temp float, color varchar(10));
 -- create hypertable with two chunks
 SELECT create_hypertable('alter_test', 'time', 'color', 2, chunk_time_interval => 2628000000000);
+WARNING:  column type "character varying" used for "color" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
@@ -531,6 +532,7 @@ ERROR:  cannot drop column named in partition key
 -- test expression index creation where physical layout of chunks differs from hypertable
 CREATE TABLE i2504(time timestamp NOT NULL, a int, b int, c int, d int);
 select create_hypertable('i2504', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
   create_hypertable  
 ---------------------
  (11,public,i2504,t)

--- a/test/expected/ddl_extra.out
+++ b/test/expected/ddl_extra.out
@@ -24,6 +24,7 @@ CREATE TABLE conditions (
   humidity DOUBLE PRECISION NULL
 );
 SELECT create_hypertable('conditions', 'time', chunk_time_interval := '1 day'::interval);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
     create_hypertable    
 -------------------------
  (1,public,conditions,t)

--- a/test/expected/drop_extension.out
+++ b/test/expected/drop_extension.out
@@ -3,6 +3,7 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE drop_test(time timestamp, temp float8, device text);
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
    create_hypertable    
 ------------------------
@@ -49,6 +50,7 @@ CREATE EXTENSION IF NOT EXISTS timescaledb;
 NOTICE:  extension "timescaledb" already exists, skipping
 -- Make the table a hypertable again
 SELECT create_hypertable('drop_test', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
    create_hypertable    
 ------------------------
  (1,public,drop_test,t)

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -13,6 +13,7 @@ SELECT * from _timescaledb_catalog.dimension;
 
 CREATE TABLE should_drop (time timestamp, temp float8);
 SELECT create_hypertable('should_drop', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
@@ -21,6 +22,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 CREATE TABLE hyper_with_dependencies (time timestamp, temp float8);
 SELECT create_hypertable('hyper_with_dependencies', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
@@ -43,6 +45,7 @@ NOTICE:  drop cascades to view dependent_view
 
 CREATE TABLE chunk_with_dependencies (time timestamp, temp float8);
 SELECT create_hypertable('chunk_with_dependencies', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------
@@ -87,6 +90,7 @@ SELECT * from _timescaledb_catalog.dimension;
 DROP TABLE should_drop;
 CREATE TABLE should_drop (time timestamp, temp float8);
 SELECT create_hypertable('should_drop', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -554,6 +554,7 @@ CREATE TABLE reindex_test(time timestamp, temp float, PRIMARY KEY(time, temp));
 CREATE UNIQUE INDEX reindex_test_time_unique_idx ON reindex_test(time);
 -- create hypertable with three chunks
 SELECT create_hypertable('reindex_test', 'time', chunk_time_interval => 2628000000000);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
      create_hypertable      
 ----------------------------
  (12,public,reindex_test,t)

--- a/test/expected/insert-12.out
+++ b/test/expected/insert-12.out
@@ -189,6 +189,7 @@ SELECT * FROM ONLY "two_Partitions";
 
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
@@ -279,6 +280,7 @@ select * from chunk_assert_fail;
 
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
@@ -425,6 +427,7 @@ INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity
 INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
 CREATE TABLE timestamp_inf(time TIMESTAMP);
 SELECT create_hypertable('timestamp_inf', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
@@ -644,6 +647,7 @@ CREATE TABLE sample_table (
 );
 SELECT * FROM create_hypertable('sample_table', 'time',
        chunk_time_interval => INTERVAL '1 day');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             12 | public      | sample_table | t

--- a/test/expected/insert-13.out
+++ b/test/expected/insert-13.out
@@ -189,6 +189,7 @@ SELECT * FROM ONLY "two_Partitions";
 
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
@@ -279,6 +280,7 @@ select * from chunk_assert_fail;
 
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
@@ -425,6 +427,7 @@ INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity
 INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
 CREATE TABLE timestamp_inf(time TIMESTAMP);
 SELECT create_hypertable('timestamp_inf', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
@@ -644,6 +647,7 @@ CREATE TABLE sample_table (
 );
 SELECT * FROM create_hypertable('sample_table', 'time',
        chunk_time_interval => INTERVAL '1 day');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             12 | public      | sample_table | t

--- a/test/expected/insert-14.out
+++ b/test/expected/insert-14.out
@@ -189,6 +189,7 @@ SELECT * FROM ONLY "two_Partitions";
 
 CREATE TABLE error_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('error_test', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable    
 -------------------------
@@ -279,6 +280,7 @@ select * from chunk_assert_fail;
 
 CREATE TABLE one_space_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('one_space_test', 'time', 'device', 1);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
       create_hypertable      
 -----------------------------
@@ -425,6 +427,7 @@ INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time <= '-infinity
 INSERT INTO one_space_test SELECT * FROM one_space_test WHERE time > '-infinity' LIMIT 1;
 CREATE TABLE timestamp_inf(time TIMESTAMP);
 SELECT create_hypertable('timestamp_inf', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable      
 ----------------------------
@@ -644,6 +647,7 @@ CREATE TABLE sample_table (
 );
 SELECT * FROM create_hypertable('sample_table', 'time',
        chunk_time_interval => INTERVAL '1 day');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------
             12 | public      | sample_table | t

--- a/test/expected/insert_many.out
+++ b/test/expected/insert_many.out
@@ -3,6 +3,7 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE  many_partitions_test(time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('many_partitions_test', 'time', 'device', 1000);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
          create_hypertable         
 -----------------------------------
@@ -31,6 +32,7 @@ SELECT count(*) FROM  many_partitions_test;
 
 CREATE TABLE many_partitions_test_1m (time timestamp, temp float8, device text NOT NULL);
 SELECT create_hypertable('many_partitions_test_1m', 'time', 'device', 1000);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -121,6 +121,7 @@ SELECT * FROM "one_Partition" ORDER BY "timeCustom", device_id, series_0, series
 --test that we can insert data into a 1-dimensional table (only time partitioning)
 CREATE TABLE "1dim"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim"', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_hypertable 
 -------------------
  (2,public,1dim,t)
@@ -176,6 +177,7 @@ SELECT "1dim" FROM "1dim";
 --test that we can insert pre-1970 dates
 CREATE TABLE "1dim_pre1970"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim_pre1970"', 'time', chunk_time_interval=> INTERVAL '1 Month');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
      create_hypertable     
 ---------------------------
  (3,public,1dim_pre1970,t)
@@ -189,6 +191,7 @@ INSERT INTO "1dim_pre1970" VALUES('1969-02-20T09:00:00', 29.9);
 BEGIN;
 CREATE TABLE "1dim_usec_interval"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim_usec_interval"', 'time', chunk_time_interval=> 10);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 WARNING:  unexpected interval: smaller than one second
         create_hypertable        
 ---------------------------------
@@ -199,6 +202,7 @@ INSERT INTO "1dim_usec_interval" VALUES('1969-12-01T19:00:00', 21.2);
 ROLLBACK;
 CREATE TABLE "1dim_usec_interval"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"1dim_usec_interval"', 'time', chunk_time_interval=> 1000000);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
         create_hypertable        
 ---------------------------------
  (5,public,1dim_usec_interval,t)
@@ -282,6 +286,7 @@ SELECT * FROM _timescaledb_catalog.dimension_slice;
 -- Create a three-dimensional table
 CREATE TABLE "3dim" (time timestamp, temp float, device text, location text);
 SELECT create_hypertable('"3dim"', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------
@@ -426,6 +431,7 @@ RESET timezone;
 SET timezone = 'UTC';
 CREATE TABLE "test_tz"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"test_tz"', 'time', chunk_time_interval=> INTERVAL '1 day');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
    create_hypertable   
 -----------------------
  (11,public,test_tz,t)
@@ -454,6 +460,7 @@ SET timescaledb.max_open_chunks_per_insert = 10;
 SET timescaledb.max_cached_chunks_per_hypertable = 10;
 CREATE TABLE "nondefault_mem_settings"(time timestamp PRIMARY KEY, temp float);
 SELECT create_hypertable('"nondefault_mem_settings"', 'time', chunk_time_interval=> INTERVAL '1 Month');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
            create_hypertable           
 ---------------------------------------
  (12,public,nondefault_mem_settings,t)

--- a/test/expected/parallel.out
+++ b/test/expected/parallel.out
@@ -9,6 +9,7 @@
 \set CHUNK2 _timescaledb_internal._hyper_1_2_chunk
 CREATE TABLE test (i int, j double precision, ts timestamp);
 SELECT create_hypertable('test','i',chunk_time_interval:=500000);
+WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
 NOTICE:  adding not-null constraint to column "i"
  create_hypertable 
 -------------------

--- a/test/expected/plan_expand_hypertable-12.out
+++ b/test/expected/plan_expand_hypertable-12.out
@@ -69,6 +69,7 @@ psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
 CREATE TABLE metrics_timestamp(time timestamp);
 SELECT create_hypertable('metrics_timestamp','time');
+psql:include/plan_expand_hypertable_load.sql:62: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------

--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -69,6 +69,7 @@ psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
 CREATE TABLE metrics_timestamp(time timestamp);
 SELECT create_hypertable('metrics_timestamp','time');
+psql:include/plan_expand_hypertable_load.sql:62: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------

--- a/test/expected/plan_expand_hypertable-14.out
+++ b/test/expected/plan_expand_hypertable-14.out
@@ -69,6 +69,7 @@ psql:include/plan_expand_hypertable_load.sql:57: WARNING:  unexpected interval: 
 INSERT INTO hyper_timefunc (time, device_id, value) SELECT g, 'dev' || g, g FROM generate_series(0,30) g;
 CREATE TABLE metrics_timestamp(time timestamp);
 SELECT create_hypertable('metrics_timestamp','time');
+psql:include/plan_expand_hypertable_load.sql:62: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 psql:include/plan_expand_hypertable_load.sql:62: NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------

--- a/test/expected/plan_hashagg.out
+++ b/test/expected/plan_hashagg.out
@@ -10,6 +10,7 @@ CREATE TABLE metric (id SERIAL PRIMARY KEY, value INT);
 CREATE TABLE hyper(time TIMESTAMP NOT NULL, time_int BIGINT, time_broken DATE, metricid int, value double precision);
 CREATE TABLE regular(time TIMESTAMP NOT NULL, time_int BIGINT, time_date DATE, metricid int, value double precision);
 SELECT create_hypertable('hyper', 'time', chunk_time_interval => interval '20 day', create_default_indexes=>FALSE);
+psql:include/plan_hashagg_load.sql:9: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_hypertable  
 --------------------
  (1,public,hyper,t)

--- a/test/expected/query.out
+++ b/test/expected/query.out
@@ -22,6 +22,7 @@ CREATE TABLE PUBLIC.hyper_1 (
 );
 CREATE INDEX "time_plain" ON PUBLIC.hyper_1 (time DESC, series_0);
 SELECT * FROM create_hypertable('"public"."hyper_1"'::regclass, 'time'::name, number_partitions => 1, create_default_indexes=>false);
+psql:include/query_load.sql:13: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | hyper_1    | t

--- a/test/expected/relocate_extension.out
+++ b/test/expected/relocate_extension.out
@@ -16,6 +16,7 @@ CREATE TABLE test_ts(time timestamp, temp float8, device text);
 CREATE TABLE test_tz(time timestamptz, temp float8, device text);
 CREATE TABLE test_dt(time date, temp float8, device text);
 SELECT "testSchema0".create_hypertable('test_ts', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
   create_hypertable   
 ----------------------

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -101,6 +101,7 @@ SELECT * FROM chunks_detailed_size('"public"."two_Partitions"') order by chunk_n
 
 CREATE TABLE timestamp_partitioned(time TIMESTAMP, value TEXT);
 SELECT * FROM create_hypertable('timestamp_partitioned', 'time', 'value', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |      table_name       | created 
 ---------------+-------------+-----------------------+---------
@@ -118,6 +119,7 @@ SELECT * FROM chunks_detailed_size('timestamp_partitioned') order by chunk_name;
 
 CREATE TABLE timestamp_partitioned_2(time TIMESTAMP, value CHAR(9));
 SELECT * FROM create_hypertable('timestamp_partitioned_2', 'time', 'value', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |       table_name        | created 
 ---------------+-------------+-------------------------+---------
@@ -138,6 +140,7 @@ CREATE TABLE toast_test(time TIMESTAMP, value TEXT);
 -- easily compressable string and instead store it with TOAST
 ALTER TABLE toast_test ALTER COLUMN value SET STORAGE EXTERNAL;
 SELECT * FROM create_hypertable('toast_test', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
@@ -416,6 +419,7 @@ SELECT
 --
 CREATE TABLE approx_count(time TIMESTAMP, value int);
 SELECT * FROM create_hypertable('approx_count', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  hypertable_id | schema_name |  table_name  | created 
 ---------------+-------------+--------------+---------

--- a/test/expected/sql_query.out
+++ b/test/expected/sql_query.out
@@ -94,6 +94,7 @@ EXPLAIN (verbose ON, costs off) SELECT * FROM PUBLIC."two_Partitions" WHERE 'dev
 --test integer partition key
 CREATE TABLE "int_part"(time timestamp, object_id int, temp float);
 SELECT create_hypertable('"int_part"', 'time', 'object_id', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
    create_hypertable   
 -----------------------

--- a/test/expected/tablespace.out
+++ b/test/expected/tablespace.out
@@ -18,6 +18,7 @@ CREATE TABLESPACE tablespace1 OWNER :ROLE_DEFAULT_PERM_USER LOCATION :TEST_TABLE
 --assigning a tablespace via the main table should work
 CREATE TABLE tspace_2dim(time timestamp, temp float, device text) TABLESPACE tablespace1;
 SELECT create_hypertable('tspace_2dim', 'time', 'device', 2);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
@@ -186,6 +187,7 @@ data_nodes             |
 SET ROLE :ROLE_DEFAULT_PERM_USER_2;
 CREATE TABLE tspace_1dim(time timestamp, temp float, device text);
 SELECT create_hypertable('tspace_1dim', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
@@ -443,6 +445,7 @@ SELECT * FROM _timescaledb_catalog.tablespace;
 -- that dropping a tablespace from multiple tables work as expected.
 CREATE TABLE tbl_1(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_1', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
@@ -451,6 +454,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 CREATE TABLE tbl_2(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_2', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
@@ -459,6 +463,7 @@ NOTICE:  adding not-null constraint to column "time"
 
 CREATE TABLE tbl_3(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_3', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------
@@ -576,6 +581,7 @@ DROP TABLE tbl_3;
 -- hypertable
 CREATE TABLE tbl_1(time timestamp, temp float, device text);
 SELECT create_hypertable('tbl_1', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable  
 --------------------

--- a/test/expected/timestamp.out
+++ b/test/expected/timestamp.out
@@ -25,6 +25,7 @@ CREATE INDEX ON PUBLIC."testNs" (device_id, "timeCustom" DESC NULLS LAST) WHERE 
 CREATE SCHEMA "testNs" AUTHORIZATION :ROLE_DEFAULT_PERM_USER;
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 SELECT * FROM create_hypertable('"public"."testNs"', 'timeCustom', 'device_id', 2, associated_schema_name=>'testNs' );
+WARNING:  column type "timestamp without time zone" used for "timeCustom" does not follow best practices
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
              1 | public      | testNs     | t

--- a/test/expected/triggers.out
+++ b/test/expected/triggers.out
@@ -344,6 +344,7 @@ CREATE TRIGGER create_color_trigger
     BEFORE INSERT OR UPDATE ON location
     FOR EACH ROW EXECUTE FUNCTION create_color_trigger_fn();
 SELECT create_hypertable('location', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
    create_hypertable   
 -----------------------
  (2,public,location,t)

--- a/test/expected/truncate.out
+++ b/test/expected/truncate.out
@@ -244,6 +244,7 @@ RESET client_min_messages;
 \c test_trunc_ht owner
 CREATE TABLE test_hypertable (time TIMESTAMP WITHOUT TIME ZONE NOT NULL, value DOUBLE PRECISION);
 SELECT create_hypertable('test_hypertable', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
       create_hypertable       
 ------------------------------
  (1,public,test_hypertable,t)

--- a/test/expected/upsert.out
+++ b/test/expected/upsert.out
@@ -3,6 +3,7 @@
 -- LICENSE-APACHE for a copy of the license.
 CREATE TABLE upsert_test(time timestamp PRIMARY KEY, temp float, color text);
 SELECT create_hypertable('upsert_test', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
     create_hypertable     
 --------------------------
  (1,public,upsert_test,t)
@@ -50,6 +51,7 @@ ERROR:  duplicate key value violates unique constraint "1_1_upsert_test_pkey"
 -- Test with UNIQUE index on multiple columns instead of PRIMARY KEY constraint
 CREATE TABLE upsert_test_unique(time timestamp, temp float, color text);
 SELECT create_hypertable('upsert_test_unique', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable        
 ---------------------------------
@@ -84,6 +86,7 @@ SELECT * FROM upsert_test_unique ORDER BY time, color DESC;
 -- Test with multiple UNIQUE indexes
 CREATE TABLE upsert_test_multi_unique(time timestamp, temp float, color text);
 SELECT create_hypertable('upsert_test_multi_unique', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------
@@ -142,6 +145,7 @@ ALTER TABLE upsert_test_space DROP to_drop;
 ALTER TABLE upsert_test_space DROP device_id_1, ADD device_id char(20);
 ALTER TABLE upsert_test_space ADD CONSTRAINT time_space_constraint UNIQUE (time, device_id);
 SELECT create_hypertable('upsert_test_space', 'time', 'device_id', 2, partitioning_func=>'_timescaledb_internal.get_partition_for_key'::regproc);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
        create_hypertable        
 --------------------------------
@@ -340,6 +344,7 @@ ERROR:  could not find arbiter index for hypertable index "multi_time_color_idx"
 --to ensure this, create a chunk before altering the table this chunk will not have a tup_conv_map
 CREATE TABLE upsert_test_diffchunk(time timestamp, device_id char(20), to_drop int, temp float, color text);
 SELECT create_hypertable('upsert_test_diffchunk', 'time', chunk_time_interval=> interval '1 month');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
          create_hypertable          
 ------------------------------------
@@ -397,6 +402,7 @@ select * from upsert_test_diffchunk order by time, device_id;
 --arbiter index tests
 CREATE TABLE upsert_test_arbiter(time timestamp, to_drop int);
 SELECT create_hypertable('upsert_test_arbiter', 'time', chunk_time_interval=> interval '1 month');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
         create_hypertable         
 ----------------------------------

--- a/test/expected/vacuum.out
+++ b/test/expected/vacuum.out
@@ -4,6 +4,7 @@
 CREATE TABLE vacuum_test(time timestamp, temp float);
 -- create hypertable with three chunks
 SELECT create_hypertable('vacuum_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
@@ -60,6 +61,7 @@ DROP TABLE vacuum_test;
 --test plain analyze (no_vacuum)
 CREATE TABLE analyze_test(time timestamp, temp float);
 SELECT create_hypertable('analyze_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------
@@ -139,6 +141,7 @@ DROP TABLE vacuum_norm;
 CREATE TABLE vacuum_test(time timestamp, temp float);
 -- create hypertable with three chunks
 SELECT create_hypertable('vacuum_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
     create_hypertable     
 --------------------------
@@ -153,6 +156,7 @@ INSERT INTO vacuum_test VALUES ('2017-01-20T16:00:01', 17.5),
                                ('2017-06-21T16:00:01', 11.0);
 CREATE TABLE analyze_test(time timestamp, temp float);
 SELECT create_hypertable('analyze_test', 'time', chunk_time_interval => 2628000000000, create_default_indexes => false);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
      create_hypertable     
 ---------------------------

--- a/test/expected/vacuum_parallel.out
+++ b/test/expected/vacuum_parallel.out
@@ -9,6 +9,7 @@ CREATE TABLE vacuum_test(time timestamp NOT NULL, temp1 float, temp2 int);
 -- we create chunks in public schema cause otherwise we would need
 -- elevated privileges to create indexes directly
 SELECT create_hypertable('vacuum_test', 'time', create_default_indexes => false, associated_schema_name => 'public');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
     create_hypertable     
 --------------------------
  (1,public,vacuum_test,t)

--- a/test/sql/create_hypertable.sql
+++ b/test/sql/create_hypertable.sql
@@ -425,3 +425,20 @@ select set_integer_now_func('test_table_int', 'my_user_schema.dummy_now4', repla
 \c :TEST_DBNAME :ROLE_SUPERUSER
 ALTER SCHEMA my_user_schema RENAME TO my_new_schema;
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
+
+-- github issue #4650
+CREATE TABLE sample_table (
+       cpu double precision null,
+       time TIMESTAMP WITH TIME ZONE NOT NULL,
+       sensor_id INTEGER NOT NULL,
+       name varchar(100) default 'this is a default string value',
+       UNIQUE(sensor_id, time)
+);
+
+ALTER TABLE sample_table DROP COLUMN name;
+
+-- below creation should not report any warnings.
+SELECT * FROM create_hypertable('sample_table', 'time');
+
+-- cleanup
+DROP TABLE sample_table CASCADE;

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -414,6 +414,7 @@ CREATE TABLE conditions (
   humidity DOUBLE PRECISION NULL
 ) WITH (autovacuum_enabled = FALSE);
 SELECT create_hypertable('conditions', 'time', chunk_time_interval := '15 days'::interval);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
     create_hypertable    
 -------------------------
  (1,public,conditions,t)

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -344,6 +344,7 @@ create or replace function dummy_now2() returns BIGINT LANGUAGE SQL IMMUTABLE as
 create or replace function overflow_now() returns SMALLINT LANGUAGE SQL IMMUTABLE as  'SELECT 32767::SMALLINT';
 CREATE TABLE test_table_perm(time timestamp PRIMARY KEY);
 SELECT create_hypertable('test_table_perm', 'time', chunk_time_interval => 1);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 WARNING:  unexpected interval: smaller than one second
       create_hypertable       
 ------------------------------

--- a/tsl/test/expected/cagg_policy.out
+++ b/tsl/test/expected/cagg_policy.out
@@ -666,6 +666,7 @@ RESET client_min_messages;
 DROP MATERIALIZED VIEW max_mat_view_date;
 CREATE TABLE continuous_agg_timestamp(time TIMESTAMP);
 SELECT create_hypertable('continuous_agg_timestamp', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------

--- a/tsl/test/expected/cagg_policy_run.out
+++ b/tsl/test/expected/cagg_policy_run.out
@@ -44,6 +44,7 @@ DROP MATERIALIZED VIEW max_mat_view_date;
 NOTICE:  drop cascades to table _timescaledb_internal._hyper_2_3_chunk
 CREATE TABLE continuous_agg_timestamp(time TIMESTAMP);
 SELECT create_hypertable('continuous_agg_timestamp', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
            create_hypertable           
 ---------------------------------------

--- a/tsl/test/expected/cagg_union_view-12.out
+++ b/tsl/test/expected/cagg_union_view-12.out
@@ -641,6 +641,7 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT create_hypertable('timestamp_table', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------

--- a/tsl/test/expected/cagg_union_view-13.out
+++ b/tsl/test/expected/cagg_union_view-13.out
@@ -644,6 +644,7 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT create_hypertable('timestamp_table', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------

--- a/tsl/test/expected/cagg_union_view-14.out
+++ b/tsl/test/expected/cagg_union_view-14.out
@@ -644,6 +644,7 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT create_hypertable('timestamp_table', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
        create_hypertable       
 -------------------------------

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -514,6 +514,7 @@ SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => :'DN
 
 CREATE TABLE disthyper (timec timestamp, device integer);
 SELECT create_distributed_hypertable('disthyper', 'timec', 'device');
+WARNING:  column type "timestamp without time zone" used for "timec" does not follow best practices
 NOTICE:  adding not-null constraint to column "timec"
  create_distributed_hypertable 
 -------------------------------

--- a/tsl/test/expected/compressed_collation.out
+++ b/tsl/test/expected/compressed_collation.out
@@ -13,6 +13,7 @@ order by priority limit 1 \gset
 create table compressed_collation_ht(time timestamp, name text collate :"COLLATION",
     value float);
 select create_hypertable('compressed_collation_ht', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
           create_hypertable           
 --------------------------------------

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -875,6 +875,7 @@ CREATE TABLE datatype_test(
   char_column char
 );
 SELECT create_hypertable('datatype_test','time');
+WARNING:  column type "timestamp without time zone" used for "timestamp_column" does not follow best practices
       create_hypertable      
 -----------------------------
  (11,public,datatype_test,t)

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -65,6 +65,7 @@ ALTER TABLE test1 ALTER COLUMN b SET STATISTICS 10;
 --test adding boolean columns with default and not null
 CREATE TABLE records (time timestamp NOT NULL);
 SELECT create_hypertable('records', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
   create_hypertable   
 ----------------------
  (3,public,records,t)

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -555,6 +555,8 @@ CREATE TABLE test (
 SELECT create_hypertable(
     'test', 'time'
 );
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
+HINT:  Use datatype TIMESTAMPTZ instead.
  create_hypertable  
 --------------------
  (29,public,test,t)

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -614,6 +614,7 @@ DROP TABLE test6;
 -- test 7, compress misc types, and NULLs in dictionaries
 CREATE TABLE test7(time INT, c1 DATE, c2 TIMESTAMP, c3 FLOAT, n TEXT);
 SELECT create_hypertable('test7', 'time', chunk_time_interval=> 200);
+WARNING:  column type "timestamp without time zone" used for "c2" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
   create_hypertable  
 ---------------------

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -947,6 +947,7 @@ CREATE TABLE test4 (
     two double precision
 );
 SELECT * FROM create_hypertable('test4', 'timestamp');
+WARNING:  column type "timestamp without time zone" used for "timestamp" does not follow best practices
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
             20 | public      | test4      | t

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -947,6 +947,7 @@ CREATE TABLE test4 (
     two double precision
 );
 SELECT * FROM create_hypertable('test4', 'timestamp');
+WARNING:  column type "timestamp without time zone" used for "timestamp" does not follow best practices
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
             20 | public      | test4      | t

--- a/tsl/test/expected/compression_insert-14.out
+++ b/tsl/test/expected/compression_insert-14.out
@@ -947,6 +947,7 @@ CREATE TABLE test4 (
     two double precision
 );
 SELECT * FROM create_hypertable('test4', 'timestamp');
+WARNING:  column type "timestamp without time zone" used for "timestamp" does not follow best practices
  hypertable_id | schema_name | table_name | created 
 ---------------+-------------+------------+---------
             20 | public      | test4      | t

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -85,6 +85,8 @@ logret double precision,
 knowledge_date date NOT NULL
 );
 SELECT create_hypertable('metaseg_tab', 'end_dt', chunk_time_interval=>interval '1 month', create_default_indexes=>false);
+WARNING:  column type "timestamp without time zone" used for "start_dt" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "end_dt" does not follow best practices
 NOTICE:  adding not-null constraint to column "end_dt"
     create_hypertable     
 --------------------------
@@ -179,6 +181,7 @@ ERROR:  invalid input syntax for type date: "dec 2010" at character 86
 -- test casts between different char types are pushed down
 CREATE TABLE pushdown_relabel(time timestamptz NOT NULL, dev_vc varchar(10), dev_c char(10));
 SELECT table_name FROM create_hypertable('pushdown_relabel', 'time');
+WARNING:  column type "character varying" used for "dev_vc" does not follow best practices
     table_name    
 ------------------
  pushdown_relabel

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -1266,6 +1266,7 @@ CREATE TABLE water_consumption
     water_index integer
 );
 SELECT create_hypertable('water_consumption', 'timestamp', 'sensor_id', 2);
+WARNING:  column type "timestamp without time zone" used for "timestamp" does not follow best practices
         create_hypertable        
 ---------------------------------
  (34,public,water_consumption,t)

--- a/tsl/test/expected/continuous_aggs_deprecated.out
+++ b/tsl/test/expected/continuous_aggs_deprecated.out
@@ -1293,6 +1293,7 @@ CREATE TABLE water_consumption
     water_index integer
 );
 SELECT create_hypertable('water_consumption', 'timestamp', 'sensor_id', 2);
+WARNING:  column type "timestamp without time zone" used for "timestamp" does not follow best practices
         create_hypertable        
 ---------------------------------
  (34,public,water_consumption,t)

--- a/tsl/test/expected/ddl_hook.out
+++ b/tsl/test/expected/ddl_hook.out
@@ -245,6 +245,7 @@ CREATE TABLE test (time timestamp, v int);
 NOTICE:  test_ddl_command_start: 0 hypertables, query: CREATE TABLE test (time timestamp, v int);
 NOTICE:  test_ddl_command_end: CREATE TABLE
 SELECT create_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_hypertable 
 -------------------

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -4863,6 +4863,8 @@ CREATE TABLE test_1702 (
 	dummy71	int	
 );
 SELECT create_distributed_hypertable('test_1702', 'time', 'id');
+WARNING:  column type "character varying" used for "id" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (22,public,test_1702,t)
@@ -4919,6 +4921,8 @@ CREATE TABLE test_1702 (
 	dummy5	int
 	);
 SELECT create_distributed_hypertable('test_1702', 'time', 'id');
+WARNING:  column type "character varying" used for "id" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (23,public,test_1702,t)
@@ -5528,6 +5532,7 @@ SELECT * FROM disttable ORDER BY 1;
 --
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5542,6 +5547,7 @@ $$;
 CALL test_drop();
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5571,6 +5577,7 @@ SELECT test.tsl_override_current_timestamptz(null);
 CREATE TABLE test_tz (time timestamp, v int);
 SELECT create_distributed_hypertable('test_tz','time',
 	chunk_time_interval => interval '1 hour');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5892,6 +5899,7 @@ DROP TABLE test_tz;
 CREATE TABLE test_now (time timestamp, v int);
 SELECT create_distributed_hypertable('test_now','time',
 	chunk_time_interval => interval '1 hour');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5961,6 +5969,7 @@ DEALLOCATE test_query;
 --
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5983,6 +5992,7 @@ SELECT compress_chunk(show_chunks) FROM show_chunks('test');
 DROP TABLE test;
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -6015,6 +6025,7 @@ DROP TABLE test;
 --
 CREATE TABLE test (time timestamp NOT NULL, my_column int NOT NULL);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (35,public,test,t)

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -4862,6 +4862,8 @@ CREATE TABLE test_1702 (
 	dummy71	int	
 );
 SELECT create_distributed_hypertable('test_1702', 'time', 'id');
+WARNING:  column type "character varying" used for "id" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (22,public,test_1702,t)
@@ -4918,6 +4920,8 @@ CREATE TABLE test_1702 (
 	dummy5	int
 	);
 SELECT create_distributed_hypertable('test_1702', 'time', 'id');
+WARNING:  column type "character varying" used for "id" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (23,public,test_1702,t)
@@ -5527,6 +5531,7 @@ SELECT * FROM disttable ORDER BY 1;
 --
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5541,6 +5546,7 @@ $$;
 CALL test_drop();
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5570,6 +5576,7 @@ SELECT test.tsl_override_current_timestamptz(null);
 CREATE TABLE test_tz (time timestamp, v int);
 SELECT create_distributed_hypertable('test_tz','time',
 	chunk_time_interval => interval '1 hour');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5891,6 +5898,7 @@ DROP TABLE test_tz;
 CREATE TABLE test_now (time timestamp, v int);
 SELECT create_distributed_hypertable('test_now','time',
 	chunk_time_interval => interval '1 hour');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5960,6 +5968,7 @@ DEALLOCATE test_query;
 --
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5982,6 +5991,7 @@ SELECT compress_chunk(show_chunks) FROM show_chunks('test');
 DROP TABLE test;
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -6014,6 +6024,7 @@ DROP TABLE test;
 --
 CREATE TABLE test (time timestamp NOT NULL, my_column int NOT NULL);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (35,public,test,t)

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -4869,6 +4869,8 @@ CREATE TABLE test_1702 (
 	dummy71	int	
 );
 SELECT create_distributed_hypertable('test_1702', 'time', 'id');
+WARNING:  column type "character varying" used for "id" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (22,public,test_1702,t)
@@ -4925,6 +4927,8 @@ CREATE TABLE test_1702 (
 	dummy5	int
 	);
 SELECT create_distributed_hypertable('test_1702', 'time', 'id');
+WARNING:  column type "character varying" used for "id" does not follow best practices
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (23,public,test_1702,t)
@@ -5572,6 +5576,7 @@ SELECT * FROM disttable ORDER BY 1;
 --
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5586,6 +5591,7 @@ $$;
 CALL test_drop();
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5615,6 +5621,7 @@ SELECT test.tsl_override_current_timestamptz(null);
 CREATE TABLE test_tz (time timestamp, v int);
 SELECT create_distributed_hypertable('test_tz','time',
 	chunk_time_interval => interval '1 hour');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -5936,6 +5943,7 @@ DROP TABLE test_tz;
 CREATE TABLE test_now (time timestamp, v int);
 SELECT create_distributed_hypertable('test_now','time',
 	chunk_time_interval => interval '1 hour');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -6005,6 +6013,7 @@ DEALLOCATE test_query;
 --
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -6027,6 +6036,7 @@ SELECT compress_chunk(show_chunks) FROM show_chunks('test');
 DROP TABLE test;
 CREATE TABLE test (time timestamp, v int);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
  create_distributed_hypertable 
 -------------------------------
@@ -6059,6 +6069,7 @@ DROP TABLE test;
 --
 CREATE TABLE test (time timestamp NOT NULL, my_column int NOT NULL);
 SELECT create_distributed_hypertable('test','time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (35,public,test,t)

--- a/tsl/test/expected/dist_move_chunk.out
+++ b/tsl/test/expected/dist_move_chunk.out
@@ -32,6 +32,7 @@ GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
 SET ROLE :ROLE_1;
 CREATE TABLE dist_test(time timestamp NOT NULL, device int, temp float);
 SELECT create_distributed_hypertable('dist_test', 'time', 'device', 3);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (1,public,dist_test,t)
@@ -148,6 +149,7 @@ ERROR:  function must be run on the access node only
 -- ensure that hypertable chunks are distributed
 CREATE TABLE nondist_test(time timestamp NOT NULL, device int, temp float);
 SELECT create_hypertable('nondist_test', 'time', 'device', 3);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
      create_hypertable     
 ---------------------------
  (2,public,nondist_test,t)
@@ -327,6 +329,7 @@ DROP TABLE dist_test;
 -- Create a compressed hypertable
 CREATE TABLE dist_test(time timestamp NOT NULL, device int, temp float);
 SELECT create_distributed_hypertable('dist_test', 'time', 'device', 3);
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
  create_distributed_hypertable 
 -------------------------------
  (3,public,dist_test,t)

--- a/tsl/test/expected/dist_views.out
+++ b/tsl/test/expected/dist_views.out
@@ -116,6 +116,7 @@ ORDER BY node_name;;
 ---tables with special characters in the name ----
 CREATE TABLE "quote'tab" ( a timestamp,  b integer);
 SELECT create_distributed_hypertable( '"quote''tab"', 'a', 'b', replication_factor=>2, chunk_time_interval=>INTERVAL '1 day');
+WARNING:  column type "timestamp without time zone" used for "a" does not follow best practices
 NOTICE:  adding not-null constraint to column "a"
  create_distributed_hypertable 
 -------------------------------
@@ -138,6 +139,7 @@ SELECT * FROM  chunks_detailed_size( '"quote''tab"') ORDER BY chunk_name, node_n
 
 CREATE TABLE "special#tab" ( a timestamp,  b integer);
 SELECT create_hypertable( 'special#tab', 'a', 'b', replication_factor=>2, chunk_time_interval=>INTERVAL '1 day');
+WARNING:  column type "timestamp without time zone" used for "a" does not follow best practices
 NOTICE:  adding not-null constraint to column "a"
     create_hypertable     
 --------------------------

--- a/tsl/test/expected/exp_cagg_next_gen.out
+++ b/tsl/test/expected/exp_cagg_next_gen.out
@@ -63,6 +63,7 @@ SELECT create_hypertable(
   'conditions', 'tstamp',
   chunk_time_interval => INTERVAL '1 day'
 );
+WARNING:  column type "timestamp without time zone" used for "tstamp" does not follow best practices
     create_hypertable    
 -------------------------
  (3,public,conditions,t)

--- a/tsl/test/expected/exp_cagg_origin.out
+++ b/tsl/test/expected/exp_cagg_origin.out
@@ -774,6 +774,7 @@ SELECT create_hypertable(
   'conditions_timestamp', 'tstamp',
   chunk_time_interval => INTERVAL '1 day'
 );
+WARNING:  column type "timestamp without time zone" used for "tstamp" does not follow best practices
          create_hypertable          
 ------------------------------------
  (14,public,conditions_timestamp,t)

--- a/tsl/test/expected/exp_cagg_timezone.out
+++ b/tsl/test/expected/exp_cagg_timezone.out
@@ -10,6 +10,7 @@ SELECT create_hypertable(
   'conditions', 'day',
   chunk_time_interval => INTERVAL '1 day'
 );
+WARNING:  column type "timestamp without time zone" used for "day" does not follow best practices
     create_hypertable    
 -------------------------
  (1,public,conditions,t)

--- a/tsl/test/expected/jit-12.out
+++ b/tsl/test/expected/jit-12.out
@@ -22,6 +22,7 @@ SET jit_tuple_deforming=on;
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE jit_test(time timestamp NOT NULL, device int, temp float);
 SELECT create_hypertable('jit_test', 'time');
+psql:include/jit_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
    create_hypertable   
 -----------------------
  (1,public,jit_test,t)

--- a/tsl/test/expected/jit-13.out
+++ b/tsl/test/expected/jit-13.out
@@ -22,6 +22,7 @@ SET jit_tuple_deforming=on;
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE jit_test(time timestamp NOT NULL, device int, temp float);
 SELECT create_hypertable('jit_test', 'time');
+psql:include/jit_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
    create_hypertable   
 -----------------------
  (1,public,jit_test,t)

--- a/tsl/test/expected/jit-14.out
+++ b/tsl/test/expected/jit-14.out
@@ -22,6 +22,7 @@ SET jit_tuple_deforming=on;
 -- LICENSE-TIMESCALE for a copy of the license.
 CREATE TABLE jit_test(time timestamp NOT NULL, device int, temp float);
 SELECT create_hypertable('jit_test', 'time');
+psql:include/jit_load.sql:6: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
    create_hypertable   
 -----------------------
  (1,public,jit_test,t)

--- a/tsl/test/expected/modify_exclusion.out
+++ b/tsl/test/expected/modify_exclusion.out
@@ -38,6 +38,7 @@ SELECT table_name FROM create_hypertable('metrics_date','time');
 (1 row)
 
 SELECT table_name FROM create_hypertable('metrics_timestamp','time');
+psql:include/modify_exclusion_load.sql:17: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
     table_name     
 -------------------
  metrics_timestamp
@@ -50,6 +51,7 @@ SELECT table_name FROM create_hypertable('metrics_timestamptz','time');
 (1 row)
 
 SELECT table_name FROM create_hypertable('metrics_space','time','device',4);
+psql:include/modify_exclusion_load.sql:19: WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
   table_name   
 ---------------
  metrics_space

--- a/tsl/test/expected/plan_skip_scan-12.out
+++ b/tsl/test/expected/plan_skip_scan-12.out
@@ -3943,6 +3943,7 @@ SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
 -- #3720 skipscan not being used on varchar column
 CREATE TABLE i3720(time timestamptz not null,data varchar);
 SELECT table_name FROM create_hypertable('i3720','time');
+WARNING:  column type "character varying" used for "data" does not follow best practices
  table_name 
 ------------
  i3720

--- a/tsl/test/expected/plan_skip_scan-13.out
+++ b/tsl/test/expected/plan_skip_scan-13.out
@@ -3944,6 +3944,7 @@ SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
 -- #3720 skipscan not being used on varchar column
 CREATE TABLE i3720(time timestamptz not null,data varchar);
 SELECT table_name FROM create_hypertable('i3720','time');
+WARNING:  column type "character varying" used for "data" does not follow best practices
  table_name 
 ------------
  i3720

--- a/tsl/test/expected/plan_skip_scan-14.out
+++ b/tsl/test/expected/plan_skip_scan-14.out
@@ -3942,6 +3942,7 @@ SELECT DISTINCT ON (a) * FROM i3629 WHERE a in (2) ORDER BY a ASC, time DESC;
 -- #3720 skipscan not being used on varchar column
 CREATE TABLE i3720(time timestamptz not null,data varchar);
 SELECT table_name FROM create_hypertable('i3720','time');
+WARNING:  column type "character varying" used for "data" does not follow best practices
  table_name 
 ------------
  i3720

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -4,6 +4,7 @@
 --TEST github issue 1650 character segment by column 
 CREATE TABLE test_chartab ( job_run_id INTEGER NOT NULL, mac_id CHAR(16) NOT NULL, rtt INTEGER NOT NULL, ts TIMESTAMP(3) NOT NULL );
 SELECT create_hypertable('test_chartab', 'ts', chunk_time_interval => interval '1 day', migrate_data => true);
+WARNING:  column type "timestamp without time zone" used for "ts" does not follow best practices
      create_hypertable     
 ---------------------------
  (1,public,test_chartab,t)
@@ -56,6 +57,7 @@ select * from test_chartab order by mac_id , ts limit 2;
 SET enable_hashagg TO false;
 CREATE TABLE public.merge_sort (time timestamp NOT NULL, measure_id integer NOT NULL, device_id integer NOT NULL, value float);
 SELECT create_hypertable('merge_sort', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
     create_hypertable    
 -------------------------
  (3,public,merge_sort,t)

--- a/tsl/test/shared/expected/decompress_placeholdervar.out
+++ b/tsl/test/shared/expected/decompress_placeholdervar.out
@@ -16,6 +16,7 @@ CREATE TABLE decompress_phv_ping (
     insert_ts timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 SELECT table_name FROM create_hypertable('decompress_phv_ping', 'insert_ts', chunk_time_interval => interval '1 day');
+WARNING:  column type "timestamp without time zone" used for "insert_ts" does not follow best practices
      table_name      
  decompress_phv_ping
 (1 row)

--- a/tsl/test/shared/expected/timestamp_limits.out
+++ b/tsl/test/shared/expected/timestamp_limits.out
@@ -175,6 +175,7 @@ pg_get_constraintdef | CHECK (("time" >= '294246-12-31'::date))
 
 CREATE TABLE timestamp_table(time timestamp);
 SELECT table_name FROM create_hypertable('timestamp_table', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]---------------
 table_name | timestamp_table
@@ -199,6 +200,7 @@ pg_get_constraintdef | CHECK (("time" >= '294246-12-31 00:00:00'::timestamp with
 
 CREATE TABLE timestamptz_table(time timestamp);
 SELECT table_name FROM create_hypertable('timestamptz_table', 'time');
+WARNING:  column type "timestamp without time zone" used for "time" does not follow best practices
 NOTICE:  adding not-null constraint to column "time"
 -[ RECORD 1 ]-----------------
 table_name | timestamptz_table


### PR DESCRIPTION
The schema of base table on which hypertables are created, should define
columns with proper data types. As per postgres best practices Wiki
(https://wiki.postgresql.org/wiki/Don't_Do_This), one should not define
columns with CHAR, VARCHAR, VARCHAR(N), instead use TEXT data type.
Similarly instead of using timestamp, one should use timestamptz.
This patch reports a WARNING to end user when creating hypertables,
if underlying parent table, has columns of above mentioned data types.

Fixes #4335