### PR TITLE
Try to enable statement logging in the tests

### DIFF
--- a/tsl/test/expected/cagg_ddl.out
+++ b/tsl/test/expected/cagg_ddl.out
@@ -185,7 +185,7 @@ SELECT current_user;
 
 ALTER SCHEMA foo_name_schema RENAME TO rename_schema;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name | partial_view_schema | partial_view_name 
@@ -442,7 +442,7 @@ psql:include/cagg_ddl_common.sql:303: ERROR:  operation not supported on materia
 ALTER TABLE :drop_chunks_mat_table_u SET SCHEMA public;
 ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 SELECT * FROM new_name;
  time_bucket | count 
 -------------+-------

--- a/tsl/test/expected/cagg_ddl_dist_ht.out
+++ b/tsl/test/expected/cagg_ddl_dist_ht.out
@@ -217,7 +217,7 @@ SELECT current_user;
 
 ALTER SCHEMA foo_name_schema RENAME TO rename_schema;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
  user_view_schema | user_view_name | partial_view_schema | partial_view_name 
@@ -474,7 +474,7 @@ psql:include/cagg_ddl_common.sql:303: ERROR:  operation not supported on materia
 ALTER TABLE :drop_chunks_mat_table_u SET SCHEMA public;
 ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 SELECT * FROM new_name;
  time_bucket | count 
 -------------+-------

--- a/tsl/test/expected/cagg_dump.out
+++ b/tsl/test/expected/cagg_dump.out
@@ -96,7 +96,7 @@ CREATE MATERIALIZED VIEW mat_after
 WITH (timescaledb.continuous)
 AS :QUERY_AFTER WITH NO DATA;
 --materialize mat_before
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CALL refresh_continuous_aggregate('mat_before', NULL, NULL);
 SELECT count(*) FROM conditions_before;
  count 

--- a/tsl/test/expected/cagg_multi.out
+++ b/tsl/test/expected/cagg_multi.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);
 select create_hypertable('continuous_agg_test', 'timeval', chunk_time_interval=> 2);
 NOTICE:  adding not-null constraint to column "timeval"

--- a/tsl/test/expected/cagg_query-12.out
+++ b/tsl/test/expected/cagg_query-12.out
@@ -11,7 +11,7 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "
       format('\! diff %s %s', :'TEST_RESULTS_VIEW_HASHAGG', :'TEST_RESULTS_TABLE') as "DIFF_CMD2"
 \gset
 \set EXPLAIN 'EXPLAIN (VERBOSE, COSTS OFF)'
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,

--- a/tsl/test/expected/cagg_query-13.out
+++ b/tsl/test/expected/cagg_query-13.out
@@ -11,7 +11,7 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "
       format('\! diff %s %s', :'TEST_RESULTS_VIEW_HASHAGG', :'TEST_RESULTS_TABLE') as "DIFF_CMD2"
 \gset
 \set EXPLAIN 'EXPLAIN (VERBOSE, COSTS OFF)'
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,

--- a/tsl/test/expected/cagg_query-14.out
+++ b/tsl/test/expected/cagg_query-14.out
@@ -11,7 +11,7 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "
       format('\! diff %s %s', :'TEST_RESULTS_VIEW_HASHAGG', :'TEST_RESULTS_TABLE') as "DIFF_CMD2"
 \gset
 \set EXPLAIN 'EXPLAIN (VERBOSE, COSTS OFF)'
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,
       location    TEXT              NOT NULL,

--- a/tsl/test/expected/cagg_refresh.out
+++ b/tsl/test/expected/cagg_refresh.out
@@ -121,10 +121,12 @@ ORDER BY day DESC, device;
 -- Refresh the rest (and try DEBUG output)
 SET client_min_messages TO DEBUG1;
 CALL refresh_continuous_aggregate('daily_temp', '2020-04-30', '2020-05-04');
+LOG:  statement: CALL refresh_continuous_aggregate('daily_temp', '2020-04-30', '2020-05-04');
 DEBUG:  refreshing continuous aggregate "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sun May 03 17:00:00 2020 PDT ]
 DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 1588723200000000 1588550400000000
 DEBUG:  invalidation refresh on "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sat May 02 17:00:00 2020 PDT ]
 RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
 -- Compare the aggregate to the equivalent query on the source table
 SELECT * FROM daily_temp
 ORDER BY day DESC, device;

--- a/tsl/test/expected/cagg_usage.out
+++ b/tsl/test/expected/cagg_usage.out
@@ -3,7 +3,7 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- TEST SETUP --
 \set ON_ERROR_STOP 0
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 -- START OF USAGE TEST --
 --First create your hypertable

--- a/tsl/test/expected/compression_bgw.out
+++ b/tsl/test/expected/compression_bgw.out
@@ -342,8 +342,10 @@ SELECT alter_job(id,config:=jsonb_set(config,'{verbose_log}', 'true'))
 
 set client_min_messages TO LOG;
 CALL run_job(:job_id);
+LOG:  statement: CALL run_job(1004);
 LOG:  job 1004 completed processing chunk _timescaledb_internal._hyper_11_40_chunk
 set client_min_messages TO NOTICE;
+LOG:  statement: set client_min_messages TO NOTICE;
 SELECT count(*) FROM timescaledb_information.chunks
 WHERE hypertable_name = 'conditions' and is_compressed = true;
  count 

--- a/tsl/test/expected/continuous_aggs.out
+++ b/tsl/test/expected/continuous_aggs.out
@@ -754,7 +754,7 @@ FROM _timescaledb_catalog.continuous_agg ca
 INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/continuous_aggs_deprecated.out
+++ b/tsl/test/expected/continuous_aggs_deprecated.out
@@ -767,7 +767,7 @@ FROM _timescaledb_catalog.continuous_agg ca
 INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 --force invalidation
 insert into conditions

--- a/tsl/test/expected/debug_notice.out
+++ b/tsl/test/expected/debug_notice.out
@@ -65,14 +65,22 @@ SET client_min_messages TO DEBUG2;
 -- Turning on show_rel should show a message
 -- But disable the code which avoids dist chunk planning
 SET timescaledb.debug_allow_datanode_only_path = 'off';
+LOG:  statement: SET timescaledb.debug_allow_datanode_only_path = 'off';
 SET timescaledb.debug_optimizer_flags = 'show_rel';
+LOG:  statement: SET timescaledb.debug_optimizer_flags = 'show_rel';
 SHOW timescaledb.debug_optimizer_flags;
+LOG:  statement: SHOW timescaledb.debug_optimizer_flags;
  timescaledb.debug_optimizer_flags 
 -----------------------------------
  show_rel
 (1 row)
 
 SELECT time, device, avg(temp) AS temp
+FROM hyper
+WHERE time BETWEEN '2018-04-19 00:01' AND '2018-06-01 00:00'
+GROUP BY 1, 2
+ORDER BY 1, 2;
+LOG:  statement: SELECT time, device, avg(temp) AS temp
 FROM hyper
 WHERE time BETWEEN '2018-04-19 00:01' AND '2018-06-01 00:00'
 GROUP BY 1, 2
@@ -178,16 +186,24 @@ Path list:
 -- Enable session level datanode only path parameter which doesn't
 -- plan distributed chunk scans unnecessarily
 SET timescaledb.debug_allow_datanode_only_path = 'on';
+LOG:  statement: SET timescaledb.debug_allow_datanode_only_path = 'on';
 -- Turning off the show_rel (and turning on another flag) should not
 -- show a notice on the relations, but show the upper paths.
 SET timescaledb.debug_optimizer_flags = 'show_upper=*';
+LOG:  statement: SET timescaledb.debug_optimizer_flags = 'show_upper=*';
 SHOW timescaledb.debug_optimizer_flags;
+LOG:  statement: SHOW timescaledb.debug_optimizer_flags;
  timescaledb.debug_optimizer_flags 
 -----------------------------------
  show_upper=*
 (1 row)
 
 SELECT time, device, avg(temp) AS temp
+FROM hyper
+WHERE time BETWEEN '2018-04-19 00:01' AND '2018-06-01 00:00'
+GROUP BY 1, 2
+ORDER BY 1, 2;
+LOG:  statement: SELECT time, device, avg(temp) AS temp
 FROM hyper
 WHERE time BETWEEN '2018-04-19 00:01' AND '2018-06-01 00:00'
 GROUP BY 1, 2
@@ -228,13 +244,20 @@ Pruned paths:
 
 -- Turning off both relations should not show anything.
 RESET timescaledb.debug_optimizer_flags;
+LOG:  statement: RESET timescaledb.debug_optimizer_flags;
 SHOW timescaledb.debug_optimizer_flags;
+LOG:  statement: SHOW timescaledb.debug_optimizer_flags;
  timescaledb.debug_optimizer_flags 
 -----------------------------------
  
 (1 row)
 
 SELECT time, device, avg(temp) AS temp
+FROM hyper
+WHERE time BETWEEN '2018-04-19 00:01' AND '2018-06-01 00:00'
+GROUP BY 1, 2
+ORDER BY 1, 2;
+LOG:  statement: SELECT time, device, avg(temp) AS temp
 FROM hyper
 WHERE time BETWEEN '2018-04-19 00:01' AND '2018-06-01 00:00'
 GROUP BY 1, 2
@@ -250,6 +273,7 @@ DEBUG:  avoiding per chunk append paths
 (5 rows)
 
 SET client_min_messages TO ERROR;
+LOG:  statement: SET client_min_messages TO ERROR;
 DROP DATABASE :DN_DBNAME_1;
 DROP DATABASE :DN_DBNAME_2;
 DROP DATABASE :DN_DBNAME_3;

--- a/tsl/test/expected/dist_ddl.out
+++ b/tsl/test/expected/dist_ddl.out
@@ -1358,9 +1358,16 @@ SET timescaledb_experimental.enable_distributed_ddl TO 'off';
 SET client_min_messages TO DEBUG1;
 -- CREATE SCHEMA
 CREATE SCHEMA schema_global;
+LOG:  statement: CREATE SCHEMA schema_global;
 DEBUG:  skipping dist DDL on object: CREATE SCHEMA schema_global;
 -- Ensure SCHEMA is not created on data nodes
 SELECT * FROM test.remote_exec(NULL, $$
+SELECT s.nspname, u.usename
+FROM pg_catalog.pg_namespace s
+JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+WHERE s.nspname = 'schema_global';
+$$);
+LOG:  statement: SELECT * FROM test.remote_exec(NULL, $$
 SELECT s.nspname, u.usename
 FROM pg_catalog.pg_namespace s
 JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
@@ -1406,15 +1413,19 @@ nspname|usename
 
 -- RENAME SCHEMA
 ALTER SCHEMA schema_global RENAME TO schema_global_2;
+LOG:  statement: ALTER SCHEMA schema_global RENAME TO schema_global_2;
 DEBUG:  skipping dist DDL on object: ALTER SCHEMA schema_global RENAME TO schema_global_2;
 -- ALTER SCHEMA OWNER TO
 ALTER SCHEMA schema_global_2 OWNER TO :ROLE_1;
+LOG:  statement: ALTER SCHEMA schema_global_2 OWNER TO test_role_1;
 DEBUG:  skipping dist DDL on object: ALTER SCHEMA schema_global_2 OWNER TO test_role_1;
 -- REASSIGN OWNED BY TO
 REASSIGN OWNED BY :ROLE_1 TO :ROLE_1;
+LOG:  statement: REASSIGN OWNED BY test_role_1 TO test_role_1;
 DEBUG:  skipping dist DDL on object: REASSIGN OWNED BY test_role_1 TO test_role_1;
 -- Reset earlier to avoid different debug output between PG versions
 RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
 -- DROP OWNED BY schema_global_2
 DROP OWNED BY :ROLE_1;
 -- DROP SCHEMA

--- a/tsl/test/expected/dist_grant-12.out
+++ b/tsl/test/expected/dist_grant-12.out
@@ -1038,62 +1038,74 @@ SET client_min_messages TO DEBUG1;
 -- Test GRANT/REVOKE command being deparsed with the database name and
 -- being propagated to the data nodes
 GRANT ALL ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT ALL ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT ALL ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT ALL ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT ALL ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT temp ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT temp ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER, :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO cluster_super_user, default_perm_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO cluster_super_user, default_perm_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO cluster_super_user, default_perm_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO cluster_super_user, default_perm_user 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO cluster_super_user, default_perm_user 
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER WITH GRANT OPTION;
+LOG:  statement: GRANT TEMP ON DATABASE db_dist_grant TO cluster_super_user WITH GRANT OPTION;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data3]: GRANT temp ON DATABASE db_dist_grant_3 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data4]: GRANT temp ON DATABASE db_dist_grant_4 TO cluster_super_user WITH GRANT OPTION 
 REVOKE TEMP ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE TEMP ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  [data1]: REVOKE temp ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE temp ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE temp ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE temp ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER CASCADE;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user CASCADE;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user CASCADE
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user CASCADE
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user CASCADE
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user CASCADE
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER RESTRICT;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user RESTRICT;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 -- Grant to specific role types
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO PUBLIC;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO PUBLIC;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO PUBLIC 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO PUBLIC 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO PUBLIC 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO PUBLIC 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO CURRENT_USER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO CURRENT_USER;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO CURRENT_USER 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO CURRENT_USER 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO CURRENT_USER 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO CURRENT_USER 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO SESSION_USER, :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO SESSION_USER, cluster_super_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO SESSION_USER, cluster_super_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO SESSION_USER, cluster_super_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO SESSION_USER, cluster_super_user 
@@ -1105,31 +1117,43 @@ ERROR:  syntax error at or near "CURRENT_ROLE" at character 52
 \set ON_ERROR_STOP 1
 -- Grant on other database should not be propagated
 GRANT CREATE ON DATABASE :DN_DBNAME_1 TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT CREATE ON DATABASE db_dist_grant_1 TO cluster_super_user;
 -- Prevent mixing databases
 \set ON_ERROR_STOP 0
 GRANT CREATE ON DATABASE :TEST_DBNAME, :DN_DBNAME_1 TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT CREATE ON DATABASE db_dist_grant, db_dist_grant_1 TO cluster_super_user;
 ERROR:  cannot change privileges on multiple databases
 \set ON_ERROR_STOP 1
 -- Test disabling DDL commands on global objects
 SET timescaledb_experimental.enable_distributed_ddl TO 'off';
+LOG:  statement: SET timescaledb_experimental.enable_distributed_ddl TO 'off';
 -- ALTER DEFAULT PRIVELEGES
 ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO :ROLE_1;
+LOG:  statement: ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO test_role_1;
 DEBUG:  skipping dist DDL on object: ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO test_role_1;
 -- GRANT/REVOKE
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 GRANT ALL ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 REVOKE ALL ON SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: REVOKE ALL ON SCHEMA public FROM default_perm_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON SCHEMA public FROM default_perm_user;
 GRANT ALL ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT ALL ON SCHEMA public TO default_perm_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON SCHEMA public TO default_perm_user;
 REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;
 SET timescaledb_experimental.enable_distributed_ddl TO 'on';
+LOG:  statement: SET timescaledb_experimental.enable_distributed_ddl TO 'on';
 RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
 -- Test GRANT on foreign server and data node authentication using a
 -- user mapping
 SET ROLE :ROLE_3;

--- a/tsl/test/expected/dist_grant-13.out
+++ b/tsl/test/expected/dist_grant-13.out
@@ -1038,62 +1038,74 @@ SET client_min_messages TO DEBUG1;
 -- Test GRANT/REVOKE command being deparsed with the database name and
 -- being propagated to the data nodes
 GRANT ALL ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT ALL ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT ALL ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT ALL ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT ALL ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT temp ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT temp ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER, :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO cluster_super_user, default_perm_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO cluster_super_user, default_perm_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO cluster_super_user, default_perm_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO cluster_super_user, default_perm_user 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO cluster_super_user, default_perm_user 
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER WITH GRANT OPTION;
+LOG:  statement: GRANT TEMP ON DATABASE db_dist_grant TO cluster_super_user WITH GRANT OPTION;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data3]: GRANT temp ON DATABASE db_dist_grant_3 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data4]: GRANT temp ON DATABASE db_dist_grant_4 TO cluster_super_user WITH GRANT OPTION 
 REVOKE TEMP ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE TEMP ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  [data1]: REVOKE temp ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE temp ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE temp ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE temp ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER CASCADE;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user CASCADE;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user CASCADE
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user CASCADE
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user CASCADE
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user CASCADE
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER RESTRICT;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user RESTRICT;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 -- Grant to specific role types
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO PUBLIC;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO PUBLIC;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO PUBLIC 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO PUBLIC 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO PUBLIC 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO PUBLIC 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO CURRENT_USER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO CURRENT_USER;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO CURRENT_USER 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO CURRENT_USER 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO CURRENT_USER 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO CURRENT_USER 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO SESSION_USER, :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO SESSION_USER, cluster_super_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO SESSION_USER, cluster_super_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO SESSION_USER, cluster_super_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO SESSION_USER, cluster_super_user 
@@ -1105,31 +1117,43 @@ ERROR:  syntax error at or near "CURRENT_ROLE" at character 52
 \set ON_ERROR_STOP 1
 -- Grant on other database should not be propagated
 GRANT CREATE ON DATABASE :DN_DBNAME_1 TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT CREATE ON DATABASE db_dist_grant_1 TO cluster_super_user;
 -- Prevent mixing databases
 \set ON_ERROR_STOP 0
 GRANT CREATE ON DATABASE :TEST_DBNAME, :DN_DBNAME_1 TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT CREATE ON DATABASE db_dist_grant, db_dist_grant_1 TO cluster_super_user;
 ERROR:  cannot change privileges on multiple databases
 \set ON_ERROR_STOP 1
 -- Test disabling DDL commands on global objects
 SET timescaledb_experimental.enable_distributed_ddl TO 'off';
+LOG:  statement: SET timescaledb_experimental.enable_distributed_ddl TO 'off';
 -- ALTER DEFAULT PRIVELEGES
 ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO :ROLE_1;
+LOG:  statement: ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO test_role_1;
 DEBUG:  skipping dist DDL on object: ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO test_role_1;
 -- GRANT/REVOKE
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 GRANT ALL ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 REVOKE ALL ON SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: REVOKE ALL ON SCHEMA public FROM default_perm_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON SCHEMA public FROM default_perm_user;
 GRANT ALL ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT ALL ON SCHEMA public TO default_perm_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON SCHEMA public TO default_perm_user;
 REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;
 SET timescaledb_experimental.enable_distributed_ddl TO 'on';
+LOG:  statement: SET timescaledb_experimental.enable_distributed_ddl TO 'on';
 RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
 -- Test GRANT on foreign server and data node authentication using a
 -- user mapping
 SET ROLE :ROLE_3;

--- a/tsl/test/expected/dist_grant-14.out
+++ b/tsl/test/expected/dist_grant-14.out
@@ -1038,62 +1038,74 @@ SET client_min_messages TO DEBUG1;
 -- Test GRANT/REVOKE command being deparsed with the database name and
 -- being propagated to the data nodes
 GRANT ALL ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT ALL ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT ALL ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT ALL ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT ALL ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT temp ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT temp ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO cluster_super_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO cluster_super_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO cluster_super_user 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO cluster_super_user 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER, :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO cluster_super_user, default_perm_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO cluster_super_user, default_perm_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO cluster_super_user, default_perm_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO cluster_super_user, default_perm_user 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO cluster_super_user, default_perm_user 
 GRANT TEMP ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER WITH GRANT OPTION;
+LOG:  statement: GRANT TEMP ON DATABASE db_dist_grant TO cluster_super_user WITH GRANT OPTION;
 DEBUG:  [data1]: GRANT temp ON DATABASE db_dist_grant_1 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data2]: GRANT temp ON DATABASE db_dist_grant_2 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data3]: GRANT temp ON DATABASE db_dist_grant_3 TO cluster_super_user WITH GRANT OPTION 
 DEBUG:  [data4]: GRANT temp ON DATABASE db_dist_grant_4 TO cluster_super_user WITH GRANT OPTION 
 REVOKE TEMP ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE TEMP ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  [data1]: REVOKE temp ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE temp ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE temp ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE temp ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER CASCADE;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user CASCADE;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user CASCADE
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user CASCADE
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user CASCADE
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user CASCADE
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER RESTRICT;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user RESTRICT;
 DEBUG:  [data1]: REVOKE ALL ON DATABASE db_dist_grant_1 FROM cluster_super_user 
 DEBUG:  [data2]: REVOKE ALL ON DATABASE db_dist_grant_2 FROM cluster_super_user 
 DEBUG:  [data3]: REVOKE ALL ON DATABASE db_dist_grant_3 FROM cluster_super_user 
 DEBUG:  [data4]: REVOKE ALL ON DATABASE db_dist_grant_4 FROM cluster_super_user 
 -- Grant to specific role types
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO PUBLIC;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO PUBLIC;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO PUBLIC 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO PUBLIC 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO PUBLIC 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO PUBLIC 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO CURRENT_USER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO CURRENT_USER;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO CURRENT_USER 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO CURRENT_USER 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO CURRENT_USER 
 DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO CURRENT_USER 
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO SESSION_USER, :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO SESSION_USER, cluster_super_user;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO SESSION_USER, cluster_super_user 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO SESSION_USER, cluster_super_user 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO SESSION_USER, cluster_super_user 
@@ -1101,6 +1113,7 @@ DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO SESSION_US
 -- PG14 added support for CURRENT_ROLE
 \set ON_ERROR_STOP 0
 GRANT TEMP, TEMPORARY ON DATABASE :TEST_DBNAME TO CURRENT_ROLE;
+LOG:  statement: GRANT TEMP, TEMPORARY ON DATABASE db_dist_grant TO CURRENT_ROLE;
 DEBUG:  [data1]: GRANT temp, temporary ON DATABASE db_dist_grant_1 TO CURRENT_ROLE 
 DEBUG:  [data2]: GRANT temp, temporary ON DATABASE db_dist_grant_2 TO CURRENT_ROLE 
 DEBUG:  [data3]: GRANT temp, temporary ON DATABASE db_dist_grant_3 TO CURRENT_ROLE 
@@ -1108,31 +1121,43 @@ DEBUG:  [data4]: GRANT temp, temporary ON DATABASE db_dist_grant_4 TO CURRENT_RO
 \set ON_ERROR_STOP 1
 -- Grant on other database should not be propagated
 GRANT CREATE ON DATABASE :DN_DBNAME_1 TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT CREATE ON DATABASE db_dist_grant_1 TO cluster_super_user;
 -- Prevent mixing databases
 \set ON_ERROR_STOP 0
 GRANT CREATE ON DATABASE :TEST_DBNAME, :DN_DBNAME_1 TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT CREATE ON DATABASE db_dist_grant, db_dist_grant_1 TO cluster_super_user;
 ERROR:  cannot change privileges on multiple databases
 \set ON_ERROR_STOP 1
 -- Test disabling DDL commands on global objects
 SET timescaledb_experimental.enable_distributed_ddl TO 'off';
+LOG:  statement: SET timescaledb_experimental.enable_distributed_ddl TO 'off';
 -- ALTER DEFAULT PRIVELEGES
 ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO :ROLE_1;
+LOG:  statement: ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO test_role_1;
 DEBUG:  skipping dist DDL on object: ALTER DEFAULT PRIVILEGES GRANT INSERT ON TABLES TO test_role_1;
 -- GRANT/REVOKE
 REVOKE ALL ON DATABASE :TEST_DBNAME FROM :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON DATABASE db_dist_grant FROM cluster_super_user;
 GRANT ALL ON DATABASE :TEST_DBNAME TO :ROLE_CLUSTER_SUPERUSER;
+LOG:  statement: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON DATABASE db_dist_grant TO cluster_super_user;
 REVOKE ALL ON SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: REVOKE ALL ON SCHEMA public FROM default_perm_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON SCHEMA public FROM default_perm_user;
 GRANT ALL ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT ALL ON SCHEMA public TO default_perm_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON SCHEMA public TO default_perm_user;
 REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 DEBUG:  skipping dist DDL on object: REVOKE ALL ON ALL TABLES  IN SCHEMA public FROM default_perm_user;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
+LOG:  statement: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;
 DEBUG:  skipping dist DDL on object: GRANT ALL ON ALL TABLES IN SCHEMA public TO default_perm_user;
 SET timescaledb_experimental.enable_distributed_ddl TO 'on';
+LOG:  statement: SET timescaledb_experimental.enable_distributed_ddl TO 'on';
 RESET client_min_messages;
+LOG:  statement: RESET client_min_messages;
 -- Test GRANT on foreign server and data node authentication using a
 -- user mapping
 SET ROLE :ROLE_3;

--- a/tsl/test/isolation/specs/cagg_insert.spec
+++ b/tsl/test/isolation/specs/cagg_insert.spec
@@ -51,11 +51,11 @@ session "SV"
 step "SV1"	{ SELECT * FROM continuous_view order by 1; }
 
 session "R"
-setup { SET client_min_messages TO LOG; }
+setup { SET client_min_messages TO NOTICE; }
 step "Refresh"	{ CALL refresh_continuous_aggregate('continuous_view', NULL, 15); }
 
 session "R1"
-setup { SET client_min_messages TO LOG; }
+setup { SET client_min_messages TO NOTICE; }
 step "Refresh1"	{ CALL refresh_continuous_aggregate('continuous_view', NULL, 15); }
 
 session "R2"

--- a/tsl/test/isolation/specs/cagg_multi.spec
+++ b/tsl/test/isolation/specs/cagg_multi.spec
@@ -42,14 +42,14 @@ step "I1"	{ INSERT INTO ts_continuous_test SELECT 0, i*10 FROM (SELECT generate_
 step "I2"   { INSERT INTO ts_continuous_test SELECT 40, 1000 ; }
 
 session "R1"
-setup { SET client_min_messages TO LOG; }
+setup { SET client_min_messages TO NOTICE; }
 step "Refresh1"	{ CALL refresh_continuous_aggregate('continuous_view_1', NULL, 30); }
 
 session "R1_sel"
 step "Refresh1_sel"	{ select * from continuous_view_1 where bkt = 0 or bkt > 30 }
 
 session "R2"
-setup { SET client_min_messages TO LOG; }
+setup { SET client_min_messages TO NOTICE; }
 step "Refresh2"	{ CALL refresh_continuous_aggregate('continuous_view_2', NULL, NULL); }
 
 session "R2_sel"

--- a/tsl/test/isolation/specs/cagg_multi_dist_ht.spec
+++ b/tsl/test/isolation/specs/cagg_multi_dist_ht.spec
@@ -55,14 +55,14 @@ step "I1"	{ INSERT INTO ts_continuous_test SELECT 0, i*10 FROM (SELECT generate_
 step "I2"   { INSERT INTO ts_continuous_test SELECT 40, 1000 ; }
 
 session "R1"
-setup { SET client_min_messages TO LOG; }
+setup { SET client_min_messages TO NOTICE; }
 step "Refresh1"	{ CALL refresh_continuous_aggregate('continuous_view_1', NULL, 30); }
 
 session "R1_sel"
 step "Refresh1_sel"	{ select * from continuous_view_1 where bkt = 0 or bkt > 30 }
 
 session "R2"
-setup { SET client_min_messages TO LOG; }
+setup { SET client_min_messages TO NOTICE; }
 step "Refresh2"	{ CALL refresh_continuous_aggregate('continuous_view_2', NULL, NULL); }
 
 session "R2_sel"

--- a/tsl/test/postgresql.conf.in
+++ b/tsl/test/postgresql.conf.in
@@ -34,4 +34,4 @@ log_error_verbosity='VERBOSE'
 log_min_messages='INFO'
 # This breaks isolation tests, not sure why the statements end in
 # the isolation tester output.
-# log_statement='all'
+log_statement='all'

--- a/tsl/test/sql/cagg_dump.sql
+++ b/tsl/test/sql/cagg_dump.sql
@@ -98,7 +98,7 @@ AS :QUERY_AFTER WITH NO DATA;
 
 --materialize mat_before
 
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CALL refresh_continuous_aggregate('mat_before', NULL, NULL);
 
 SELECT count(*) FROM conditions_before;

--- a/tsl/test/sql/cagg_multi.sql
+++ b/tsl/test/sql/cagg_multi.sql
@@ -4,7 +4,7 @@
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 
 CREATE TABLE continuous_agg_test(timeval integer, col1 integer, col2 integer);
 select create_hypertable('continuous_agg_test', 'timeval', chunk_time_interval=> 2);

--- a/tsl/test/sql/cagg_query.sql.in
+++ b/tsl/test/sql/cagg_query.sql.in
@@ -15,7 +15,7 @@ SELECT format('\! diff %s %s', :'TEST_RESULTS_VIEW', :'TEST_RESULTS_TABLE') as "
 
 \set EXPLAIN 'EXPLAIN (VERBOSE, COSTS OFF)'
 
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 
 CREATE TABLE conditions (
       timec        TIMESTAMPTZ       NOT NULL,

--- a/tsl/test/sql/cagg_usage.sql
+++ b/tsl/test/sql/cagg_usage.sql
@@ -4,7 +4,7 @@
 
 -- TEST SETUP --
 \set ON_ERROR_STOP 0
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 SET work_mem TO '64MB';
 
 -- START OF USAGE TEST --

--- a/tsl/test/sql/continuous_aggs.sql
+++ b/tsl/test/sql/continuous_aggs.sql
@@ -605,7 +605,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 
 --force invalidation

--- a/tsl/test/sql/continuous_aggs_deprecated.sql
+++ b/tsl/test/sql/continuous_aggs_deprecated.sql
@@ -605,7 +605,7 @@ INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
 WHERE user_view_name = 'mat_drop_test'
 \gset
 
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 CALL refresh_continuous_aggregate('mat_drop_test', NULL, NULL);
 
 --force invalidation

--- a/tsl/test/sql/include/cagg_ddl_common.sql
+++ b/tsl/test/sql/include/cagg_ddl_common.sql
@@ -132,7 +132,7 @@ SELECT current_user;
 ALTER SCHEMA foo_name_schema RENAME TO rename_schema;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 
 SELECT user_view_schema, user_view_name, partial_view_schema, partial_view_name
       FROM _timescaledb_catalog.continuous_agg;
@@ -307,7 +307,7 @@ ALTER TABLE :drop_chunks_mat_table_u SET SCHEMA public;
 ALTER TABLE :drop_chunks_mat_table_u_name RENAME TO new_name;
 
 SET ROLE :ROLE_DEFAULT_PERM_USER;
-SET client_min_messages TO LOG;
+SET client_min_messages TO NOTICE;
 
 SELECT * FROM new_name;
 


### PR DESCRIPTION
Remove client_min_messages = LOG where not needed. In tests where it's necessary, adjust the output to include the `LOG: statement` messages.

The statement logging is needed to debug the test failures.