### PR TITLE
Adjust reorder code for PG15

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -571,4 +571,60 @@ pg_strtoint64(const char *str)
 #include <utils/builtins.h>
 #endif
 
+/*
+ * PG 15 removes "recheck" argument from check_index_is_clusterable
+ *
+ * https://github.com/postgres/postgres/commit/b940918d
+ */
+#if PG15_GE
+#define check_index_is_clusterable_compat(rel, indexOid, lock)                                     \
+	check_index_is_clusterable(rel, indexOid, lock)
+#else
+#define check_index_is_clusterable_compat(rel, indexOid, lock)                                     \
+	check_index_is_clusterable(rel, indexOid, true, lock)
+#endif
+
+/*
+ * PG15 consolidate VACUUM xid cutoff logic.
+ *
+ * https://github.com/postgres/postgres/commit/efa4a946
+ */
+#if PG15_LT
+#define vacuum_set_xid_limits_compat(rel,                                                          \
+									 freeze_min_age,                                               \
+									 freeze_table_age,                                             \
+									 multixact_freeze_min_age,                                     \
+									 multixact_freeze_table_age,                                   \
+									 oldestXmin,                                                   \
+									 freezeLimit,                                                  \
+									 multiXactCutoff)                                              \
+	vacuum_set_xid_limits(rel,                                                                     \
+						  freeze_min_age,                                                          \
+						  freeze_table_age,                                                        \
+						  multixact_freeze_min_age,                                                \
+						  multixact_freeze_table_age,                                              \
+						  oldestXmin,                                                              \
+						  freezeLimit,                                                             \
+						  NULL,                                                                    \
+						  multiXactCutoff,                                                         \
+						  NULL)
+#else
+#define vacuum_set_xid_limits_compat(rel,                                                          \
+									 freeze_min_age,                                               \
+									 freeze_table_age,                                             \
+									 multixact_freeze_min_age,                                     \
+									 multixact_freeze_table_age,                                   \
+									 oldestXmin,                                                   \
+									 freezeLimit,                                                  \
+									 multiXactCutoff)                                              \
+	vacuum_set_xid_limits(rel,                                                                     \
+						  freeze_min_age,                                                          \
+						  freeze_table_age,                                                        \
+						  multixact_freeze_min_age,                                                \
+						  multixact_freeze_table_age,                                              \
+						  oldestXmin,                                                              \
+						  freezeLimit,                                                             \
+						  multiXactCutoff)
+#endif
+
 #endif /* TIMESCALEDB_COMPAT_H */

--- a/tsl/src/reorder.c
+++ b/tsl/src/reorder.c
@@ -611,7 +611,7 @@ reorder_rel(Oid tableOid, Oid indexOid, bool verbose, Oid wait_id, Oid destinati
 	CheckTableNotInUse(OldHeap, "CLUSTER");
 
 	/* Check heap and index are valid to cluster on */
-	check_index_is_clusterable(OldHeap, indexOid, true, ExclusiveLock);
+	check_index_is_clusterable_compat(OldHeap, indexOid, ExclusiveLock);
 
 	/* rebuild_relation does all the dirty work */
 	rebuild_relation(OldHeap, indexOid, verbose, wait_id, destination_tablespace, index_tablespace);
@@ -799,16 +799,7 @@ copy_heap_data(Oid OIDNewHeap, Oid OIDOldHeap, Oid OIDOldIndex, bool verbose,
 	 * Since we're going to rewrite the whole table anyway, there's no reason
 	 * not to be aggressive about this.
 	 */
-	vacuum_set_xid_limits(OldHeap,
-						  0,
-						  0,
-						  0,
-						  0,
-						  &OldestXmin,
-						  &FreezeXid,
-						  NULL,
-						  &MultiXactCutoff,
-						  NULL);
+	vacuum_set_xid_limits_compat(OldHeap, 0, 0, 0, 0, &OldestXmin, &FreezeXid, &MultiXactCutoff);
 
 	/*
 	 * FreezeXid will become the table's new relfrozenxid, and that mustn't go


### PR DESCRIPTION
PG15 removes "recheck" argument from check_index_is_clusterable
and consolidate VACUUM xid cutoff logic.

https://github.com/postgres/postgres/commit/b940918d
https://github.com/postgres/postgres/commit/efa4a946