### PR TITLE
Fix coverity warning about potential overflow

### DIFF
--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -203,9 +203,9 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 	float8 multiplier = (consecutive_failures > MAX_FAILURES_MULTIPLIER ? MAX_FAILURES_MULTIPLIER :
 																		  consecutive_failures);
 	MemoryContext oldctx;
-	Assert(consecutive_failures > 0 && consecutive_failures < 63);
+	Assert(consecutive_failures > 0 && multiplier < 63);
 	/* 2^(consecutive_failures) - 1, at most 2^20 */
-	int64 max_slots = (INT64CONST(1) << consecutive_failures) - INT64CONST(1);
+	int64 max_slots = (INT64CONST(1) << (int64) multiplier) - INT64CONST(1);
 	int64 rand_backoff = random() % (max_slots * USECS_PER_SEC);
 
 	if (!IS_VALID_TIMESTAMP(finish_time))

--- a/src/bgw/job_stat.c
+++ b/src/bgw/job_stat.c
@@ -203,9 +203,9 @@ calculate_next_start_on_failure(TimestampTz finish_time, int consecutive_failure
 	float8 multiplier = (consecutive_failures > MAX_FAILURES_MULTIPLIER ? MAX_FAILURES_MULTIPLIER :
 																		  consecutive_failures);
 	MemoryContext oldctx;
-	Assert(consecutive_failures > 0);
-	int64 max_slots =
-		(1 << consecutive_failures) - 1; /* 2^(consecutive_failures) - 1, at most 2^20 */
+	Assert(consecutive_failures > 0 && consecutive_failures < 63);
+	/* 2^(consecutive_failures) - 1, at most 2^20 */
+	int64 max_slots = (INT64CONST(1) << consecutive_failures) - INT64CONST(1);
 	int64 rand_backoff = random() % (max_slots * USECS_PER_SEC);
 
 	if (!IS_VALID_TIMESTAMP(finish_time))


### PR DESCRIPTION
There is a potential overflow in shifting in the code. The shift count
should be less than 20, so this should be safe, but adding a cast to
ensure that types match later usage and also extending the assert to
capture bugs.

----

Fix max backoff on MAX_CONSECUTIVE_FAILURES

----

Disable-check: commit-count