### PR TITLE
Fix planner chunk exclusion for VIEWs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@ argument or resolve the type ambiguity by casting to the intended type.
 
 **Bugfixes**
 * #4619 Improve handling enum columns in compressed hypertables
+* #4673 Fix now() constification for VIEWs
 * #4681 Fix compression_chunk_size primary key
-* #4685 Improve chunk exclusion for space partitions
+* #4685 Improve chunk exclusion for space dimensions
 
 **Thanks**
-* @maxtwardowski for reporting problems with chunk exclusion and space partitions
+* @maxtwardowski for reporting problems with chunk exclusion and space dimensions
 * @yuezhihan for reporting GROUP BY error when setting compress_segmentby with an enum column
 
 ## 2.8.0 (2022-08-30)

--- a/tsl/test/shared/expected/constify_now-12.out
+++ b/tsl/test/shared/expected/constify_now-12.out
@@ -452,3 +452,42 @@ QUERY PLAN
 (11 rows)
 
 DROP TABLE const_now_dst;
+-- test now constification with VIEWs
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE now_view_test(time timestamptz,device text, value float);
+SELECT table_name FROM create_hypertable('now_view_test','time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+ now_view_test
+(1 row)
+
+-- create 5 chunks
+INSERT INTO now_view_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP BY 1,2;
+-- should have all 5 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view;
+QUERY PLAN
+ HashAggregate
+   Group Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+(8 rows)
+
+-- should have 2 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view WHERE time > now() - '168h'::interval;
+QUERY PLAN
+ HashAggregate
+   Group Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device
+   ->  Append
+         ->  Index Scan using _hyper_X_X_chunk_now_view_test_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" > (now() - '@ 168 hours'::interval))
+         ->  Index Scan using _hyper_X_X_chunk_now_view_test_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" > (now() - '@ 168 hours'::interval))
+(7 rows)
+
+DROP TABLE now_view_test CASCADE;
+NOTICE:  drop cascades to view now_view

--- a/tsl/test/shared/expected/constify_now-13.out
+++ b/tsl/test/shared/expected/constify_now-13.out
@@ -452,3 +452,42 @@ QUERY PLAN
 (11 rows)
 
 DROP TABLE const_now_dst;
+-- test now constification with VIEWs
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE now_view_test(time timestamptz,device text, value float);
+SELECT table_name FROM create_hypertable('now_view_test','time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+ now_view_test
+(1 row)
+
+-- create 5 chunks
+INSERT INTO now_view_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP BY 1,2;
+-- should have all 5 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view;
+QUERY PLAN
+ HashAggregate
+   Group Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+(8 rows)
+
+-- should have 2 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view WHERE time > now() - '168h'::interval;
+QUERY PLAN
+ HashAggregate
+   Group Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device
+   ->  Append
+         ->  Index Scan Backward using _hyper_X_X_chunk_now_view_test_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" > (now() - '@ 168 hours'::interval))
+         ->  Index Scan Backward using _hyper_X_X_chunk_now_view_test_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" > (now() - '@ 168 hours'::interval))
+(7 rows)
+
+DROP TABLE now_view_test CASCADE;
+NOTICE:  drop cascades to view now_view

--- a/tsl/test/shared/expected/constify_now-14.out
+++ b/tsl/test/shared/expected/constify_now-14.out
@@ -449,3 +449,42 @@ QUERY PLAN
 (11 rows)
 
 DROP TABLE const_now_dst;
+-- test now constification with VIEWs
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE now_view_test(time timestamptz,device text, value float);
+SELECT table_name FROM create_hypertable('now_view_test','time');
+NOTICE:  adding not-null constraint to column "time"
+  table_name   
+ now_view_test
+(1 row)
+
+-- create 5 chunks
+INSERT INTO now_view_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP BY 1,2;
+-- should have all 5 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view;
+QUERY PLAN
+ HashAggregate
+   Group Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device
+   ->  Append
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+         ->  Seq Scan on _hyper_X_X_chunk
+(8 rows)
+
+-- should have 2 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view WHERE time > now() - '168h'::interval;
+QUERY PLAN
+ HashAggregate
+   Group Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device
+   ->  Append
+         ->  Index Scan Backward using _hyper_X_X_chunk_now_view_test_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" > (now() - '@ 168 hours'::interval))
+         ->  Index Scan Backward using _hyper_X_X_chunk_now_view_test_time_idx on _hyper_X_X_chunk
+               Index Cond: ("time" > (now() - '@ 168 hours'::interval))
+(7 rows)
+
+DROP TABLE now_view_test CASCADE;
+NOTICE:  drop cascades to view now_view

--- a/tsl/test/shared/sql/constify_now.sql.in
+++ b/tsl/test/shared/sql/constify_now.sql.in
@@ -157,3 +157,17 @@ set timezone to 'utc-1';
 
 DROP TABLE const_now_dst;
 
+-- test now constification with VIEWs
+SET timescaledb.current_timestamp_mock TO '2003-01-01 0:30:00+00';
+CREATE TABLE now_view_test(time timestamptz,device text, value float);
+SELECT table_name FROM create_hypertable('now_view_test','time');
+-- create 5 chunks
+INSERT INTO now_view_test SELECT generate_series('2000-01-01'::timestamptz,'2004-01-01'::timestamptz,'1year'::interval), 'a', 0.5;
+CREATE VIEW now_view AS SELECT time, device, avg(value) from now_view_test GROUP BY 1,2;
+-- should have all 5 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view;
+-- should have 2 chunks in EXPLAIN
+:PREFIX SELECT * FROM now_view WHERE time > now() - '168h'::interval;
+DROP TABLE now_view_test CASCADE;
+
+


### PR DESCRIPTION
Allow planner chunk exclusion in subqueries. When we decicde on
whether a query may benefit from constifying now and encounter a
subquery peek into the subquery and check if the constraint
references a hypertable partitioning column.

Fixes #4524