### PR TITLE
Fix bad TupleTableSlot drop

### DIFF
--- a/src/event_trigger.c
+++ b/src/event_trigger.c
@@ -74,9 +74,9 @@ ts_event_trigger_ddl_commands(void)
 		}
 	}
 
+	ExecDropSingleTupleTableSlot(slot);
 	FreeExprContext(rsinfo.econtext, false);
 	FreeExecutorState(estate);
-	ExecDropSingleTupleTableSlot(slot);
 
 	return objects;
 }
@@ -319,9 +319,9 @@ ts_event_trigger_dropped_objects(void)
 			heap_freetuple(tuple);
 	}
 
+	ExecDropSingleTupleTableSlot(slot);
 	FreeExprContext(rsinfo.econtext, false);
 	FreeExecutorState(estate);
-	ExecDropSingleTupleTableSlot(slot);
 
 	return objects;
 }


### PR DESCRIPTION
PostgreSQL 15 exposed a use after free bug that went undetected in
previous versions.