### PR TITLE
Fix compression_chunk_size primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ argument or resolve the type ambiguity by casting to the intended type.
 
 **Bugfixes**
 * #4619 Improve handling enum columns in compressed hypertables
+* #4681 Fix compression_chunk_size primary key
 
 **Thanks**
 * @yuezhihan for reporting GROUP BY error when setting compress_segmentby with an enum column

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -458,7 +458,7 @@ CREATE TABLE _timescaledb_catalog.compression_chunk_size (
   numrows_pre_compression bigint,
   numrows_post_compression bigint,
   -- table constraints
-  CONSTRAINT compression_chunk_size_pkey PRIMARY KEY (chunk_id, compressed_chunk_id),
+  CONSTRAINT compression_chunk_size_pkey PRIMARY KEY (chunk_id),
   CONSTRAINT compression_chunk_size_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE,
   CONSTRAINT compression_chunk_size_compressed_chunk_id_fkey FOREIGN KEY (compressed_chunk_id) REFERENCES _timescaledb_catalog.chunk (id) ON DELETE CASCADE
 );

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -3,3 +3,6 @@
 CREATE FUNCTION @extschema@.time_bucket_gapfill(bucket_width INTERVAL, ts TIMESTAMPTZ, timezone TEXT, start TIMESTAMPTZ=NULL, finish TIMESTAMPTZ=NULL) RETURNS TIMESTAMPTZ
 AS '@MODULE_PATHNAME@', 'ts_gapfill_timestamptz_timezone_bucket' LANGUAGE C VOLATILE PARALLEL SAFE;
 
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_pkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_pkey PRIMARY KEY(chunk_id);
+

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -2,3 +2,6 @@
 -- gapfill with timezone support
 DROP FUNCTION @extschema@.time_bucket_gapfill(INTERVAL,TIMESTAMPTZ,TEXT,TIMESTAMPTZ,TIMESTAMPTZ);
 
+ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_pkey;
+ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_pkey PRIMARY KEY(chunk_id,compressed_chunk_id);
+

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1227,7 +1227,6 @@ enum
 typedef enum Anum_compression_chunk_size_pkey
 {
 	Anum_compression_chunk_size_pkey_chunk_id = 1,
-	Anum_compression_chunk_size_pkey_compressed_chunk_id,
 	_Anum_compression_chunk_size_pkey_max,
 } Anum_compression_chunk_size_pkey;
 


### PR DESCRIPTION
The primary key for compression_chunk_size was defined as chunk_id, compressed_chunk_id but other places assumed chunk_id is actually unique and would error when it was not. Since it makes no sense to have multiple entries per chunk since that reference would be to a no longer existing chunk the primary key is changed to chunk_id only with this patch.