### PR TITLE
Change parameter names of cagg_migrate procedure

### DIFF
--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -22,6 +22,7 @@ jobs:
         --proc-without-search-path '_timescaledb_internal.policy_compression_execute(job_id integer,htid integer,lag anyelement,maxchunks integer,verbose_log boolean,recompress_enabled boolean)'
         --proc-without-search-path '_timescaledb_internal.cagg_migrate_execute_plan(_cagg_data _timescaledb_catalog.continuous_agg)'
         --proc-without-search-path 'extschema.cagg_migrate(_cagg regclass,_override boolean = FALSE,_drop_old boolean = FALSE)'
+        --proc-without-search-path 'extschema.cagg_migrate(cagg regclass,override boolean = FALSE,drop_old boolean = FALSE)'
 
     steps:
 

--- a/sql/cagg_migrate.sql
+++ b/sql/cagg_migrate.sql
@@ -242,8 +242,8 @@ BEGIN
 
         UPDATE _timescaledb_config.bgw_job
         SET scheduled = TRUE
-        WHERE id = ANY(_policies);
-        -- AND scheduled IS FALSE;
+        WHERE id = ANY(_policies)
+        AND scheduled IS FALSE;
     END IF;
 END;
 $BODY$ SET search_path TO pg_catalog, pg_temp;
@@ -469,9 +469,9 @@ $BODY$;
 
 -- Execute the entire migration
 CREATE OR REPLACE PROCEDURE @extschema@.cagg_migrate (
-    _cagg REGCLASS,
-    _override BOOLEAN DEFAULT FALSE,
-    _drop_old BOOLEAN DEFAULT FALSE
+    cagg REGCLASS,
+    override BOOLEAN DEFAULT FALSE,
+    drop_old BOOLEAN DEFAULT FALSE
 )
 LANGUAGE plpgsql AS
 $BODY$
@@ -485,7 +485,7 @@ BEGIN
     INTO _cagg_schema, _cagg_name
     FROM pg_catalog.pg_class
     JOIN pg_catalog.pg_namespace ON pg_namespace.oid OPERATOR(pg_catalog.=) pg_class.relnamespace
-    WHERE pg_class.oid OPERATOR(pg_catalog.=) _cagg::pg_catalog.oid;
+    WHERE pg_class.oid OPERATOR(pg_catalog.=) cagg::pg_catalog.oid;
 
     -- maximum size of an identifier in Postgres is 63 characters, se we need to left space for '_new'
     _cagg_name_new := pg_catalog.format('%s_new', pg_catalog.substr(_cagg_name, 1, 59));
@@ -494,7 +494,7 @@ BEGIN
     _cagg_data := _timescaledb_internal.cagg_migrate_pre_validation(_cagg_schema, _cagg_name, _cagg_name_new);
 
     -- create new migration plan
-    CALL _timescaledb_internal.cagg_migrate_create_plan(_cagg_data, _cagg_name_new, _override, _drop_old);
+    CALL _timescaledb_internal.cagg_migrate_create_plan(_cagg_data, _cagg_name_new, override, drop_old);
     COMMIT;
 
     -- execute the migration plan

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -6,3 +6,43 @@ AS '@MODULE_PATHNAME@', 'ts_gapfill_timestamptz_timezone_bucket' LANGUAGE C VOLA
 ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_pkey;
 ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_pkey PRIMARY KEY(chunk_id);
 
+DROP PROCEDURE IF EXISTS @extschema@.cagg_migrate (REGCLASS, BOOLEAN, BOOLEAN);
+
+CREATE PROCEDURE @extschema@.cagg_migrate (
+    cagg REGCLASS,
+    override BOOLEAN DEFAULT FALSE,
+    drop_old BOOLEAN DEFAULT FALSE
+)
+LANGUAGE plpgsql AS
+$BODY$
+DECLARE
+    _cagg_schema TEXT;
+    _cagg_name TEXT;
+    _cagg_name_new TEXT;
+    _cagg_data _timescaledb_catalog.continuous_agg;
+BEGIN
+    SELECT nspname, relname
+    INTO _cagg_schema, _cagg_name
+    FROM pg_catalog.pg_class
+    JOIN pg_catalog.pg_namespace ON pg_namespace.oid OPERATOR(pg_catalog.=) pg_class.relnamespace
+    WHERE pg_class.oid OPERATOR(pg_catalog.=) cagg::pg_catalog.oid;
+
+    -- maximum size of an identifier in Postgres is 63 characters, se we need to left space for '_new'
+    _cagg_name_new := pg_catalog.format('%s_new', pg_catalog.substr(_cagg_name, 1, 59));
+
+    -- pre-validate the migration and get some variables
+    _cagg_data := _timescaledb_internal.cagg_migrate_pre_validation(_cagg_schema, _cagg_name, _cagg_name_new);
+
+    -- create new migration plan
+    CALL _timescaledb_internal.cagg_migrate_create_plan(_cagg_data, _cagg_name_new, override, drop_old);
+    COMMIT;
+
+    -- execute the migration plan
+    CALL _timescaledb_internal.cagg_migrate_execute_plan(_cagg_data);
+
+    -- finish the migration plan
+    UPDATE _timescaledb_catalog.continuous_agg_migrate_plan
+    SET end_ts = pg_catalog.clock_timestamp()
+    WHERE mat_hypertable_id OPERATOR(pg_catalog.=) _cagg_data.mat_hypertable_id;
+END;
+$BODY$;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -5,3 +5,43 @@ DROP FUNCTION @extschema@.time_bucket_gapfill(INTERVAL,TIMESTAMPTZ,TEXT,TIMESTAM
 ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compression_chunk_size_pkey;
 ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_pkey PRIMARY KEY(chunk_id,compressed_chunk_id);
 
+DROP PROCEDURE @extschema@.cagg_migrate (REGCLASS, BOOLEAN, BOOLEAN);
+
+CREATE PROCEDURE @extschema@.cagg_migrate (
+    _cagg REGCLASS,
+    _override BOOLEAN DEFAULT FALSE,
+    _drop_old BOOLEAN DEFAULT FALSE
+)
+LANGUAGE plpgsql AS
+$BODY$
+DECLARE
+    _cagg_schema TEXT;
+    _cagg_name TEXT;
+    _cagg_name_new TEXT;
+    _cagg_data _timescaledb_catalog.continuous_agg;
+BEGIN
+    SELECT nspname, relname
+    INTO _cagg_schema, _cagg_name
+    FROM pg_catalog.pg_class
+    JOIN pg_catalog.pg_namespace ON pg_namespace.oid OPERATOR(pg_catalog.=) pg_class.relnamespace
+    WHERE pg_class.oid OPERATOR(pg_catalog.=) _cagg::pg_catalog.oid;
+
+    -- maximum size of an identifier in Postgres is 63 characters, se we need to left space for '_new'
+    _cagg_name_new := pg_catalog.format('%s_new', pg_catalog.substr(_cagg_name, 1, 59));
+
+    -- pre-validate the migration and get some variables
+    _cagg_data := _timescaledb_internal.cagg_migrate_pre_validation(_cagg_schema, _cagg_name, _cagg_name_new);
+
+    -- create new migration plan
+    CALL _timescaledb_internal.cagg_migrate_create_plan(_cagg_data, _cagg_name_new, _override, _drop_old);
+    COMMIT;
+
+    -- execute the migration plan
+    CALL _timescaledb_internal.cagg_migrate_execute_plan(_cagg_data);
+
+    -- finish the migration plan
+    UPDATE _timescaledb_catalog.continuous_agg_migrate_plan
+    SET end_ts = pg_catalog.clock_timestamp()
+    WHERE mat_hypertable_id OPERATOR(pg_catalog.=) _cagg_data.mat_hypertable_id;
+END;
+$BODY$;

--- a/tsl/test/expected/cagg_migrate_integer.out
+++ b/tsl/test/expected/cagg_migrate_integer.out
@@ -301,7 +301,7 @@ DROP MATERIALIZED VIEW conditions_summary_daily_new;
 psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 10 other objects
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
 psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
@@ -371,7 +371,7 @@ ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq
 DROP MATERIALIZED VIEW conditions_summary_daily;
 psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
-CALL cagg_migrate('conditions_summary_daily', TRUE, TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
 psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden

--- a/tsl/test/expected/cagg_migrate_integer_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_integer_dist_ht.out
@@ -333,7 +333,7 @@ DROP MATERIALIZED VIEW conditions_summary_daily_new;
 psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 10 other objects
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
 psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
@@ -403,7 +403,7 @@ ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq
 DROP MATERIALIZED VIEW conditions_summary_daily;
 psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
-CALL cagg_migrate('conditions_summary_daily', TRUE, TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
 psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden

--- a/tsl/test/expected/cagg_migrate_timestamp.out
+++ b/tsl/test/expected/cagg_migrate_timestamp.out
@@ -288,7 +288,7 @@ DROP MATERIALIZED VIEW conditions_summary_daily_new;
 psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 6 other objects
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
 psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
@@ -358,7 +358,7 @@ ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq
 DROP MATERIALIZED VIEW conditions_summary_daily;
 psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
-CALL cagg_migrate('conditions_summary_daily', TRUE, TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
 psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden

--- a/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
@@ -320,7 +320,7 @@ DROP MATERIALIZED VIEW conditions_summary_daily_new;
 psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 6 other objects
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
 psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
@@ -390,7 +390,7 @@ ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq
 DROP MATERIALIZED VIEW conditions_summary_daily;
 psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
-CALL cagg_migrate('conditions_summary_daily', TRUE, TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
 psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden

--- a/tsl/test/sql/include/cagg_migrate_common.sql
+++ b/tsl/test/sql/include/cagg_migrate_common.sql
@@ -214,7 +214,7 @@ SELECT * FROM conditions_summary_daily_new;
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
 -- cagg with the old format because it was overriden
@@ -229,7 +229,7 @@ DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
-CALL cagg_migrate('conditions_summary_daily', TRUE, TRUE);
+CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
 \set ON_ERROR_STOP 0


### PR DESCRIPTION
Removed the underline character prefix '_' from the parameter names of the procedure `cagg_migrate`. The new signature is:

```sql
cagg_migrate(
    IN cagg regclass,
    IN override boolean DEFAULT false,
    IN drop_old boolean DEFAULT false
)
```