### PR TITLE
Do not use row-by-row fetcher for parameterized plans

### DIFF
--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -615,6 +615,7 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 	PG_CATCH();
 	{
 		ts_baserel_info = NULL;
+		ts_data_node_fetcher_scan_type = AutoFetcherType;
 		/* Pop the cache, but do not release since caches are auto-released on
 		 * error */
 		planner_hcache_pop(false);

--- a/tsl/test/shared/expected/dist_fetcher_type.out
+++ b/tsl/test/shared/expected/dist_fetcher_type.out
@@ -221,3 +221,50 @@ ORDER BY 1,2;
  Sun Jan 01 08:01:00 2017 PST |      1 |   7.3
 (2 rows)
 
+-- Check that we don't use row-by-row fetcher for parameterized plans.
+CREATE TABLE lookup (id SERIAL NOT NULL, key TEXT, val TEXT);
+CREATE TABLE metric (ts TIMESTAMPTZ NOT NULL, val FLOAT8 NOT NULL, lookup_id INT NOT NULL);
+SELECT 1 FROM create_distributed_hypertable('metric', 'ts');
+ ?column? 
+        1
+(1 row)
+
+INSERT INTO lookup (key, val) VALUES ('host', 'localhost');
+INSERT INTO metric (ts, val, lookup_id) SELECT s.*, 3.14+1, 1
+FROM generate_series('2021-08-17 00:00:00'::timestamp, '2021-08-17 00:59:59'::timestamp, '1 s'::interval) s;
+SELECT
+    m.ts,
+    m.val
+FROM metric m
+WHERE
+    ARRAY[m.lookup_id] && (SELECT array_agg(l.id)::int[] FROM lookup l WHERE l.key = 'host' AND l.val = 'localhost')
+    AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
+ORDER BY 1 DESC LIMIT 1;
+              ts              | val  
+------------------------------+------
+ Tue Aug 17 00:59:59 2021 PDT | 4.14
+(1 row)
+
+SELECT
+    m.ts,
+    m.val
+FROM metric m
+WHERE
+    m.lookup_id = ANY((SELECT array_agg(l.id) FROM lookup l WHERE l.key = 'host' AND l.val = 'localhost')::int[])
+    AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
+ORDER BY 1 DESC LIMIT 1;
+              ts              | val  
+------------------------------+------
+ Tue Aug 17 00:59:59 2021 PDT | 4.14
+(1 row)
+
+SET timescaledb.remote_data_fetcher = 'rowbyrow';
+SELECT
+    m.ts,
+    m.val
+FROM metric m
+WHERE
+    m.lookup_id = ANY((SELECT array_agg(l.id) FROM lookup l WHERE l.key = 'host' AND l.val = 'localhost')::int[])
+    AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
+ORDER BY 1 DESC LIMIT 1;
+ERROR:  cannot use row-by-row fetcher because the plan is parameterized


### PR DESCRIPTION
We have to prepare the data node statement in this case, and COPY queries don't work with prepared statements.

Fixes #4695