### PR TITLE
Update procedural.yml

### DIFF
--- a/.github/workflows/procedural.yaml
+++ b/.github/workflows/procedural.yaml
@@ -2,7 +2,7 @@ name: Add bugs to bugs project
 
 on:
   issues:
-    types: [ opened, labeled ]
+    types: [opened, labeled]
   issue_comment:
     types: [created, edited]
 
@@ -29,6 +29,19 @@ jobs:
           column: Waiting for Author
           repo-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
-  waiting-for-engineer:
-    name: Waiting for Engineer
-    if: github.event_name == 'issue_comment' && github.event.action == 'labeled' && github.event.label.name == 'need-more-info'
+  waiting-for-engineering:
+    name: Waiting for Engineering
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'need-more-info')
+    steps:
+      - name: Remove need-more-info label
+        uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260
+        with:
+          remove-labels: 'need-more-info'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Move to waiting for engineering column
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Database - TimescaleDB Bugs Board
+          column: Waiting for Engineering
+          repo-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Fix the 'Waiting for Engineering' job. Issues that contain the label
'need-more-info' that receive an issue_comment are automatically
moved to the 'Waiting for Engineering' column on the bug board and
the 'need-more-info' is removed.