### PR TITLE
Fix Continuous Aggregate migration policies

### DIFF
--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -7,6 +7,132 @@ ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compress
 ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_pkey PRIMARY KEY(chunk_id);
 
 DROP PROCEDURE IF EXISTS @extschema@.cagg_migrate (REGCLASS, BOOLEAN, BOOLEAN);
+DROP PROCEDURE IF EXISTS _timescaledb_internal.cagg_migrate_create_plan (_timescaledb_catalog.continuous_agg, TEXT, BOOLEAN, BOOLEAN);
+
+CREATE PROCEDURE _timescaledb_internal.cagg_migrate_create_plan (
+    _cagg_data _timescaledb_catalog.continuous_agg,
+    _cagg_name_new TEXT,
+    _override BOOLEAN DEFAULT FALSE,
+    _drop_old BOOLEAN DEFAULT FALSE
+)
+LANGUAGE plpgsql AS
+$BODY$
+DECLARE
+    _sql TEXT;
+    _matht RECORD;
+    _time_interval INTERVAL;
+    _integer_interval BIGINT;
+    _watermark TEXT;
+    _policies JSONB;
+    _bucket_column_name TEXT;
+    _bucket_column_type TEXT;
+    _interval_type TEXT;
+    _interval_value TEXT;
+BEGIN
+    IF _timescaledb_internal.cagg_migrate_plan_exists(_cagg_data.mat_hypertable_id) IS TRUE THEN
+        RAISE EXCEPTION 'plan already exists for materialized hypertable %', _cagg_data.mat_hypertable_id;
+    END IF;
+
+    INSERT INTO
+        _timescaledb_catalog.continuous_agg_migrate_plan (mat_hypertable_id)
+    VALUES
+        (_cagg_data.mat_hypertable_id);
+
+    SELECT schema_name, table_name
+    INTO _matht
+    FROM _timescaledb_catalog.hypertable
+    WHERE id = _cagg_data.mat_hypertable_id;
+
+    SELECT time_interval, integer_interval, column_name, column_type
+    INTO _time_interval, _integer_interval, _bucket_column_name, _bucket_column_type
+    FROM timescaledb_information.dimensions
+    WHERE hypertable_schema = _matht.schema_name
+    AND hypertable_name = _matht.table_name
+    AND dimension_type = 'Time';
+
+    IF _integer_interval IS NOT NULL THEN
+        _interval_value := _integer_interval::TEXT;
+        _interval_type  := _bucket_column_type;
+        IF _bucket_column_type = 'bigint' THEN
+            _watermark := COALESCE(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)::bigint, '-9223372036854775808'::bigint)::TEXT;
+        ELSIF _bucket_column_type = 'integer' THEN
+            _watermark := COALESCE(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)::integer, '-2147483648'::integer)::TEXT;
+        ELSE
+            _watermark := COALESCE(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)::smallint, '-32768'::smallint)::TEXT;
+        END IF;
+    ELSE
+        _interval_value := _time_interval::TEXT;
+        _interval_type  := 'interval';
+        _watermark      := COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)), '-infinity'::timestamptz)::TEXT;
+    END IF;
+
+    -- get all scheduled policies except the refresh
+    SELECT jsonb_build_object('policies', array_agg(id))
+    INTO _policies
+    FROM _timescaledb_config.bgw_job
+    WHERE hypertable_id = _cagg_data.mat_hypertable_id
+    AND proc_name IS DISTINCT FROM 'policy_refresh_continuous_aggregate'
+    AND scheduled IS TRUE
+    AND id >= 1000;
+
+    INSERT INTO
+        _timescaledb_catalog.continuous_agg_migrate_plan_step (mat_hypertable_id, type, config)
+    VALUES
+        (_cagg_data.mat_hypertable_id, 'SAVE WATERMARK', jsonb_build_object('watermark', _watermark)),
+        (_cagg_data.mat_hypertable_id, 'CREATE NEW CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new)),
+        (_cagg_data.mat_hypertable_id, 'DISABLE POLICIES', _policies),
+        (_cagg_data.mat_hypertable_id, 'REFRESH NEW CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new, 'window_start', _watermark, 'window_start_type', _bucket_column_type));
+
+    -- Finish the step because don't require any extra step
+    UPDATE _timescaledb_catalog.continuous_agg_migrate_plan_step
+    SET status = 'FINISHED', start_ts = now(), end_ts = clock_timestamp()
+    WHERE type = 'SAVE WATERMARK';
+
+    _sql := format (
+        $$
+        WITH boundaries AS (
+            SELECT min(%1$I), max(%1$I), %1$L AS bucket_column_name, %2$L AS bucket_column_type, %3$L AS cagg_name_new
+            FROM %4$I.%5$I
+            WHERE %1$I < CAST(%6$L AS %2$s)
+        )
+        INSERT INTO
+            _timescaledb_catalog.continuous_agg_migrate_plan_step (mat_hypertable_id, type, config)
+        SELECT
+            %7$L,
+            'COPY DATA',
+            jsonb_build_object (
+                'start_ts', start::text,
+                'end_ts', (start + CAST(%8$L AS %9$s))::text,
+                'bucket_column_name', bucket_column_name,
+                'bucket_column_type', bucket_column_type,
+                'cagg_name_new', cagg_name_new
+            )
+        FROM boundaries,
+             LATERAL generate_series(min, max, CAST(%8$L AS %9$s)) AS start;
+        $$,
+        _bucket_column_name, _bucket_column_type, _cagg_name_new, _cagg_data.user_view_schema,
+        _cagg_data.user_view_name, _watermark, _cagg_data.mat_hypertable_id, _interval_value, _interval_type
+    );
+
+    EXECUTE _sql;
+
+    -- get all scheduled policies
+    SELECT jsonb_build_object('policies', array_agg(id))
+    INTO _policies
+    FROM _timescaledb_config.bgw_job
+    WHERE hypertable_id = _cagg_data.mat_hypertable_id
+    AND scheduled IS TRUE
+    AND id >= 1000;
+
+    INSERT INTO
+        _timescaledb_catalog.continuous_agg_migrate_plan_step (mat_hypertable_id, type, config)
+    VALUES
+        (_cagg_data.mat_hypertable_id, 'OVERRIDE CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new, 'override', _override, 'drop_old', _drop_old)),
+        (_cagg_data.mat_hypertable_id, 'DROP OLD CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new, 'override', _override, 'drop_old', _drop_old)),
+        (_cagg_data.mat_hypertable_id, 'COPY POLICIES', _policies || jsonb_build_object('cagg_name_new', _cagg_name_new)),
+        (_cagg_data.mat_hypertable_id, 'ENABLE POLICIES', NULL);
+END;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE PROCEDURE @extschema@.cagg_migrate (
     cagg REGCLASS,

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -6,6 +6,124 @@ ALTER TABLE _timescaledb_catalog.compression_chunk_size DROP CONSTRAINT compress
 ALTER TABLE _timescaledb_catalog.compression_chunk_size ADD CONSTRAINT compression_chunk_size_pkey PRIMARY KEY(chunk_id,compressed_chunk_id);
 
 DROP PROCEDURE @extschema@.cagg_migrate (REGCLASS, BOOLEAN, BOOLEAN);
+DROP PROCEDURE _timescaledb_internal.cagg_migrate_create_plan (_timescaledb_catalog.continuous_agg, TEXT, BOOLEAN, BOOLEAN);
+
+CREATE PROCEDURE _timescaledb_internal.cagg_migrate_create_plan (
+    _cagg_data _timescaledb_catalog.continuous_agg,
+    _cagg_name_new TEXT,
+    _override BOOLEAN DEFAULT FALSE,
+    _drop_old BOOLEAN DEFAULT FALSE
+)
+LANGUAGE plpgsql AS
+$BODY$
+DECLARE
+    _sql TEXT;
+    _matht RECORD;
+    _time_interval INTERVAL;
+    _integer_interval BIGINT;
+    _watermark TEXT;
+    _policies JSONB;
+    _bucket_column_name TEXT;
+    _bucket_column_type TEXT;
+    _interval_type TEXT;
+    _interval_value TEXT;
+BEGIN
+    IF _timescaledb_internal.cagg_migrate_plan_exists(_cagg_data.mat_hypertable_id) IS TRUE THEN
+        RAISE EXCEPTION 'plan already exists for materialized hypertable %', _cagg_data.mat_hypertable_id;
+    END IF;
+
+    INSERT INTO
+        _timescaledb_catalog.continuous_agg_migrate_plan (mat_hypertable_id)
+    VALUES
+        (_cagg_data.mat_hypertable_id);
+
+    SELECT schema_name, table_name
+    INTO _matht
+    FROM _timescaledb_catalog.hypertable
+    WHERE id = _cagg_data.mat_hypertable_id;
+
+    SELECT time_interval, integer_interval, column_name, column_type
+    INTO _time_interval, _integer_interval, _bucket_column_name, _bucket_column_type
+    FROM timescaledb_information.dimensions
+    WHERE hypertable_schema = _matht.schema_name
+    AND hypertable_name = _matht.table_name
+    AND dimension_type = 'Time';
+
+    IF _integer_interval IS NOT NULL THEN
+        _interval_value := _integer_interval::TEXT;
+        _interval_type  := _bucket_column_type;
+        IF _bucket_column_type = 'bigint' THEN
+            _watermark := COALESCE(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)::bigint, '-9223372036854775808'::bigint)::TEXT;
+        ELSIF _bucket_column_type = 'integer' THEN
+            _watermark := COALESCE(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)::integer, '-2147483648'::integer)::TEXT;
+        ELSE
+            _watermark := COALESCE(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)::smallint, '-32768'::smallint)::TEXT;
+        END IF;
+    ELSE
+        _interval_value := _time_interval::TEXT;
+        _interval_type  := 'interval';
+        _watermark      := COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(_cagg_data.mat_hypertable_id)), '-infinity'::timestamptz)::TEXT;
+    END IF;
+
+    -- get all scheduled policies except the refresh
+    SELECT jsonb_build_object('policies', array_agg(id))
+    INTO _policies
+    FROM _timescaledb_config.bgw_job
+    WHERE hypertable_id = _cagg_data.mat_hypertable_id
+    AND proc_name IS DISTINCT FROM 'policy_refresh_continuous_aggregate'
+    AND scheduled IS TRUE
+    AND id >= 1000;
+
+    INSERT INTO
+        _timescaledb_catalog.continuous_agg_migrate_plan_step (mat_hypertable_id, type, config)
+    VALUES
+        (_cagg_data.mat_hypertable_id, 'SAVE WATERMARK', jsonb_build_object('watermark', _watermark)),
+        (_cagg_data.mat_hypertable_id, 'CREATE NEW CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new)),
+        (_cagg_data.mat_hypertable_id, 'DISABLE POLICIES', _policies),
+        (_cagg_data.mat_hypertable_id, 'REFRESH NEW CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new, 'window_start', _watermark, 'window_start_type', _bucket_column_type));
+
+    -- Finish the step because don't require any extra step
+    UPDATE _timescaledb_catalog.continuous_agg_migrate_plan_step
+    SET status = 'FINISHED', start_ts = now(), end_ts = clock_timestamp()
+    WHERE type = 'SAVE WATERMARK';
+
+    _sql := format (
+        $$
+        WITH boundaries AS (
+            SELECT min(%1$I), max(%1$I), %1$L AS bucket_column_name, %2$L AS bucket_column_type, %3$L AS cagg_name_new
+            FROM %4$I.%5$I
+            WHERE %1$I < CAST(%6$L AS %2$s)
+        )
+        INSERT INTO
+            _timescaledb_catalog.continuous_agg_migrate_plan_step (mat_hypertable_id, type, config)
+        SELECT
+            %7$L,
+            'COPY DATA',
+            jsonb_build_object (
+                'start_ts', start::text,
+                'end_ts', (start + CAST(%8$L AS %9$s))::text,
+                'bucket_column_name', bucket_column_name,
+                'bucket_column_type', bucket_column_type,
+                'cagg_name_new', cagg_name_new
+            )
+        FROM boundaries,
+             LATERAL generate_series(min, max, CAST(%8$L AS %9$s)) AS start;
+        $$,
+        _bucket_column_name, _bucket_column_type, _cagg_name_new, _cagg_data.user_view_schema,
+        _cagg_data.user_view_name, _watermark, _cagg_data.mat_hypertable_id, _interval_value, _interval_type
+    );
+
+    EXECUTE _sql;
+
+    INSERT INTO
+        _timescaledb_catalog.continuous_agg_migrate_plan_step (mat_hypertable_id, type, config)
+    VALUES
+        (_cagg_data.mat_hypertable_id, 'OVERRIDE CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new, 'override', _override, 'drop_old', _drop_old)),
+        (_cagg_data.mat_hypertable_id, 'DROP OLD CAGG', jsonb_build_object('cagg_name_new', _cagg_name_new, 'override', _override, 'drop_old', _drop_old)),
+        (_cagg_data.mat_hypertable_id, 'COPY POLICIES', _policies || jsonb_build_object('cagg_name_new', _cagg_name_new)),
+        (_cagg_data.mat_hypertable_id, 'ENABLE POLICIES', NULL);
+END;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
 
 CREATE PROCEDURE @extschema@.cagg_migrate (
     _cagg REGCLASS,

--- a/tsl/test/expected/cagg_migrate_integer.out
+++ b/tsl/test/expected/cagg_migrate_integer.out
@@ -188,14 +188,29 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      18 | NOT STARTED | ENABLE POLICIES  | 
 (18 rows)
 
--- policy for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- policies for test
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
 \else
-SELECT add_retention_policy('conditions_summary_daily', '30'::integer);
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
  add_retention_policy 
 ----------------------
                  1000
+(1 row)
+
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1001
+(1 row)
+
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
+ add_compression_policy 
+------------------------
+                   1002
 (1 row)
 
 \endif
@@ -204,16 +219,18 @@ FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                 config                 
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+----------------------------------------
-   1000 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": 30, "hypertable_id": 3}
-(1 row)
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
+   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": 100}
+   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
+   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": 400, "hypertable_id": 3}
+(3 rows)
 
 -- execute the migration
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:181: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
     ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
     h.schema_name AS "NEW_MAT_SCHEMA_NAME",
@@ -238,82 +255,6 @@ WHERE
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_4.bucket,
-    _materialized_hypertable_4.min,
-    _materialized_hypertable_4.max,
-    _materialized_hypertable_4.avg,
-    _materialized_hypertable_4.sum
-   FROM _timescaledb_internal._materialized_hypertable_4
-  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_internal.cagg_watermark(4)::integer, '-2147483648'::integer)
-UNION ALL
- SELECT time_bucket(24, conditions."time") AS bucket,
-    min(conditions.temperature) AS min,
-    max(conditions.temperature) AS max,
-    avg(conditions.temperature) AS avg,
-    sum(conditions.temperature) AS sum
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(4)::integer, '-2147483648'::integer)
-  GROUP BY (time_bucket(24, conditions."time"));
-
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
-FROM timescaledb_information.jobs
-WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
-AND hypertable_name = :'NEW_MAT_TABLE_NAME'
-AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                 config                 
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+----------------------------------------
-   1001 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_4 | {"drop_after": 30, "hypertable_id": 3}
-(1 row)
-
-SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
- mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
--------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
-                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1000]}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
-                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": [1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1001]}
-(18 rows)
-
--- check migrated data. should return 0 (zero) rows
-SELECT * FROM conditions_summary_daily
-EXCEPT
-SELECT * FROM conditions_summary_daily_new;
- bucket | min | max | avg | sum 
---------+-----+-----+-----+-----
-(0 rows)
-
--- test migration overriding the new cagg and keeping the old
-DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 10 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
--- cagg with the new format because it was overriden
-\d+ conditions_summary_daily
-                  View "public.conditions_summary_daily"
- Column |  Type   | Collation | Nullable | Default | Storage | Description 
---------+---------+-----------+----------+---------+---------+-------------
- bucket | integer |           |          |         | plain   | 
- min    | numeric |           |          |         | main    | 
- max    | numeric |           |          |         | main    | 
- avg    | numeric |           |          |         | main    | 
- sum    | numeric |           |          |         | main    | 
-View definition:
  SELECT _materialized_hypertable_5.bucket,
     _materialized_hypertable_5.min,
     _materialized_hypertable_5.max,
@@ -329,6 +270,123 @@ UNION ALL
     sum(conditions.temperature) AS sum
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(5)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(24, conditions."time"));
+
+SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
+AND hypertable_name = :'NEW_MAT_TABLE_NAME'
+AND job_id >= 1000;
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": 100}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": 400, "hypertable_id": 3}
+(3 rows)
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1002, 1000]}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+(18 rows)
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_3_102_chunk
+ _timescaledb_internal._hyper_3_103_chunk
+ _timescaledb_internal._hyper_3_104_chunk
+ _timescaledb_internal._hyper_3_105_chunk
+ _timescaledb_internal._hyper_3_106_chunk
+ _timescaledb_internal._hyper_3_107_chunk
+ _timescaledb_internal._hyper_3_108_chunk
+ _timescaledb_internal._hyper_3_109_chunk
+ _timescaledb_internal._hyper_3_110_chunk
+ _timescaledb_internal._hyper_3_111_chunk
+(10 rows)
+
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_5_112_chunk
+ _timescaledb_internal._hyper_5_113_chunk
+ _timescaledb_internal._hyper_5_114_chunk
+ _timescaledb_internal._hyper_5_115_chunk
+ _timescaledb_internal._hyper_5_116_chunk
+ _timescaledb_internal._hyper_5_117_chunk
+ _timescaledb_internal._hyper_5_118_chunk
+ _timescaledb_internal._hyper_5_119_chunk
+ _timescaledb_internal._hyper_5_120_chunk
+ _timescaledb_internal._hyper_5_121_chunk
+(10 rows)
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
+DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                  View "public.conditions_summary_daily"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ bucket | integer |           |          |         | plain   | 
+ min    | numeric |           |          |         | main    | 
+ max    | numeric |           |          |         | main    | 
+ avg    | numeric |           |          |         | main    | 
+ sum    | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_7.bucket,
+    _materialized_hypertable_7.min,
+    _materialized_hypertable_7.max,
+    _materialized_hypertable_7.avg,
+    _materialized_hypertable_7.sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -363,17 +421,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:224: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -385,13 +443,13 @@ psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 10 other obj
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_6.bucket,
-    _materialized_hypertable_6.min,
-    _materialized_hypertable_6.max,
-    _materialized_hypertable_6.avg,
-    _materialized_hypertable_6.sum
-   FROM _timescaledb_internal._materialized_hypertable_6
-  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_9.bucket,
+    _materialized_hypertable_9.min,
+    _materialized_hypertable_9.max,
+    _materialized_hypertable_9.avg,
+    _materialized_hypertable_9.sum
+   FROM _timescaledb_internal._materialized_hypertable_9
+  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -399,22 +457,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:237: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:239: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 10 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -433,11 +491,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:264: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:268: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -445,7 +503,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:278: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -453,14 +511,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:288: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:297: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -472,23 +530,23 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
-                 7 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
-                 7 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 7 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                 7 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
-                 7 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      18 | FINISHED | ENABLE POLICIES  | 
+                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 

--- a/tsl/test/expected/cagg_migrate_integer_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_integer_dist_ht.out
@@ -223,14 +223,29 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      18 | NOT STARTED | ENABLE POLICIES  | 
 (18 rows)
 
--- policy for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- policies for test
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
 \else
-SELECT add_retention_policy('conditions_summary_daily', '30'::integer);
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
  add_retention_policy 
 ----------------------
                  1000
+(1 row)
+
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1001
+(1 row)
+
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
+ add_compression_policy 
+------------------------
+                   1002
 (1 row)
 
 \endif
@@ -239,16 +254,18 @@ FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                 config                 
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+----------------------------------------
-   1000 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": 30, "hypertable_id": 3}
-(1 row)
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
+   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": 100}
+   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
+   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": 400, "hypertable_id": 3}
+(3 rows)
 
 -- execute the migration
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:181: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
     ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
     h.schema_name AS "NEW_MAT_SCHEMA_NAME",
@@ -273,82 +290,6 @@ WHERE
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_4.bucket,
-    _materialized_hypertable_4.min,
-    _materialized_hypertable_4.max,
-    _materialized_hypertable_4.avg,
-    _materialized_hypertable_4.sum
-   FROM _timescaledb_internal._materialized_hypertable_4
-  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_internal.cagg_watermark(4)::integer, '-2147483648'::integer)
-UNION ALL
- SELECT time_bucket(24, conditions."time") AS bucket,
-    min(conditions.temperature) AS min,
-    max(conditions.temperature) AS max,
-    avg(conditions.temperature) AS avg,
-    sum(conditions.temperature) AS sum
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(4)::integer, '-2147483648'::integer)
-  GROUP BY (time_bucket(24, conditions."time"));
-
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
-FROM timescaledb_information.jobs
-WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
-AND hypertable_name = :'NEW_MAT_TABLE_NAME'
-AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                 config                 
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+----------------------------------------
-   1001 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_4 | {"drop_after": 30, "hypertable_id": 3}
-(1 row)
-
-SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
- mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
--------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
-                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1000]}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
-                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": [1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1001]}
-(18 rows)
-
--- check migrated data. should return 0 (zero) rows
-SELECT * FROM conditions_summary_daily
-EXCEPT
-SELECT * FROM conditions_summary_daily_new;
- bucket | min | max | avg | sum 
---------+-----+-----+-----+-----
-(0 rows)
-
--- test migration overriding the new cagg and keeping the old
-DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 10 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
--- cagg with the new format because it was overriden
-\d+ conditions_summary_daily
-                  View "public.conditions_summary_daily"
- Column |  Type   | Collation | Nullable | Default | Storage | Description 
---------+---------+-----------+----------+---------+---------+-------------
- bucket | integer |           |          |         | plain   | 
- min    | numeric |           |          |         | main    | 
- max    | numeric |           |          |         | main    | 
- avg    | numeric |           |          |         | main    | 
- sum    | numeric |           |          |         | main    | 
-View definition:
  SELECT _materialized_hypertable_5.bucket,
     _materialized_hypertable_5.min,
     _materialized_hypertable_5.max,
@@ -364,6 +305,123 @@ UNION ALL
     sum(conditions.temperature) AS sum
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(5)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(24, conditions."time"));
+
+SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
+AND hypertable_name = :'NEW_MAT_TABLE_NAME'
+AND job_id >= 1000;
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": 100}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": 400, "hypertable_id": 3}
+(3 rows)
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1002, 1000]}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+(18 rows)
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_3_102_chunk
+ _timescaledb_internal._hyper_3_103_chunk
+ _timescaledb_internal._hyper_3_104_chunk
+ _timescaledb_internal._hyper_3_105_chunk
+ _timescaledb_internal._hyper_3_106_chunk
+ _timescaledb_internal._hyper_3_107_chunk
+ _timescaledb_internal._hyper_3_108_chunk
+ _timescaledb_internal._hyper_3_109_chunk
+ _timescaledb_internal._hyper_3_110_chunk
+ _timescaledb_internal._hyper_3_111_chunk
+(10 rows)
+
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_5_112_chunk
+ _timescaledb_internal._hyper_5_113_chunk
+ _timescaledb_internal._hyper_5_114_chunk
+ _timescaledb_internal._hyper_5_115_chunk
+ _timescaledb_internal._hyper_5_116_chunk
+ _timescaledb_internal._hyper_5_117_chunk
+ _timescaledb_internal._hyper_5_118_chunk
+ _timescaledb_internal._hyper_5_119_chunk
+ _timescaledb_internal._hyper_5_120_chunk
+ _timescaledb_internal._hyper_5_121_chunk
+(10 rows)
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
+DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                  View "public.conditions_summary_daily"
+ Column |  Type   | Collation | Nullable | Default | Storage | Description 
+--------+---------+-----------+----------+---------+---------+-------------
+ bucket | integer |           |          |         | plain   | 
+ min    | numeric |           |          |         | main    | 
+ max    | numeric |           |          |         | main    | 
+ avg    | numeric |           |          |         | main    | 
+ sum    | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_7.bucket,
+    _materialized_hypertable_7.min,
+    _materialized_hypertable_7.max,
+    _materialized_hypertable_7.avg,
+    _materialized_hypertable_7.sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(24, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -398,17 +456,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:224: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -420,13 +478,13 @@ psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 10 other obj
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_6.bucket,
-    _materialized_hypertable_6.min,
-    _materialized_hypertable_6.max,
-    _materialized_hypertable_6.avg,
-    _materialized_hypertable_6.sum
-   FROM _timescaledb_internal._materialized_hypertable_6
-  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_9.bucket,
+    _materialized_hypertable_9.min,
+    _materialized_hypertable_9.max,
+    _materialized_hypertable_9.avg,
+    _materialized_hypertable_9.sum
+   FROM _timescaledb_internal._materialized_hypertable_9
+  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -434,22 +492,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:237: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:239: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 10 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -468,11 +526,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:264: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:268: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -480,7 +538,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:278: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -488,14 +546,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:288: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:297: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -507,24 +565,24 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
-                 7 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
-                 7 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 7 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                 7 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
-                 7 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 7 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      18 | FINISHED | ENABLE POLICIES  | 
+                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                11 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 
 -- cleanup

--- a/tsl/test/expected/cagg_migrate_timestamp.out
+++ b/tsl/test/expected/cagg_migrate_timestamp.out
@@ -179,7 +179,8 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      14 | NOT STARTED | ENABLE POLICIES  | 
 (14 rows)
 
--- policy for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- policies for test
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
  add_retention_policy 
@@ -187,24 +188,40 @@ SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
                  1000
 (1 row)
 
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1001
+(1 row)
+
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
+ add_compression_policy 
+------------------------
+                   1002
+(1 row)
+
 \else
-SELECT add_retention_policy('conditions_summary_daily', '30'::integer);
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
 \endif
 SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                     config                      
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+-------------------------------------------------
-   1000 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": "@ 30 days", "hypertable_id": 3}
-(1 row)
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
+   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
+   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
+   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+(3 rows)
 
 -- execute the migration
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:181: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
     ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
     h.schema_name AS "NEW_MAT_SCHEMA_NAME",
@@ -229,78 +246,6 @@ WHERE
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_4.bucket,
-    _materialized_hypertable_4.min,
-    _materialized_hypertable_4.max,
-    _materialized_hypertable_4.avg,
-    _materialized_hypertable_4.sum
-   FROM _timescaledb_internal._materialized_hypertable_4
-  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
-    min(conditions.temperature) AS min,
-    max(conditions.temperature) AS max,
-    avg(conditions.temperature) AS avg,
-    sum(conditions.temperature) AS sum
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
-
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
-FROM timescaledb_information.jobs
-WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
-AND hypertable_name = :'NEW_MAT_TABLE_NAME'
-AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                     config                      
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+-------------------------------------------------
-   1001 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_4 | {"drop_after": "@ 30 days", "hypertable_id": 3}
-(1 row)
-
-SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
- mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
--------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
-                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1000]}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
-                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": [1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1001]}
-(14 rows)
-
--- check migrated data. should return 0 (zero) rows
-SELECT * FROM conditions_summary_daily
-EXCEPT
-SELECT * FROM conditions_summary_daily_new;
- bucket | min | max | avg | sum 
---------+-----+-----+-----+-----
-(0 rows)
-
--- test migration overriding the new cagg and keeping the old
-DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 6 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
--- cagg with the new format because it was overriden
-\d+ conditions_summary_daily
-                           View "public.conditions_summary_daily"
- Column |           Type           | Collation | Nullable | Default | Storage | Description 
---------+--------------------------+-----------+----------+---------+---------+-------------
- bucket | timestamp with time zone |           |          |         | plain   | 
- min    | numeric                  |           |          |         | main    | 
- max    | numeric                  |           |          |         | main    | 
- avg    | numeric                  |           |          |         | main    | 
- sum    | numeric                  |           |          |         | main    | 
-View definition:
  SELECT _materialized_hypertable_5.bucket,
     _materialized_hypertable_5.min,
     _materialized_hypertable_5.max,
@@ -316,6 +261,111 @@ UNION ALL
     sum(conditions.temperature) AS sum
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(5)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
+AND hypertable_name = :'NEW_MAT_TABLE_NAME'
+AND job_id >= 1000;
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+(3 rows)
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1002, 1000]}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+(14 rows)
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_54_chunk
+ _timescaledb_internal._hyper_3_55_chunk
+ _timescaledb_internal._hyper_3_56_chunk
+ _timescaledb_internal._hyper_3_57_chunk
+ _timescaledb_internal._hyper_3_58_chunk
+ _timescaledb_internal._hyper_3_59_chunk
+(6 rows)
+
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_60_chunk
+ _timescaledb_internal._hyper_5_61_chunk
+ _timescaledb_internal._hyper_5_62_chunk
+ _timescaledb_internal._hyper_5_63_chunk
+ _timescaledb_internal._hyper_5_64_chunk
+ _timescaledb_internal._hyper_5_65_chunk
+(6 rows)
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
+DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                           View "public.conditions_summary_daily"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+ min    | numeric                  |           |          |         | main    | 
+ max    | numeric                  |           |          |         | main    | 
+ avg    | numeric                  |           |          |         | main    | 
+ sum    | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_7.bucket,
+    _materialized_hypertable_7.min,
+    _materialized_hypertable_7.max,
+    _materialized_hypertable_7.avg,
+    _materialized_hypertable_7.sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -350,17 +400,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:224: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -372,13 +422,13 @@ psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 6 other obje
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_6.bucket,
-    _materialized_hypertable_6.min,
-    _materialized_hypertable_6.max,
-    _materialized_hypertable_6.avg,
-    _materialized_hypertable_6.sum
-   FROM _timescaledb_internal._materialized_hypertable_6
-  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_9.bucket,
+    _materialized_hypertable_9.min,
+    _materialized_hypertable_9.max,
+    _materialized_hypertable_9.avg,
+    _materialized_hypertable_9.sum
+   FROM _timescaledb_internal._materialized_hypertable_9
+  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -386,22 +436,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:237: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:239: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 6 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -420,11 +470,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:264: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:268: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -432,7 +482,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:278: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -440,14 +490,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:288: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:297: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -459,19 +509,19 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 7 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
-                 7 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 7 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                 7 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
-                 7 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      14 | FINISHED | ENABLE POLICIES  | 
+                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 

--- a/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
@@ -214,7 +214,8 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      14 | NOT STARTED | ENABLE POLICIES  | 
 (14 rows)
 
--- policy for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- policies for test
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
  add_retention_policy 
@@ -222,24 +223,40 @@ SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
                  1000
 (1 row)
 
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1001
+(1 row)
+
+SELECT add_compression_policy('conditions_summary_daily', '45 days'::interval);
+ add_compression_policy 
+------------------------
+                   1002
+(1 row)
+
 \else
-SELECT add_retention_policy('conditions_summary_daily', '30'::integer);
+SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
+SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
+SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
 \endif
 SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                     config                      
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+-------------------------------------------------
-   1000 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": "@ 30 days", "hypertable_id": 3}
-(1 row)
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
+   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
+   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
+   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+(3 rows)
 
 -- execute the migration
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:181: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
     ca.raw_hypertable_id AS "NEW_RAW_HYPERTABLE_ID",
     h.schema_name AS "NEW_MAT_SCHEMA_NAME",
@@ -264,78 +281,6 @@ WHERE
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_4.bucket,
-    _materialized_hypertable_4.min,
-    _materialized_hypertable_4.max,
-    _materialized_hypertable_4.avg,
-    _materialized_hypertable_4.sum
-   FROM _timescaledb_internal._materialized_hypertable_4
-  WHERE _materialized_hypertable_4.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone)
-UNION ALL
- SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
-    min(conditions.temperature) AS min,
-    max(conditions.temperature) AS max,
-    avg(conditions.temperature) AS avg,
-    sum(conditions.temperature) AS sum
-   FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(4)), '-infinity'::timestamp with time zone)
-  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
-
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
-FROM timescaledb_information.jobs
-WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
-AND hypertable_name = :'NEW_MAT_TABLE_NAME'
-AND job_id >= 1000;
- job_id |    application_name     |      proc_schema      |    proc_name     | scheduled |   hypertable_schema   |      hypertable_name       |                     config                      
---------+-------------------------+-----------------------+------------------+-----------+-----------------------+----------------------------+-------------------------------------------------
-   1001 | Retention Policy [1000] | _timescaledb_internal | policy_retention | t         | _timescaledb_internal | _materialized_hypertable_4 | {"drop_after": "@ 30 days", "hypertable_id": 3}
-(1 row)
-
-SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
- mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
--------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
-                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1000]}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
-                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": [1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1001]}
-(14 rows)
-
--- check migrated data. should return 0 (zero) rows
-SELECT * FROM conditions_summary_daily
-EXCEPT
-SELECT * FROM conditions_summary_daily_new;
- bucket | min | max | avg | sum 
---------+-----+-----+-----+-----
-(0 rows)
-
--- test migration overriding the new cagg and keeping the old
-DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:214: NOTICE:  drop cascades to 6 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:217: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
--- cagg with the new format because it was overriden
-\d+ conditions_summary_daily
-                           View "public.conditions_summary_daily"
- Column |           Type           | Collation | Nullable | Default | Storage | Description 
---------+--------------------------+-----------+----------+---------+---------+-------------
- bucket | timestamp with time zone |           |          |         | plain   | 
- min    | numeric                  |           |          |         | main    | 
- max    | numeric                  |           |          |         | main    | 
- avg    | numeric                  |           |          |         | main    | 
- sum    | numeric                  |           |          |         | main    | 
-View definition:
  SELECT _materialized_hypertable_5.bucket,
     _materialized_hypertable_5.min,
     _materialized_hypertable_5.max,
@@ -351,6 +296,111 @@ UNION ALL
     sum(conditions.temperature) AS sum
    FROM conditions
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(5)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
+AND hypertable_name = :'NEW_MAT_TABLE_NAME'
+AND job_id >= 1000;
+ job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
+--------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+(3 rows)
+
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1002, 1000]}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+(14 rows)
+
+-- check migrated data. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- compress both caggs
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY c::regclass::text;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_3_54_chunk
+ _timescaledb_internal._hyper_3_55_chunk
+ _timescaledb_internal._hyper_3_56_chunk
+ _timescaledb_internal._hyper_3_57_chunk
+ _timescaledb_internal._hyper_3_58_chunk
+ _timescaledb_internal._hyper_3_59_chunk
+(6 rows)
+
+SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_5_60_chunk
+ _timescaledb_internal._hyper_5_61_chunk
+ _timescaledb_internal._hyper_5_62_chunk
+ _timescaledb_internal._hyper_5_63_chunk
+ _timescaledb_internal._hyper_5_64_chunk
+ _timescaledb_internal._hyper_5_65_chunk
+(6 rows)
+
+-- check migrated data after compression. should return 0 (zero) rows
+SELECT * FROM conditions_summary_daily
+EXCEPT
+SELECT * FROM conditions_summary_daily_new;
+ bucket | min | max | avg | sum 
+--------+-----+-----+-----+-----
+(0 rows)
+
+-- test migration overriding the new cagg and keeping the old
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
+DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
+ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+CALL cagg_migrate('conditions_summary_daily', override => TRUE);
+psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+-- cagg with the new format because it was overriden
+\d+ conditions_summary_daily
+                           View "public.conditions_summary_daily"
+ Column |           Type           | Collation | Nullable | Default | Storage | Description 
+--------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket | timestamp with time zone |           |          |         | plain   | 
+ min    | numeric                  |           |          |         | main    | 
+ max    | numeric                  |           |          |         | main    | 
+ avg    | numeric                  |           |          |         | main    | 
+ sum    | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_7.bucket,
+    _materialized_hypertable_7.min,
+    _materialized_hypertable_7.max,
+    _materialized_hypertable_7.avg,
+    _materialized_hypertable_7.sum
+   FROM _timescaledb_internal._materialized_hypertable_7
+  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    min(conditions.temperature) AS min,
+    max(conditions.temperature) AS max,
+    avg(conditions.temperature) AS avg,
+    sum(conditions.temperature) AS sum
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -385,17 +435,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:224: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:232: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -407,13 +457,13 @@ psql:include/cagg_migrate_common.sql:232: NOTICE:  drop cascades to 6 other obje
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_6.bucket,
-    _materialized_hypertable_6.min,
-    _materialized_hypertable_6.max,
-    _materialized_hypertable_6.avg,
-    _materialized_hypertable_6.sum
-   FROM _timescaledb_internal._materialized_hypertable_6
-  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_9.bucket,
+    _materialized_hypertable_9.min,
+    _materialized_hypertable_9.max,
+    _materialized_hypertable_9.avg,
+    _materialized_hypertable_9.sum
+   FROM _timescaledb_internal._materialized_hypertable_9
+  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -421,22 +471,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:237: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:239: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
 DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 6 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -455,11 +505,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:264: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:268: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -467,7 +517,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:278: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -475,14 +525,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:288: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:297: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -494,20 +544,20 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 7 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
-                 7 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                 7 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                 7 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
-                 7 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 7 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                 7 |      14 | FINISHED | ENABLE POLICIES  | 
+                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                11 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                11 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 
 -- cleanup


### PR DESCRIPTION
After migrate a Continuous Aggregate from the old format to the new using `cagg_migrate` procedure we end up with the following problems:
* Refresh policy is not copied from the OLD to the NEW cagg;
* Compression setting is not copied from the OLD to the NEW cagg.

Fixed it by properly copying the refresh policy and setting the `timescaledb.compress=true` flag to the new CAGG.

Fix #4710