### PR TITLE
Include running query in CI coredump information

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -96,7 +96,7 @@ jobs:
           apt-get install postgresql-${PG_MAJOR}-dbgsym >/dev/null
           for file in /tmp/core*
           do
-            gdb /usr/lib/postgresql/${PG_MAJOR}/bin/postgres -c $file <<<'bt full' | tee -a stacktraces.log
+            echo 'printf "%s", debug_query_string\nbt full' | gdb /usr/lib/postgresql/${PG_MAJOR}/bin/postgres -c $file | tee -a stacktraces.log
           done
           echo "::set-output name=coredumps::true"
           exit 1

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -162,11 +162,11 @@ jobs:
       with:
         name: PostgreSQL log ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: postgres.log
-      
+
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        echo "bt full" | sudo coredumpctl gdb
+        echo 'printf "%s", debug_query_string\nbt full' | sudo coredumpctl gdb
         ./scripts/bundle_coredumps.sh
         false
 

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -140,7 +140,7 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        echo "bt full" | sudo coredumpctl gdb
+        echo 'printf "%s", debug_query_string\nbt full' | sudo coredumpctl gdb
         ./scripts/bundle_coredumps.sh
         false
 

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -113,7 +113,7 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        echo "bt full" | sudo coredumpctl gdb
+        echo 'printf "%s", debug_query_string\nbt full' | sudo coredumpctl gdb
         ./scripts/bundle_coredumps.sh
         false
 

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -3,7 +3,6 @@ include(GenerateTestSchedule)
 # These are the files for the 'postgresql' configuration. This is the default,
 # so unless you have a good reason, add new test files here.
 set(TEST_FILES
-    bgw_db_scheduler.sql
     bgw_custom.sql
     bgw_policy.sql
     cagg_errors.sql
@@ -31,6 +30,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(
     APPEND
     TEST_FILES
+    bgw_db_scheduler.sql
     bgw_reorder_drop_chunks.sql
     compress_bgw_reorder_drop_chunks.sql
     chunk_api.sql


### PR DESCRIPTION
Pretty print the active query during a coredump when printing the stacktrace for a coredump.

Disable-check: commit-count
