### PR TITLE
Fix vacuum_set_xid_limits_compat() macro

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -656,15 +656,19 @@ pg_strtoint64(const char *str)
 									 oldestXmin,                                                   \
 									 freezeLimit,                                                  \
 									 multiXactCutoff)                                              \
-	vacuum_set_xid_limits(rel,                                                                     \
-						  freeze_min_age,                                                          \
-						  freeze_table_age,                                                        \
-						  multixact_freeze_min_age,                                                \
-						  multixact_freeze_table_age,                                              \
-						  oldestXmin,                                                              \
-						  freezeLimit,                                                             \
-						  multiXactCutoff,                                                         \
-						  NULL)
+	do                                                                                             \
+	{                                                                                              \
+		MultiXactId oldestMxact;                                                                   \
+		vacuum_set_xid_limits(rel,                                                                 \
+							  freeze_min_age,                                                      \
+							  freeze_table_age,                                                    \
+							  multixact_freeze_min_age,                                            \
+							  multixact_freeze_table_age,                                          \
+							  oldestXmin,                                                          \
+							  &oldestMxact,                                                        \
+							  freezeLimit,                                                         \
+							  multiXactCutoff);                                                    \
+	} while (0)
 #endif
 
 #if PG15_LT


### PR DESCRIPTION
Fix an error in the PG15 portion of the vacuum_set_xid_limits_compat() preprocessor macro.