### PR TITLE
Fix insufficient permissions message in delete_job

### DIFF
--- a/tsl/src/bgw_policy/job_api.c
+++ b/tsl/src/bgw_policy/job_api.c
@@ -207,10 +207,12 @@ job_delete(PG_FUNCTION_ARGS)
 	owner = get_role_oid(NameStr(job->fd.owner), false);
 
 	if (!has_privs_of_role(GetUserId(), owner))
+	{
+		char *username = GetUserNameFromId(GetUserId(), false);
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
-				 errmsg("insufficient permissions to delete job for user \"%s\"",
-						NameStr(job->fd.owner))));
+				 errmsg("insufficient permissions to delete job for user \"%s\"", username)));
+	}
 
 	ts_bgw_job_delete_by_id(job_id);
 


### PR DESCRIPTION
Previously, when the user executing delete_job did not have owner permissions, the error message stated that the owner has insufficient permissions to delete the job, which is not true and might be misleading. This patch alters the error message to print the name of the user attempting to perform the delete without the required privileges.