### PR TITLE
Roll up uncompressed chunks into compressed ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ argument or resolve the type ambiguity by casting to the intended type.
 **Features**
 * #4650 Show warnings when not following best practices
 * #4670 Add timezone support to time_bucket_gapfill
+* #4718 Add ability to merge chunks while compressing
 * #4786 Extend the now() optimization to also apply to CURRENT_TIMESTAMP
 
 **Bugfixes**

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -112,6 +112,9 @@ CREATE TABLE _timescaledb_catalog.dimension (
   partitioning_func name NULL,
   -- open dimensions (e.g., time)
   interval_length bigint NULL,
+  -- compress interval is used by rollup procedure during compression
+  -- in order to merge multiple chunks into a single one
+  compress_interval_length bigint NULL,
   integer_now_func_schema name NULL,
   integer_now_func name NULL,
   -- table constraints
@@ -121,6 +124,7 @@ CREATE TABLE _timescaledb_catalog.dimension (
   CONSTRAINT dimension_check1 CHECK ((num_slices IS NULL AND interval_length IS NOT NULL) OR (num_slices IS NOT NULL AND interval_length IS NULL)),
   CONSTRAINT dimension_check2 CHECK ((integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)),
   CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0),
+  CONSTRAINT dimension_compress_interval_length_check CHECK (compress_interval_length IS NULL OR compress_interval_length > 0),
   CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
 );
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -297,3 +297,84 @@ CREATE FUNCTION @extschema@.add_reorder_policy(
 ) RETURNS INTEGER
 AS '@MODULE_PATHNAME@', 'ts_policy_reorder_add'
 LANGUAGE C VOLATILE;
+
+-- Recreate _timescaledb_catalog.dimension table with the compress_interval_length column --
+CREATE TABLE _timescaledb_internal.dimension_tmp
+AS SELECT * from _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_internal.tmp_dimension_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.dimension_id_seq;
+
+--drop foreign keys on dimension table
+ALTER TABLE _timescaledb_catalog.dimension_partition DROP CONSTRAINT 
+dimension_partition_dimension_id_fkey;
+ALTER TABLE _timescaledb_catalog.dimension_slice DROP CONSTRAINT 
+dimension_slice_dimension_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS timescaledb_information.dimensions;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.dimension;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.dimension_id_seq;
+DROP TABLE _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_catalog.dimension (
+  id serial NOT NULL ,
+  hypertable_id integer NOT NULL,
+  column_name name NOT NULL,
+  column_type REGTYPE NOT NULL,
+  aligned boolean NOT NULL,
+  -- closed dimensions
+  num_slices smallint NULL,
+  partitioning_func_schema name NULL,
+  partitioning_func name NULL,
+  -- open dimensions (e.g., time)
+  interval_length bigint NULL,
+  compress_interval_length bigint NULL,
+  integer_now_func_schema name NULL,
+  integer_now_func name NULL,
+  -- table constraints
+  CONSTRAINT dimension_pkey PRIMARY KEY (id),
+  CONSTRAINT dimension_hypertable_id_column_name_key UNIQUE (hypertable_id, column_name),
+  CONSTRAINT dimension_check CHECK ((partitioning_func_schema IS NULL AND partitioning_func IS NULL) OR (partitioning_func_schema IS NOT NULL AND partitioning_func IS NOT NULL)),
+  CONSTRAINT dimension_check1 CHECK ((num_slices IS NULL AND interval_length IS NOT NULL) OR (num_slices IS NOT NULL AND interval_length IS NULL)),
+  CONSTRAINT dimension_check2 CHECK ((integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)),
+  CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0),
+  CONSTRAINT dimension_compress_interval_length_check CHECK (compress_interval_length IS NULL OR compress_interval_length > 0),
+  CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+INSERT INTO _timescaledb_catalog.dimension
+( id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func)
+SELECT id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func
+FROM _timescaledb_internal.dimension_tmp;
+
+ALTER SEQUENCE _timescaledb_catalog.dimension_id_seq OWNED BY _timescaledb_catalog.dimension.id;
+SELECT setval('_timescaledb_catalog.dimension_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_dimension_seq_value;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension', '');
+SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.dimension', 'id'), '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.dimension_partition ADD CONSTRAINT 
+dimension_partition_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.dimension_slice ADD CONSTRAINT
+dimension_slice_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.dimension_tmp;
+DROP TABLE _timescaledb_internal.tmp_dimension_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.dimension_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.dimension TO PUBLIC;
+
+-- end recreate _timescaledb_catalog.dimension table --

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -226,3 +226,82 @@ ALTER TABLE _timescaledb_internal.bgw_policy_chunk_stats
           ON DELETE CASCADE;
 
 DROP FUNCTION _timescaledb_internal.health;
+
+-- Recreate _timescaledb_catalog.dimension table without the compress_interval_length column --
+CREATE TABLE _timescaledb_internal.dimension_tmp
+AS SELECT * from _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_internal.tmp_dimension_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.dimension_id_seq;
+
+--drop foreign keys on dimension table
+ALTER TABLE _timescaledb_catalog.dimension_partition DROP CONSTRAINT 
+dimension_partition_dimension_id_fkey;
+ALTER TABLE _timescaledb_catalog.dimension_slice DROP CONSTRAINT 
+dimension_slice_dimension_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS timescaledb_information.dimensions;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.dimension;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.dimension_id_seq;
+DROP TABLE _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_catalog.dimension (
+  id serial NOT NULL ,
+  hypertable_id integer NOT NULL,
+  column_name name NOT NULL,
+  column_type REGTYPE NOT NULL,
+  aligned boolean NOT NULL,
+  -- closed dimensions
+  num_slices smallint NULL,
+  partitioning_func_schema name NULL,
+  partitioning_func name NULL,
+  -- open dimensions (e.g., time)
+  interval_length bigint NULL,
+  integer_now_func_schema name NULL,
+  integer_now_func name NULL,
+  -- table constraints
+  CONSTRAINT dimension_pkey PRIMARY KEY (id),
+  CONSTRAINT dimension_hypertable_id_column_name_key UNIQUE (hypertable_id, column_name),
+  CONSTRAINT dimension_check CHECK ((partitioning_func_schema IS NULL AND partitioning_func IS NULL) OR (partitioning_func_schema IS NOT NULL AND partitioning_func IS NOT NULL)),
+  CONSTRAINT dimension_check1 CHECK ((num_slices IS NULL AND interval_length IS NOT NULL) OR (num_slices IS NOT NULL AND interval_length IS NULL)),
+  CONSTRAINT dimension_check2 CHECK ((integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)),
+  CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0),
+  CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+INSERT INTO _timescaledb_catalog.dimension
+( id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func)
+SELECT id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func
+FROM _timescaledb_internal.dimension_tmp;
+
+ALTER SEQUENCE _timescaledb_catalog.dimension_id_seq OWNED BY _timescaledb_catalog.dimension.id;
+SELECT setval('_timescaledb_catalog.dimension_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_dimension_seq_value;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension', '');
+SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.dimension', 'id'), '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.dimension_partition ADD CONSTRAINT 
+dimension_partition_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.dimension_slice ADD CONSTRAINT
+dimension_slice_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.dimension_tmp;
+DROP TABLE _timescaledb_internal.tmp_dimension_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.dimension_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.dimension TO PUBLIC;
+
+-- end recreate _timescaledb_catalog.dimension table --

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4671,6 +4671,119 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	chunk_add_inheritance(chunk, parent_ht);
 }
 
+void
+ts_chunk_merge_on_dimension(Chunk *chunk, const Chunk *merge_chunk, int32 dimension_id)
+{
+	const DimensionSlice *slice, *merge_slice;
+	int num_ccs, i;
+	bool dimension_slice_found = false;
+
+	if (chunk->hypertable_relid != merge_chunk->hypertable_relid)
+		ereport(ERROR,
+				(errmsg("cannot merge chunks from different hypertables"),
+				 errhint("chunk 1: \"%s\", chunk 2: \"%s\"",
+						 get_rel_name(chunk->table_id),
+						 get_rel_name(merge_chunk->table_id))));
+
+	for (int i = 0; i < chunk->cube->num_slices; i++)
+	{
+		if (chunk->cube->slices[i]->fd.dimension_id == dimension_id)
+		{
+			slice = chunk->cube->slices[i];
+			merge_slice = merge_chunk->cube->slices[i];
+			dimension_slice_found = true;
+		}
+		else if (chunk->cube->slices[i]->fd.id != merge_chunk->cube->slices[i]->fd.id)
+		{
+			/* If the slices do not match (except on time dimension), we cannot merge the chunks. */
+			ereport(ERROR,
+					(errmsg("cannot merge chunks with different partitioning schemas"),
+					 errhint("chunk 1: \"%s\", chunk 2: \"%s\" have different slices on "
+							 "dimension ID %d",
+							 get_rel_name(chunk->table_id),
+							 get_rel_name(merge_chunk->table_id),
+							 chunk->cube->slices[i]->fd.dimension_id)));
+		}
+	}
+
+	if (!dimension_slice_found)
+		ereport(ERROR,
+				(errmsg("cannot find slice for merging dimension"),
+				 errhint("chunk 1: \"%s\", chunk 2: \"%s\", dimension ID %d",
+						 get_rel_name(chunk->table_id),
+						 get_rel_name(merge_chunk->table_id),
+						 dimension_id)));
+
+	if (slice->fd.range_end != merge_slice->fd.range_start)
+		ereport(ERROR,
+				(errmsg("cannot merge non-adjacent chunks over supplied dimension"),
+				 errhint("chunk 1: \"%s\", chunk 2: \"%s\", dimension ID %d",
+						 get_rel_name(chunk->table_id),
+						 get_rel_name(merge_chunk->table_id),
+						 dimension_id)));
+
+	num_ccs =
+		ts_chunk_constraint_scan_by_dimension_slice_id(slice->fd.id, NULL, CurrentMemoryContext);
+
+	/* There should always be an associated chunk constraint to a dimension slice.
+	 * This can only occur when the catalog metadata is corrupt.
+	 */
+	if (num_ccs <= 0)
+		ereport(ERROR,
+				(errmsg("missing chunk constraint for dimension slice"),
+				 errhint("chunk: \"%s\", slice ID %d",
+						 get_rel_name(chunk->table_id),
+						 slice->fd.id)));
+
+	DimensionSlice *new_slice =
+		ts_dimension_slice_create(dimension_id, slice->fd.range_start, merge_slice->fd.range_end);
+
+	/* Only if there is exactly one chunk constraint for the merged dimension slice
+	 * we can go ahead and delete it since we are dropping the chunk.
+	 */
+	if (num_ccs == 1)
+		ts_dimension_slice_delete_by_id(slice->fd.id, false);
+
+	/* Check for dimension slice already exists, if not create a new one. */
+	ScanTupLock tuplock = {
+		.lockmode = LockTupleKeyShare,
+		.waitpolicy = LockWaitBlock,
+	};
+	if (!ts_dimension_slice_scan_for_existing(new_slice, &tuplock))
+	{
+		ts_dimension_slice_insert(new_slice);
+	}
+
+	ts_chunk_constraint_update_slice_id(chunk->fd.id, slice->fd.id, new_slice->fd.id);
+	ChunkConstraints *ccs = ts_chunk_constraints_alloc(1, CurrentMemoryContext);
+	num_ccs =
+		ts_chunk_constraint_scan_by_dimension_slice_id(new_slice->fd.id, ccs, CurrentMemoryContext);
+
+	if (num_ccs <= 0)
+		ereport(ERROR,
+				(errmsg("missing chunk constraint for merged dimension slice"),
+				 errhint("chunk: \"%s\", slice ID %d",
+						 get_rel_name(chunk->table_id),
+						 new_slice->fd.id)));
+
+	/* We have to recreate the chunk constraints since we are changing
+	 * table constraints when updating the slice.
+	 */
+	for (i = 0; i < ccs->capacity; i++)
+	{
+		ChunkConstraint cc = ccs->constraints[i];
+		if (cc.fd.chunk_id == chunk->fd.id)
+		{
+			ts_process_utility_set_expect_chunk_modification(true);
+			ts_chunk_constraint_recreate(&cc, chunk->table_id);
+			ts_process_utility_set_expect_chunk_modification(false);
+			break;
+		}
+	}
+
+	ts_chunk_drop(merge_chunk, DROP_RESTRICT, 1);
+}
+
 /* Internal API used by OSM extension. OSM table is a foreign table that is
  * attached as a chunk of the hypertable. A chunk needs dimension constraints. We
  * add dummy constraints for the OSM chunk and then attach it to the hypertable.

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -231,6 +231,8 @@ extern void ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id
 extern bool ts_chunk_lock_if_exists(Oid chunk_oid, LOCKMODE chunk_lockmode);
 extern int ts_chunk_oid_cmp(const void *p1, const void *p2);
 int ts_chunk_get_osm_chunk_id(int hypertable_id);
+extern TSDLLEXPORT void ts_chunk_merge_on_dimension(Chunk *chunk, const Chunk *merge_chunk,
+													int32 dimension_id);
 
 #define chunk_get_by_name(schema_name, table_name, fail_if_not_found)                              \
 	ts_chunk_get_by_name_with_memory_context(schema_name,                                          \

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -77,6 +77,8 @@ extern int ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, cons
 															const char *new_name);
 extern int ts_chunk_constraint_adjust_meta(int32 chunk_id, const char *ht_constraint_name,
 										   const char *old_name, const char *new_name);
+extern TSDLLEXPORT bool ts_chunk_constraint_update_slice_id(int32 chunk_id, int32 old_slice_id,
+															int32 new_slice_id);
 
 extern char *
 ts_chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid,

--- a/src/compression_with_clause.c
+++ b/src/compression_with_clause.c
@@ -35,6 +35,10 @@ static const WithClauseDefinition compress_hypertable_with_clause_def[] = {
 			 .arg_name = "compress_orderby",
 			 .type_id = TEXTOID,
 		},
+		[CompressChunkTimeInterval] = {
+			 .arg_name = "compress_chunk_time_interval",
+			 .type_id = INTERVALOID,
+		},
 };
 
 WithClauseResult *
@@ -276,4 +280,20 @@ ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options, Hypertab
 	}
 	else
 		return NIL;
+}
+
+/* returns List of CompressedParsedCol
+ * E.g. timescaledb.compress_orderby = 'col1 asc nulls first,col2 desc,col3'
+ */
+Interval *
+ts_compress_hypertable_parse_chunk_time_interval(WithClauseResult *parsed_options,
+												 Hypertable *hypertable)
+{
+	if (parsed_options[CompressChunkTimeInterval].is_default == false)
+	{
+		Datum textarg = parsed_options[CompressChunkTimeInterval].parsed;
+		return DatumGetIntervalP(textarg);
+	}
+	else
+		return NULL;
 }

--- a/src/compression_with_clause.h
+++ b/src/compression_with_clause.h
@@ -18,6 +18,7 @@ typedef enum CompressHypertableOption
 	CompressEnabled = 0,
 	CompressSegmentBy,
 	CompressOrderBy,
+	CompressChunkTimeInterval,
 } CompressHypertableOption;
 
 typedef struct
@@ -33,5 +34,8 @@ extern TSDLLEXPORT List *ts_compress_hypertable_parse_segment_by(WithClauseResul
 																 Hypertable *hypertable);
 extern TSDLLEXPORT List *ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options,
 															   Hypertable *hypertable);
+extern TSDLLEXPORT Interval *
+ts_compress_hypertable_parse_chunk_time_interval(WithClauseResult *parsed_options,
+												 Hypertable *hypertable);
 
 #endif

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -125,6 +125,7 @@ extern int ts_dimension_set_type(Dimension *dim, Oid newtype);
 extern TSDLLEXPORT Oid ts_dimension_get_partition_type(const Dimension *dim);
 extern int ts_dimension_set_name(Dimension *dim, const char *newname);
 extern int ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
+extern int ts_dimension_set_compress_interval(Dimension *dim, int64 compress_interval);
 extern TSDLLEXPORT int ts_dimension_set_number_of_slices(Dimension *dim, int16 num_slices);
 extern Datum ts_dimension_transform_value(const Dimension *dim, Oid collation, Datum value,
 										  Oid const_datum_type, Oid *restype);

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -975,6 +975,22 @@ ts_dimension_slice_insert_multi(DimensionSlice **slices, Size num_slices)
 	return n;
 }
 
+void
+ts_dimension_slice_insert(DimensionSlice *slice)
+{
+	Catalog *catalog = ts_catalog_get();
+	Relation rel;
+
+	rel = table_open(catalog_get_table_id(catalog, DIMENSION_SLICE), RowExclusiveLock);
+
+	dimension_slice_insert_relation(rel, slice);
+
+	/* Keeping a row lock to prevent VACUUM or ALTER TABLE from running while working on the table.
+	 * This is known to cause issues in certain situations.
+	 */
+	table_close(rel, NoLock);
+}
+
 static ScanTupleResult
 dimension_slice_nth_tuple_found(TupleInfo *ti, void *data)
 {

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -76,6 +76,7 @@ extern bool ts_dimension_slice_cut(DimensionSlice *to_cut, const DimensionSlice 
 								   int64 coord);
 extern void ts_dimension_slice_free(DimensionSlice *slice);
 extern int ts_dimension_slice_insert_multi(DimensionSlice **slice, Size num_slices);
+extern void ts_dimension_slice_insert(DimensionSlice *slice);
 extern int ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right);
 extern int ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2538,6 +2538,18 @@ ts_hypertable_unset_compressed(Hypertable *ht)
 	return ts_hypertable_update(ht) > 0;
 }
 
+bool
+ts_hypertable_set_compress_interval(Hypertable *ht, int64 compress_interval)
+{
+	Assert(!TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht));
+	Assert(TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
+
+	Dimension *time_dimension =
+		ts_hyperspace_get_mutable_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);
+
+	return ts_dimension_set_compress_interval(time_dimension, compress_interval) > 0;
+}
+
 /* create a compressed hypertable
  * table_relid - already created table which we are going to
  *               set up as a compressed hypertable

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -149,6 +149,8 @@ extern bool ts_is_partitioning_column(const Hypertable *ht, AttrNumber column_at
 extern TSDLLEXPORT bool ts_hypertable_set_compressed(Hypertable *ht,
 													 int32 compressed_hypertable_id);
 extern TSDLLEXPORT bool ts_hypertable_unset_compressed(Hypertable *ht);
+extern TSDLLEXPORT bool ts_hypertable_set_compress_interval(Hypertable *ht,
+															int64 compress_interval);
 extern TSDLLEXPORT void ts_hypertable_clone_constraints_to_compressed(const Hypertable *ht,
 																	  List *constraint_list);
 extern List *ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cube);

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -241,6 +241,7 @@ enum Anum_dimension
 	Anum_dimension_partitioning_func_schema,
 	Anum_dimension_partitioning_func,
 	Anum_dimension_interval_length,
+	Anum_dimension_compress_interval_length,
 	Anum_dimension_integer_now_func_schema,
 	Anum_dimension_integer_now_func,
 	_Anum_dimension_max,
@@ -261,6 +262,7 @@ typedef struct FormData_dimension
 	NameData partitioning_func;
 	/* open (time) columns */
 	int64 interval_length;
+	int64 compress_interval_length;
 	NameData integer_now_func_schema;
 	NameData integer_now_func;
 } FormData_dimension;

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -82,9 +82,9 @@ FROM _timescaledb_catalog.hypertable;
 -- Check that adaptive chunking sets a 1 day default chunk time
 -- interval => 86400000000 microseconds
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000 |                          |                         | 
 (1 row)
 
 -- Change the target size

--- a/test/expected/chunk_merge.out
+++ b/test/expected/chunk_merge.out
@@ -1,0 +1,95 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_across_dimension(chunk REGCLASS, merge_chunk REGCLASS, dimension_id INTEGER)
+ RETURNS VOID
+    AS :MODULE_PATHNAME, 'ts_test_merge_chunks_across_dimension' LANGUAGE C VOLATILE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
+SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test1
+(1 row)
+
+SELECT table_name FROM  add_dimension('test1', 'i', chunk_time_interval=> 1);
+NOTICE:  adding not-null constraint to column "i"
+ table_name 
+------------
+ test1
+(1 row)
+
+-- This creates chunks 1 - 3 on first hypertable.
+INSERT INTO test1 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+-- This creates chunks 4 - 6 on first hypertable.
+INSERT INTO test1 SELECT t, 2, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+CREATE TABLE test2 ("Time" timestamptz, i integer, value integer);
+SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test2
+(1 row)
+
+-- This creates chunks 7 - 9 on second hypertable.
+INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f
+  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f       |      0 | f
+  7 |             2 | _timescaledb_internal | _hyper_2_7_chunk |                     | f       |      0 | f
+  8 |             2 | _timescaledb_internal | _hyper_2_8_chunk |                     | f       |      0 | f
+  9 |             2 | _timescaledb_internal | _hyper_2_9_chunk |                     | f       |      0 | f
+(9 rows)
+
+\set ON_ERROR_STOP 0
+-- Cannot merge chunks from different hypertables
+SELECT _timescaledb_internal.test_merge_chunks_across_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_2_7_chunk', 1);
+ERROR:  cannot merge chunks from different hypertables
+-- Cannot merge non-adjacent chunks
+SELECT _timescaledb_internal.test_merge_chunks_across_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_3_chunk', 1);
+ERROR:  cannot merge non-adjacent chunks over supplied dimension
+-- Cannot merge same chunk to itself (its not adjacent to itself).
+SELECT _timescaledb_internal.test_merge_chunks_across_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 1);
+ERROR:  cannot merge non-adjacent chunks over supplied dimension
+-- Cannot merge chunks on with different partitioning schemas.
+SELECT _timescaledb_internal.test_merge_chunks_across_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 1);
+ERROR:  cannot merge chunks with different partitioning schemas
+-- Cannot merge chunks on with non-existant dimension slice.
+-- NOTE: we are merging the same chunk just so they have the exact same partitioning schema and we don't hit the previous test error.
+SELECT _timescaledb_internal.test_merge_chunks_across_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 999);
+ERROR:  cannot find slice for merging dimension
+\set ON_ERROR_STOP 1
+-- Merge on open (time) dimension.
+SELECT _timescaledb_internal.test_merge_chunks_across_dimension('_timescaledb_internal._hyper_1_5_chunk','_timescaledb_internal._hyper_1_6_chunk', 1);
+ test_merge_chunks_across_dimension 
+------------------------------------
+ 
+(1 row)
+
+-- Merge on close dimension.
+SELECT _timescaledb_internal.test_merge_chunks_across_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 2);
+ test_merge_chunks_across_dimension 
+------------------------------------
+ 
+(1 row)
+
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f
+  7 |             2 | _timescaledb_internal | _hyper_2_7_chunk |                     | f       |      0 | f
+  8 |             2 | _timescaledb_internal | _hyper_2_8_chunk |                     | f       |      0 | f
+  9 |             2 | _timescaledb_internal | _hyper_2_9_chunk |                     | f       |      0 | f
+(7 rows)
+

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -82,10 +82,10 @@ SELECT set_chunk_time_interval('chunk_test', 5::bigint);
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  1 |             1 | time        | integer     | t       |            |                          |                    |               5 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  1 |             1 | time        | integer     | t       |            |                          |                    |               5 |                          |                         | 
 (2 rows)
 
 INSERT INTO chunk_test VALUES (7, 24.3, 79669, 1);

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -92,13 +92,13 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  5 |             2 | location    | text        | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  5 |             2 | location    | text        | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 --test that we can change the number of partitions and that 1 is allowed
@@ -109,9 +109,9 @@ SELECT set_number_partitions('test_schema.test_table', 1, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  5 |             2 | location    | text        | f       |          1 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  5 |             2 | location    | text        | f       |          1 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (1 row)
 
 SELECT set_number_partitions('test_schema.test_table', 2, 'location');
@@ -121,9 +121,9 @@ SELECT set_number_partitions('test_schema.test_table', 2, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -155,14 +155,14 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  6 |             2 | id          | integer     | t       |            |                          |                    |            1000 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  6 |             2 | id          | integer     | t       |            |                          |                    |            1000 |                          |                         | 
 (6 rows)
 
 -- Test add_dimension: can use interval types for TIMESTAMPTZ columns
@@ -757,9 +757,9 @@ select set_integer_now_func('test_table_int', 'dummy_now');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
- 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 | public                  | dummy_now
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | public                  | dummy_now
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -779,9 +779,9 @@ select set_integer_now_func('test_table_int', 'my_user_schema.dummy_now4', repla
 \c :TEST_DBNAME :ROLE_SUPERUSER
 ALTER SCHEMA my_user_schema RENAME TO my_new_schema;
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
- 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 | my_new_schema           | dummy_now4
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now4
 (1 row)
 
 -- github issue #4650

--- a/test/expected/ddl-12.out
+++ b/test/expected/ddl-12.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/ddl-13.out
+++ b/test/expected/ddl-13.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/ddl-14.out
+++ b/test/expected/ddl-14.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/ddl-15.out
+++ b/test/expected/ddl-15.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -7,8 +7,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
 (0 rows)
 
 CREATE TABLE should_drop (time timestamp, temp float8);
@@ -82,9 +82,9 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
 (1 row)
 
 DROP TABLE should_drop;
@@ -105,8 +105,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
 (1 row)
 

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -64,8 +64,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -96,8 +96,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/partition.out
+++ b/test/expected/partition.out
@@ -11,10 +11,10 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Show legacy partitioning function is used
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (2 rows)
 
 INSERT INTO part_legacy VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -54,12 +54,12 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
-  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
+  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
 (4 rows)
 
 INSERT INTO part_new VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -133,17 +133,17 @@ SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => '_times
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
-  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
-  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000 |                         | 
-  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
+  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
+  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- Test that we support custom SQL-based partitioning functions and

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -13,7 +13,7 @@ extern Datum tsl_create_compressed_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_recompress_chunk(PG_FUNCTION_ARGS);
-extern void tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed);
+extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed);
 extern bool tsl_recompress_chunk_wrapper(Chunk *chunk);
 
 #endif /* TIMESCALEDB_TSL_COMPRESSION_API_H */

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -94,6 +94,7 @@ typedef struct SegmentInfo
 	int16 typlen;
 	bool is_null;
 	bool typ_by_val;
+	Oid collation;
 } SegmentInfo;
 
 typedef struct PerColumn
@@ -110,6 +111,7 @@ typedef struct PerColumn
 
 	/* segment info; only used if compressor is NULL */
 	SegmentInfo *segment_info;
+	int16 segmentby_column_index;
 } PerColumn;
 
 typedef struct RowCompressor
@@ -120,6 +122,8 @@ typedef struct RowCompressor
 	/* the table we're writing the compressed data to */
 	Relation compressed_table;
 	BulkInsertState bistate;
+	/* segment by index Oid if any */
+	Oid index_oid;
 
 	/* in theory we could have more input columns than outputted ones, so we
 	   store the number of inputs/compressors seperately*/
@@ -218,6 +222,27 @@ restore_pgclass_stats(Oid table_oid, int pages, int visible, float tuples)
 
 	heap_freetuple(tuple);
 	table_close(pg_class, RowExclusiveLock);
+}
+
+/* Merge the relstats when merging chunks while compressing them.
+ * We need to do this in order to update the relstats of the chunk
+ * that is merged into since the compressed one will be dropped by
+ * the merge.
+ */
+extern void
+merge_chunk_relstats(Oid merged_relid, Oid compressed_relid)
+{
+	int comp_pages, merged_pages, comp_visible, merged_visible;
+	float comp_tuples, merged_tuples;
+
+	capture_pgclass_stats(compressed_relid, &comp_pages, &comp_visible, &comp_tuples);
+	capture_pgclass_stats(merged_relid, &merged_pages, &merged_visible, &merged_tuples);
+
+	merged_pages += comp_pages;
+	merged_visible += comp_visible;
+	merged_tuples += comp_tuples;
+
+	restore_pgclass_stats(merged_relid, merged_pages, merged_visible, merged_tuples);
 }
 
 /* Truncate the relation WITHOUT applying triggers. This is the
@@ -530,6 +555,227 @@ static SegmentInfo *segment_info_new(Form_pg_attribute column_attr);
 static void segment_info_update(SegmentInfo *segment_info, Datum val, bool is_null);
 static bool segment_info_datum_is_in_group(SegmentInfo *segment_info, Datum datum, bool is_null);
 
+/* Find segment by index for setting the correct sequence number if
+ * we are trying to roll up chunks while compressing
+ */
+static Oid
+get_compressed_chunk_index(Relation compressed_chunk, int16 *uncompressed_col_to_compressed_col,
+						   PerColumn *per_column, int n_input_columns)
+{
+	ListCell *lc;
+	int i;
+
+	List *index_oids = RelationGetIndexList(compressed_chunk);
+
+	foreach (lc, index_oids)
+	{
+		Oid index_oid = lfirst_oid(lc);
+		bool matches = true;
+		int num_segmentby_columns = 0;
+		Relation index_rel = index_open(index_oid, AccessShareLock);
+		IndexInfo *index_info = BuildIndexInfo(index_rel);
+
+		for (i = 0; i < n_input_columns; i++)
+		{
+			if (per_column[i].segmentby_column_index < 1)
+				continue;
+
+			/* Last member of the index must be the sequence number column. */
+			if (per_column[i].segmentby_column_index >= index_rel->rd_att->natts)
+			{
+				matches = false;
+				break;
+			}
+
+			int index_att_offset = AttrNumberGetAttrOffset(per_column[i].segmentby_column_index);
+
+			if (index_info->ii_IndexAttrNumbers[index_att_offset] !=
+				AttrOffsetGetAttrNumber(uncompressed_col_to_compressed_col[i]))
+			{
+				matches = false;
+				break;
+			}
+
+			num_segmentby_columns++;
+		}
+
+		/* Check that we have the correct number of index attributes
+		 * and that the last one is the sequence number
+		 */
+		if (num_segmentby_columns != index_rel->rd_att->natts - 1 ||
+			namestrcmp((Name) &index_rel->rd_att->attrs[num_segmentby_columns].attname,
+					   COMPRESSION_COLUMN_METADATA_SEQUENCE_NUM_NAME) != 0)
+			matches = false;
+
+		index_close(index_rel, AccessShareLock);
+
+		if (matches)
+			return index_oid;
+	}
+
+	return InvalidOid;
+}
+
+static int32
+index_scan_sequence_number(Relation table_rel, Oid index_oid, ScanKeyData *scankey,
+						   int num_scankeys)
+{
+	int32 result = 0;
+	bool is_null;
+	Relation index_rel = index_open(index_oid, AccessShareLock);
+	RelationInitIndexAccessInfo(index_rel);
+
+	IndexScanDesc index_scan =
+		index_beginscan(table_rel, index_rel, GetTransactionSnapshot(), num_scankeys, 0);
+	index_scan->xs_want_itup = true;
+	index_rescan(index_scan, scankey, num_scankeys, NULL, 0);
+
+	if (index_getnext_tid(index_scan, BackwardScanDirection))
+	{
+		result = index_getattr(index_scan->xs_itup,
+							   index_scan->xs_itupdesc->natts -
+								   1, /* Last attribute of the index is sequence number. */
+							   index_scan->xs_itupdesc,
+							   &is_null);
+		if (is_null)
+			result = 0;
+	}
+
+	index_endscan(index_scan);
+	index_close(index_rel, AccessShareLock);
+
+	return result;
+}
+
+static int32
+table_scan_sequence_number(Relation table_rel, int16 seq_num_column_num, ScanKeyData *scankey,
+						   int num_scankeys)
+{
+	int32 curr_seq_num = 0, max_seq_num = 0;
+	bool is_null;
+	HeapTuple compressed_tuple;
+	Datum seq_num;
+	TupleDesc in_desc = RelationGetDescr(table_rel);
+
+	TableScanDesc heap_scan =
+		table_beginscan(table_rel, GetLatestSnapshot(), num_scankeys, scankey);
+
+	for (compressed_tuple = heap_getnext(heap_scan, ForwardScanDirection); compressed_tuple != NULL;
+		 compressed_tuple = heap_getnext(heap_scan, ForwardScanDirection))
+	{
+		Assert(HeapTupleIsValid(compressed_tuple));
+
+		seq_num = heap_getattr(compressed_tuple, seq_num_column_num, in_desc, &is_null);
+		if (!is_null)
+		{
+			curr_seq_num = DatumGetInt32(seq_num);
+			if (max_seq_num < curr_seq_num)
+			{
+				max_seq_num = curr_seq_num;
+			}
+		}
+	}
+
+	heap_endscan(heap_scan);
+
+	return max_seq_num;
+}
+
+/* Scan compressed chunk to get the sequence number for current group.
+ * This is necessary to do when merging chunks. If the chunk is empty,
+ * scan will always return 0 and the sequence number will start from
+ * SEQUENCE_NUM_GAP.
+ */
+static int32
+get_sequence_number_for_current_group(Relation table_rel, Oid index_oid,
+									  int16 *uncompressed_col_to_compressed_col,
+									  PerColumn *per_column, int n_input_columns,
+									  int16 seq_num_column_num)
+{
+	/* No point scanning an empty relation. */
+	if (table_rel->rd_rel->relpages == 0)
+		return SEQUENCE_NUM_GAP;
+
+	/* If there is a suitable index, use index scan otherwise fallback to heap scan. */
+	bool is_index_scan = index_oid != InvalidOid;
+
+	int i, num_scankeys = 0;
+	int32 result = 0;
+
+	for (i = 0; i < n_input_columns; i++)
+	{
+		if (per_column[i].segmentby_column_index < 1)
+			continue;
+
+		num_scankeys++;
+	}
+
+	MemoryContext scan_ctx = AllocSetContextCreate(CurrentMemoryContext,
+												   "get max sequence number scan",
+												   ALLOCSET_DEFAULT_SIZES);
+	MemoryContext old_ctx;
+	old_ctx = MemoryContextSwitchTo(scan_ctx);
+
+	ScanKeyData *scankey = NULL;
+
+	if (num_scankeys > 0)
+	{
+		scankey = palloc0(sizeof(ScanKeyData) * num_scankeys);
+
+		for (i = 0; i < n_input_columns; i++)
+		{
+			if (per_column[i].segmentby_column_index < 1)
+				continue;
+
+			PerColumn col = per_column[i];
+			int16 attno = is_index_scan ?
+							  col.segmentby_column_index :
+							  AttrOffsetGetAttrNumber(uncompressed_col_to_compressed_col[i]);
+
+			if (col.segment_info->is_null)
+			{
+				ScanKeyEntryInitialize(&scankey[col.segmentby_column_index - 1],
+									   SK_ISNULL | SK_SEARCHNULL,
+									   attno,
+									   InvalidStrategy, /* no strategy */
+									   InvalidOid,		/* no strategy subtype */
+									   InvalidOid,		/* no collation */
+									   InvalidOid,		/* no reg proc for this */
+									   (Datum) 0);		/* constant */
+			}
+			else
+			{
+				ScanKeyEntryInitializeWithInfo(&scankey[col.segmentby_column_index - 1],
+											   0, /* flags */
+											   attno,
+											   BTEqualStrategyNumber,
+											   InvalidOid, /* No strategy subtype. */
+											   col.segment_info->collation,
+											   &col.segment_info->eq_fn,
+											   col.segment_info->val);
+			}
+		}
+	}
+
+	if (is_index_scan)
+	{
+		/* Index scan should always use at least one scan key to get the sequence number. */
+		Assert(num_scankeys > 0);
+
+		result = index_scan_sequence_number(table_rel, index_oid, scankey, num_scankeys);
+	}
+	else
+	{
+		/* Table scan can work without scan keys. */
+		result = table_scan_sequence_number(table_rel, seq_num_column_num, scankey, num_scankeys);
+	}
+
+	MemoryContextSwitchTo(old_ctx);
+	MemoryContextDelete(scan_ctx);
+
+	return result + SEQUENCE_NUM_GAP;
+}
+
 /* num_compression_infos is the number of columns we will write to in the compressed table */
 static void
 row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_desc,
@@ -631,6 +877,7 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 				.min_metadata_attr_offset = segment_min_attr_offset,
 				.max_metadata_attr_offset = segment_max_attr_offset,
 				.min_max_metadata_builder = segment_min_max_builder,
+				.segmentby_column_index = -1,
 			};
 		}
 		else
@@ -641,11 +888,18 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 					 compression_info->attname.data);
 			*column = (PerColumn){
 				.segment_info = segment_info_new(column_attr),
+				.segmentby_column_index = compression_info->segmentby_column_index,
 				.min_metadata_attr_offset = -1,
 				.max_metadata_attr_offset = -1,
 			};
 		}
 	}
+
+	row_compressor->index_oid =
+		get_compressed_chunk_index(compressed_table,
+								   row_compressor->uncompressed_col_to_compressed_col,
+								   row_compressor->per_column,
+								   row_compressor->n_input_columns);
 }
 
 static void
@@ -709,6 +963,7 @@ row_compressor_update_group(RowCompressor *row_compressor, TupleTableSlot *row)
 	int col;
 	/* save original memory context */
 	const MemoryContext oldcontext = CurrentMemoryContext;
+
 	Assert(row_compressor->rows_compressed_into_current_value == 0);
 	Assert(row_compressor->n_input_columns <= row->tts_nvalid);
 
@@ -731,6 +986,22 @@ row_compressor_update_group(RowCompressor *row_compressor, TupleTableSlot *row)
 	}
 	/* switch to original memory context */
 	MemoryContextSwitchTo(oldcontext);
+
+	/*
+	 * The sequence number of the compressed tuple is per segment by grouping
+	 * and should be reset when the grouping changes to prevent overflows with
+	 * many segmentby columns.
+	 *
+	 */
+	row_compressor->sequence_num =
+		get_sequence_number_for_current_group(row_compressor->compressed_table,
+											  row_compressor->index_oid,
+											  row_compressor->uncompressed_col_to_compressed_col,
+											  row_compressor->per_column,
+											  row_compressor->n_input_columns,
+											  AttrOffsetGetAttrNumber(
+												  row_compressor
+													  ->sequence_num_metadata_column_offset));
 }
 
 static bool
@@ -928,14 +1199,6 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 	row_compressor->num_compressed_rows++;
 	row_compressor->rows_compressed_into_current_value = 0;
 
-	/*
-	 * The sequence number of the compressed tuple is per segment by grouping
-	 * and should be reset when the grouping changes to prevent overflows with
-	 * many segmentby columns.
-	 */
-	if (changed_groups)
-		row_compressor->sequence_num = SEQUENCE_NUM_GAP;
-
 	MemoryContextReset(row_compressor->per_row_ctx);
 }
 
@@ -967,6 +1230,7 @@ segment_info_new(Form_pg_attribute column_attr)
 	fmgr_info_cxt(eq_fn_oid, &segment_info->eq_fn, CurrentMemoryContext);
 
 	segment_info->eq_fcinfo = HEAP_FCINFO(2);
+	segment_info->collation = column_attr->attcollation;
 	InitFunctionCallInfoData(*segment_info->eq_fcinfo,
 							 &segment_info->eq_fn /*=Flinfo*/,
 							 2 /*=Nargs*/,

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -151,6 +151,7 @@ extern void decompress_chunk(Oid in_table, Oid out_table);
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(
 	CompressionAlgorithms algorithm, bool reverse))(Datum, Oid element_type);
 extern void update_compressed_chunk_relstats(Oid uncompressed_relid, Oid compressed_relid);
+extern void merge_chunk_relstats(Oid merged_relid, Oid compressed_relid);
 
 /* CompressSingleRowState methods */
 struct CompressSingleRowState;

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -588,14 +588,14 @@ select remove_retention_policy('part_time_now_func');
 alter function dummy_now() rename to dummy_now_renamed;
 alter schema public rename to new_public;
 select * from  _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | chunk_id    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  5 |             4 | time        | timestamp without time zone | t       |            |                          |                    |               1 |                         | 
-  6 |             5 | time        | double precision            | t       |            | new_public               | time_partfunc      |               1 | new_public              | dummy_now
-  3 |             2 | time        | bigint                      | t       |            |                          |                    |               1 | new_public              | nowstamp
-  4 |             3 | time        | smallint                    | t       |            |                          |                    |               1 | new_public              | overflow_now
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | chunk_id    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  5 |             4 | time        | timestamp without time zone | t       |            |                          |                    |               1 |                          |                         | 
+  6 |             5 | time        | double precision            | t       |            | new_public               | time_partfunc      |               1 |                          | new_public              | dummy_now
+  3 |             2 | time        | bigint                      | t       |            |                          |                    |               1 |                          | new_public              | nowstamp
+  4 |             3 | time        | smallint                    | t       |            |                          |                    |               1 |                          | new_public              | overflow_now
 (6 rows)
 
 alter schema new_public rename to public;

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -1,0 +1,114 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_on_dimension(chunk REGCLASS, merge_chunk REGCLASS, dimension_id INTEGER)
+ RETURNS VOID
+    AS :TSL_MODULE_PATHNAME, 'ts_test_merge_chunks_on_dimension' LANGUAGE C VOLATILE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
+SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test1
+(1 row)
+
+SELECT table_name FROM  add_dimension('test1', 'i', number_partitions=> 2);
+ table_name 
+------------
+ test1
+(1 row)
+
+ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+-- This creates chunks 1 - 3 on first hypertable.
+INSERT INTO test1 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+-- This creates chunks 4 - 6 on first hypertable.
+INSERT INTO test1 SELECT t, 2, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+CREATE TABLE test2 ("Time" timestamptz, i integer, value integer);
+SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test2
+(1 row)
+
+-- This creates chunks 7 - 9 on second hypertable.
+INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+SELECT * FROM _timescaledb_catalog.chunk;
+ id | hypertable_id |      schema_name      |    table_name    | compressed_chunk_id | dropped | status | osm_chunk 
+----+---------------+-----------------------+------------------+---------------------+---------+--------+-----------
+  1 |             1 | _timescaledb_internal | _hyper_1_1_chunk |                     | f       |      0 | f
+  2 |             1 | _timescaledb_internal | _hyper_1_2_chunk |                     | f       |      0 | f
+  3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |                     | f       |      0 | f
+  4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |                     | f       |      0 | f
+  5 |             1 | _timescaledb_internal | _hyper_1_5_chunk |                     | f       |      0 | f
+  6 |             1 | _timescaledb_internal | _hyper_1_6_chunk |                     | f       |      0 | f
+  7 |             3 | _timescaledb_internal | _hyper_3_7_chunk |                     | f       |      0 | f
+  8 |             3 | _timescaledb_internal | _hyper_3_8_chunk |                     | f       |      0 | f
+  9 |             3 | _timescaledb_internal | _hyper_3_9_chunk |                     | f       |      0 | f
+(9 rows)
+
+\set ON_ERROR_STOP 0
+-- Cannot merge chunks from different hypertables
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_3_7_chunk', 1);
+ERROR:  cannot merge chunks from different hypertables
+-- Cannot merge non-adjacent chunks
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_3_chunk', 1);
+ERROR:  cannot merge non-adjacent chunks over supplied dimension
+-- Cannot merge same chunk to itself (its not adjacent to itself).
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 1);
+ERROR:  cannot merge non-adjacent chunks over supplied dimension
+-- Cannot merge chunks on with different partitioning schemas.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 1);
+ERROR:  cannot merge chunks with different partitioning schemas
+-- Cannot merge chunks on with non-existant dimension slice.
+-- NOTE: we are merging the same chunk just so they have the exact same partitioning schema and we don't hit the previous test error.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 999);
+ERROR:  cannot find slice for merging dimension
+\set ON_ERROR_STOP 1
+-- Merge on open (time) dimension.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_5_chunk','_timescaledb_internal._hyper_1_6_chunk', 1);
+ test_merge_chunks_on_dimension 
+--------------------------------
+ 
+(1 row)
+
+-- Merge on closed dimension.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 2);
+ test_merge_chunks_on_dimension 
+--------------------------------
+ 
+(1 row)
+
+SELECT compress_chunk(i) FROM show_chunks('test1') i;
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+(4 rows)
+
+\set ON_ERROR_STOP 0
+-- Cannot merge chunks internal compressed chunks, no dimensions on them.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_10_chunk','_timescaledb_internal.compress_hyper_2_11_chunk', 1);
+ERROR:  cannot find slice for merging dimension
+\set ON_ERROR_STOP 1
+-- This creates more data so caggs has multiple chunks.
+INSERT INTO test1 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 3:00'::TIMESTAMPTZ, '2018-03-03 3:00', '1 minute') t;
+CREATE MATERIALIZED VIEW test_cagg
+WITH (timescaledb.continuous) AS
+SELECT i,
+   time_bucket(INTERVAL '1 hour', "Time") AS bucket,
+   AVG(value)
+FROM test1
+GROUP BY i, bucket;
+NOTICE:  refreshing continuous aggregate "test_cagg"
+-- Merging cagg chunks should also work.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_4_37_chunk','_timescaledb_internal._hyper_4_39_chunk', 4);
+ test_merge_chunks_on_dimension 
+--------------------------------
+ 
+(1 row)
+

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -1,0 +1,440 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\ir include/rand_generator.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--------------------------
+-- cheap rand generator --
+--------------------------
+create table rand_minstd_state(i bigint);
+create function rand_minstd_advance(bigint) returns bigint
+language sql immutable as
+$$
+	select (16807 * $1) % 2147483647
+$$;
+create function gen_rand_minstd() returns bigint
+language sql security definer as
+$$
+	update rand_minstd_state set i = rand_minstd_advance(i) returning i
+$$;
+-- seed the random num generator
+insert into rand_minstd_state values (321);
+\c :TEST_DBNAME :ROLE_SUPERUSER
+\ir include/compression_utils.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test1
+(1 row)
+
+-- This will generate 24 chunks
+INSERT INTO test1 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks
+ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+SELECT
+  $$
+  SELECT * FROM test1 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test1' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+psql:include/compression_test_merge.sql:7: NOTICE:  table "merge_result" does not exist, skipping
+ count_compressed 
+------------------
+               24
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                 12
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+\set TYPE timestamptz
+\set ORDER_BY_COL_NAME Time
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               12
+(1 row)
+
+ min_correct | max_correct 
+-------------+-------------
+ t           | t
+(1 row)
+
+DROP TABLE test1;
+CREATE TABLE test2 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test2
+(1 row)
+
+-- This will generate 24 1 hour chunks.
+INSERT INTO test2 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+-- Compression is set to merge those 24 chunks into 3 chunks, two 10 hour chunks and a single 4 hour chunk.
+ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='10 hours');
+SELECT
+  $$
+  SELECT * FROM test2 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test2' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               24
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                  3
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+                3
+(1 row)
+
+ min_correct | max_correct 
+-------------+-------------
+ t           | t
+(1 row)
+
+DROP TABLE test2;
+CREATE TABLE test3 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test3', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test3
+(1 row)
+
+SELECT table_name from  add_dimension('test3', 'i', number_partitions=> 3);
+ table_name 
+------------
+ test3
+(1 row)
+
+-- This will generate 25 1 hour chunks with a closed space dimension.
+INSERT INTO test3 SELECT t, 1, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 12:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 2, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 13:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 3, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 2:00'::TIMESTAMPTZ, '2018-03-02 2:01', '1 minute') t;
+-- Compression is set to merge those 25 chunks into 12 2 hour chunks and a single 1 hour chunks on a different space dimensions.
+ALTER TABLE test3 set (timescaledb.compress, timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+SELECT
+  $$
+  SELECT * FROM test3 WHERE i = 1 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test3' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               25
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                 13
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               13
+(1 row)
+
+ min_correct | max_correct 
+-------------+-------------
+ t           | t
+(1 row)
+
+DROP TABLE test3;
+CREATE TABLE test4 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test4', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test4
+(1 row)
+
+-- Setting compress_chunk_time_interval to non-multiple of chunk_time_interval should emit a warning.
+ALTER TABLE test4 set (timescaledb.compress, timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='90 minutes');
+WARNING:  compress chunk interval is not a multiple of chunk interval, you should use a factor of chunk interval to merge as much as possible
+DROP TABLE test4;
+CREATE TABLE test5 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test5', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test5
+(1 row)
+
+-- This will generate 24 chunks. Note that we are forcing everyting into a single segment so we use table scan to when merging chunks.
+INSERT INTO test5 SELECT t, 1, gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+-- Compression is set to merge those 24 chunks into 1 24 hour chunk
+ALTER TABLE test5 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='24 hours');
+SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 1;
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_9_163_chunk
+(1 row)
+
+SELECT schemaname || '.' || indexname AS "INDEXNAME"
+FROM pg_indexes i
+INNER JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name and i.tablename = cc.table_name 
+INNER JOIN _timescaledb_catalog.chunk c ON (cc.id = c.compressed_chunk_id) 
+LIMIT 1 \gset
+DROP INDEX :INDEXNAME;
+-- We dropped the index from compressed chunk thats needed to determine sequence numbers
+-- during merge, merging will fallback to doing heap scans and work just fine.
+SELECT
+  $$
+  SELECT * FROM test5 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test5' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+psql:include/compression_test_merge.sql:12: NOTICE:  chunk "_hyper_9_163_chunk" is already compressed
+ count_compressed 
+------------------
+               24
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                  1
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+DROP TABLE test5;
+CREATE TABLE test6 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test6', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test6
+(1 row)
+
+-- This will generate 24 chunks
+INSERT INTO test6 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks.
+ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+SELECT compress_chunk(i) FROM show_chunks('test6') i;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_11_188_chunk
+ _timescaledb_internal._hyper_11_188_chunk
+ _timescaledb_internal._hyper_11_190_chunk
+ _timescaledb_internal._hyper_11_190_chunk
+ _timescaledb_internal._hyper_11_192_chunk
+ _timescaledb_internal._hyper_11_192_chunk
+ _timescaledb_internal._hyper_11_194_chunk
+ _timescaledb_internal._hyper_11_194_chunk
+ _timescaledb_internal._hyper_11_196_chunk
+ _timescaledb_internal._hyper_11_196_chunk
+ _timescaledb_internal._hyper_11_198_chunk
+ _timescaledb_internal._hyper_11_198_chunk
+ _timescaledb_internal._hyper_11_200_chunk
+ _timescaledb_internal._hyper_11_200_chunk
+ _timescaledb_internal._hyper_11_202_chunk
+ _timescaledb_internal._hyper_11_202_chunk
+ _timescaledb_internal._hyper_11_204_chunk
+ _timescaledb_internal._hyper_11_204_chunk
+ _timescaledb_internal._hyper_11_206_chunk
+ _timescaledb_internal._hyper_11_206_chunk
+ _timescaledb_internal._hyper_11_208_chunk
+ _timescaledb_internal._hyper_11_208_chunk
+ _timescaledb_internal._hyper_11_210_chunk
+ _timescaledb_internal._hyper_11_210_chunk
+(24 rows)
+
+SELECT 12 as expected_number_of_chunks, count(*) as number_of_chunks FROM show_chunks('test6');
+ expected_number_of_chunks | number_of_chunks 
+---------------------------+------------------
+                        12 |               12
+(1 row)
+
+SELECT decompress_chunk(i) FROM show_chunks('test6') i;
+             decompress_chunk              
+-------------------------------------------
+ _timescaledb_internal._hyper_11_188_chunk
+ _timescaledb_internal._hyper_11_190_chunk
+ _timescaledb_internal._hyper_11_192_chunk
+ _timescaledb_internal._hyper_11_194_chunk
+ _timescaledb_internal._hyper_11_196_chunk
+ _timescaledb_internal._hyper_11_198_chunk
+ _timescaledb_internal._hyper_11_200_chunk
+ _timescaledb_internal._hyper_11_202_chunk
+ _timescaledb_internal._hyper_11_204_chunk
+ _timescaledb_internal._hyper_11_206_chunk
+ _timescaledb_internal._hyper_11_208_chunk
+ _timescaledb_internal._hyper_11_210_chunk
+(12 rows)
+
+-- Altering compress chunk time interval will cause us to create 6 chunks instead of 12.
+ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='4 hours');
+SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_11_188_chunk
+ _timescaledb_internal._hyper_11_188_chunk
+ _timescaledb_internal._hyper_11_192_chunk
+ _timescaledb_internal._hyper_11_192_chunk
+ _timescaledb_internal._hyper_11_196_chunk
+ _timescaledb_internal._hyper_11_196_chunk
+ _timescaledb_internal._hyper_11_200_chunk
+ _timescaledb_internal._hyper_11_200_chunk
+ _timescaledb_internal._hyper_11_204_chunk
+ _timescaledb_internal._hyper_11_204_chunk
+ _timescaledb_internal._hyper_11_208_chunk
+ _timescaledb_internal._hyper_11_208_chunk
+(12 rows)
+
+SELECT 6 as expected_number_of_chunks, count(*) as number_of_chunks FROM show_chunks('test6');
+ expected_number_of_chunks | number_of_chunks 
+---------------------------+------------------
+                         6 |                6
+(1 row)
+
+DROP TABLE test6;
+CREATE TABLE test7 ("Time" timestamptz, i integer, j integer, k integer, value integer);
+SELECT table_name from create_hypertable('test7', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test7
+(1 row)
+
+-- This will generate 24 chunks
+INSERT INTO test7 
+SELECT t, i, gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd()  
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks with ordering by j column before time column, causing recompression to occur during merge.
+ALTER TABLE test7 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='j, "Time" desc', timescaledb.compress_chunk_time_interval='2 hours');
+SELECT
+  $$
+  SELECT * FROM test7 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test7' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               24
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                 12
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+DROP TABLE test7;

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -2140,13 +2140,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2175,13 +2175,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2209,13 +2209,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2243,13 +2243,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2371,17 +2371,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2391,17 +2391,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2411,47 +2411,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -3421,9 +3421,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3431,9 +3431,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3441,9 +3441,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3471,10 +3471,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3482,10 +3482,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3493,10 +3493,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3537,10 +3537,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3548,10 +3548,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3559,10 +3559,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -2139,13 +2139,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2174,13 +2174,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2208,13 +2208,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2242,13 +2242,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2370,17 +2370,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2390,17 +2390,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2410,47 +2410,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -3420,9 +3420,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3430,9 +3430,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3440,9 +3440,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3470,10 +3470,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3481,10 +3481,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3492,10 +3492,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3536,10 +3536,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3547,10 +3547,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3558,10 +3558,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -2143,13 +2143,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2178,13 +2178,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2212,13 +2212,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2246,13 +2246,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2374,17 +2374,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2394,17 +2394,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2414,47 +2414,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -3427,9 +3427,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3437,9 +3437,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3447,9 +3447,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3477,10 +3477,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3488,10 +3488,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3499,10 +3499,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3543,10 +3543,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3554,10 +3554,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3565,10 +3565,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -189,10 +189,10 @@ select remove_retention_policy('test_table');
 -- Test set_integer_now_func and add_retention_policy with
 -- hypertables that have integer time dimension
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
-  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          |                         | 
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -207,10 +207,10 @@ select set_integer_now_func('test_table_int', 'my_new_schema.dummy_now2');
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
-  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 | my_new_schema           | dummy_now2
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now2
 (2 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_retention' ORDER BY id;

--- a/tsl/test/isolation/expected/compression_merge_race.out
+++ b/tsl/test/isolation/expected/compression_merge_race.out
@@ -1,0 +1,105 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s3_count_chunks_pre_compression s3_lock_compression s1_compress_first_half_of_chunks s2_compress_second_half_of_chunks s3_unlock_compression s3_count_chunks_post_compression
+step s3_count_chunks_pre_compression: 
+    select count(*), 48 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   48|      48
+(1 row)
+
+step s3_lock_compression: 
+    SELECT debug_waitpoint_enable('compress_chunk_impl_start');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_compress_first_half_of_chunks: 
+   call compress_chunks_in_individual_transactions(
+     $$
+       select show_chunks('sensor_data') limit 24
+     $$
+   ); 
+ <waiting ...>
+step s2_compress_second_half_of_chunks: 
+   call compress_chunks_in_individual_transactions($$select show_chunks('sensor_data') i  offset 24$$); 
+ <waiting ...>
+step s3_unlock_compression: 
+    SELECT debug_waitpoint_release('compress_chunk_impl_start');
+ <waiting ...>
+step s1_compress_first_half_of_chunks: <... completed>
+step s2_compress_second_half_of_chunks: <... completed>
+step s3_unlock_compression: <... completed>
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s3_count_chunks_post_compression: 
+    select count(*), 24 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   24|      24
+(1 row)
+
+
+starting permutation: s3_count_chunks_pre_compression s3_lock_compression s1_compress_first_two_by_two s2_compress_second_two_by_two s3_unlock_compression s3_count_chunks_post_compression
+step s3_count_chunks_pre_compression: 
+    select count(*), 48 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   48|      48
+(1 row)
+
+step s3_lock_compression: 
+    SELECT debug_waitpoint_enable('compress_chunk_impl_start');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_compress_first_two_by_two: 
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (1,2) 
+     $$); 
+ <waiting ...>
+step s2_compress_second_two_by_two: 
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (3,0) 
+     $$); 
+ <waiting ...>
+step s3_unlock_compression: 
+    SELECT debug_waitpoint_release('compress_chunk_impl_start');
+ <waiting ...>
+step s1_compress_first_two_by_two: <... completed>
+step s2_compress_second_two_by_two: <... completed>
+step s3_unlock_compression: <... completed>
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s3_count_chunks_post_compression: 
+    select count(*), 24 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   24|      24
+(1 row)
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_TEMPLATES_MODULE_DEBUG
     cagg_drop_chunks.spec.in
     telemetry.spec.in
     compression_chunk_race.spec.in
+    compression_merge_race.spec.in
     decompression_chunk_and_parallel_query.in
     decompression_chunk_and_parallel_query_wo_idx.in)
 

--- a/tsl/test/isolation/specs/compression_merge_race.spec.in
+++ b/tsl/test/isolation/specs/compression_merge_race.spec.in
@@ -1,0 +1,124 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+###
+# Test the execution of two merge compression jobs in parallel
+###
+
+setup {
+   CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+     AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_enable';
+
+   CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+     AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_release';
+
+
+   -- Compressing a lot of chunks from a single hypertable in a single transaction can
+   -- cause deadlocks due to locking the compressed hypertable when creating compressed chunks.
+   -- Hence we compress them in their individual transactions, similar how the compression
+   -- policies work.
+   CREATE OR REPLACE PROCEDURE compress_chunks_in_individual_transactions(query text)
+   LANGUAGE plpgsql
+   AS $$
+   DECLARE
+     chunk regclass;
+   BEGIN
+     FOR chunk in execute query
+     LOOP 
+       PERFORM public.compress_chunk(chunk); 
+       COMMIT;
+     END LOOP;
+   END;
+   $$;
+   
+   CREATE TABLE sensor_data (
+   time timestamptz not null,
+   sensor_id integer not null,
+   cpu double precision null,
+   temperature double precision null);
+
+   -- Create large chunks that take a long time to compress
+   SELECT FROM create_hypertable('sensor_data','time', chunk_time_interval => INTERVAL '1 hour', create_default_indexes => false);
+
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-02 23:59:59', INTERVAL '1 minute') AS g1(time),
+   generate_series(1, 50, 1) AS g2(sensor_id)
+   ORDER BY time;
+
+   
+   ALTER TABLE sensor_data SET (
+   timescaledb.compress, 
+   timescaledb.compress_segmentby = 'sensor_id, cpu',
+   timescaledb.compress_chunk_time_interval = '2 hours');
+}
+
+teardown {
+   DROP TABLE sensor_data;
+}
+
+session "s1"
+step "s1_compress_first_half_of_chunks" {
+   call compress_chunks_in_individual_transactions(
+     $$
+       select show_chunks('sensor_data') limit 24
+     $$
+   ); 
+}
+
+# Compress first two chunks, skip two and compress next two etc.
+step "s1_compress_first_two_by_two" {
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (1,2) 
+     $$); 
+}
+
+session "s2"
+step "s2_compress_second_half_of_chunks" {
+   call compress_chunks_in_individual_transactions($$select show_chunks('sensor_data') i  offset 24$$); 
+}
+
+# Compress second two chunks, skip two and compress next two etc.
+step "s2_compress_second_two_by_two" {
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (3,0) 
+     $$); 
+}
+
+session "s3"
+step "s3_lock_compression" {
+    SELECT debug_waitpoint_enable('compress_chunk_impl_start');
+}
+
+step "s3_unlock_compression" {
+    SELECT debug_waitpoint_release('compress_chunk_impl_start');
+}
+
+step "s3_count_chunks_pre_compression" {
+    select count(*), 48 as expected from show_chunks('sensor_data');
+}
+
+step "s3_count_chunks_post_compression" {
+    select count(*), 24 as expected from show_chunks('sensor_data');
+}
+
+
+# Check that we produce 24 chunks out of 48 chunks by merging two 1hour chunks
+# into 2 hour chunks from two different sessions. First session will run until
+# it hits an already compressed chunk.
+permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_half_of_chunks" "s2_compress_second_half_of_chunks" (s1_compress_first_half_of_chunks) "s3_unlock_compression" (s2_compress_second_half_of_chunks, s1_compress_first_half_of_chunks) "s3_count_chunks_post_compression"
+permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_two_by_two" "s2_compress_second_two_by_two" (s1_compress_first_two_by_two) "s3_unlock_compression" (s2_compress_second_two_by_two, s1_compress_first_two_by_two) "s3_count_chunks_post_compression"

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -37,11 +37,13 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     scheduler_fixed.sql
     compress_bgw_reorder_drop_chunks.sql
     chunk_api.sql
+    chunk_merge.sql
     chunk_utils_compression.sql
     compression_algos.sql
     compression_ddl.sql
     compression_errors.sql
     compression_hypertable.sql
+    compression_merge.sql
     compression_segment_meta.sql
     compression.sql
     compress_table.sql

--- a/tsl/test/sql/chunk_merge.sql
+++ b/tsl/test/sql/chunk_merge.sql
@@ -1,0 +1,77 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION _timescaledb_internal.test_merge_chunks_on_dimension(chunk REGCLASS, merge_chunk REGCLASS, dimension_id INTEGER)
+ RETURNS VOID
+    AS :TSL_MODULE_PATHNAME, 'ts_test_merge_chunks_on_dimension' LANGUAGE C VOLATILE;
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
+SELECT table_name FROM Create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+SELECT table_name FROM  add_dimension('test1', 'i', number_partitions=> 2);
+ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+
+-- This creates chunks 1 - 3 on first hypertable.
+INSERT INTO test1 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+-- This creates chunks 4 - 6 on first hypertable.
+INSERT INTO test1 SELECT t, 2, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+
+CREATE TABLE test2 ("Time" timestamptz, i integer, value integer);
+SELECT table_name FROM Create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This creates chunks 7 - 9 on second hypertable.
+INSERT INTO test2 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 3:00', '1 minute') t;
+
+SELECT * FROM _timescaledb_catalog.chunk;
+
+\set ON_ERROR_STOP 0
+
+-- Cannot merge chunks from different hypertables
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_3_7_chunk', 1);
+
+-- Cannot merge non-adjacent chunks
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_3_chunk', 1);
+
+-- Cannot merge same chunk to itself (its not adjacent to itself).
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 1);
+
+-- Cannot merge chunks on with different partitioning schemas.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 1);
+
+-- Cannot merge chunks on with non-existant dimension slice.
+-- NOTE: we are merging the same chunk just so they have the exact same partitioning schema and we don't hit the previous test error.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_1_chunk', 999);
+
+
+\set ON_ERROR_STOP 1
+
+-- Merge on open (time) dimension.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_5_chunk','_timescaledb_internal._hyper_1_6_chunk', 1);
+
+-- Merge on closed dimension.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_1_1_chunk','_timescaledb_internal._hyper_1_4_chunk', 2);
+
+SELECT compress_chunk(i) FROM show_chunks('test1') i;
+
+\set ON_ERROR_STOP 0
+
+-- Cannot merge chunks internal compressed chunks, no dimensions on them.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal.compress_hyper_2_10_chunk','_timescaledb_internal.compress_hyper_2_11_chunk', 1);
+
+\set ON_ERROR_STOP 1
+
+-- This creates more data so caggs has multiple chunks.
+INSERT INTO test1 SELECT t, 1, 1.0 FROM generate_series('2018-03-02 3:00'::TIMESTAMPTZ, '2018-03-03 3:00', '1 minute') t;
+
+CREATE MATERIALIZED VIEW test_cagg
+WITH (timescaledb.continuous) AS
+SELECT i,
+   time_bucket(INTERVAL '1 hour', "Time") AS bucket,
+   AVG(value)
+FROM test1
+GROUP BY i, bucket;
+
+-- Merging cagg chunks should also work.
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_4_37_chunk','_timescaledb_internal._hyper_4_39_chunk', 4);

--- a/tsl/test/sql/compression_merge.sql
+++ b/tsl/test/sql/compression_merge.sql
@@ -1,0 +1,174 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\ir include/rand_generator.sql
+\c :TEST_DBNAME :ROLE_SUPERUSER
+\ir include/compression_utils.sql
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This will generate 24 chunks
+INSERT INTO test1 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks
+ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+
+SELECT
+  $$
+  SELECT * FROM test1 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test1' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+\set TYPE timestamptz
+\set ORDER_BY_COL_NAME Time
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+
+DROP TABLE test1;
+
+CREATE TABLE test2 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This will generate 24 1 hour chunks.
+INSERT INTO test2 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+
+-- Compression is set to merge those 24 chunks into 3 chunks, two 10 hour chunks and a single 4 hour chunk.
+ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='10 hours');
+
+SELECT
+  $$
+  SELECT * FROM test2 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test2' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+
+DROP TABLE test2;
+
+CREATE TABLE test3 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test3', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+SELECT table_name from  add_dimension('test3', 'i', number_partitions=> 3);
+
+-- This will generate 25 1 hour chunks with a closed space dimension.
+INSERT INTO test3 SELECT t, 1, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 12:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 2, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 13:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 3, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 2:00'::TIMESTAMPTZ, '2018-03-02 2:01', '1 minute') t;
+
+-- Compression is set to merge those 25 chunks into 12 2 hour chunks and a single 1 hour chunks on a different space dimensions.
+ALTER TABLE test3 set (timescaledb.compress, timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+
+SELECT
+  $$
+  SELECT * FROM test3 WHERE i = 1 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test3' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+
+DROP TABLE test3;
+
+CREATE TABLE test4 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test4', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+-- Setting compress_chunk_time_interval to non-multiple of chunk_time_interval should emit a warning.
+ALTER TABLE test4 set (timescaledb.compress, timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='90 minutes');
+
+DROP TABLE test4;
+
+CREATE TABLE test5 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test5', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This will generate 24 chunks. Note that we are forcing everyting into a single segment so we use table scan to when merging chunks.
+INSERT INTO test5 SELECT t, 1, gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+
+-- Compression is set to merge those 24 chunks into 1 24 hour chunk
+ALTER TABLE test5 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='24 hours');
+
+SELECT compress_chunk(i) FROM show_chunks('test5') i LIMIT 1;
+
+SELECT schemaname || '.' || indexname AS "INDEXNAME"
+FROM pg_indexes i
+INNER JOIN _timescaledb_catalog.chunk cc ON i.schemaname = cc.schema_name and i.tablename = cc.table_name 
+INNER JOIN _timescaledb_catalog.chunk c ON (cc.id = c.compressed_chunk_id) 
+LIMIT 1 \gset
+
+DROP INDEX :INDEXNAME;
+
+-- We dropped the index from compressed chunk thats needed to determine sequence numbers
+-- during merge, merging will fallback to doing heap scans and work just fine.
+SELECT
+  $$
+  SELECT * FROM test5 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test5' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+
+DROP TABLE test5;
+
+CREATE TABLE test6 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test6', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This will generate 24 chunks
+INSERT INTO test6 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks.
+ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+
+SELECT compress_chunk(i) FROM show_chunks('test6') i;
+SELECT 12 as expected_number_of_chunks, count(*) as number_of_chunks FROM show_chunks('test6');
+SELECT decompress_chunk(i) FROM show_chunks('test6') i;
+
+-- Altering compress chunk time interval will cause us to create 6 chunks instead of 12.
+ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='4 hours');
+
+SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
+SELECT 6 as expected_number_of_chunks, count(*) as number_of_chunks FROM show_chunks('test6');
+
+DROP TABLE test6;
+
+CREATE TABLE test7 ("Time" timestamptz, i integer, j integer, k integer, value integer);
+SELECT table_name from create_hypertable('test7', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This will generate 24 chunks
+INSERT INTO test7 
+SELECT t, i, gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd()  
+FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks with ordering by j column before time column, causing recompression to occur during merge.
+ALTER TABLE test7 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='j, "Time" desc', timescaledb.compress_chunk_time_interval='2 hours');
+
+SELECT
+  $$
+  SELECT * FROM test7 ORDER BY i, "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test7' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+
+DROP TABLE test7;

--- a/tsl/test/sql/include/compression_test_merge.sql
+++ b/tsl/test/sql/include/compression_test_merge.sql
@@ -1,0 +1,43 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set ECHO errors
+
+DROP TABLE IF EXISTS merge_result;
+
+CREATE TABLE merge_result AS :QUERY;
+
+SELECT count(compress_chunk(chunk, true)) as count_compressed
+FROM show_chunks(:'HYPERTABLE_NAME') chunk;
+
+with original AS (
+  SELECT row_number() OVER() row_number, * FROM merge_result
+),
+compressed AS (
+  SELECT row_number() OVER() row_number, * FROM (:QUERY) as q
+)
+SELECT 'Number of rows different between original and query on compressed data (expect 0)', count(*)
+FROM original
+FULL OUTER JOIN compressed ON (original.row_number = compressed.row_number)
+WHERE (original.*) IS DISTINCT FROM (compressed.*);
+
+SELECT count(decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_decompressed
+FROM _timescaledb_catalog.chunk chunk
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NOT NULL;
+
+
+--run data on data that's been compressed and decompressed, make sure it's the same.
+with original AS (
+  SELECT row_number() OVER() row_number, * FROM merge_result
+),
+uncompressed AS (
+  SELECT row_number() OVER() row_number, * FROM (:QUERY) as q
+)
+SELECT 'Number of rows different between original and data that has been compressed and then decompressed (expect 0)', count(*)
+FROM original
+FULL OUTER JOIN uncompressed ON (original.row_number = uncompressed.row_number)
+WHERE (original.*) IS DISTINCT FROM (uncompressed.*);
+
+\set ECHO all

--- a/tsl/test/src/CMakeLists.txt
+++ b/tsl/test/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     data_node.c
     deparse.c
     test_chunk_stats.c
+    test_merge_chunk.c
     test_compression.c
     test_continuous_agg.c
     test_ddl_hook.c

--- a/tsl/test/src/test_merge_chunk.c
+++ b/tsl/test/src/test_merge_chunk.c
@@ -1,0 +1,33 @@
+/*
+ * This file and its contents are licensed under the Timescale License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-TIMESCALE for a copy of the license.
+ */
+
+#include <string.h>
+#include <unistd.h>
+#include <postgres.h>
+#include <fmgr.h>
+#include <utils/builtins.h>
+
+#include "export.h"
+#include "chunk.h"
+
+TS_FUNCTION_INFO_V1(ts_test_merge_chunks_on_dimension);
+
+Datum
+ts_test_merge_chunks_on_dimension(PG_FUNCTION_ARGS)
+{
+	Oid chunk_id = PG_ARGISNULL(0) ? InvalidOid : PG_GETARG_OID(0);
+
+	Oid merge_chunk_id = PG_ARGISNULL(1) ? InvalidOid : PG_GETARG_OID(1);
+
+	int32 dimension_id = PG_ARGISNULL(2) ? 0 : PG_GETARG_INT32(2);
+
+	Chunk *chunk = ts_chunk_get_by_relid(chunk_id, true);
+	Chunk *merge_chunk = ts_chunk_get_by_relid(merge_chunk_id, true);
+
+	ts_chunk_merge_on_dimension(chunk, merge_chunk, dimension_id);
+
+	PG_RETURN_VOID();
+}


### PR DESCRIPTION
This change introduces a new option to the compression procedure which decouples the uncompressed chunk interval from the compressed chunk interval. It does this by allowing multiple uncompressed chunks into one compressed chunk as part of the compression procedure. The main use-case is to allow much smaller uncompressed chunks than compressed ones. This has several advantages:
- Reduce the size of btrees on uncompressed data (thus allowing faster inserts because those indexes are memory-resident).
- Decrease disk-space usage for uncompressed data.
- Reduce number of chunks over historical data.

From a UX point of view, we simple add a compression with clause option `compress_chunk_time_interval`. The user should set that according to their needs for constraint exclusion over historical data. Ideally, it should be a multiple of the uncompressed chunk interval and so we throw a warning if it is not.

Fixes #4079 