### PR TITLE
Fix CI coredump information print

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -96,7 +96,10 @@ jobs:
           apt-get install postgresql-${PG_MAJOR}-dbgsym >/dev/null
           for file in /tmp/core*
           do
-            echo 'printf "%s", debug_query_string\nbt full' | gdb /usr/lib/postgresql/${PG_MAJOR}/bin/postgres -c $file | tee -a stacktraces.log
+            gdb /usr/lib/postgresql/${PG_MAJOR}/bin/postgres -c $file <<EOT | tee -a stacktraces.log
+              printf "%s", debug_query_string
+              bt full
+        EOT
           done
           echo "::set-output name=coredumps::true"
           exit 1

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -166,7 +166,10 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        echo 'printf "%s", debug_query_string\nbt full' | sudo coredumpctl gdb
+        sudo coredumpctl gdb <<EOT
+          printf "%s", debug_query_string
+          bt full
+        EOT
         ./scripts/bundle_coredumps.sh
         false
 

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -140,7 +140,10 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        echo 'printf "%s", debug_query_string\nbt full' | sudo coredumpctl gdb
+        sudo coredumpctl gdb <<EOT
+          printf "%s", debug_query_string
+          bt full
+        EOT
         ./scripts/bundle_coredumps.sh
         false
 

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -113,7 +113,10 @@ jobs:
     - name: Stack trace
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
       run: |
-        echo 'printf "%s", debug_query_string\nbt full' | sudo coredumpctl gdb
+        sudo coredumpctl gdb <<EOT
+          printf "%s", debug_query_string
+          bt full
+        EOT
         ./scripts/bundle_coredumps.sh
         false
 


### PR DESCRIPTION
The patch #4714 introduces the extraction of the running query from a coredump by calling `gdb` with two commands. These commands are separated by a newline character. This character may not always be correctly converted to a new line before being processed by gdb, resulting in the following error ([link to failed CI run](https://github.com/timescale/timescaledb/actions/runs/3078445332/jobs/4974007557)):

`Invalid character '\' in expression.`

This PR ensures the proper handling of the newline character.