### PR TITLE
Fix gapfill function signature

### DIFF
--- a/tsl/src/nodes/gapfill/gapfill_plan.c
+++ b/tsl/src/nodes/gapfill/gapfill_plan.c
@@ -199,7 +199,8 @@ static CustomPathMethods gapfill_path_methods = {
 };
 
 static bool
-gapfill_expression_walker(Expr *node, bool (*walker)(), gapfill_walker_context *context)
+gapfill_expression_walker(Expr *node, bool (*walker)(Node *, gapfill_walker_context *),
+						  gapfill_walker_context *context)
 {
 	context->count = 0;
 	context->call.node = NULL;


### PR DESCRIPTION
Very recent compilers will warn about function pointers with empty argument list. While currently in C func() means a function with an unspecified argument list the next version of the C standard will change this to mean func(void).