### PR TITLE
Fix continuous aggregate migrate check constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ argument or resolve the type ambiguity by casting to the intended type.
 * #4685 Improve chunk exclusion for space dimensions
 * #4696 Report warning when enabling compression on hypertable
 * #4676 Fix a deadlock when decompressing chunks and performing SELECTs
+* #4739 Fix continuous aggregate migrate check constraint
 
 **Thanks**
 * @maxtwardowski for reporting problems with chunk exclusion and space dimensions
 * @yuezhihan for reporting GROUP BY error when setting compress_segmentby with an enum column
+* @carobme for reporting constraint error during continuous aggregate migration
 
 ## 2.8.0 (2022-08-30)
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -46,3 +46,11 @@ BEGIN
     WHERE mat_hypertable_id OPERATOR(pg_catalog.=) _cagg_data.mat_hypertable_id;
 END;
 $BODY$;
+
+-- Issue #4727
+ALTER TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step
+    DROP CONSTRAINT IF EXISTS continuous_agg_migrate_plan_step_check2;
+
+ALTER TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step
+    ADD CONSTRAINT continuous_agg_migrate_plan_step_check2
+    CHECK (type IN ('CREATE NEW CAGG', 'DISABLE POLICIES', 'COPY POLICIES', 'ENABLE POLICIES', 'SAVE WATERMARK', 'REFRESH NEW CAGG', 'COPY DATA', 'OVERRIDE CAGG', 'DROP OLD CAGG'));

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -45,3 +45,11 @@ BEGIN
     WHERE mat_hypertable_id OPERATOR(pg_catalog.=) _cagg_data.mat_hypertable_id;
 END;
 $BODY$;
+
+-- Issue #4727
+ALTER TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step
+    DROP CONSTRAINT IF EXISTS continuous_agg_migrate_plan_step_check2;
+
+ALTER TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step
+    ADD CONSTRAINT continuous_agg_migrate_plan_step_check2
+    CHECK (type IN ('CREATE NEW CAGG', 'DISABLE POLICIES', 'COPY POLICIES', 'ENABLE POLICIES', 'SAVE WATERMARK', 'REFRESH NEW CAGG', 'COPY DATA'));


### PR DESCRIPTION
Instances upgraded to 2.8.0 will end up with a wrong check constraint in catalog table `continuous_aggregate_migrate_plan_step`.

Fixed it by removing and adding the constraint with the correct checks.

Fix #4727