### PR TITLE
Change project management github action

### DIFF
--- a/.github/workflows/procedural.yaml
+++ b/.github/workflows/procedural.yaml
@@ -23,11 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'need-more-info'
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.1
+      - uses: leonsteinhaeuser/project-beta-automations@v2.0.0
         with:
-          project: Database - TimescaleDB Bugs Board
-          column: Waiting for Author
-          repo-token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          gh_token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          organization: timescale
+          project_id: 55
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: 'Waiting for Author'
 
   waiting-for-engineering:
     name: Waiting for Engineering
@@ -40,8 +42,10 @@ jobs:
           remove-labels: 'need-more-info'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Move to waiting for engineering column
-        uses: alex-page/github-project-automation-plus@v0.8.1
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.0
         with:
-          project: Database - TimescaleDB Bugs Board
-          column: Waiting for Engineering
-          repo-token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          gh_token: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+          organization: timescale
+          project_id: 55
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: 'Waiting for Engineering'


### PR DESCRIPTION
In af8e3c6b12035dd45bc7bf61e9420489cfa56eaa, an GitHub action to assign issues to a project column has been introduced. However, this action does not work with organization-wide projects. This patch replaces the used project management action with a more recent one.

Link to failed action run: https://github.com/timescale/timescaledb/actions/runs/3104545193