### PR TITLE
Fix missing upgrade/downgrade tests DDL validation

### DIFF
--- a/scripts/test_downgrade_from_tag.sh
+++ b/scripts/test_downgrade_from_tag.sh
@@ -92,14 +92,14 @@ docker_pgcmd() {
 
 docker_pgscript() {
     local database=${3:-single}
-    docker_exec $1 "psql -h localhost -U postgres -d $database $PGOPTS -v ON_ERROR_STOP=1 -f $2"
+    docker_exec $1 "psql --set VERBOSITY=verbose --set ECHO=all -h localhost -U postgres -d $database $PGOPTS -v ON_ERROR_STOP=1 -f $2"
 }
 
 docker_pgtest() {
     local database=${3:-single}
     set +e
     >&2 echo -e "\033[1m$1\033[0m: $2"
-    if ! docker exec $1 psql -X -v ECHO=ALL -v ON_ERROR_STOP=1 -h localhost -U postgres -d $database -f $2 > ${TEST_TMPDIR}/$1.out
+    if ! docker exec $1 psql -X -v ECHO=ALL -v ON_ERROR_STOP=1 -h localhost -U postgres -d $database $PGOPTS -f $2 > ${TEST_TMPDIR}/$1.out
     then
       docker_logs $1
       exit 1

--- a/test/sql/updates/post.catalog.sql
+++ b/test/sql/updates/post.catalog.sql
@@ -27,9 +27,9 @@ WHERE classoid = 'pg_class'::regclass
 ORDER BY schema, name, initpriv;
 
 \di _timescaledb_catalog.*
-\ds+ _timescaledb_catalog.*;
-\df _timescaledb_internal.*;
-\df+ _timescaledb_internal.*;
+\ds+ _timescaledb_catalog.*
+\df _timescaledb_internal.*
+\df+ _timescaledb_internal.*
 \df public.*;
 \df+ public.*;
 
@@ -43,9 +43,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
 
 -- The list of tables configured to be dumped.
-SELECT obj::regclass::text
-FROM (SELECT unnest(extconfig) AS obj FROM pg_extension WHERE extname='timescaledb') AS objects
-ORDER BY obj::regclass::text;
+SELECT unnest(extconfig)::regclass::text AS obj FROM pg_extension WHERE extname='timescaledb' ORDER BY 1;
 
 -- Show dropped chunks
 SELECT *
@@ -75,3 +73,8 @@ FROM pg_depend dep
 WHERE classid='pg_class'::regclass
 ORDER BY attrelid::regclass::text,att.attnum;
 
+-- Show constraints
+SELECT conrelid::regclass::text, conname, pg_get_constraintdef(oid)
+FROM pg_constraint
+WHERE conrelid::regclass::text ~ '^_timescaledb_'
+ORDER BY 1, 2, 3;


### PR DESCRIPTION
Recently we fixed a DDL error (#4739) after upgrading to 2.8.0 version that surprisly the CI upgrade/dowgrade tests didn't complained during the development of the feature (#4552).

Fixed it by adding an specific query in the `post.catalog.sql` script to make sure we'll check all the constraints of our internal tables and catalog.