### PR TITLE
Move perltidyrc to root

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
       - name: Format Perl files, if needed
-        run: find . -name '*.p[lm]' -exec perltidy --profile=scripts/perltidyrc {} +
+        run: find . -name '*.p[lm]' -exec perltidy -b -bext=/ {} +
       - name: Check for diff
         run: git diff --exit-code
   misc_checks:

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,6 +1,4 @@
 --add-whitespace
---backup-and-modify-in-place
---backup-file-extension=/
 --delete-old-whitespace
 --entab-leading-whitespace=4
 --keep-old-blank-lines=2


### PR DESCRIPTION
To allow perltidy to be used from editors and IDEs, the perltidyrc file is moved from `scripts/perltidyrc` to `.perltidyrc`. This will allow editors and IDEs to quickly find the style file in the root of the repository, where `perltidy` normally searches for the style file.

The workflow is then updated to use the new location, and the two options `--backup-file-extension` and `--backup-and-modify-in-place` are moved to the workflow file to allow editors and IDEs to use whatever method they find useful to process the file.