### PR TITLE
Improve compression job IO performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ argument or resolve the type ambiguity by casting to the intended type.
 * #4720 Fix chunk exclusion for prepared statements and dst changes
 * #4738 Fix the assorted epoll_ctl() errors that could occur with COPY into a distributed hypertable
 * #4739 Fix continuous aggregate migrate check constraint
+* #4756 Improve compression job IO performance
 * #4745 Fix FK constraint violation error while insert into hypertable which references partitioned table
 
 **Thanks**

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -419,7 +419,7 @@ compress_chunk_sort_relation(Relation in_rel, int n_keys, const ColumnCompressio
 										  sort_operators,
 										  sort_collations,
 										  nulls_first,
-										  work_mem,
+										  maintenance_work_mem,
 										  NULL,
 										  false /*=randomAccess*/);
 


### PR DESCRIPTION
This PR does a couple of changes to improve IO usage for compression jobs:

- changes sort memory limits from `work_mem` to `maintenance_work_mem`, reducing the chance to use temp buffers for larger chunks
- moves uncompressed chunk ANALYZE operation after heap has been loaded into shared buffers by the heap scan we need to do in order to sort the chunk contents

Disable-check: commit-count