### PR TITLE
Continue compressing other chunks after an error

### DIFF
--- a/sql/policy_internal.sql
+++ b/sql/policy_internal.sql
@@ -47,6 +47,8 @@ DECLARE
   htoid       REGCLASS;
   chunk_rec   RECORD;
   numchunks   INTEGER := 1;
+  _message     text;
+  _detail      text;
 BEGIN
 
   -- procedures with SET clause cannot execute transaction
@@ -76,15 +78,35 @@ BEGIN
       AND (ch.status = 0 OR ch.status = 3)
   LOOP
     IF chunk_rec.status = 0 THEN
-       PERFORM @extschema@.compress_chunk( chunk_rec.oid );
+      BEGIN
+        PERFORM @extschema@.compress_chunk( chunk_rec.oid );
+      EXCEPTION WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS
+            _message = MESSAGE_TEXT,
+            _detail = PG_EXCEPTION_DETAIL;
+        RAISE WARNING 'compressing chunk "%" failed when compression policy is executed', chunk_rec.oid::regclass::text
+            USING DETAIL = format('Message: (%s), Detail: (%s).', _message, _detail),
+                  ERRCODE = sqlstate;
+      END;
     ELSIF chunk_rec.status = 3 AND recompress_enabled IS TRUE THEN
-       PERFORM @extschema@.decompress_chunk(chunk_rec.oid, if_compressed => true);
-       COMMIT;
-       -- SET LOCAL is only active until end of transaction.
-       -- While we could use SET at the start of the function we do not
-       -- want to bleed out search_path to caller, so we do SET LOCAL
-       -- again after COMMIT
-       PERFORM @extschema@.compress_chunk(chunk_rec.oid);
+      BEGIN
+        PERFORM @extschema@.decompress_chunk(chunk_rec.oid, if_compressed => true);
+      EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'decompressing chunk "%" failed when compression policy is executed', chunk_rec.oid::regclass::text
+            USING DETAIL = format('Message: (%s), Detail: (%s).', _message, _detail),
+                  ERRCODE = sqlstate;
+      END;
+      -- SET LOCAL is only active until end of transaction.
+      -- While we could use SET at the start of the function we do not
+      -- want to bleed out search_path to caller, so we do SET LOCAL
+      -- again after COMMIT
+      BEGIN
+        PERFORM @extschema@.compress_chunk(chunk_rec.oid);
+      EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'compressing chunk "%" failed when compression policy is executed', chunk_rec.oid::regclass::text
+            USING DETAIL = format('Message: (%s), Detail: (%s).', _message, _detail),
+                  ERRCODE = sqlstate;
+      END;
     END IF;
     COMMIT;
     -- SET LOCAL is only active until end of transaction.

--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -869,3 +869,64 @@ CREATE AGGREGATE sum_jsb (jsonb)
 -- for test coverage, check unsupported aggregate type
 select add_job('test_proc_with_check', '5 secs', config => '{}', check_config => 'sum_jsb'::regproc);
 ERROR:  unsupported function type
+-- github issue 4610
+CREATE TABLE sensor_data
+(
+    time timestamptz not null,
+    sensor_id integer not null,
+    cpu double precision null,
+    temperature double precision null
+);
+SELECT FROM create_hypertable('sensor_data','time');
+--
+(1 row)
+
+INSERT INTO sensor_data
+	SELECT
+		time + (INTERVAL '1 minute' * random()) AS time,
+		sensor_id,
+		random() AS cpu,
+		random()* 100 AS temperature
+	FROM
+		generate_series(now() - INTERVAL '1 months', now() - INTERVAL '1 week', INTERVAL '1 minute') AS g1(time),
+		generate_series(1, 50, 1 ) AS g2(sensor_id)
+	ORDER BY
+		time;
+-- enable compression
+ALTER TABLE sensor_data SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+-- add new compression policy job
+SELECT add_compression_policy('sensor_data', INTERVAL '1' minute) AS compressjob_id \gset
+-- set recompress to true
+SELECT alter_job(id,config:=jsonb_set(config,'{recompress}', 'true')) FROM _timescaledb_config.bgw_job WHERE id = :compressjob_id;
+                                                                                         alter_job                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ (1014,"@ 3 days 12 hours","@ 0",-1,"@ 1 hour",t,"{""recompress"": true, ""hypertable_id"": 4, ""compress_after"": ""@ 1 min""}",-infinity,_timescaledb_internal.policy_compression_check)
+(1 row)
+
+-- create new chunks
+INSERT INTO sensor_data
+	SELECT
+		time + (INTERVAL '1 minute' * random()) AS time,
+		sensor_id,
+		random() AS cpu,
+		random()* 100 AS temperature
+	FROM
+		generate_series(now() - INTERVAL '2 months', now() - INTERVAL '2 week', INTERVAL '2 minute') AS g1(time),
+		generate_series(1, 30, 1 ) AS g2(sensor_id)
+	ORDER BY
+		time;
+-- change compression status so that this chunk is skipped when policy is run
+update _timescaledb_catalog.chunk set status=3 where table_name = '_hyper_4_17_chunk';
+CALL run_job(:compressjob_id);
+NOTICE:  chunk "_hyper_4_17_chunk" is not compressed
+WARNING:  compressing chunk "_timescaledb_internal._hyper_4_17_chunk" failed when compression policy is executed
+-- check compression status is not changed
+SELECT status FROM _timescaledb_catalog.chunk where table_name = '_hyper_4_17_chunk';
+ status 
+--------
+      3
+(1 row)
+
+-- cleanup
+DROP TABLE sensor_data CASCADE;
+NOTICE:  drop cascades to 7 other objects

--- a/tsl/test/expected/read_only.out
+++ b/tsl/test/expected/read_only.out
@@ -282,8 +282,8 @@ FROM
 GROUP BY bucket, device_id WITH NO DATA;
 ERROR:  cannot execute CREATE MATERIALIZED VIEW in a read-only transaction
 -- policy API
--- compression policy will throw an error only if it attempts to compress
--- atleast 1 chunk
+-- compression policy will not throw an error, as it is expected to continue
+-- with next chunks
 SET default_transaction_read_only TO off;
 CREATE TABLE test_table_int(time bigint NOT NULL, device int);
 SELECt create_hypertable('test_table_int', 'time', chunk_time_interval=>'1'::bigint);
@@ -306,7 +306,7 @@ SELECT config as comp_job_config
 FROM _timescaledb_config.bgw_job WHERE id = :comp_job_id \gset
 SET default_transaction_read_only TO on;
 CALL _timescaledb_internal.policy_compression(:comp_job_id, :'comp_job_config');
-ERROR:  cannot execute compress_chunk() in a read-only transaction
+WARNING:  compressing chunk "_timescaledb_internal._hyper_5_2_chunk" failed when compression policy is executed
 SET default_transaction_read_only TO off;
 --verify chunks are not compressed
 SELECT count(*) , count(*) FILTER ( WHERE is_compressed is true) 

--- a/tsl/test/sql/read_only.sql
+++ b/tsl/test/sql/read_only.sql
@@ -247,8 +247,8 @@ FROM
 GROUP BY bucket, device_id WITH NO DATA;
 
 -- policy API
--- compression policy will throw an error only if it attempts to compress
--- atleast 1 chunk
+-- compression policy will not throw an error, as it is expected to continue
+-- with next chunks
 SET default_transaction_read_only TO off;
 CREATE TABLE test_table_int(time bigint NOT NULL, device int);
 SELECt create_hypertable('test_table_int', 'time', chunk_time_interval=>'1'::bigint);


### PR DESCRIPTION
When a compression_policy is executed by a background worker, the policy
should continue to execute even if compressing or decompressing one of
the chunks fails.

Fixes: #4610