### PR TITLE
Add connection cache invalidation ignore logic

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -68,6 +68,10 @@ set(TS_MODULE_PATHNAME
     ${MODULE_PATHNAME}
     PARENT_SCOPE)
 
+set(TSL_MODULE_PATHNAME
+    "$libdir/timescaledb-tsl-${PROJECT_VERSION_MOD}"
+    PARENT_SCOPE)
+
 if(NOT GENERATE_DOWNGRADE_SCRIPT)
   message(
     STATUS "Not generating downgrade script: downgrade generation disabled.")

--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -6,6 +6,7 @@
 #include <postgres.h>
 #include <access/tupdesc.h>
 #include <access/htup_details.h>
+#include <access/xact.h>
 #include <postmaster/postmaster.h>
 #include <utils/builtins.h>
 #include <utils/syscache.h>
@@ -22,6 +23,7 @@
 #include "connection_cache.h"
 
 static Cache *connection_cache = NULL;
+static bool ignore_connection_invalidation = false;
 
 typedef struct ConnectionCacheEntry
 {
@@ -91,6 +93,12 @@ connection_cache_get_key(CacheQuery *query)
 	return (TSConnectionId *) query->data;
 }
 
+void
+remote_connection_cache_invalidation_ignore(bool value)
+{
+	ignore_connection_invalidation = value;
+}
+
 /*
  * Check if a connection needs to be remade.
  *
@@ -102,6 +110,8 @@ connection_cache_get_key(CacheQuery *query)
 static bool
 connection_should_be_remade(const ConnectionCacheEntry *entry)
 {
+	bool invalidated;
+
 	if (NULL == entry->conn)
 		return true;
 
@@ -126,8 +136,10 @@ connection_should_be_remade(const ConnectionCacheEntry *entry)
 	 * an async call was aborted. The connection could also have been
 	 * invalidated, but we only care if we aren't still processing a
 	 * transaction. */
-	if (remote_connection_get_status(entry->conn) == CONN_PROCESSING ||
-		(entry->invalidated && remote_connection_xact_depth_get(entry->conn) == 0))
+
+	invalidated = !ignore_connection_invalidation && entry->invalidated &&
+				  remote_connection_xact_depth_get(entry->conn) == 0;
+	if (remote_connection_get_status(entry->conn) == CONN_PROCESSING || invalidated)
 		return true;
 
 	return false;
@@ -487,10 +499,18 @@ remote_connection_cache_show(PG_FUNCTION_ARGS)
 	SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
 }
 
+static void
+connection_cache_xact_callback(XactEvent event, void *arg)
+{
+	/* Reset ignore_connection_invalidation to default value */
+	remote_connection_cache_invalidation_ignore(false);
+}
+
 void
 _remote_connection_cache_init(void)
 {
 	connection_cache = connection_cache_create();
+	RegisterXactCallback(connection_cache_xact_callback, NULL);
 }
 
 void

--- a/tsl/src/remote/connection_cache.h
+++ b/tsl/src/remote/connection_cache.h
@@ -22,7 +22,7 @@
 
 extern TSConnection *remote_connection_cache_get_connection(TSConnectionId id);
 extern bool remote_connection_cache_remove(TSConnectionId id);
-
+extern void remote_connection_cache_invalidation_ignore(bool value);
 extern void remote_connection_cache_invalidate_callback(Datum arg, int cacheid, uint32 hashvalue);
 extern void remote_connection_cache_dropped_db_callback(const char *dbname);
 extern void remote_connection_cache_dropped_role_callback(const char *rolename);

--- a/tsl/test/isolation/expected/dist_cmd_exec.out
+++ b/tsl/test/isolation/expected/dist_cmd_exec.out
@@ -1,0 +1,64 @@
+Parsed test spec with 2 sessions
+
+starting permutation: s1_lock1 s1_lock2 s2_set_search_path s2_analyze s1_invalidate s1_unlock1 s1_invalidate s1_unlock2
+node_name  
+-----------
+data_node_1
+(1 row)
+
+created
+-------
+t      
+(1 row)
+
+step s1_lock1: SELECT debug_waitpoint_enable('dist_cmd_using_search_path_1');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_lock2: SELECT debug_waitpoint_enable('dist_cmd_using_search_path_2');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s2_set_search_path: 
+	SET search_path = dist_schema;
+	SHOW search_path;
+
+search_path
+-----------
+dist_schema
+(1 row)
+
+step s2_analyze: ANALYZE disttable; <waiting ...>
+step s1_invalidate: 
+	SELECT invalidate_data_node('data_node_1');
+
+invalidate_data_node
+--------------------
+f                   
+(1 row)
+
+step s1_unlock1: SELECT debug_waitpoint_release('dist_cmd_using_search_path_1');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_invalidate: 
+	SELECT invalidate_data_node('data_node_1');
+
+invalidate_data_node
+--------------------
+f                   
+(1 row)
+
+step s1_unlock2: SELECT debug_waitpoint_release('dist_cmd_using_search_path_2');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s2_analyze: <... completed>

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_TEMPLATES_MODULE_DEBUG
     reorder_vs_select.spec.in
     remote_create_chunk.spec.in
     dist_restore_point.spec.in
+    dist_cmd_exec.spec.in
     cagg_drop_chunks.spec.in
     telemetry.spec.in
     compression_chunk_race.spec.in

--- a/tsl/test/isolation/specs/dist_cmd_exec.spec.in
+++ b/tsl/test/isolation/specs/dist_cmd_exec.spec.in
@@ -1,0 +1,73 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+#
+# Test dist_cmd_invoke_on_data_nodes_using_search_path() connection cache
+# invalidation race
+#
+setup
+{
+	CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_enable';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_release';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_id(TEXT) RETURNS BIGINT LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_id';
+
+	CREATE FUNCTION invalidate_data_node(node_name NAME) RETURNS BOOL LANGUAGE C STRICT
+	AS '@TSL_MODULE_PATHNAME@', 'ts_test_alter_data_node';
+
+	SET timescaledb_experimental.enable_distributed_ddl=off;
+	CREATE SCHEMA dist_schema;
+	CREATE TABLE IF NOT EXISTS dist_schema.disttable(time timestamptz NOT NULL, device int, temp float);
+}
+setup { SELECT node_name FROM add_data_node('data_node_1', host => 'localhost', database => 'dn_1', if_not_exists => true); }
+setup { CALL distributed_exec('CREATE SCHEMA dist_schema', transactional => false); }
+setup { SELECT created FROM create_distributed_hypertable('dist_schema.disttable', 'time', 'device'); }
+
+teardown
+{
+   DROP SCHEMA dist_schema CASCADE;
+}
+
+# locking session
+session "s1"
+setup
+{
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET application_name = 's1';
+}
+step "s1_lock1"      { SELECT debug_waitpoint_enable('dist_cmd_using_search_path_1'); }
+step "s1_unlock1"    { SELECT debug_waitpoint_release('dist_cmd_using_search_path_1'); }
+step "s1_lock2"      { SELECT debug_waitpoint_enable('dist_cmd_using_search_path_2'); }
+step "s1_unlock2"    { SELECT debug_waitpoint_release('dist_cmd_using_search_path_2'); }
+step "s1_invalidate" {
+	SELECT invalidate_data_node('data_node_1');
+}
+
+session "s2"
+setup
+{
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET application_name = 's2';
+}
+step "s2_set_search_path" {
+	SET search_path = dist_schema;
+	SHOW search_path;
+}
+
+step "s2_analyze" { ANALYZE disttable; }
+
+#
+# Test connection cache invalidation ignore between sequential execution of
+# non-transactional commands using the same connection.
+#
+# Invalidate connection after search_path being executed, this will force to reopen
+# connection and produce an error otherwise.
+#
+# Issue: #4022
+#
+permutation "s1_lock1" "s1_lock2" "s2_set_search_path" "s2_analyze" "s1_invalidate" "s1_unlock1" "s1_invalidate" "s1_unlock2"

--- a/tsl/test/shared/expected/dist_parallel_agg.out
+++ b/tsl/test/shared/expected/dist_parallel_agg.out
@@ -17,6 +17,9 @@ WARNING:  only one data node was assigned to the hypertable
 (1 row)
 
 insert into metrics_dist1 select * from metrics_dist order by metrics_dist limit 20000;
+-- Start transaction in order to keep same connection
+-- during the test and avoid connection cache invalidations
+begin;
 \set safe 'create or replace aggregate ts_debug_shippable_safe_count(*) (sfunc = int8inc, combinefunc=int8pl, stype = bigint, initcond = 0, parallel = safe);'
 \set unsafe 'create or replace aggregate ts_debug_shippable_unsafe_count(*) (sfunc = int8inc, combinefunc=int8pl, stype = bigint, initcond = 0, parallel = unsafe);'
 :safe
@@ -102,3 +105,4 @@ QUERY PLAN
  
 (14 rows)
 
+commit;

--- a/tsl/test/shared/sql/dist_parallel_agg.sql
+++ b/tsl/test/shared/sql/dist_parallel_agg.sql
@@ -15,6 +15,10 @@ select table_name from create_distributed_hypertable('metrics_dist1', 'time', 'd
     data_nodes => '{"data_node_1"}');
 insert into metrics_dist1 select * from metrics_dist order by metrics_dist limit 20000;
 
+-- Start transaction in order to keep same connection
+-- during the test and avoid connection cache invalidations
+begin;
+
 \set safe 'create or replace aggregate ts_debug_shippable_safe_count(*) (sfunc = int8inc, combinefunc=int8pl, stype = bigint, initcond = 0, parallel = safe);'
 \set unsafe 'create or replace aggregate ts_debug_shippable_unsafe_count(*) (sfunc = int8inc, combinefunc=int8pl, stype = bigint, initcond = 0, parallel = unsafe);'
 
@@ -40,3 +44,5 @@ select ts_debug_shippable_safe_count(*) from metrics_dist1;
 
 :analyze
 select ts_debug_shippable_unsafe_count(*) from metrics_dist1;
+
+commit;


### PR DESCRIPTION
Calling `ts_dist_cmd_invoke_on_data_nodes_using_search_path()` function without an active transaction allows connection invalidation event happen between applying `search_path` and the actual command execution, which leads to an error.

This change introduces a way to ignore connection cache invalidations using `remote_connection_cache_invalidation_ignore()` function.

This work is based on @nikkhils original fix and the problem research.

Fix #4022