### PR TITLE
Extend the now() optimization to also apply to CURRENT_TIMESTAMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ might need to be adjusted and either explicitly name the positional
 argument or resolve the type ambiguity by casting to the intended type.
 
 **Features**
-* #4670 Add timezone support to time_bucket_gapfill
 * #4650 Show warnings when not following best practices
+* #4670 Add timezone support to time_bucket_gapfill
+* #4786 Extend the now() optimization to also apply to CURRENT_TIMESTAMP
 
 **Bugfixes**
 * #4673 Fix now() constification for VIEWs

--- a/tsl/test/shared/expected/constify_now-12.out
+++ b/tsl/test/shared/expected/constify_now-12.out
@@ -84,6 +84,96 @@ QUERY PLAN
    Index Cond: ("time" > (now() - '@ 1 mon'::interval))
 (2 rows)
 
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > CURRENT_TIMESTAMP)
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > CURRENT_TIMESTAMP)
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= CURRENT_TIMESTAMP)
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= CURRENT_TIMESTAMP)
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '24h'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 24 hours'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 24 hours'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP - '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP - '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP - '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP + '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '2d'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 2 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 2 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '3d'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 3 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 3 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1week'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 7 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 1 mon'::interval))
+(5 rows)
+
 -- test bitmapheapscan
 SET enable_indexscan TO false;
 :PREFIX SELECT FROM const_now WHERE time > now();

--- a/tsl/test/shared/expected/constify_now-13.out
+++ b/tsl/test/shared/expected/constify_now-13.out
@@ -84,6 +84,96 @@ QUERY PLAN
    Index Cond: ("time" > (now() - '@ 1 mon'::interval))
 (2 rows)
 
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > CURRENT_TIMESTAMP)
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > CURRENT_TIMESTAMP)
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= CURRENT_TIMESTAMP)
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= CURRENT_TIMESTAMP)
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '24h'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 24 hours'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 24 hours'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP - '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP - '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP - '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP + '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '2d'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 2 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 2 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '3d'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 3 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 3 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1week'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 7 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 1 mon'::interval))
+(5 rows)
+
 -- test bitmapheapscan
 SET enable_indexscan TO false;
 :PREFIX SELECT FROM const_now WHERE time > now();

--- a/tsl/test/shared/expected/constify_now-14.out
+++ b/tsl/test/shared/expected/constify_now-14.out
@@ -84,6 +84,96 @@ QUERY PLAN
    Index Cond: ("time" > (now() - '@ 1 mon'::interval))
 (2 rows)
 
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > CURRENT_TIMESTAMP)
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > CURRENT_TIMESTAMP)
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= CURRENT_TIMESTAMP)
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= CURRENT_TIMESTAMP)
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '24h'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 24 hours'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 24 hours'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP - '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP - '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP - '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP + '10m'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" >= (CURRENT_TIMESTAMP + '@ 10 mins'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '2d'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 2 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 2 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '3d'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 3 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP + '@ 3 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1week'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 7 days'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 7 days'::interval))
+(5 rows)
+
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1month'::interval;
+QUERY PLAN
+ Append
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 1 mon'::interval))
+   ->  Index Only Scan using _hyper_X_X_chunk_const_now_time_idx on _hyper_X_X_chunk
+         Index Cond: ("time" > (CURRENT_TIMESTAMP - '@ 1 mon'::interval))
+(5 rows)
+
 -- test bitmapheapscan
 SET enable_indexscan TO false;
 :PREFIX SELECT FROM const_now WHERE time > now();

--- a/tsl/test/shared/sql/constify_now.sql.in
+++ b/tsl/test/shared/sql/constify_now.sql.in
@@ -33,6 +33,17 @@ INSERT INTO const_now SELECT '3000-01-01','3000-01-01',2,0.5;
 :PREFIX SELECT FROM const_now WHERE time > now() + '3d'::interval;
 :PREFIX SELECT FROM const_now WHERE time > now() - '1week'::interval;
 :PREFIX SELECT FROM const_now WHERE time > now() - '1month'::interval;
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP;
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP;
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '24h'::interval;
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '10m'::interval;
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP - '10m'::interval;
+:PREFIX SELECT FROM const_now WHERE time >= CURRENT_TIMESTAMP + '10m'::interval;
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '2d'::interval;
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP + '3d'::interval;
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1week'::interval;
+:PREFIX SELECT FROM const_now WHERE time > CURRENT_TIMESTAMP - '1month'::interval;
+
 
 -- test bitmapheapscan
 SET enable_indexscan TO false;


### PR DESCRIPTION
The optimization that constifies certain now() expressions before hypertable expansion did not apply to CURRENT_TIMESTAMP even though it is functionally similar to now(). This patch extends the optimization to CURRENT_TIMESTAMP.

Fixes #4782