### PR TITLE
Update .clang-format for version 14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,6 +21,7 @@ AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: false
 BinPackParameters: true
 BraceWrapping:
+  AfterCaseLabel: true
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       true

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   cmake_checks:
     name: Check CMake files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install prerequisites
         run: pip install cmakelang
@@ -24,7 +24,7 @@ jobs:
         run: git diff --exit-code
   perl_checks:
     name: Check Perl code in tree
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install prerequisites
         run: sudo apt install perltidy
@@ -36,7 +36,7 @@ jobs:
         run: git diff --exit-code
   misc_checks:
     name: Check formatting, license, update scripts and git hooks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:
@@ -56,9 +56,9 @@ jobs:
     - name: Check code formatting
       if: always()
       run: |
-        sudo apt install clang-format-8
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 100
-        sudo update-alternatives --set clang-format /usr/bin/clang-format-8
+        sudo apt install clang-format-14
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
+        sudo update-alternatives --set clang-format /usr/bin/clang-format-14
         ./scripts/clang_format_all.sh
         git diff --exit-code
     - name: Check update scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,18 +371,9 @@ configure_file(${EXT_CONTROL_FILE}.in ${EXT_CONTROL_FILE})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${EXT_CONTROL_FILE}
         DESTINATION "${PG_SHAREDIR}/extension")
 
-# We look for specific versions installed by distributions before the default
-# name since distros that have installed clang-format-9 will not work and the
-# user need to install an earlier version, which will then be named
-# "clang-format-N".
-#
-# This breaks the CMake convention of using the "default" name first to handle
-# local installs. If this turns out to be something that we want to support, we
-# need to look specifically for "clang-format" in the local installation paths
-# before looking for the versioned names in standard installation paths.
 find_program(
   CLANG_FORMAT
-  NAMES clang-format-8 clang-format-7 clang-format
+  NAMES clang-format
   PATHS /usr/bin /usr/local/bin /usr/local/opt/ /usr/local/opt/llvm/bin /opt/bin
   DOC "The path to clang-format")
 
@@ -399,8 +390,8 @@ if(CLANG_FORMAT)
         "Could not parse clang-format version ${CLANG_FORMAT_VERSION_OUTPUT}")
   endif()
 
-  if((${CMAKE_MATCH_1} LESS "7") OR (${CMAKE_MATCH_1} GREATER "8"))
-    message(WARNING "clang-format version 7 or 8 required")
+  if((${CMAKE_MATCH_1} LESS "14"))
+    message(WARNING "clang-format version 14 or greater required")
     set(CLANG_FORMAT False)
   endif()
 endif()

--- a/scripts/clang_format_wrapper.sh
+++ b/scripts/clang_format_wrapper.sh
@@ -66,7 +66,7 @@ echo "formatting"
 
 cd ${TEMP_DIR}
 
-${CLANG_FORMAT:-clang-format} ${CLANG_FORMAT_FLAGS} ${FILE_NAMES}
+${CLANG_FORMAT:-clang-format} -Wno-error=unknown ${CLANG_FORMAT_FLAGS} ${FILE_NAMES}
 
 cd ${CURR_DIR}
 

--- a/src/bgw/scheduler.c
+++ b/src/bgw/scheduler.c
@@ -845,7 +845,8 @@ ts_bgw_scheduler_setup_mctx()
 	MemoryContextSwitchTo(scratch_mctx);
 }
 
-static void handle_sighup(SIGNAL_ARGS)
+static void
+handle_sighup(SIGNAL_ARGS)
 {
 	/* based on av_sighup_handler */
 	int save_errno = errno;

--- a/src/bgw/timer.c
+++ b/src/bgw/timer.c
@@ -57,7 +57,7 @@ get_timeout_millisec(TimestampTz by_time)
 	if (timeout_sec < 0 || timeout_usec < 0)
 		return 0;
 
-	return (int64)(timeout_sec * MILLISECS_PER_SEC + ((int64) timeout_usec) / USECS_PER_MILLISEC);
+	return (int64) (timeout_sec * MILLISECS_PER_SEC + ((int64) timeout_usec) / USECS_PER_MILLISEC);
 }
 
 static bool

--- a/src/cache.h
+++ b/src/cache.h
@@ -56,7 +56,7 @@ typedef struct Cache
 	bool handle_txn_callbacks; /* Auto-release caches on (sub)txn
 								* aborts and commits. Should be off
 								* if cache used in txn callbacks */
-	bool release_on_commit;	/* This should be false if doing
+	bool release_on_commit;	   /* This should be false if doing
 								* cross-commit operations like CLUSTER or
 								* VACUUM */
 } Cache;

--- a/src/chunk_adaptive.c
+++ b/src/chunk_adaptive.c
@@ -118,7 +118,7 @@ get_memory_cache_size(void)
 extern inline int64
 ts_chunk_calculate_initial_chunk_target_size(void)
 {
-	return (int64)((double) get_memory_cache_size() * DEFAULT_CACHE_MEMORY_SLACK);
+	return (int64) ((double) get_memory_cache_size() * DEFAULT_CACHE_MEMORY_SLACK);
 }
 
 typedef enum MinMaxResult
@@ -564,7 +564,7 @@ ts_calculate_chunk_interval(PG_FUNCTION_ARGS)
 			 "some undersized ones found. increase interval to probe for better"
 			 " threshold. factor=%lf",
 			 incr_factor);
-		chunk_interval = (int64)(avg_interval * incr_factor);
+		chunk_interval = (int64) (avg_interval * incr_factor);
 	}
 	/* No data & insufficient amount of undersized chunks, keep old interval */
 	else if (num_intervals == 0)

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -303,7 +303,7 @@ ts_chunk_index_create_post_adjustment(int32 hypertable_id, Relation template_ind
 									template_indexrel->rd_indoption,
 									reloptions,
 									flags,
-									0,	 /* constr_flags constant and 0
+									0,	   /* constr_flags constant and 0
 											* for now */
 									false, /* allow system table mods */
 									false, /* is internal */

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -492,8 +492,8 @@ get_reindex_options(ReindexStmt *stmt)
  * https://github.com/postgres/postgres/commit/3ed2005ff59
  */
 #if PG12
-#define TYPALIGN_CHAR 'c'   /* char alignment (i.e. unaligned) */
-#define TYPALIGN_SHORT 's'  /* short alignment (typically 2 bytes) */
+#define TYPALIGN_CHAR 'c'	/* char alignment (i.e. unaligned) */
+#define TYPALIGN_SHORT 's'	/* short alignment (typically 2 bytes) */
 #define TYPALIGN_INT 'i'	/* int alignment (typically 4 bytes) */
 #define TYPALIGN_DOUBLE 'd' /* double alignment (often 8 bytes) */
 #endif

--- a/src/copy.c
+++ b/src/copy.c
@@ -663,7 +663,7 @@ copyfrom(CopyChunkState *ccstate, List *range_table, Hypertable *ht, MemoryConte
 	};
 	CommandId mycid = GetCurrentCommandId(true);
 	CopyInsertMethod insertMethod;				   /* The insert method for the table */
-	CopyInsertMethod currentTupleInsertMethod;	 /* The insert method of the current tuple */
+	CopyInsertMethod currentTupleInsertMethod;	   /* The insert method of the current tuple */
 	TSCopyMultiInsertInfo multiInsertInfo = { 0 }; /* pacify compiler */
 	int ti_options = 0;							   /* start with default options for insert */
 	BulkInsertState bistate = NULL;

--- a/src/debug_guc.h
+++ b/src/debug_guc.h
@@ -22,7 +22,7 @@
 	(1UL << UPPERREL_PARTIAL_GROUP_AGG)				/* Enabled using "partial_group_agg" */
 #define STAGE_GROUP_AGG (1UL << UPPERREL_GROUP_AGG) /* Enabled using "group_agg" */
 #define STAGE_WINDOW (1UL << UPPERREL_WINDOW)		/* Enabled using "window" */
-#define STAGE_DISTINCT (1UL << UPPERREL_DISTINCT)   /* Enabled using "distinct" */
+#define STAGE_DISTINCT (1UL << UPPERREL_DISTINCT)	/* Enabled using "distinct" */
 #define STAGE_ORDERED (1UL << UPPERREL_ORDERED)		/* Enabled using "ordered" */
 #define STAGE_FINAL (1UL << UPPERREL_FINAL)			/* Enabled using "final" */
 

--- a/src/debug_point.c
+++ b/src/debug_point.c
@@ -66,7 +66,7 @@ debug_point_init(DebugPoint *point, const char *name)
 	/* Use 64-bit hashing to get two independent 32-bit hashes */
 	uint64 hash = debug_point_name_to_id(name);
 
-	SET_LOCKTAG_ADVISORY(point->tag, MyDatabaseId, (uint32)(hash >> 32), (uint32) hash, 1);
+	SET_LOCKTAG_ADVISORY(point->tag, MyDatabaseId, (uint32) (hash >> 32), (uint32) hash, 1);
 	point->name = pstrdup(name);
 	ereport(DEBUG3,
 			(errmsg("initializing debug point '%s' to use " UINT64_FORMAT, point->name, hash)));

--- a/src/dimension_vector.h
+++ b/src/dimension_vector.h
@@ -16,7 +16,7 @@
  */
 typedef struct DimensionVec
 {
-	int32 capacity;   /* The capacity of the slices array */
+	int32 capacity;	  /* The capacity of the slices array */
 	int32 num_slices; /* The current number of slices in slices
 					   * array */
 	DimensionSlice *slices[FLEXIBLE_ARRAY_MEMBER];

--- a/src/histogram.c
+++ b/src/histogram.c
@@ -162,7 +162,7 @@ ts_hist_combinefunc(PG_FUNCTION_ARGS)
 			if (val + other >= PG_INT32_MAX)
 				elog(ERROR, "overflow in histogram combine");
 
-			result->buckets[i] = Int32GetDatum((int32)(val + other));
+			result->buckets[i] = Int32GetDatum((int32) (val + other));
 		}
 	}
 

--- a/src/hypercube.h
+++ b/src/hypercube.h
@@ -17,7 +17,7 @@
  */
 typedef struct Hypercube
 {
-	int16 capacity;   /* capacity of slices[] */
+	int16 capacity;	  /* capacity of slices[] */
 	int16 num_slices; /* actual number of slices (should equal
 					   * capacity after create) */
 	/* Slices are stored in dimension order */

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -1686,7 +1686,7 @@ ts_validate_replication_factor(const char *hypertable_name, int32 replication_fa
 				 errhint("A hypertable's replication factor must be between 1 and %d.",
 						 PG_INT16_MAX)));
 
-	return (int16)(replication_factor & 0xFFFF);
+	return (int16) (replication_factor & 0xFFFF);
 }
 
 static int16

--- a/src/hypertable_restrict_info.c
+++ b/src/hypertable_restrict_info.c
@@ -53,7 +53,7 @@ typedef struct DimensionValues
 {
 	List *values;
 	bool use_or; /* ORed or ANDed values */
-	Oid type;	/* Oid type for values */
+	Oid type;	 /* Oid type for values */
 } DimensionValues;
 
 static DimensionRestrictInfoOpen *

--- a/src/import/planner.c
+++ b/src/import/planner.c
@@ -90,7 +90,7 @@ ts_make_inh_translation_list(Relation oldrelation, Relation newrelation, Index n
 		{
 			vars = lappend(vars,
 						   makeVar(newvarno,
-								   (AttrNumber)(old_attno + 1),
+								   (AttrNumber) (old_attno + 1),
 								   atttypid,
 								   atttypmod,
 								   attcollation,
@@ -140,7 +140,7 @@ ts_make_inh_translation_list(Relation oldrelation, Relation newrelation, Index n
 
 		vars = lappend(vars,
 					   makeVar(newvarno,
-							   (AttrNumber)(new_attno + 1),
+							   (AttrNumber) (new_attno + 1),
 							   atttypid,
 							   atttypmod,
 							   attcollation,

--- a/src/loader/bgw_launcher.c
+++ b/src/loader/bgw_launcher.c
@@ -84,7 +84,8 @@ typedef enum SchedulerState
 
 static volatile sig_atomic_t got_SIGHUP = false;
 
-static void launcher_sighup(SIGNAL_ARGS)
+static void
+launcher_sighup(SIGNAL_ARGS)
 {
 	/* based on av_sighup_handler */
 	int save_errno = errno;

--- a/src/loader/bgw_message_queue.c
+++ b/src/loader/bgw_message_queue.c
@@ -40,8 +40,8 @@ typedef struct MessageQueue
 {
 	pid_t reader_pid; /* Should only be set once at cluster launcher
 					   * startup */
-	slock_t mutex;	/* Controls access to the reader pid */
-	LWLock *lock;	 /* Pointer to the lock to control
+	slock_t mutex;	  /* Controls access to the reader pid */
+	LWLock *lock;	  /* Pointer to the lock to control
 					   * adding/removing elements from queue */
 	uint8 read_upto;
 	uint8 num_elements;

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -408,7 +408,7 @@ ts_get_partition_for_key(PG_FUNCTION_ARGS)
 	data = DatumGetTextPP(arg);
 	hash_u = DatumGetUInt32(hash_any((unsigned char *) VARDATA_ANY(data), VARSIZE_ANY_EXHDR(data)));
 
-	res = (int32)(hash_u & 0x7fffffff); /* Only positive numbers */
+	res = (int32) (hash_u & 0x7fffffff); /* Only positive numbers */
 
 	PG_FREE_IF_COPY(data, 0);
 	PG_RETURN_INT32(res);
@@ -461,7 +461,7 @@ ts_get_partition_hash(PG_FUNCTION_ARGS)
 	hash = FunctionCall1Coll(&pfc->tce->hash_proc_finfo, collation, arg);
 
 	/* Only positive numbers */
-	res = (int32)(DatumGetUInt32(hash) & 0x7fffffff);
+	res = (int32) (DatumGetUInt32(hash) & 0x7fffffff);
 
 	PG_RETURN_INT32(res);
 }

--- a/src/planner/agg_bookend.c
+++ b/src/planner/agg_bookend.c
@@ -248,7 +248,7 @@ ts_preprocess_first_last_aggregates(PlannerInfo *root, List *tlist)
 	if (!parse->hasAggs)
 		return;
 
-	Assert(!parse->setOperations);  /* shouldn't get here if a setop */
+	Assert(!parse->setOperations);	/* shouldn't get here if a setop */
 	Assert(parse->rowMarks == NIL); /* nor if FOR UPDATE */
 
 	/*

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -162,9 +162,9 @@ const_datum_get_int(Const *cnst)
 	switch (cnst->consttype)
 	{
 		case INT2OID:
-			return (int64)(DatumGetInt16(cnst->constvalue));
+			return (int64) (DatumGetInt16(cnst->constvalue));
 		case INT4OID:
-			return (int64)(DatumGetInt32(cnst->constvalue));
+			return (int64) (DatumGetInt32(cnst->constvalue));
 		case INT8OID:
 			return DatumGetInt64(cnst->constvalue);
 	}

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -568,9 +568,9 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 		if (prev_planner_hook != NULL)
 		/* Call any earlier hooks */
 #if PG13_GE
-			stmt = (prev_planner_hook)(parse, query_string, cursor_opts, bound_params);
+			stmt = (prev_planner_hook) (parse, query_string, cursor_opts, bound_params);
 #else
-			stmt = (prev_planner_hook)(parse, cursor_opts, bound_params);
+			stmt = (prev_planner_hook) (parse, cursor_opts, bound_params);
 #endif
 		else
 		/* Call the standard planner */

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -237,9 +237,9 @@ check_alter_table_allowed_on_ht_with_compression(Hypertable *ht, AlterTableStmt 
 			case AT_SetTableSpace:
 				/* this is passed down in `process_altertable_set_tablespace_end` */
 			case AT_SetStatistics: /* should this be pushed down in some way? */
-			case AT_AddColumn:	 /* this is passed down */
+			case AT_AddColumn:	   /* this is passed down */
 			case AT_ColumnDefault: /* this is passed down */
-			case AT_DropColumn:	/* this is passed down */
+			case AT_DropColumn:	   /* this is passed down */
 #if PG14_GE
 			case AT_ReAddStatistics:
 			case AT_SetCompression:
@@ -3752,7 +3752,7 @@ process_altertable_end_subcmd(Hypertable *ht, Node *parsetree, ObjectAddress *ob
 		case AT_AddColumnToView:		   /* only used with views */
 		case AT_AlterColumnGenericOptions: /* only used with foreign tables */
 		case AT_GenericOptions:			   /* only used with foreign tables */
-		case AT_ReAddDomainConstraint:	 /* We should handle this in future,
+		case AT_ReAddDomainConstraint:	   /* We should handle this in future,
 											* new subset of constraints in PG11
 											* currently not hit in test code */
 		case AT_AttachPartition:		   /* handled in

--- a/test/perl/TimescaleNode.pm
+++ b/test/perl/TimescaleNode.pm
@@ -7,7 +7,7 @@
 
 package TimescaleNode;
 use if $ENV{PG_VERSION_MAJOR} >= 15, 'parent', qw(PostgreSQL::Test::Cluster);
-use if $ENV{PG_VERSION_MAJOR} < 15, 'parent', qw(PostgresNode);
+use if $ENV{PG_VERSION_MAJOR} < 15,  'parent', qw(PostgresNode);
 use
   if $ENV{PG_VERSION_MAJOR} >= 15, 'PostgreSQL::Test::Utils', qw(slurp_file);
 use if $ENV{PG_VERSION_MAJOR} < 15, 'TestLib', qw(slurp_file);

--- a/test/src/bgw/scheduler_mock.c
+++ b/test/src/bgw/scheduler_mock.c
@@ -197,7 +197,8 @@ test_job_2_error()
 
 static pqsigfunc prev_signal_func = NULL;
 
-static void log_terminate_signal(SIGNAL_ARGS)
+static void
+log_terminate_signal(SIGNAL_ARGS)
 {
 	write_stderr("job got term signal\n");
 	if (prev_signal_func != NULL)

--- a/test/src/symbol_conflict.c
+++ b/test/src/symbol_conflict.c
@@ -26,7 +26,8 @@ test_symbol_conflict(void)
 
 TS_FUNCTION_INFO_V1(FUNC(MODULE_NAME, hello));
 
-Datum FUNC(MODULE_NAME, hello)(PG_FUNCTION_ARGS)
+Datum
+FUNC(MODULE_NAME, hello)(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_TEXT_P(cstring_to_text(test_symbol_conflict()));
 }

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -735,7 +735,7 @@ collect_colstat_slots(const HeapTuple tuple, const Form_pg_statistic formdata, D
 		ATTSTATSSLOT_NUMBERS,						/* DECHIST */
 		/* ATTSTATSSLOT_VALUES is not always present for all HISTOGRAM operators.. */
 		ATTSTATSSLOT_NUMBERS, /* RANGE_LENGTH_HISTOGRAM */
-		ATTSTATSSLOT_VALUES   /* BOUNDS_HISTOGRAM */
+		ATTSTATSSLOT_VALUES	  /* BOUNDS_HISTOGRAM */
 	};
 
 	int i;

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -52,7 +52,7 @@ typedef struct CompressColInfo
 {
 	int numcols;
 	FormData_hypertable_compression
-		*col_meta;	/* metadata about columns from src hypertable that will be compressed*/
+		*col_meta;	  /* metadata about columns from src hypertable that will be compressed*/
 	List *coldeflist; /*list of ColumnDef for the compressed column */
 } CompressColInfo;
 

--- a/tsl/src/compression/deltadelta.c
+++ b/tsl/src/compression/deltadelta.c
@@ -702,5 +702,5 @@ static inline uint64
 zig_zag_decode(uint64 value)
 {
 	/* ZigZag turns negative numbers into odd ones, and positive numbers into even ones*/
-	return (value >> 1) ^ (uint64) - (int64)(value & 1);
+	return (value >> 1) ^ (uint64) - (int64) (value & 1);
 }

--- a/tsl/src/compression/simple8b_rle.h
+++ b/tsl/src/compression/simple8b_rle.h
@@ -804,7 +804,7 @@ simple8brle_selector_is_rle(uint8 selector)
 static inline uint32
 simple8brle_rledata_repeatcount(uint64 rledata)
 {
-	return (uint32)((rledata >> SIMPLE8B_RLE_MAX_VALUE_BITS) & SIMPLE8B_RLE_MAX_COUNT_MASK);
+	return (uint32) ((rledata >> SIMPLE8B_RLE_MAX_VALUE_BITS) & SIMPLE8B_RLE_MAX_COUNT_MASK);
 }
 
 static inline uint64

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -131,7 +131,7 @@
 typedef struct MatTableColumnInfo
 {
 	List *matcollist;		 /* column defns for materialization tbl*/
-	List *partial_seltlist;  /* tlist entries for populating the materialization table columns */
+	List *partial_seltlist;	 /* tlist entries for populating the materialization table columns */
 	List *partial_grouplist; /* group clauses used for populating the materialization table */
 	List *mat_groupcolname_list; /* names of columns that are populated by the group-by clause
 									correspond to the partial_grouplist.
@@ -143,7 +143,7 @@ typedef struct MatTableColumnInfo
 
 typedef struct FinalizeQueryInfo
 {
-	List *final_seltlist;   /* select target list for finalize query */
+	List *final_seltlist;	/* select target list for finalize query */
 	Node *final_havingqual; /* having qual for finalize query */
 	Query *final_userquery; /* user query used to compute the finalize_query */
 	bool finalized;			/* finalized form? */
@@ -490,11 +490,11 @@ mattablecolumninfo_add_mattable_index(MatTableColumnInfo *matcolinfo, Hypertable
 							   InvalidOid, /* indexRelationId */
 							   InvalidOid, /* parentIndexId */
 							   InvalidOid, /* parentConstraintId */
-							   false,	  /* is_alter_table */
-							   false,	  /* check_rights */
-							   false,	  /* check_not_in_use */
-							   false,	  /* skip_build */
-							   false);	 /* quiet */
+							   false,	   /* is_alter_table */
+							   false,	   /* check_rights */
+							   false,	   /* check_not_in_use */
+							   false,	   /* skip_build */
+							   false);	   /* quiet */
 		indxtuple = SearchSysCache1(RELOID, ObjectIdGetDatum(indxaddr.objectId));
 
 		if (!HeapTupleIsValid(indxtuple))
@@ -1195,7 +1195,7 @@ static Oid
 get_finalizefnoid()
 {
 	Oid finalfnoid;
-	Oid finalfnargtypes[] = { TEXTOID,  NAMEOID,	  NAMEOID, get_array_type(NAMEOID),
+	Oid finalfnargtypes[] = { TEXTOID,	NAMEOID,	  NAMEOID, get_array_type(NAMEOID),
 							  BYTEAOID, ANYELEMENTOID };
 	List *funcname = list_make2(makeString(INTERNAL_SCHEMA_NAME), makeString(FINALFN));
 	int nargs = sizeof(finalfnargtypes) / sizeof(finalfnargtypes[0]);

--- a/tsl/src/continuous_aggs/invalidation.c
+++ b/tsl/src/continuous_aggs/invalidation.c
@@ -1382,7 +1382,7 @@ remote_invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertab
 									 &bucket_functions);
 
 	static const Oid type_id[INVALIDATION_PROCESS_CAGG_LOG_NARGS] = {
-		INT4OID,	  INT4OID,		REGTYPEOID,   INT8OID,		INT8OID,
+		INT4OID,	  INT4OID,		REGTYPEOID,	  INT8OID,		INT8OID,
 		INT4ARRAYOID, INT8ARRAYOID, INT8ARRAYOID, TEXTARRAYOID,
 	};
 	List *const fqn = list_make2(makeString(INTERNAL_SCHEMA_NAME),
@@ -1434,7 +1434,7 @@ remote_invalidation_process_cagg_log(int32 mat_hypertable_id, int32 raw_hypertab
 		InternalTimeRange merged_window = {
 			.type = refresh_window->type,
 			.start = TS_TIME_NOEND, /* initial state invalid */
-			.end = TS_TIME_NOBEGIN  /* initial state invalid */
+			.end = TS_TIME_NOBEGIN	/* initial state invalid */
 		};
 
 		for (i = 0; i < num_dist_res; ++i)

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -32,7 +32,7 @@ typedef struct InternalTimeRange
 {
 	Oid type;
 	int64 start; /* inclusive */
-	int64 end;   /* exclusive */
+	int64 end;	 /* exclusive */
 } InternalTimeRange;
 
 InternalTimeRange continuous_agg_materialize_window_max(Oid timetype);

--- a/tsl/src/dist_util.h
+++ b/tsl/src/dist_util.h
@@ -13,7 +13,7 @@
 typedef enum DistUtilMembershipStatus
 {
 	DIST_MEMBER_NONE,		/* Database doesn't belong to a distributed database */
-	DIST_MEMBER_DATA_NODE,  /* Database is a data node */
+	DIST_MEMBER_DATA_NODE,	/* Database is a data node */
 	DIST_MEMBER_ACCESS_NODE /* Database is an access node */
 } DistUtilMembershipStatus;
 

--- a/tsl/src/fdw/modify_exec.c
+++ b/tsl/src/fdw/modify_exec.c
@@ -57,7 +57,7 @@ typedef struct TsFdwDataNodeState
 {
 	TSConnectionId id;
 	/* for remote query execution */
-	TSConnection *conn;   /* connection for the scan */
+	TSConnection *conn;	  /* connection for the scan */
 	PreparedStmt *p_stmt; /* prepared statement handle, if created */
 } TsFdwDataNodeState;
 

--- a/tsl/src/fdw/relinfo.h
+++ b/tsl/src/fdw/relinfo.h
@@ -115,7 +115,7 @@ typedef struct TsFdwRelInfo
 								  * subquery? */
 	bool make_innerrel_subquery; /* do we deparse innerrel as a
 								  * subquery? */
-	Relids lower_subquery_rels;  /* all relids appearing in lower
+	Relids lower_subquery_rels;	 /* all relids appearing in lower
 								  * subqueries */
 
 	/*

--- a/tsl/src/fdw/scan_exec.h
+++ b/tsl/src/fdw/scan_exec.h
@@ -31,12 +31,12 @@ typedef struct TsFdwScanState
 	List *retrieved_attrs; /* list of retrieved attribute numbers */
 
 	/* for remote query execution */
-	struct TSConnection *conn;   /* connection for the scan */
+	struct TSConnection *conn;	 /* connection for the scan */
 	struct DataFetcher *fetcher; /* fetches tuples from data node */
 	int num_params;				 /* number of parameters passed to query */
 	FmgrInfo *param_flinfo;		 /* output conversion functions for them */
 	List *param_exprs;			 /* executable expressions for param values */
-	const char **param_values;   /* textual values of query parameters */
+	const char **param_values;	 /* textual values of query parameters */
 	int fetch_size;				 /* number of tuples per fetch */
 	/*
 	 * The type of data fetcher to use. Note that we still can revert to

--- a/tsl/src/fdw/shippable.c
+++ b/tsl/src/fdw/shippable.c
@@ -57,7 +57,7 @@ static HTAB *ShippableCacheHash = NULL;
 typedef struct
 {
 	/* XXX we assume this struct contains no padding bytes */
-	Oid objid;	/* function/operator/type OID */
+	Oid objid;	  /* function/operator/type OID */
 	Oid classid;  /* OID of its catalog (pg_proc, etc) */
 	Oid serverid; /* FDW server we are concerned with */
 } ShippableCacheKey;

--- a/tsl/src/nodes/async_append.c
+++ b/tsl/src/nodes/async_append.c
@@ -114,7 +114,7 @@ typedef struct AsyncAppendState
 {
 	CustomScanState css;
 	PlanState *subplan_state; /* AppendState or MergeAppendState */
-	List *data_node_scans;	/* DataNodeScan states */
+	List *data_node_scans;	  /* DataNodeScan states */
 	bool first_run;
 } AsyncAppendState;
 

--- a/tsl/src/nodes/data_node_copy.c
+++ b/tsl/src/nodes/data_node_copy.c
@@ -336,7 +336,11 @@ static CustomScanMethods data_node_copy_plan_methods = {
  * assignment (see transam.h). We can assume that any type created with an OID
  * starting at this number is a "custom" (user-created) type.
  */
-static bool type_is_custom(Oid typeid) { return typeid >= FirstNormalObjectId; }
+static bool
+type_is_custom(Oid typeid)
+{
+	return typeid >= FirstNormalObjectId;
+}
 
 /*
  * Get and validate the attributes we send in the COPY command.

--- a/tsl/src/nodes/data_node_dispatch.c
+++ b/tsl/src/nodes/data_node_dispatch.c
@@ -156,7 +156,7 @@ typedef struct DataNodeDispatchState
 	Relation rel;			 /* The (local) relation we're inserting into */
 	bool set_processed;		 /* Indicates whether to set the number or processed tuples */
 	DeparsedInsertStmt stmt; /* Partially deparsed insert statement */
-	const char *sql_stmt;	/* Fully deparsed insert statement */
+	const char *sql_stmt;	 /* Fully deparsed insert statement */
 	TupleFactory *tupfactory;
 	List *target_attrs;		  /* The attributes to send to remote data nodes */
 	List *responses;		  /* List of responses to process in RETURNING state */
@@ -166,7 +166,7 @@ typedef struct DataNodeDispatchState
 	int64 num_tuples;		  /* Total number of tuples flushed each round */
 	int64 next_tuple;		  /* Next tuple to return to the parent node when in
 							   * RETURNING state */
-	int replication_factor;   /* > 1 if we replicate tuples across data nodes */
+	int replication_factor;	  /* > 1 if we replicate tuples across data nodes */
 	StmtParams *stmt_params;  /* Parameters to send with statement. Format can be binary or text */
 	int flush_threshold;	  /* Batch size used for this dispatch state */
 	TupleTableSlot *batch_slot; /* Slot used for sending tuples to data

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -2132,8 +2132,8 @@ send_binary_copy_header(const TSConnection *conn, TSConnectionError *err)
 	/* File header for binary format */
 	static const char file_header[] = {
 		'P', 'G', 'C', 'O', 'P', 'Y', '\n', '\377', '\r', '\n', '\0', /* Signature */
-		0,   0,   0,   0,											  /* 4 bytes flags */
-		0,   0,   0,   0 /* 4 bytes header extension length (unused) */
+		0,	 0,	  0,   0,											  /* 4 bytes flags */
+		0,	 0,	  0,   0 /* 4 bytes header extension length (unused) */
 	};
 
 	int res = PQputCopyData(conn->pg_conn, file_header, sizeof(file_header));

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -108,7 +108,7 @@ typedef enum TSConnectionStatus
 {
 	CONN_IDLE,		 /* No command being processed */
 	CONN_PROCESSING, /* Command/query is being processed */
-	CONN_COPY_IN,	/* Connection is in COPY_IN mode */
+	CONN_COPY_IN,	 /* Connection is in COPY_IN mode */
 } TSConnectionStatus;
 
 TSConnectionResult remote_connection_drain(TSConnection *conn, TimestampTz endtime,

--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -404,7 +404,7 @@ static const char *conn_status_str[] = {
 };
 
 static const char *conn_txn_status_str[] = {
-	[PQTRANS_IDLE] = "IDLE",	   [PQTRANS_ACTIVE] = "ACTIVE",   [PQTRANS_INTRANS] = "INTRANS",
+	[PQTRANS_IDLE] = "IDLE",	   [PQTRANS_ACTIVE] = "ACTIVE",	  [PQTRANS_INTRANS] = "INTRANS",
 	[PQTRANS_INERROR] = "INERROR", [PQTRANS_UNKNOWN] = "UNKNOWN",
 };
 

--- a/tsl/src/remote/data_fetcher.h
+++ b/tsl/src/remote/data_fetcher.h
@@ -41,14 +41,14 @@ typedef struct DataFetcher
 	TSConnection *conn;
 	TupleFactory *tf;
 
-	MemoryContext req_mctx;   /* Stores async request and response */
+	MemoryContext req_mctx;	  /* Stores async request and response */
 	MemoryContext batch_mctx; /* Stores batches of fetched tuples */
 	MemoryContext tuple_mctx;
 
 	const char *stmt;		 /* sql statement */
 	StmtParams *stmt_params; /* sql statement params */
 
-	HeapTuple *tuples;  /* array of currently-retrieved tuples */
+	HeapTuple *tuples;	/* array of currently-retrieved tuples */
 	int num_tuples;		/* # of tuples in array */
 	int next_tuple_idx; /* index of next one to return */
 	int fetch_size;		/* # of tuples to fetch */

--- a/tsl/src/remote/stmt_params.c
+++ b/tsl/src/remote/stmt_params.c
@@ -33,7 +33,7 @@ typedef struct StmtParams
 	int converted_tuples;
 	bool ctid;
 	List *target_attr_nums;
-	MemoryContext mctx;	/* where we allocate param values */
+	MemoryContext mctx;	   /* where we allocate param values */
 	MemoryContext tmp_ctx; /* used for converting values */
 	bool preset;		   /* idicating if we set values explicitly */
 } StmtParams;

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -42,7 +42,7 @@
 
 typedef struct RemoteTxn
 {
-	TSConnectionId id;  /* hash key (must be first) */
+	TSConnectionId id;	/* hash key (must be first) */
 	TSConnection *conn; /* connection to data node, or NULL */
 	/* Remaining fields are invalid when conn is NULL: */
 	bool have_prep_stmt;	/* have we prepared any stmts in this xact? */


### PR DESCRIPTION
The only thing we're missing is the configuration for braces after case labels, and the rest of the stuff was just missed by the version 8 we used to use.