### PR TITLE
Add hook for ssl options

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -111,6 +111,16 @@ bool ts_shutdown_bgw = false;
 char *ts_current_timestamp_mock = "";
 #endif
 
+/* Hook for plugins to allow additional SSL options */
+set_ssl_options_hook_type ts_set_ssl_options_hook = NULL;
+
+/* Assign the hook to the passed in function argument */
+void
+ts_assign_ssl_options_hook(void *fn)
+{
+	ts_set_ssl_options_hook = (set_ssl_options_hook_type) fn;
+}
+
 static void
 assign_max_cached_chunks_per_hypertable_hook(int newval, void *extra)
 {

--- a/src/guc.h
+++ b/src/guc.h
@@ -75,6 +75,10 @@ typedef enum DistCopyTransferFormat
 
 extern TSDLLEXPORT DistCopyTransferFormat ts_guc_dist_copy_transfer_format;
 
+/* Hook for plugins to allow additional SSL options */
+typedef void (*set_ssl_options_hook_type)(const char *user_name);
+extern TSDLLEXPORT set_ssl_options_hook_type ts_set_ssl_options_hook;
+
 #ifdef TS_DEBUG
 extern bool ts_shutdown_bgw;
 extern char *ts_current_timestamp_mock;
@@ -84,5 +88,6 @@ extern char *ts_current_timestamp_mock;
 
 void _guc_init(void);
 void _guc_fini(void);
+extern TSDLLEXPORT void ts_assign_ssl_options_hook(void *fn);
 
 #endif /* TIMESCALEDB_GUC_H */

--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -1270,6 +1270,10 @@ set_ssl_options(const char *user_name, const char **keywords, const char **value
 	values[option_pos] = make_user_path(user_name, PATH_KIND_KEY)->data;
 	option_pos++;
 
+	/* if ts_set_ssl_options_hook is enabled then invoke that hook */
+	if (ts_set_ssl_options_hook)
+		ts_set_ssl_options_hook(user_name);
+
 	*option_start = option_pos;
 }
 


### PR DESCRIPTION
External components like timescaledb_cloudutils might want to add additional options or do additional ssl related processing. They can do so by implementing a hook and then assigning it to a timescaledb variable to allow timescale to invoke it as appropriate.