### PR TITLE
Fix flaky bgw_custom test

### DIFF
--- a/tsl/test/expected/bgw_custom.out
+++ b/tsl/test/expected/bgw_custom.out
@@ -640,10 +640,10 @@ as job_with_func_check_id \gset
 --- test alter_job
 select alter_job(:job_with_func_check_id, config => '{"drop_after":"chicken"}');
 ERROR:  invalid input syntax for type interval: "chicken"
-select alter_job(:job_with_func_check_id, config => '{"drop_after":"5 years"}');
-                                                    alter_job                                                    
------------------------------------------------------------------------------------------------------------------
- (1006,"@ 5 secs","@ 0",-1,"@ 5 mins",t,"{""drop_after"": ""5 years""}",-infinity,public.test_config_check_func)
+select config from alter_job(:job_with_func_check_id, config => '{"drop_after":"5 years"}');
+          config           
+---------------------------
+ {"drop_after": "5 years"}
 (1 row)
 
 -- test that jobs with an incorrect check function signature will not be registered
@@ -710,35 +710,35 @@ NOTICE:  I print a message, and then I return least(1,2)
 -- drop the registered check function, verify that alter_job will work and print a warning that 
 -- the check is being skipped due to the check function missing
 ALTER FUNCTION test_config_check_func RENAME TO renamed_func;
-select alter_job(:job_id, schedule_interval => '1 hour');
+select job_id, schedule_interval, config, check_config from alter_job(:job_id, schedule_interval => '1 hour');
 WARNING:  function public.test_config_check_func(config jsonb) not found, skipping config validation for job 1008
-                                     alter_job                                      
-------------------------------------------------------------------------------------
- (1008,"@ 1 hour","@ 0",-1,"@ 5 mins",t,{},-infinity,public.test_config_check_func)
+ job_id | schedule_interval | config |         check_config          
+--------+-------------------+--------+-------------------------------
+   1008 | @ 1 hour          | {}     | public.test_config_check_func
 (1 row)
 
 DROP FUNCTION test_config_check_func_returns_int;
-select alter_job(:job_id_int, config => '{"field":"value"}');
+select job_id, schedule_interval, config, check_config from alter_job(:job_id_int, config => '{"field":"value"}');
 WARNING:  function public.test_config_check_func_returns_int(config jsonb) not found, skipping config validation for job 1009
-                                                      alter_job                                                       
-----------------------------------------------------------------------------------------------------------------------
- (1009,"@ 5 secs","@ 0",-1,"@ 5 mins",t,"{""field"": ""value""}",-infinity,public.test_config_check_func_returns_int)
+ job_id | schedule_interval |       config       |               check_config                
+--------+-------------------+--------------------+-------------------------------------------
+   1009 | @ 5 secs          | {"field": "value"} | public.test_config_check_func_returns_int
 (1 row)
 
 -- rename the check function and then call alter_job to register the new name
-select alter_job(:job_id, check_config => 'renamed_func'::regproc);
+select job_id, schedule_interval, config, check_config from alter_job(:job_id, check_config => 'renamed_func'::regproc);
 NOTICE:  This message will get printed for both NULL and not NULL config
-                                alter_job                                 
---------------------------------------------------------------------------
- (1008,"@ 1 hour","@ 0",-1,"@ 5 mins",t,{},-infinity,public.renamed_func)
+ job_id | schedule_interval | config |    check_config     
+--------+-------------------+--------+---------------------
+   1008 | @ 1 hour          | {}     | public.renamed_func
 (1 row)
 
 -- run alter again, should get a config check
-select alter_job(:job_id, config => '{}');
+select job_id, schedule_interval, config, check_config from alter_job(:job_id, config => '{}');
 NOTICE:  This message will get printed for both NULL and not NULL config
-                                alter_job                                 
---------------------------------------------------------------------------
- (1008,"@ 1 hour","@ 0",-1,"@ 5 mins",t,{},-infinity,public.renamed_func)
+ job_id | schedule_interval | config |    check_config     
+--------+-------------------+--------+---------------------
+   1008 | @ 1 hour          | {}     | public.renamed_func
 (1 row)
 
 -- do not drop the current check function but register a new one
@@ -749,18 +749,18 @@ BEGIN
 END
 $$ LANGUAGE PLPGSQL;
 -- register the new check
-select alter_job(:job_id, check_config => 'substitute_check_func');
+select job_id, schedule_interval, config, check_config from alter_job(:job_id, check_config => 'substitute_check_func');
 NOTICE:  This message is a substitute of the previously printed one
-                                     alter_job                                     
------------------------------------------------------------------------------------
- (1008,"@ 1 hour","@ 0",-1,"@ 5 mins",t,{},-infinity,public.substitute_check_func)
+ job_id | schedule_interval | config |         check_config         
+--------+-------------------+--------+------------------------------
+   1008 | @ 1 hour          | {}     | public.substitute_check_func
 (1 row)
 
-select alter_job(:job_id, config => '{}');
+select job_id, schedule_interval, config, check_config from alter_job(:job_id, config => '{}');
 NOTICE:  This message is a substitute of the previously printed one
-                                     alter_job                                     
------------------------------------------------------------------------------------
- (1008,"@ 1 hour","@ 0",-1,"@ 5 mins",t,{},-infinity,public.substitute_check_func)
+ job_id | schedule_interval | config |         check_config         
+--------+-------------------+--------+------------------------------
+   1008 | @ 1 hour          | {}     | public.substitute_check_func
 (1 row)
 
 RESET client_min_messages;
@@ -794,27 +794,27 @@ ERROR:  permission denied for function "test_config_check_func_privileges"
 -- check that alter_job rejects a check function with invalid signature
 select add_job('test_proc_with_check', '5 secs', config => '{}', check_config => 'renamed_func') as job_id_alter \gset
 NOTICE:  This message will get printed for both NULL and not NULL config
-select alter_job(:job_id_alter, check_config => 'test_config_check_func_0args');
+select job_id, schedule_interval, config, check_config from alter_job(:job_id_alter, check_config => 'test_config_check_func_0args');
 ERROR:  function or procedure public.test_config_check_func_0args(config jsonb) not found
-select alter_job(:job_id_alter);
+select job_id, schedule_interval, config, check_config from alter_job(:job_id_alter);
 NOTICE:  This message will get printed for both NULL and not NULL config
-                                alter_job                                 
---------------------------------------------------------------------------
- (1010,"@ 5 secs","@ 0",-1,"@ 5 mins",t,{},-infinity,public.renamed_func)
+ job_id | schedule_interval | config |    check_config     
+--------+-------------------+--------+---------------------
+   1010 | @ 5 secs          | {}     | public.renamed_func
 (1 row)
 
 -- test that we can unregister the check function
-select alter_job(:job_id_alter, check_config => 0);
-                       alter_job                       
--------------------------------------------------------
- (1010,"@ 5 secs","@ 0",-1,"@ 5 mins",t,{},-infinity,)
+select job_id, schedule_interval, config, check_config from alter_job(:job_id_alter, check_config => 0);
+ job_id | schedule_interval | config | check_config 
+--------+-------------------+--------+--------------
+   1010 | @ 5 secs          | {}     | 
 (1 row)
 
 -- no message printed now
-select alter_job(:job_id_alter, config => '{}'); 
-                       alter_job                       
--------------------------------------------------------
- (1010,"@ 5 secs","@ 0",-1,"@ 5 mins",t,{},-infinity,)
+select job_id, schedule_interval, config, check_config from alter_job(:job_id_alter, config => '{}'); 
+ job_id | schedule_interval | config | check_config 
+--------+-------------------+--------+--------------
+   1010 | @ 5 secs          | {}     | 
 (1 row)
 
 -- test the case where we have a background job that registers jobs with a check fn


### PR DESCRIPTION
The test was flaky because the scheduler was launching the scheduled jobs, therefore their next_start field could differ depending on whether they had finished executing.
Fixed by not selecting the next_start field in alter_job calls, when it is not of interest.

Fixes #4719