### PR TITLE
Fix libpq disconnect for PG15

### DIFF
--- a/tsl/src/remote/connection.c
+++ b/tsl/src/remote/connection.c
@@ -917,7 +917,10 @@ remote_connection_exec(TSConnection *conn, const char *cmd)
 		ResultEntry *entry = PQresultInstanceData(res, eventproc);
 
 		if (status == PGRES_FATAL_ERROR && entry == NULL)
+		{
+			res = PQmakeEmptyPGresult(conn->pg_conn, PGRES_FATAL_ERROR);
 			PQfireResultCreateEvents(conn->pg_conn, res);
+		}
 	}
 	return res;
 }


### PR DESCRIPTION
Make sure the FATAL error message before the data node disconnects is not lost when using PG15.

https://github.com/postgres/postgres/commit/618c1670