### PR TITLE
Fix a warning with clang 14

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -17,3 +17,5 @@
 3f5872ec61650519e2c5e6fe1dfb60d07696cac7
 # Fix various misspellings
 68aec9593c0f37dddbaa4f2e2b34a9ba3f5b11d9
+# Switch to clang-format-14
+7758f5959c8ed64499ab0e6bb66c30464b11dd81

--- a/tsl/src/fdw/scan_plan.c
+++ b/tsl/src/fdw/scan_plan.c
@@ -192,7 +192,7 @@ evaluate_stable_function(Oid funcid, Oid result_type, int32 result_typmod, Oid r
 						 Oid input_collid, List *args, bool funcvariadic, Form_pg_proc funcform)
 {
 	bool has_nonconst_input = false;
-	bool has_null_input = false;
+	PG_USED_FOR_ASSERTS_ONLY bool has_null_input = false;
 	ListCell *arg;
 	FuncExpr *newexpr;
 


### PR DESCRIPTION
Mark the variable as used for asserts only.

Disable-check: commit-count