### PR TITLE
Show information about OOM killer in CI 

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -144,6 +144,8 @@ jobs:
           # wait in case there are in-progress coredumps
           sleep 10
           if coredumpctl -q list >/dev/null; then echo "::set-output name=coredumps::true"; fi
+          # print OOM killer information
+          sudo journalctl --system -q --facility=kern --grep "Killed process" || true
         fi
         if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -118,6 +118,8 @@ jobs:
           # wait in case there are in-progress coredumps
           sleep 10
           if coredumpctl -q list >/dev/null; then echo "::set-output name=coredumps::true"; fi
+          # print OOM killer information
+          sudo journalctl --system -q --facility=kern --grep "Killed process" || true
         fi
         if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true


### PR DESCRIPTION
Include OOM kill event logs into error printout. Previously these
would only be visible by inspecting the postgres log and looking
for killed by signal 9.