### PR TITLE
Add indexes to job_errors table

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -556,6 +556,9 @@ CREATE TABLE _timescaledb_internal.job_errors (
   error_data jsonb
 );
 
+CREATE INDEX job_errors_job_id_idx ON _timescaledb_internal.job_errors(job_id);
+CREATE INDEX job_errors_finish_time_idx ON _timescaledb_internal.job_errors(finish_time); -- error retention policy filters on finish_time
+
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_internal.job_errors', '');
 -- Set table permissions
 -- We need to grant SELECT to PUBLIC for all tables even those not

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -14,6 +14,10 @@ CREATE TABLE _timescaledb_internal.job_errors (
   error_data jsonb
 );
 
+-- don't need to drop indexes in reverse-dev because the table itself is dropped
+CREATE INDEX job_errors_job_id_idx ON _timescaledb_internal.job_errors(job_id);
+CREATE INDEX job_errors_finish_time_idx ON _timescaledb_internal.job_errors(finish_time);
+
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_internal.job_errors', '');
 
 CREATE VIEW timescaledb_information.job_errors AS


### PR DESCRIPTION
This commit adds two indexes to the job_errors table. One index on job_id to make filtering by job_id faster, and one on the finish_time of the failed job, as the retention job for the job_errors table selects which records to drop based on the value of finish_time.