### PR TITLE
Adjust TAP tests permissions

### DIFF
--- a/tsl/test/t/002_chunk_copy_move.pl
+++ b/tsl/test/t/002_chunk_copy_move.pl
@@ -24,6 +24,8 @@ for my $node ($an, $dn1, $dn2)
 {
 	$node->safe_psql('postgres', "CREATE ROLE htowner LOGIN");
 }
+$an->safe_psql('postgres', "GRANT CREATE ON SCHEMA public TO htowner");
+
 #Create few distributed hypertables with default and specified schema names and insert a few rows
 $an->safe_psql(
 	'postgres',

--- a/tsl/test/t/003_connections_privs.pl
+++ b/tsl/test/t/003_connections_privs.pl
@@ -19,11 +19,12 @@ $an->add_data_node($dn2);
 $dn1->append_conf('postgresql.conf', 'log_connections=true');
 $dn2->append_conf('postgresql.conf', 'log_connections=true');
 
-my $output = $an->safe_psql(
+$an->safe_psql(
 	'postgres',
 	qq[
 	CREATE ROLE alice;
 	CALL distributed_exec('CREATE ROLE alice LOGIN');
+	GRANT CREATE ON SCHEMA public TO alice;
 	GRANT USAGE ON FOREIGN SERVER dn1,dn2 TO alice;
 	SET ROLE alice;
 	CREATE TABLE conditions (time timestamptz, location int, temp float);
@@ -43,6 +44,7 @@ my ($cmdret, $stdout, $stderr) = $an->psql(
 	RESET ROLE;
 	DROP TABLE conditions;
 	REVOKE USAGE ON FOREIGN SERVER dn1,dn2 FROM alice;
+	REVOKE CREATE ON SCHEMA public FROM alice;
 	DROP ROLE ALICE;
 	SELECT node_name, user_name, invalidated
    	FROM _timescaledb_internal.show_connection_cache()
@@ -80,6 +82,9 @@ call distributed_exec(\$\$ CREATE USER regress_dep_user2;\$\$);
 GRANT USAGE ON FOREIGN SERVER dn1,dn2 TO regress_dep_user0;
 GRANT USAGE ON FOREIGN SERVER dn1,dn2 TO regress_dep_user1;
 GRANT USAGE ON FOREIGN SERVER dn1,dn2 TO regress_dep_user2;
+GRANT CREATE ON SCHEMA public TO regress_dep_user0;
+GRANT CREATE ON SCHEMA public TO regress_dep_user1;
+GRANT CREATE ON SCHEMA public TO regress_dep_user2;
 SET SESSION AUTHORIZATION regress_dep_user0;
 CREATE TABLE conditions1 (time bigint NOT NULL, device int, temp float);
 SELECT create_distributed_hypertable('conditions1', 'time', chunk_time_interval => 10);


### PR DESCRIPTION
Starting with PG15, default permissions on the public schema is restricted for any non-superuser non-owner. Adjust TAP tests so as to not fail with "permission denied for schema public".

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=b073c3cc