### PR TITLE
Index support for compress chunk

### DIFF
--- a/src/guc.c
+++ b/src/guc.c
@@ -77,6 +77,7 @@ bool ts_guc_enable_osm_reads = true;
 TSDLLEXPORT bool ts_guc_enable_transparent_decompression = true;
 bool ts_guc_enable_per_data_node_queries = true;
 bool ts_guc_enable_async_append = true;
+TSDLLEXPORT bool ts_guc_enable_compression_indexscan = true;
 TSDLLEXPORT bool ts_guc_enable_skip_scan = true;
 int ts_guc_max_open_chunks_per_insert = 10;
 int ts_guc_max_cached_chunks_per_hypertable = 10;
@@ -380,6 +381,17 @@ _guc_init(void)
 							 "Enable getting and showing EXPLAIN output from remote nodes",
 							 &ts_guc_enable_remote_explain,
 							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
+	DefineCustomBoolVariable("timescaledb.enable_compression_indexscan",
+							 "Enable compression to take indexscan path",
+							 "Enable indexscan during compression, if matching index is found",
+							 &ts_guc_enable_compression_indexscan,
+							 true,
 							 PGC_USERSET,
 							 0,
 							 NULL,

--- a/src/guc.h
+++ b/src/guc.h
@@ -56,6 +56,7 @@ extern TSDLLEXPORT bool ts_guc_enable_client_ddl_on_data_nodes;
 extern TSDLLEXPORT char *ts_guc_ssl_dir;
 extern TSDLLEXPORT char *ts_guc_passfile;
 extern TSDLLEXPORT bool ts_guc_enable_remote_explain;
+extern TSDLLEXPORT bool ts_guc_enable_compression_indexscan;
 
 typedef enum DataFetcherType
 {

--- a/tsl/test/expected/compression_indexscan.out
+++ b/tsl/test/expected/compression_indexscan.out
@@ -1,0 +1,919 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--Enable compression path info
+SET timescaledb.show_compression_path_info= 'on';
+--Table creation
+CREATE TABLE tab1 (
+    time timestamptz not null,
+    id integer not null,
+    c1 double precision null,
+    c2 double precision null
+);
+CREATE TABLE tab2 (
+    time timestamptz not null,
+    id integer not null,
+    c1 double precision null,
+    c2 double precision null
+);
+--Hypertable creation
+SELECT FROM create_hypertable('tab1', 'time');
+--
+(1 row)
+
+SELECT FROM create_hypertable('tab2', 'time');
+--
+(1 row)
+
+--Data generation
+INSERT INTO tab1
+SELECT
+time + (INTERVAL '1 minute' * random()) AS time,
+id,
+random() AS c1,
+random()* 100 AS c2
+FROM
+generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') AS g1(time),
+generate_series(1, 100, 1 ) AS g2(id)
+ORDER BY
+time;
+--Test Set 1.1 [ Index(ASC, Null_First), Compression(ASC, Null_First) ]
+CREATE INDEX idx_asc_null_first ON tab1(id, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_asc_null_first"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 1.1
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 1.2 [Index(ASC, Null_First), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 1.2
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 1.3 [Index(ASC, Null_First), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 1.3
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--DROP INDEX idx_asc_null_last
+--Test Set 1.4 [Index(ASC, Null_First), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 1.4
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_first;
+--Test Set 2.1 [Index(ASC, Null_Last), Compression(ASC,Null_First)]
+CREATE INDEX idx_asc_null_last ON tab1(id, time);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 2.1
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 2.2 [Index(ASC, Null_Last), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_asc_null_last"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_asc_null_last"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_asc_null_last"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_asc_null_last"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 2.2
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 2.3 [Index(ASC, Null_Last), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 2.3
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--DROP INDEX idx_asc_null_last
+--Test Set 2.4 [Index(ASC, Null_Last), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 2.4
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_last;
+--Test Set 3.1 [Index(DESC, Null_First), Compression(ASC,Null_First)]
+CREATE INDEX idx_desc_null_first ON tab1(id, time DESC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 3.1
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 3.2 [Index(DESC, Null_First), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 3.2
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 3.3 [Index(DESC, Null_First), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_desc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_desc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_desc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_desc_null_first"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 3.3
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--DROP INDEX idx_asc_null_last
+--Test Set 3.4 [Index(DESC, Null_First), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 3.4
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_desc_null_first;
+--Test Set 4.1 [Index(DESC, Null_Last), Compression(ASC,Null_First)]
+CREATE INDEX idx_desc_null_last ON tab1(id, time DESC);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 4.1
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 4.2 [Index(DESC, Null_Last), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | t           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 4.2
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 4.3 [Index(DESC, Null_Last), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | t
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_desc_null_last"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_desc_null_last"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_desc_null_last"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_desc_null_last"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 4.3
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 4.4 [Index(DESC, Null_Last), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+ hypertable_schema | hypertable_name | attname | segmentby_column_index | orderby_column_index | orderby_asc | orderby_nullsfirst 
+-------------------+-----------------+---------+------------------------+----------------------+-------------+--------------------
+ public            | tab1            | id      |                      1 |                      |             | 
+ public            | tab1            | time    |                        |                    1 | f           | f
+(2 rows)
+
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'time');
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_tab1_time_idx"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_tab1_time_idx"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_tab1_time_idx"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_tab1_time_idx"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Cleanup 4.4
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_desc_null_last;
+--Test Set 5 GUC SET timescaledb.enable_compression_indexscan
+-- Default this flag will be true.
+SET timescaledb.enable_compression_indexscan = 'OFF';
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SET timescaledb.enable_compression_indexscan = 'ON';
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_tab1_time_idx"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_tab1_time_idx"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_tab1_time_idx"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_tab1_time_idx"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+--Test Set 6 Compare two compression paths
+INSERT into tab2 SELECT * from tab1;
+CREATE INDEX idx_asc_null_first ON tab1(id, time ASC NULLS FIRST);
+CREATE INDEX idx2_asc_null_first ON tab2(id, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+ALTER TABLE tab2 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SET timescaledb.enable_compression_indexscan = 'OFF';
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SET timescaledb.enable_compression_indexscan = 'ON';
+SELECT compress_chunk(show_chunks('tab2'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_81_chunk_idx2_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_82_chunk_idx2_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_83_chunk_idx2_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_2_84_chunk_idx2_asc_null_first"
+             compress_chunk              
+-----------------------------------------
+ _timescaledb_internal._hyper_2_81_chunk
+ _timescaledb_internal._hyper_2_82_chunk
+ _timescaledb_internal._hyper_2_83_chunk
+ _timescaledb_internal._hyper_2_84_chunk
+(4 rows)
+
+SELECT id, time from tab1 EXCEPT SELECT id, time from tab2;
+ id | time 
+----+------
+(0 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab2'));
+            decompress_chunk             
+-----------------------------------------
+ _timescaledb_internal._hyper_2_81_chunk
+ _timescaledb_internal._hyper_2_82_chunk
+ _timescaledb_internal._hyper_2_83_chunk
+ _timescaledb_internal._hyper_2_84_chunk
+(4 rows)
+
+DROP INDEX idx2_asc_null_first;
+DROP INDEX idx_asc_null_first;
+--Test Set 7.1 with Collation order_by
+\set ON_ERROR_STOP 1
+CREATE TABLE tab3 (
+    name text,
+    time timestamptz not null
+);
+SELECT FROM create_hypertable('tab3', 'time');
+--
+(1 row)
+
+--Data generation
+INSERT INTO tab3
+SELECT
+name,
+time + (INTERVAL '1 minute' * random()) AS time
+FROM
+md5(random()::text) as name,
+generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') AS g1(time)
+ORDER BY
+time;
+CREATE INDEX idx_asc_null_first ON tab3(name COLLATE "C", time ASC NULLS FIRST);
+ALTER TABLE tab3 SET(timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'name, time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab3'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab3'));
+             decompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
+SELECT compress_chunk(show_chunks('tab3'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_93_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_94_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_95_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_96_chunk_idxcol_asc_null_first"
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab3'));
+             decompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_first;
+DROP INDEX idxcol_asc_null_first;
+--Test Set 7.1 with Collation segment_by
+CREATE INDEX idx_asc_null_first ON tab3(name COLLATE "ucs_basic", time ASC NULLS FIRST);
+ALTER TABLE tab3 SET(timescaledb.compress, timescaledb.compress_segmentby = 'name', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab3'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab3'));
+             decompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
+SELECT compress_chunk(show_chunks('tab3'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_93_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_94_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_95_chunk_idxcol_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_22_96_chunk_idxcol_asc_null_first"
+              compress_chunk              
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab3'));
+             decompress_chunk             
+------------------------------------------
+ _timescaledb_internal._hyper_22_93_chunk
+ _timescaledb_internal._hyper_22_94_chunk
+ _timescaledb_internal._hyper_22_95_chunk
+ _timescaledb_internal._hyper_22_96_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_first;
+DROP INDEX idxcol_asc_null_first;
+--Test Set 8 with multiple segment_by
+CREATE INDEX idx_asc_null_first ON tab1(id, c1, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_1_chunk_idx_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_2_chunk_idx_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_3_chunk_idx_asc_null_first"
+INFO:  compress_chunk_indexscan_start matched index "_hyper_1_4_chunk_idx_asc_null_first"
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_first;
+CREATE INDEX idx_asc_null_first ON tab1(id, c1 DESC, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_first;
+--Test Set 9
+--Last Column mismatch
+CREATE INDEX idx_asc_null_first ON tab1(id, c1, c2);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_first;
+--Index Column out of order
+CREATE INDEX idx_asc_null_first ON tab1(c1, id, time ASC NULLS FIRST);
+SELECT compress_chunk(show_chunks('tab1'));
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+INFO:  compress_chunk_tuplesort_start
+             compress_chunk             
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+SELECT decompress_chunk(show_chunks('tab1'));
+            decompress_chunk            
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(4 rows)
+
+DROP INDEX idx_asc_null_first;
+--Tear down
+DROP TABLE tab1;
+DROP TABLE tab2;
+DROP TABLE tab3;
+SET timescaledb.show_compression_path_info = 'off';

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -44,6 +44,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     compression_errors.sql
     compression_hypertable.sql
     compression_merge.sql
+    compression_indexscan.sql
     compression_segment_meta.sql
     compression.sql
     compress_table.sql

--- a/tsl/test/sql/compression_indexscan.sql
+++ b/tsl/test/sql/compression_indexscan.sql
@@ -1,0 +1,258 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+--Enable compression path info
+SET timescaledb.show_compression_path_info= 'on';
+--Table creation
+CREATE TABLE tab1 (
+    time timestamptz not null,
+    id integer not null,
+    c1 double precision null,
+    c2 double precision null
+);
+
+CREATE TABLE tab2 (
+    time timestamptz not null,
+    id integer not null,
+    c1 double precision null,
+    c2 double precision null
+);
+--Hypertable creation
+SELECT FROM create_hypertable('tab1', 'time');
+SELECT FROM create_hypertable('tab2', 'time');
+
+--Data generation
+INSERT INTO tab1
+SELECT
+time + (INTERVAL '1 minute' * random()) AS time,
+id,
+random() AS c1,
+random()* 100 AS c2
+FROM
+generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') AS g1(time),
+generate_series(1, 100, 1 ) AS g2(id)
+ORDER BY
+time;
+
+--Test Set 1.1 [ Index(ASC, Null_First), Compression(ASC, Null_First) ]
+CREATE INDEX idx_asc_null_first ON tab1(id, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 1.1
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 1.2 [Index(ASC, Null_First), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 1.2
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 1.3 [Index(ASC, Null_First), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 1.3
+SELECT decompress_chunk(show_chunks('tab1'));
+--DROP INDEX idx_asc_null_last
+
+--Test Set 1.4 [Index(ASC, Null_First), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 1.4
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_asc_null_first;
+
+--Test Set 2.1 [Index(ASC, Null_Last), Compression(ASC,Null_First)]
+CREATE INDEX idx_asc_null_last ON tab1(id, time);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 2.1
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 2.2 [Index(ASC, Null_Last), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 2.2
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 2.3 [Index(ASC, Null_Last), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 2.3
+SELECT decompress_chunk(show_chunks('tab1'));
+--DROP INDEX idx_asc_null_last
+
+--Test Set 2.4 [Index(ASC, Null_Last), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 2.4
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_asc_null_last;
+
+--Test Set 3.1 [Index(DESC, Null_First), Compression(ASC,Null_First)]
+CREATE INDEX idx_desc_null_first ON tab1(id, time DESC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 3.1
+SELECT decompress_chunk(show_chunks('tab1'));
+
+
+--Test Set 3.2 [Index(DESC, Null_First), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 3.2
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 3.3 [Index(DESC, Null_First), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 3.3
+SELECT decompress_chunk(show_chunks('tab1'));
+--DROP INDEX idx_asc_null_last
+
+--Test Set 3.4 [Index(DESC, Null_First), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 3.4
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_desc_null_first;
+
+--Test Set 4.1 [Index(DESC, Null_Last), Compression(ASC,Null_First)]
+CREATE INDEX idx_desc_null_last ON tab1(id, time DESC);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 4.1
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 4.2 [Index(DESC, Null_Last), Compression(ASC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 4.2
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 4.3 [Index(DESC, Null_Last), Compression(DESC,Null_First)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 4.3
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 4.4 [Index(DESC, Null_Last), Compression(DESC,Null_Last)]
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time DESC NULLS LAST');
+SELECT * FROM timescaledb_information.compression_settings;
+SELECT compress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab1'));
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'time');
+SELECT compress_chunk(show_chunks('tab1'));
+--Cleanup 4.4
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_desc_null_last;
+
+--Test Set 5 GUC SET timescaledb.enable_compression_indexscan
+-- Default this flag will be true.
+SET timescaledb.enable_compression_indexscan = 'OFF';
+SELECT compress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab1'));
+SET timescaledb.enable_compression_indexscan = 'ON';
+SELECT compress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab1'));
+
+--Test Set 6 Compare two compression paths
+INSERT into tab2 SELECT * from tab1;
+CREATE INDEX idx_asc_null_first ON tab1(id, time ASC NULLS FIRST);
+CREATE INDEX idx2_asc_null_first ON tab2(id, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+ALTER TABLE tab2 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id', timescaledb.compress_orderby = 'time NULLS FIRST');
+SET timescaledb.enable_compression_indexscan = 'OFF';
+SELECT compress_chunk(show_chunks('tab1'));
+SET timescaledb.enable_compression_indexscan = 'ON';
+SELECT compress_chunk(show_chunks('tab2'));
+SELECT id, time from tab1 EXCEPT SELECT id, time from tab2;
+SELECT decompress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab2'));
+DROP INDEX idx2_asc_null_first;
+DROP INDEX idx_asc_null_first;
+
+--Test Set 7.1 with Collation order_by
+\set ON_ERROR_STOP 1
+CREATE TABLE tab3 (
+    name text,
+    time timestamptz not null
+);
+
+SELECT FROM create_hypertable('tab3', 'time');
+--Data generation
+INSERT INTO tab3
+SELECT
+name,
+time + (INTERVAL '1 minute' * random()) AS time
+FROM
+md5(random()::text) as name,
+generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') AS g1(time)
+ORDER BY
+time;
+CREATE INDEX idx_asc_null_first ON tab3(name COLLATE "C", time ASC NULLS FIRST);
+ALTER TABLE tab3 SET(timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'name, time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab3'));
+SELECT decompress_chunk(show_chunks('tab3'));
+CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
+SELECT compress_chunk(show_chunks('tab3'));
+SELECT decompress_chunk(show_chunks('tab3'));
+DROP INDEX idx_asc_null_first;
+DROP INDEX idxcol_asc_null_first;
+
+--Test Set 7.1 with Collation segment_by
+CREATE INDEX idx_asc_null_first ON tab3(name COLLATE "ucs_basic", time ASC NULLS FIRST);
+ALTER TABLE tab3 SET(timescaledb.compress, timescaledb.compress_segmentby = 'name', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab3'));
+SELECT decompress_chunk(show_chunks('tab3'));
+CREATE INDEX idxcol_asc_null_first ON tab3(name, time ASC NULLS FIRST);
+SELECT compress_chunk(show_chunks('tab3'));
+SELECT decompress_chunk(show_chunks('tab3'));
+DROP INDEX idx_asc_null_first;
+DROP INDEX idxcol_asc_null_first;
+
+--Test Set 8 with multiple segment_by
+CREATE INDEX idx_asc_null_first ON tab1(id, c1, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_asc_null_first;
+CREATE INDEX idx_asc_null_first ON tab1(id, c1 DESC, time ASC NULLS FIRST);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_asc_null_first;
+
+--Test Set 9
+--Last Column mismatch
+CREATE INDEX idx_asc_null_first ON tab1(id, c1, c2);
+ALTER TABLE tab1 SET(timescaledb.compress, timescaledb.compress_segmentby = 'id, c1', timescaledb.compress_orderby = 'time NULLS FIRST');
+SELECT compress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_asc_null_first;
+--Index Column out of order
+CREATE INDEX idx_asc_null_first ON tab1(c1, id, time ASC NULLS FIRST);
+SELECT compress_chunk(show_chunks('tab1'));
+SELECT decompress_chunk(show_chunks('tab1'));
+DROP INDEX idx_asc_null_first;
+
+--Tear down
+DROP TABLE tab1;
+DROP TABLE tab2;
+DROP TABLE tab3;
+SET timescaledb.show_compression_path_info = 'off';


### PR DESCRIPTION
 Index support for compress chunk

 It allows to override tuplesort with indexscan
 if compression setting keys matches with Index keys.
 Moreover this feature has Enable/Disable Toggle.
 To Disable from the client use the following command,
 SET timescaledb.enable_compression_indexscan = 'OFF'

Fixes #4617