### PR TITLE
Add function to alter data nodes

### DIFF
--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -216,3 +216,12 @@ CREATE OR REPLACE PROCEDURE @extschema@.refresh_continuous_aggregate(
     window_start             "any",
     window_end               "any"
 ) LANGUAGE C AS '@MODULE_PATHNAME@', 'ts_continuous_agg_refresh';
+
+CREATE OR REPLACE FUNCTION @extschema@.alter_data_node(
+    node_name              NAME,
+    host                   TEXT = NULL,
+    database               NAME = NULL,
+    port                   INTEGER = NULL,
+	available              BOOLEAN = NULL
+) RETURNS TABLE(node_name NAME, host TEXT, port INTEGER, database NAME, available BOOLEAN)
+AS '@MODULE_PATHNAME@', 'ts_data_node_alter' LANGUAGE C VOLATILE;

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -255,6 +255,8 @@ CREATE TABLE _timescaledb_catalog.chunk_data_node (
   CONSTRAINT chunk_data_node_chunk_id_fkey FOREIGN KEY (chunk_id) REFERENCES _timescaledb_catalog.chunk (id)
 );
 
+CREATE INDEX chunk_data_node_node_name_idx ON _timescaledb_catalog.chunk_data_node (node_name);
+
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.chunk_data_node', '');
 
 -- Default jobs are given the id space [1,1000). User-installed jobs and any jobs created inside tests

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -379,3 +379,14 @@ GRANT SELECT ON _timescaledb_catalog.dimension_id_seq TO PUBLIC;
 GRANT SELECT ON _timescaledb_catalog.dimension TO PUBLIC;
 
 -- end recreate _timescaledb_catalog.dimension table --
+
+-- changes related to alter_data_node():
+CREATE INDEX chunk_data_node_node_name_idx ON _timescaledb_catalog.chunk_data_node (node_name);
+CREATE FUNCTION @extschema@.alter_data_node(
+    node_name              NAME,
+    host                   TEXT = NULL,
+    database               NAME = NULL,
+    port                   INTEGER = NULL,
+	available              BOOLEAN = NULL
+) RETURNS TABLE(node_name NAME, host TEXT, port INTEGER, database NAME, available BOOLEAN)
+AS '@MODULE_PATHNAME@', 'ts_data_node_alter' LANGUAGE C VOLATILE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -305,3 +305,7 @@ GRANT SELECT ON _timescaledb_catalog.dimension_id_seq TO PUBLIC;
 GRANT SELECT ON _timescaledb_catalog.dimension TO PUBLIC;
 
 -- end recreate _timescaledb_catalog.dimension table --
+
+-- changes related to alter_data_node()
+DROP INDEX _timescaledb_catalog.chunk_data_node_node_name_idx;
+DROP FUNCTION @extschema@.alter_data_node;

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -102,6 +102,7 @@ CROSSMODULE_WRAPPER(data_node_add);
 CROSSMODULE_WRAPPER(data_node_delete);
 CROSSMODULE_WRAPPER(data_node_attach);
 CROSSMODULE_WRAPPER(data_node_detach);
+CROSSMODULE_WRAPPER(data_node_alter);
 CROSSMODULE_WRAPPER(chunk_drop_replica);
 
 CROSSMODULE_WRAPPER(chunk_set_default_data_node);
@@ -505,6 +506,7 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.data_node_attach = error_no_default_fn_pg_community,
 	.data_node_ping = error_no_default_fn_pg_community,
 	.data_node_detach = error_no_default_fn_pg_community,
+	.data_node_alter = error_no_default_fn_pg_community,
 	.data_node_allow_new_chunks = error_no_default_fn_pg_community,
 	.data_node_block_new_chunks = error_no_default_fn_pg_community,
 	.distributed_exec = error_no_default_fn_pg_community,

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -158,6 +158,7 @@ typedef struct CrossModuleFunctions
 	PGFunction data_node_attach;
 	PGFunction data_node_ping;
 	PGFunction data_node_detach;
+	PGFunction data_node_alter;
 	PGFunction data_node_allow_new_chunks;
 	PGFunction data_node_block_new_chunks;
 

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -153,7 +153,8 @@ extern TSDLLEXPORT bool ts_hypertable_set_compress_interval(Hypertable *ht,
 															int64 compress_interval);
 extern TSDLLEXPORT void ts_hypertable_clone_constraints_to_compressed(const Hypertable *ht,
 																	  List *constraint_list);
-extern List *ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cube);
+extern TSDLLEXPORT List *ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht,
+															   const Hypercube *cube);
 extern TSDLLEXPORT List *ts_hypertable_get_data_node_name_list(const Hypertable *ht);
 extern TSDLLEXPORT List *ts_hypertable_get_data_node_serverids_list(const Hypertable *ht);
 extern TSDLLEXPORT List *ts_hypertable_get_available_data_nodes(const Hypertable *ht,

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -190,6 +190,7 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.names = (char *[]) {
 			[CHUNK_DATA_NODE_CHUNK_ID_NODE_NAME_IDX] = "chunk_data_node_chunk_id_node_name_key",
 			[CHUNK_DATA_NODE_NODE_CHUNK_ID_NODE_NAME_IDX] = "chunk_data_node_node_chunk_id_node_name_key",
+			[CHUNK_DATA_NODE_NODE_NAME_IDX] = "chunk_data_node_node_name_idx",
 		}
 	},
 	[TABLESPACE] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -598,6 +598,7 @@ enum
 {
 	CHUNK_DATA_NODE_CHUNK_ID_NODE_NAME_IDX,
 	CHUNK_DATA_NODE_NODE_CHUNK_ID_NODE_NAME_IDX,
+	CHUNK_DATA_NODE_NODE_NAME_IDX,
 	_MAX_CHUNK_DATA_NODE_INDEX,
 };
 
@@ -624,6 +625,17 @@ enum Anum_chunk_data_node_node_chunk_id_node_name_idx
 struct FormData_chunk_data_node_node_chunk_id_node_name_idx
 {
 	int32 node_chunk_id;
+	NameData node_name;
+};
+
+enum Anum_chunk_data_node_node_name_idx
+{
+	Anum_chunk_data_node_name_idx_node_name = 1,
+	_Anum_chunk_data_node_node_name_idx_max,
+};
+
+struct FormData_chunk_data_node_node_name_idx
+{
 	NameData node_name;
 };
 
@@ -1460,7 +1472,7 @@ extern TSDLLEXPORT void ts_catalog_delete_tid_only(Relation rel, ItemPointer tid
 extern TSDLLEXPORT void ts_catalog_delete_tid(Relation rel, ItemPointer tid);
 extern TSDLLEXPORT void ts_catalog_delete_only(Relation rel, HeapTuple tuple);
 extern TSDLLEXPORT void ts_catalog_delete(Relation rel, HeapTuple tuple);
-extern void ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
+extern TSDLLEXPORT void ts_catalog_invalidate_cache(Oid catalog_relid, CmdType operation);
 
 bool TSDLLEXPORT ts_catalog_scan_one(CatalogTable table, int indexid, ScanKeyData *scankey,
 									 int num_keys, tuple_found_func tuple_found, LOCKMODE lockmode,

--- a/src/ts_catalog/chunk_data_node.h
+++ b/src/ts_catalog/chunk_data_node.h
@@ -32,7 +32,10 @@ extern int ts_chunk_data_node_delete_by_node_name(const char *node_name);
 extern TSDLLEXPORT List *
 ts_chunk_data_node_scan_by_node_name_and_hypertable_id(const char *node_name, int32 hypertable_id,
 													   MemoryContext mctx);
-extern ScanIterator ts_chunk_data_nodes_scan_iterator_create(MemoryContext result_mcxt);
-extern void ts_chunk_data_nodes_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id);
+extern TSDLLEXPORT ScanIterator ts_chunk_data_nodes_scan_iterator_create(MemoryContext result_mcxt);
+extern TSDLLEXPORT void ts_chunk_data_nodes_scan_iterator_set_chunk_id(ScanIterator *it,
+																	   int32 chunk_id);
+extern TSDLLEXPORT void ts_chunk_data_nodes_scan_iterator_set_node_name(ScanIterator *it,
+																		const char *node_name);
 
 #endif /* TIMESCALEDB_CHUNK_DATA_NODE_H */

--- a/src/utils.c
+++ b/src/utils.c
@@ -1302,3 +1302,26 @@ ts_copy_relation_acl(const Oid source_relid, const Oid target_relid, const Oid o
 	ReleaseSysCache(source_tuple);
 	table_close(class_rel, RowExclusiveLock);
 }
+
+bool
+ts_data_node_is_available_by_server(const ForeignServer *server)
+{
+	ListCell *lc;
+
+	foreach (lc, server->options)
+	{
+		DefElem *elem = lfirst(lc);
+
+		if (strcmp(elem->defname, "available") == 0)
+			return defGetBoolean(elem);
+	}
+
+	/* Default to available if option is not yet added */
+	return true;
+}
+
+bool
+ts_data_node_is_available(const char *name)
+{
+	return ts_data_node_is_available_by_server(GetForeignServerByName(name, false));
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -10,6 +10,7 @@
 #include <access/htup_details.h>
 #include <catalog/pg_proc.h>
 #include <common/int.h>
+#include <foreign/foreign.h>
 #include <nodes/pathnodes.h>
 #include <nodes/extensible.h>
 #include <utils/datetime.h>
@@ -201,5 +202,7 @@ extern TSDLLEXPORT void ts_alter_table_with_event_trigger(Oid relid, Node *cmd, 
 														  bool recurse);
 extern TSDLLEXPORT void ts_copy_relation_acl(const Oid source_relid, const Oid target_relid,
 											 const Oid owner_id);
+extern TSDLLEXPORT bool ts_data_node_is_available_by_server(const ForeignServer *server);
+extern TSDLLEXPORT bool ts_data_node_is_available(const char *node_name);
 
 #endif /* TIMESCALEDB_UTILS_H */

--- a/tsl/src/chunk.h
+++ b/tsl/src/chunk.h
@@ -10,7 +10,8 @@
 #include <fmgr.h>
 #include <chunk.h>
 
-extern void chunk_update_foreign_server_if_needed(int32 chunk_id, Oid existing_server_id);
+extern bool chunk_update_foreign_server_if_needed(const Chunk *chunk, Oid data_node_id,
+												  bool available);
 extern Datum chunk_set_default_data_node(PG_FUNCTION_ARGS);
 extern Datum chunk_drop_replica(PG_FUNCTION_ARGS);
 extern int chunk_invoke_drop_chunks(Oid relid, Datum older_than, Datum older_than_type);

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -1767,6 +1767,6 @@ chunk_api_call_chunk_drop_replica(const Chunk *chunk, const char *node_name, Oid
 	 * This chunk might have this data node as primary, change that association
 	 * if so. Then delete the chunk_id and node_name association.
 	 */
-	chunk_update_foreign_server_if_needed(chunk->fd.id, serverid);
+	chunk_update_foreign_server_if_needed(chunk, serverid, false);
 	ts_chunk_data_node_delete_by_chunk_id_and_node_name(chunk->fd.id, node_name);
 }

--- a/tsl/src/data_node.h
+++ b/tsl/src/data_node.h
@@ -28,6 +28,7 @@ extern Datum data_node_add(PG_FUNCTION_ARGS);
 extern Datum data_node_delete(PG_FUNCTION_ARGS);
 extern Datum data_node_attach(PG_FUNCTION_ARGS);
 extern Datum data_node_detach(PG_FUNCTION_ARGS);
+extern Datum data_node_alter(PG_FUNCTION_ARGS);
 extern Datum data_node_block_new_chunks(PG_FUNCTION_ARGS);
 extern Datum data_node_allow_new_chunks(PG_FUNCTION_ARGS);
 extern List *data_node_get_node_name_list_with_aclcheck(AclMode mode, bool fail_on_aclcheck);

--- a/tsl/src/fdw/option.c
+++ b/tsl/src/fdw/option.c
@@ -132,6 +132,11 @@ option_validate(List *options_list, Oid catalog)
 						(errcode(ERRCODE_SYNTAX_ERROR),
 						 errmsg("%s requires a non-negative integer value", def->defname)));
 		}
+		else if (strcmp(def->defname, "available") == 0)
+		{
+			/* This will throw an error if not a boolean */
+			defGetBoolean(def);
+		}
 	}
 }
 
@@ -154,6 +159,7 @@ init_ts_fdw_options(void)
 		/* fetch_size is available on both foreign data wrapper and server */
 		{ "fetch_size", ForeignDataWrapperRelationId },
 		{ "fetch_size", ForeignServerRelationId },
+		{ "available", ForeignServerRelationId },
 		{ NULL, InvalidOid }
 	};
 

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -190,6 +190,7 @@ CrossModuleFunctions tsl_cm_functions = {
 	.data_node_attach = data_node_attach,
 	.data_node_ping = data_node_ping,
 	.data_node_detach = data_node_detach,
+	.data_node_alter = data_node_alter,
 	.data_node_allow_new_chunks = data_node_allow_new_chunks,
 	.data_node_block_new_chunks = data_node_block_new_chunks,
 	.chunk_set_default_data_node = chunk_set_default_data_node,

--- a/tsl/test/expected/data_node.out
+++ b/tsl/test/expected/data_node.out
@@ -105,7 +105,10 @@ ROLLBACK;
 \set ON_ERROR_STOP 0
 -- Should not be possible to set a version:
 ALTER SERVER data_node_3 VERSION '2';
-ERROR:  operation not supported
+ERROR:  version not supported
+-- Should not be possible to set "available"
+ALTER SERVER data_node_3 OPTIONS (SET available 'true');
+ERROR:  cannot set "available" using ALTER SERVER
 \set ON_ERROR_STOP 1
 -- Make sure changing server owner is allowed
 ALTER SERVER data_node_1 OWNER TO CURRENT_USER;
@@ -1591,3 +1594,367 @@ DROP DATABASE :DN_DBNAME_3;
 DROP DATABASE :DN_DBNAME_4;
 DROP DATABASE :DN_DBNAME_5;
 DROP DATABASE :DN_DBNAME_6;
+-----------------------------------------------
+-- Test alter_data_node()
+-----------------------------------------------
+SELECT node_name, database, node_created, database_created, extension_created FROM add_data_node('data_node_1', host => 'localhost', database => :'DN_DBNAME_1');
+  node_name  |    database    | node_created | database_created | extension_created 
+-------------+----------------+--------------+------------------+-------------------
+ data_node_1 | db_data_node_1 | t            | t                | t
+(1 row)
+
+SELECT node_name, database, node_created, database_created, extension_created FROM add_data_node('data_node_2', host => 'localhost', database => :'DN_DBNAME_2');
+  node_name  |    database    | node_created | database_created | extension_created 
+-------------+----------------+--------------+------------------+-------------------
+ data_node_2 | db_data_node_2 | t            | t                | t
+(1 row)
+
+SELECT node_name, database, node_created, database_created, extension_created FROM add_data_node('data_node_3', host => 'localhost', database => :'DN_DBNAME_3');
+  node_name  |    database    | node_created | database_created | extension_created 
+-------------+----------------+--------------+------------------+-------------------
+ data_node_3 | db_data_node_3 | t            | t                | t
+(1 row)
+
+GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO :ROLE_1;
+SET ROLE :ROLE_1;
+CREATE TABLE hyper1 (time timestamptz, location int, temp float);
+CREATE TABLE hyper2 (LIKE hyper1);
+CREATE TABLE hyper3 (LIKE hyper1);
+CREATE TABLE hyper_1dim (LIKE hyper1);
+SELECT create_distributed_hypertable('hyper1', 'time', 'location', replication_factor=>1);
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (10,public,hyper1,t)
+(1 row)
+
+SELECT create_distributed_hypertable('hyper2', 'time', 'location', replication_factor=>2);
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (11,public,hyper2,t)
+(1 row)
+
+SELECT create_distributed_hypertable('hyper3', 'time', 'location', replication_factor=>3);
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (12,public,hyper3,t)
+(1 row)
+
+SELECT create_distributed_hypertable('hyper_1dim', 'time', chunk_time_interval=>interval '2 days', replication_factor=>3);
+NOTICE:  adding not-null constraint to column "time"
+ create_distributed_hypertable 
+-------------------------------
+ (13,public,hyper_1dim,t)
+(1 row)
+
+SELECT setseed(1);
+ setseed 
+---------
+ 
+(1 row)
+
+INSERT INTO hyper1
+SELECT t, (abs(timestamp_hash(t::timestamp)) % 3) + 1, random() * 30
+FROM generate_series('2022-01-01 00:00:00'::timestamptz, '2022-01-05 00:00:00', '1 h') t;
+INSERT INTO hyper2 SELECT * FROM hyper1;
+INSERT INTO hyper3 SELECT * FROM hyper1;
+INSERT INTO hyper_1dim SELECT * FROM hyper1;
+-- create view to see the data nodes and default data node of all
+-- chunks
+CREATE VIEW chunk_query_data_node AS
+SELECT ch.hypertable_name, format('%I.%I', ch.chunk_schema, ch.chunk_name)::regclass AS chunk, ch.data_nodes, fs.srvname default_data_node
+	   FROM timescaledb_information.chunks ch
+	   INNER JOIN pg_foreign_table ft ON (format('%I.%I', ch.chunk_schema, ch.chunk_name)::regclass = ft.ftrelid)
+	   INNER JOIN pg_foreign_server fs ON (ft.ftserver = fs.oid)
+	   ORDER BY 1, 2;
+SELECT * FROM chunk_query_data_node;
+ hypertable_name |                     chunk                     |              data_nodes               | default_data_node 
+-----------------+-----------------------------------------------+---------------------------------------+-------------------
+ hyper1          | _timescaledb_internal._dist_hyper_10_12_chunk | {data_node_1}                         | data_node_1
+ hyper1          | _timescaledb_internal._dist_hyper_10_13_chunk | {data_node_2}                         | data_node_2
+ hyper1          | _timescaledb_internal._dist_hyper_10_14_chunk | {data_node_3}                         | data_node_3
+ hyper2          | _timescaledb_internal._dist_hyper_11_15_chunk | {data_node_1,data_node_2}             | data_node_1
+ hyper2          | _timescaledb_internal._dist_hyper_11_16_chunk | {data_node_2,data_node_3}             | data_node_2
+ hyper2          | _timescaledb_internal._dist_hyper_11_17_chunk | {data_node_1,data_node_3}             | data_node_3
+ hyper3          | _timescaledb_internal._dist_hyper_12_18_chunk | {data_node_1,data_node_2,data_node_3} | data_node_1
+ hyper3          | _timescaledb_internal._dist_hyper_12_19_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+ hyper3          | _timescaledb_internal._dist_hyper_12_20_chunk | {data_node_1,data_node_2,data_node_3} | data_node_3
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_21_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_22_chunk | {data_node_1,data_node_2,data_node_3} | data_node_3
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_23_chunk | {data_node_1,data_node_2,data_node_3} | data_node_1
+(12 rows)
+
+-- test alter_data_node permissions
+\set ON_ERROR_STOP 0
+-- must be owner to alter a data node
+SELECT * FROM alter_data_node('data_node_1', available=>false);
+ERROR:  must be owner of foreign server data_node_1
+SELECT * FROM alter_data_node('data_node_1', port=>8989);
+ERROR:  must be owner of foreign server data_node_1
+\set ON_ERROR_STOP 1
+-- query some data from all hypertables to show its working before
+-- simulating the node being down
+SELECT time, location FROM hyper1 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper2 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper3 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper_1dim ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+-- simulate a node being down by renaming the database for
+-- data_node_1, but for that to work we need to reconnect the backend
+-- to clear out the connection cache
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+ALTER DATABASE :DN_DBNAME_1 RENAME TO data_node_1_unavailable;
+WARNING:  you need to manually restart any running background workers after this command
+\set ON_ERROR_STOP 0
+SELECT time, location FROM hyper1 ORDER BY time LIMIT 1;
+ERROR:  could not connect to "data_node_1"
+SELECT time, location FROM hyper2 ORDER BY time LIMIT 1;
+ERROR:  could not connect to "data_node_1"
+SELECT time, location FROM hyper3 ORDER BY time LIMIT 1;
+ERROR:  could not connect to "data_node_1"
+SELECT time, location FROM hyper_1dim ORDER BY time LIMIT 1;
+ERROR:  could not connect to "data_node_1"
+\set ON_ERROR_STOP 1
+-- alter the node as not available
+SELECT * FROM alter_data_node('data_node_1', available=>false);
+WARNING:  could not switch data node on 1 chunks
+  node_name  |   host    | port  |    database    | available 
+-------------+-----------+-------+----------------+-----------
+ data_node_1 | localhost | 55432 | db_data_node_1 | f
+(1 row)
+
+-- the node that is not available for reads should no longer be
+-- query data node for chunks, except for those that have no
+-- alternative (i.e., the chunk only has one data node).
+SELECT * FROM chunk_query_data_node;
+ hypertable_name |                     chunk                     |              data_nodes               | default_data_node 
+-----------------+-----------------------------------------------+---------------------------------------+-------------------
+ hyper1          | _timescaledb_internal._dist_hyper_10_12_chunk | {data_node_1}                         | data_node_1
+ hyper1          | _timescaledb_internal._dist_hyper_10_13_chunk | {data_node_2}                         | data_node_2
+ hyper1          | _timescaledb_internal._dist_hyper_10_14_chunk | {data_node_3}                         | data_node_3
+ hyper2          | _timescaledb_internal._dist_hyper_11_15_chunk | {data_node_1,data_node_2}             | data_node_2
+ hyper2          | _timescaledb_internal._dist_hyper_11_16_chunk | {data_node_2,data_node_3}             | data_node_2
+ hyper2          | _timescaledb_internal._dist_hyper_11_17_chunk | {data_node_1,data_node_3}             | data_node_3
+ hyper3          | _timescaledb_internal._dist_hyper_12_18_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+ hyper3          | _timescaledb_internal._dist_hyper_12_19_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+ hyper3          | _timescaledb_internal._dist_hyper_12_20_chunk | {data_node_1,data_node_2,data_node_3} | data_node_3
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_21_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_22_chunk | {data_node_1,data_node_2,data_node_3} | data_node_3
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_23_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+(12 rows)
+
+-- queries should work again, except on hyper1 which has no
+-- replication
+\set ON_ERROR_STOP 0
+SELECT time, location FROM hyper1 ORDER BY time LIMIT 1;
+ERROR:  could not connect to "data_node_1"
+\set ON_ERROR_STOP 1
+SELECT time, location FROM hyper2 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper3 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper_1dim ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+-- inserts should fail if going to chunks that exist on the
+-- unavailable data node
+\set ON_ERROR_STOP 0
+INSERT INTO hyper3 VALUES ('2022-01-03 00:00:00', 1, 1);
+ERROR:  could not connect to "data_node_1"
+INSERT INTO hyper_1dim VALUES ('2022-01-03 00:00:00', 1, 1);
+ERROR:  could not connect to "data_node_1"
+\set ON_ERROR_STOP 1
+-- inserts should work if going to a new chunk
+INSERT INTO hyper3 VALUES ('2022-01-10 00:00:00', 1, 1);
+WARNING:  insufficient number of data nodes
+INSERT INTO hyper_1dim VALUES ('2022-01-10 00:00:00', 1, 1);
+WARNING:  insufficient number of data nodes
+SELECT hypertable_name, chunk_name, data_nodes FROM timescaledb_information.chunks
+WHERE hypertable_name IN ('hyper3', 'hyper_1dim')
+AND range_start::timestamptz <= '2022-01-10 00:00:00'
+AND range_end::timestamptz > '2022-01-10 00:00:00'
+ORDER BY 1, 2;
+ hypertable_name |       chunk_name        |        data_nodes         
+-----------------+-------------------------+---------------------------
+ hyper3          | _dist_hyper_12_24_chunk | {data_node_2,data_node_3}
+ hyper_1dim      | _dist_hyper_13_25_chunk | {data_node_2,data_node_3}
+(2 rows)
+
+-- re-enable the data node and the chunks should "switch back" to
+-- using the data node. However, only the chunks for which the node is
+-- "primary" should switch to using the data node for queries
+ALTER DATABASE data_node_1_unavailable RENAME TO :DN_DBNAME_1;
+WARNING:  you need to manually restart any running background workers after this command
+SELECT * FROM alter_data_node('data_node_1', available=>true);
+  node_name  |   host    | port  |    database    | available 
+-------------+-----------+-------+----------------+-----------
+ data_node_1 | localhost | 55432 | db_data_node_1 | t
+(1 row)
+
+SELECT * FROM chunk_query_data_node;
+ hypertable_name |                     chunk                     |              data_nodes               | default_data_node 
+-----------------+-----------------------------------------------+---------------------------------------+-------------------
+ hyper1          | _timescaledb_internal._dist_hyper_10_12_chunk | {data_node_1}                         | data_node_1
+ hyper1          | _timescaledb_internal._dist_hyper_10_13_chunk | {data_node_2}                         | data_node_2
+ hyper1          | _timescaledb_internal._dist_hyper_10_14_chunk | {data_node_3}                         | data_node_3
+ hyper2          | _timescaledb_internal._dist_hyper_11_15_chunk | {data_node_1,data_node_2}             | data_node_1
+ hyper2          | _timescaledb_internal._dist_hyper_11_16_chunk | {data_node_2,data_node_3}             | data_node_2
+ hyper2          | _timescaledb_internal._dist_hyper_11_17_chunk | {data_node_1,data_node_3}             | data_node_3
+ hyper3          | _timescaledb_internal._dist_hyper_12_18_chunk | {data_node_1,data_node_2,data_node_3} | data_node_1
+ hyper3          | _timescaledb_internal._dist_hyper_12_19_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+ hyper3          | _timescaledb_internal._dist_hyper_12_20_chunk | {data_node_1,data_node_2,data_node_3} | data_node_3
+ hyper3          | _timescaledb_internal._dist_hyper_12_24_chunk | {data_node_2,data_node_3}             | data_node_2
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_21_chunk | {data_node_1,data_node_2,data_node_3} | data_node_2
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_22_chunk | {data_node_1,data_node_2,data_node_3} | data_node_3
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_23_chunk | {data_node_1,data_node_2,data_node_3} | data_node_1
+ hyper_1dim      | _timescaledb_internal._dist_hyper_13_25_chunk | {data_node_2,data_node_3}             | data_node_2
+(14 rows)
+
+--queries should work again on all tables
+SELECT time, location FROM hyper1 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper2 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper3 ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+SELECT time, location FROM hyper_1dim ORDER BY time LIMIT 1;
+             time             | location 
+------------------------------+----------
+ Sat Jan 01 00:00:00 2022 PST |        1
+(1 row)
+
+-- save old port so that we can restore connectivity after we test
+-- changing the connection information for the data node
+WITH options AS (
+	 SELECT unnest(options) opt
+	 FROM timescaledb_information.data_nodes
+	 WHERE node_name = 'data_node_1'
+)
+SELECT split_part(opt, '=', 2) AS old_port
+FROM options WHERE opt LIKE 'port%' \gset
+-- also test altering host, port and database
+SELECT node_name, options FROM timescaledb_information.data_nodes;
+  node_name  |                             options                              
+-------------+------------------------------------------------------------------
+ data_node_2 | {host=localhost,port=55432,dbname=db_data_node_2}
+ data_node_3 | {host=localhost,port=55432,dbname=db_data_node_3}
+ data_node_1 | {host=localhost,port=55432,dbname=db_data_node_1,available=true}
+(3 rows)
+
+SELECT * FROM alter_data_node('data_node_1', available=>true, host=>'foo.bar', port=>8989, database=>'new_db');
+  node_name  |  host   | port | database | available 
+-------------+---------+------+----------+-----------
+ data_node_1 | foo.bar | 8989 | new_db   | t
+(1 row)
+
+SELECT node_name, options FROM timescaledb_information.data_nodes;
+  node_name  |                        options                        
+-------------+-------------------------------------------------------
+ data_node_1 | {host=foo.bar,port=8989,dbname=new_db,available=true}
+ data_node_2 | {host=localhost,port=55432,dbname=db_data_node_2}
+ data_node_3 | {host=localhost,port=55432,dbname=db_data_node_3}
+(3 rows)
+
+-- just show current options:
+SELECT * FROM alter_data_node('data_node_1');
+  node_name  |  host   | port | database | available 
+-------------+---------+------+----------+-----------
+ data_node_1 | foo.bar | 8989 | new_db   | t
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- test some error cases
+SELECT * FROM alter_data_node(NULL);
+ERROR:  data node name cannot be NULL
+SELECT * FROM alter_data_node('does_not_exist');
+ERROR:  server "does_not_exist" does not exist
+SELECT * FROM alter_data_node('data_node_1', port=>89000);
+ERROR:  invalid port number 89000
+-- cannot delete data node with "drop_database" since configuration is wrong
+SELECT delete_data_node('data_node_1', drop_database=>true);
+ERROR:  could not connect to data node "data_node_1"
+\set ON_ERROR_STOP 1
+-- restore configuration for data_node_1
+SELECT * FROM alter_data_node('data_node_1', host=>'localhost', port=>:old_port, database=>:'DN_DBNAME_1');
+  node_name  |   host    | port  |    database    | available 
+-------------+-----------+-------+----------------+-----------
+ data_node_1 | localhost | 55432 | db_data_node_1 | t
+(1 row)
+
+SELECT node_name, options FROM timescaledb_information.data_nodes;
+  node_name  |                             options                              
+-------------+------------------------------------------------------------------
+ data_node_1 | {host=localhost,port=55432,dbname=db_data_node_1,available=true}
+ data_node_2 | {host=localhost,port=55432,dbname=db_data_node_2}
+ data_node_3 | {host=localhost,port=55432,dbname=db_data_node_3}
+(3 rows)
+
+DROP TABLE hyper1;
+DROP TABLE hyper2;
+DROP TABLE hyper3;
+DROP TABLE hyper_1dim;
+DROP VIEW chunk_query_data_node;
+-- create new session to clear out connection cache
+\c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
+SELECT delete_data_node('data_node_1', drop_database=>true);
+ delete_data_node 
+------------------
+ t
+(1 row)
+
+SELECT delete_data_node('data_node_2', drop_database=>true);
+ delete_data_node 
+------------------
+ t
+(1 row)
+
+SELECT delete_data_node('data_node_3', drop_database=>true);
+ delete_data_node 
+------------------
+ t
+(1 row)
+

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -155,6 +155,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  add_job(regproc,interval,jsonb,timestamp with time zone,boolean,regproc,boolean,text)
  add_reorder_policy(regclass,name,boolean,timestamp with time zone,text)
  add_retention_policy(regclass,"any",boolean,interval,timestamp with time zone,text)
+ alter_data_node(name,text,name,integer,boolean)
  alter_job(integer,interval,interval,integer,interval,boolean,jsonb,timestamp with time zone,boolean,regproc)
  approximate_row_count(regclass)
  attach_data_node(name,regclass,boolean,boolean)


### PR DESCRIPTION
Add a new function, `alter_data_node()`, which can be used to change the data node's configuration originally set up via `add_data_node()` on the access node.

The new functions introduces a new option "available" that allows configuring the availability of the data node. Setting
`available=>false` means that the node should no longer be used for reads and writes. Only read "failover" is implemented as part of this change, however.

To fail over reads, the alter data node function finds all the chunks for which the unavailable data node is the "primary" query target and "fails over" to a chunk replica on another data node instead. If some chunks do not have a replica to fail over to, a warning will be raised.

When a data node is available again, the function can be used to switch back to using the data node for queries.

Closes #2104