### PR TITLE
Fix unused sort in dimension partition lookup

### DIFF
--- a/src/ts_catalog/dimension_partition.c
+++ b/src/ts_catalog/dimension_partition.c
@@ -181,9 +181,12 @@ ts_dimension_partition_info_get(int32 dimension_id)
 
 	dpi = palloc0(sizeof(DimensionPartitionInfo));
 	dpi->num_partitions = count;
+
+	/* Reallocate the partitions array to use the exact size and save some
+	 * memory */
 	dpi->partitions = palloc0(sizeof(DimensionPartition *) * count);
 	memcpy(dpi->partitions, partitions, sizeof(DimensionPartition *) * count);
-	qsort(partitions, count, sizeof(DimensionPartition *), dimpart_cmp);
+	qsort(dpi->partitions, count, sizeof(DimensionPartition *), dimpart_cmp);
 	pfree(partitions);
 
 	return dpi;


### PR DESCRIPTION
Dimension partitions uses binary search to find the partition to place a chunk in. However, in the code, an array of partitions might not be sorted because the sort happened on a copy of the array instead of the main array. This change fixes the issue to ensure the array is sorted and binary search works properly.