### PR TITLE
Fix performance regressions in the copy code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ argument or resolve the type ambiguity by casting to the intended type.
 * #4745 Fix FK constraint violation error while insert into hypertable which references partitioned table
 * #4756 Improve compression job IO performance
 * #4807 Fix segmentation fault during INSERT into compressed hypertable.
+* #4840 Fix performance regressions in the copy code
 
 **Thanks**
 * @jvanns for reporting hypertable FK reference to vanilla PostgreSQL partitioned table doesn't seem to work

--- a/test/expected/copy_memory_usage.out
+++ b/test/expected/copy_memory_usage.out
@@ -50,12 +50,16 @@ select count(*) from portal_memory_log;
      5
 (1 row)
 
+--- Check the memory usage of the PortalContext. Ensure that the copy commands do
+--- not allocate memory in this context and the context does not grow. Allow 10%
+--- change of memory usage to account for some randomness.
+select bytes as bytes_begin from portal_memory_log order by id asc limit 1 \gset
+select bytes as bytes_end from portal_memory_log order by id desc limit 1 \gset
 -- We'll only compare the biggest runs, because the smaller ones have variance
 -- due to new chunks being created and other unknown reasons. Allow 10% change of
 -- memory usage to account for some randomness.
 select * from portal_memory_log where (
-    select (max(bytes) - min(bytes)) / max(bytes)::float > 0.1
-    from portal_memory_log where id >= 3
+   select abs(:bytes_begin - :bytes_end) / :bytes_begin::float > 0.1
 );
  id | bytes 
 ----+-------

--- a/test/sql/copy_memory_usage.sql
+++ b/test/sql/copy_memory_usage.sql
@@ -50,10 +50,16 @@ set timescaledb.max_cached_chunks_per_hypertable = 3;
 
 select count(*) from portal_memory_log;
 
+--- Check the memory usage of the PortalContext. Ensure that the copy commands do
+--- not allocate memory in this context and the context does not grow. Allow 10%
+--- change of memory usage to account for some randomness.
+select bytes as bytes_begin from portal_memory_log order by id asc limit 1 \gset
+select bytes as bytes_end from portal_memory_log order by id desc limit 1 \gset
+
 -- We'll only compare the biggest runs, because the smaller ones have variance
 -- due to new chunks being created and other unknown reasons. Allow 10% change of
 -- memory usage to account for some randomness.
 select * from portal_memory_log where (
-    select (max(bytes) - min(bytes)) / max(bytes)::float > 0.1
-    from portal_memory_log where id >= 3
+   select abs(:bytes_begin - :bytes_end) / :bytes_begin::float > 0.1
 );
+


### PR DESCRIPTION
In 8375b9aa536a619a5ac2644e0dae3c25880a4ead, a patch was added to handle chunks closes during an ongoing copy operation. However, this patch introduces a performance regression. All `MultiInsertBuffers` are deleted after they are flushed. In this PR, the performance regression is fixed. The most commonly used `MultiInsertBuffers` survive flushing. 

The 51259b31c4c62b87228b059af0bbf28caa143eb3 commit changes the way the per-tuple context is used. Since this commit, more objects are stored in this context. The size of the context was used to set the tuple size to PG < 14. The extra objects in the context lead to wrong (very large) results and flushes almost after every tuple read.

The cache synchronization introduced in 296601b1d7aba7f23aea3d47c617e2d6df81de3e is reverted. With the current implementation, `MAX_PARTITION_BUFFERS` survive the flash. If `timescaledb.max_open_chunks_per_insert` is lower than `MAX_PARTITION_BUFFERS` , a buffer flush would be performed after each tuple read.

# Evaluation
The evaluation is performed using PG 14.

## 2.6.1 (Version Before Regression)
```
Report for benchmark suite 'copy'
+-------------------------------------------------------------------------------------------------------------------+----------+
| Query                                                                                                             | 9ae47c68 |
+-------------------------------------------------------------------------------------------------------------------+----------+
| TRUNCATE sensor_data;                                                                                             |    21.72 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_sensor_data.csv' WITH CSV HEADER /* initial copy */;          | 46357.29 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_sensor_data.csv' WITH CSV HEADER /* second copy */;           | 50986.47 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_time_data.csv' WITH CSV HEADER /* initial copy */;            | 44632.01 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_time_data.csv' WITH CSV HEADER /* second copy */;             | 51910.59 |
+-------------------------------------------------------------------------------------------------------------------+----------+
```

## 2.8.1 (Version With Regression)
```
Report for benchmark suite 'copy'
+-------------------------------------------------------------------------------------------------------------------+------------------------------------------+
| Query                                                                                                             | 65078486025a5cfdd00663f524831619066c5946 |
+-------------------------------------------------------------------------------------------------------------------+------------------------------------------+
| TRUNCATE sensor_data;                                                                                             |                                    23.90 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_sensor_data.csv' WITH CSV HEADER /* initial copy */;          |                                 47655.08 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_sensor_data.csv' WITH CSV HEADER /* second copy */;           |                                 52555.64 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_time_data.csv' WITH CSV HEADER /* initial copy */;            |                                 49493.31 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_time_data.csv' WITH CSV HEADER /* second copy */;             |                                 53489.15 |
+-------------------------------------------------------------------------------------------------------------------+------------------------------------------+
```

## PR Version
```
Report for benchmark suite 'copy'
+-------------------------------------------------------------------------------------------------------------------+------------------------------------------+
| Query                                                                                                             | d55df01a5c8b2875835cf56d8c63dd2fd1be3f8d |
+-------------------------------------------------------------------------------------------------------------------+------------------------------------------+
| TRUNCATE sensor_data;                                                                                             |                                    22.82 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_sensor_data.csv' WITH CSV HEADER /* initial copy */;          |                                 31970.58 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_sensor_data.csv' WITH CSV HEADER /* second copy */;           |                                 36304.62 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_time_data.csv' WITH CSV HEADER /* initial copy */;            |                                 30163.68 |
| COPY sensor_data FROM '%%WORK_DIR%%/copy_ordered_by_time_data.csv' WITH CSV HEADER /* second copy */;             |                                 34985.83 |
+-------------------------------------------------------------------------------------------------------------------+------------------------------------------+
```

### Evaluation (Configuration Parameters)

#### Input data sorted by sensor_data, time
![copy1](https://user-images.githubusercontent.com/5753622/196153215-4d0b3e14-b5c8-4807-bfa7-6a673fcd466a.svg)

#### Input data sorted by time, sensor_data
![copy2](https://user-images.githubusercontent.com/5753622/196153220-0a74621b-888c-4737-8d3e-98944b72dbac.svg)

**Note:** Only if the `timescaledb.max_cached_chunks_per_hypertable` and `timescaledb.max_open_chunks_per_insert` parameters are decreased together, the execution time increases significantly. If only one of the parameters is decreased, the chunks do not need to be closed or can be found in the chunk cache.