### PR TITLE
Adjust partition pruning to support PG15

### DIFF
--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1538,7 +1538,12 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 
 		/* if we're performing partitionwise aggregation, we must populate part_rels */
 		if (rel->part_rels != NULL)
+		{
 			rel->part_rels[i] = child_rel;
+#if PG15_GE
+			rel->live_parts = bms_add_member(rel->live_parts, i);
+#endif
+		}
 
 		ts_get_private_reloptinfo(child_rel)->chunk = chunks[i];
 		Assert(chunks[i]->table_id == root->simple_rte_array[child_rtindex]->relid);

--- a/test/src/test_utils.c
+++ b/test/src/test_utils.c
@@ -137,7 +137,7 @@ broken_sendrecv_throw()
 
 	if (throw_after_option)
 	{
-		throw_after = pg_atoi(throw_after_option, 4, 0);
+		throw_after = pg_strtoint32(throw_after_option);
 	}
 
 	/*


### PR DESCRIPTION
PostgreSQL 15 introduced a Bitmapset for tracking non-pruned partitions for performance purposes. Adjust our code for expanding hypertable chunks to support this.

https://github.com/postgres/postgres/commit/475dbd0b718