### PR TITLE
Bump github action versions

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: config
       run: python .github/gh_config_reader.py
@@ -70,7 +70,7 @@ jobs:
     steps:
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build extension
       run: |
@@ -114,14 +114,14 @@ jobs:
 
     - name: Save regression diffs
       if: always() && steps.collectlogs.outputs.regression_diff == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Regression diff ABI Breakage ${{ matrix.type }} PG${{ matrix.pg }}
         path: regression.log
 
     - name: Save postmaster.log
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: PostgreSQL log ABI Breakage ${{ matrix.type }} PG${{ matrix.pg }}
         path: postgres.log

--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -57,7 +57,7 @@ jobs:
           dpkg -L timescaledb-2-postgresql-${{ matrix.pg }}
         EOF
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Read versions
       id: versions

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -53,7 +53,7 @@ jobs:
       run: |
         dpkg -L timescaledb-2${{ matrix.pkg_suffix }}-postgresql-${{ matrix.pg }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Read versions
       id: versions

--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -19,7 +19,7 @@ jobs:
         sudo apt-get -y install coccinelle
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run coccinelle
       run: |
@@ -27,7 +27,7 @@ jobs:
 
     - name: Save coccinelle.diff
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: coccinelle.diff
         path: coccinelle.diff

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install prerequisites
         run: pip install cmakelang
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run format on CMake files
         run: |
           find  -name CMakeLists.txt  -exec cmake-format -i {} +
@@ -29,7 +29,7 @@ jobs:
       - name: Install prerequisites
         run: sudo apt install perltidy
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Format Perl files, if needed
         run: find . -name '*.p[lm]' -exec perltidy -b -bext=/ {} +
       - name: Check for diff
@@ -42,7 +42,7 @@ jobs:
     steps:
     - name: Checkout source
       if: always()
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Check license
       if: always()
       run: ./scripts/check_license_all.sh

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -13,7 +13,7 @@ jobs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: setter
       run: python .github/gh_config_reader.py
@@ -39,7 +39,7 @@ jobs:
     # workflow since that workflow runs daily there should always be a cache hit
     - name: Cache PostgreSQL ${{ matrix.pg }}
       id: cache-postgresql
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/${{ env.PG_SRC_DIR }}
         key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-gcc-Release
@@ -56,7 +56,7 @@ jobs:
         make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Coverity tools
       run: |

--- a/.github/workflows/cron-tests.yaml
+++ b/.github/workflows/cron-tests.yaml
@@ -13,7 +13,7 @@ jobs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: setter
       run: python .github/gh_config_reader.py
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Test recovery using restore points
       run: |

--- a/.github/workflows/homebrew.yaml
+++ b/.github/workflows/homebrew.yaml
@@ -37,7 +37,7 @@ jobs:
         brew services start postgresql
 
     # checkout code to get version information
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Test Installation
       run: |

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -14,7 +14,7 @@ jobs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: setter
       run: python .github/gh_config_reader.py
@@ -59,7 +59,7 @@ jobs:
         chown -R postgres:postgres ~/postgresql
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Build TimescaleDB
       run: |
@@ -107,21 +107,21 @@ jobs:
 
     - name: Save regression diffs
       if: always() && steps.collectlogs.outputs.regression_diff == 'true'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: Regression diff linux-i386 PG${{ matrix.pg }}
         path: regression.log
 
     - name: Save stacktraces
       if: always() && steps.coredumps.outputs.coredumps == 'true'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: Stacktraces linux-i386 PG${{ matrix.pg }}
         path: stacktraces.log
 
     - name: Save postmaster.log
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: PostgreSQL log linux-i386 PG${{ matrix.pg }}
         path: postgres.log

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build matrix
       id: set-matrix
       run: python .github/gh_matrix_builder.py ${{ github.event_name }}
@@ -64,7 +64,7 @@ jobs:
     - name: Cache PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }}
       id: cache-postgresql
       if: matrix.snapshot != 'snapshot'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/${{ env.PG_SRC_DIR }}
         key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ matrix.build_type }}${{ env.CACHE_SUFFIX }}
@@ -96,7 +96,7 @@ jobs:
         make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Test telemetry without OpenSSL
       if: github.event_name != 'pull_request' && runner.os == 'Linux' && matrix.build_type == 'Debug'

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build TimescaleDB
       run: |

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -27,12 +27,12 @@ jobs:
     steps:
 
     - name: Setup python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
     - name: Checkout timescaledb
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install pgspot
       run: |

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0

--- a/.github/workflows/pull-review.yaml
+++ b/.github/workflows/pull-review.yaml
@@ -6,7 +6,7 @@ jobs:
     name: Run pull-review
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run shell script
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout TimescaleDB
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -58,7 +58,7 @@ jobs:
       run: |
         rpm -ql timescaledb-2${{ matrix.pkg_suffix }}-postgresql-${{ matrix.pg }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Read versions
       id: versions

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -42,7 +42,7 @@ jobs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: setter
       run: python .github/gh_config_reader.py
@@ -68,13 +68,13 @@ jobs:
     # leading to a tainted cache
     - name: Cache PostgreSQL ${{ matrix.pg }}
       id: cache-postgresql
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/${{ env.PG_SRC_DIR }}
         key: ${{ matrix.os }}-${{ env.name }}-postgresql-${{ matrix.pg }}-${{ env.CC }}
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build PostgreSQL ${{ matrix.pg }} if not in cache
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
@@ -127,14 +127,14 @@ jobs:
 
     - name: Save regression diffs
       if: always() && steps.collectlogs.outputs.regression_diff == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Regression diff ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: regression.log
 
     - name: Save postmaster.log
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: PostgreSQL log ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: postgres.log
@@ -151,14 +151,14 @@ jobs:
 
     - name: Coredumps
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Coredumps ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: coredumps
 
     - name: sanitizer logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: sanitizer logs ${{ matrix.os }} ${{ env.name }} ${{ matrix.pg }}
         path: ${{ github.workspace }}/sanitizer.log.*

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -17,7 +17,7 @@ jobs:
         sudo apt-get install shellcheck
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -14,7 +14,7 @@ jobs:
       pg14_latest: ${{ steps.setter.outputs.PG14_LATEST }}
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: setter
       run: python .github/gh_config_reader.py
@@ -44,7 +44,7 @@ jobs:
     # workflow since that workflow runs daily there should always be a cache hit
     - name: Cache PostgreSQL ${{ matrix.pg }}
       id: cache-postgresql
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/${{ env.PG_SRC_DIR }}
         key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ matrix.build_type }}
@@ -61,7 +61,7 @@ jobs:
         make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
 
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build TimescaleDB
       run: |
@@ -70,7 +70,7 @@ jobs:
         make -C build install
 
     - name: Checkout sqlsmith
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: 'timescale/sqlsmith'
         path: 'sqlsmith'
@@ -122,7 +122,7 @@ jobs:
 
     - name: Upload Coredumps
       if: always() && steps.collectlogs.outputs.coredumps == 'true'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Coredumps sqlsmith ${{ matrix.os }} PG${{ matrix.pg }}
         path: coredumps

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -14,7 +14,7 @@ jobs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: setter
       run: python .github/gh_config_reader.py
@@ -32,7 +32,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: trust
     steps:
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Update tests ${{ matrix.pg }}
       run: |
@@ -46,7 +46,7 @@ jobs:
 
     - name: Upload Artifacts
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Extension update diff ${{ matrix.pg }}
         path: update_test.*.diff.*
@@ -65,7 +65,7 @@ jobs:
       GENERATE_DOWNGRADE_SCRIPT: ON
     steps:
     - name: Checkout TimescaleDB
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # We need the tags to be able to build a downgrade script.
     - name: Fetch all tags
@@ -88,7 +88,7 @@ jobs:
 
     - name: Upload Artifacts
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Extension downgrade diff ${{ matrix.pg }}
         path: downgrade_test.*.diff.*

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: config
       run: python .github/gh_config_reader.py
@@ -69,7 +69,7 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
     - name: Checkout TimescaleDB source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       # Use a cache for the PostgreSQL installation to speed things up
       # and avoid unnecessary package downloads. Since we only save
       # the directory containing the binaries, the runs with a cache
@@ -78,7 +78,7 @@ jobs:
       # --extract-only and launch our own test instance, which is
       # probably better anyway since it gives us more control.
     - name: Cache PostgreSQL installation
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       id: cache-postgresql
       with:
         path: ~\PostgreSQL\${{ matrix.pg }}

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Read configuration
       id: config
       run: python .github/gh_config_reader.py
@@ -62,7 +62,7 @@ jobs:
     steps:
 
     - name: Checkout TimescaleDB source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get version
       id: version


### PR DESCRIPTION
All github actions that run on Node12 are deprecated so bumped github action versions to run on Node16.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/