### PR TITLE
Add clang-tidy warning readability-suspicious-call-argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if(LINTER)
     message(STATUS "Linter support (clang-tidy) enabled")
     if(LINTER_STRICT)
       set(CMAKE_C_CLANG_TIDY
-          "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses;--warnings-as-errors=*"
+          "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses,readability-suspicious-call-argument;--warnings-as-errors=*"
       )
     else()
       set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if(LINTER)
     message(STATUS "Linter support (clang-tidy) enabled")
     if(LINTER_STRICT)
       set(CMAKE_C_CLANG_TIDY
-          "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses,readability-suspicious-call-argument;--warnings-as-errors=*"
+          "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses,readability-suspicious-call-argument,readability-misleading-indentation;--warnings-as-errors=*"
       )
     else()
       set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")

--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -793,7 +793,7 @@ bgw_job_tuple_update_by_id(TupleInfo *ti, void *const data)
 
 	Datum values[Natts_bgw_job] = { 0 };
 	bool isnull[Natts_bgw_job] = { 0 };
-	bool repl[Natts_bgw_job] = { 0 };
+	bool doReplace[Natts_bgw_job] = { 0 };
 
 	Datum old_schedule_interval =
 		slot_getattr(ti->slot, Anum_bgw_job_schedule_interval, &isnull[0]);
@@ -819,34 +819,34 @@ bgw_job_tuple_update_by_id(TupleInfo *ti, void *const data)
 		}
 		values[AttrNumberGetAttrOffset(Anum_bgw_job_schedule_interval)] =
 			IntervalPGetDatum(&updated_job->fd.schedule_interval);
-		repl[AttrNumberGetAttrOffset(Anum_bgw_job_schedule_interval)] = true;
+		doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_schedule_interval)] = true;
 	}
 
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_max_runtime)] =
 		IntervalPGetDatum(&updated_job->fd.max_runtime);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_max_runtime)] = true;
+	doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_max_runtime)] = true;
 
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_max_retries)] =
 		Int32GetDatum(updated_job->fd.max_retries);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_max_retries)] = true;
+	doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_max_retries)] = true;
 
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_retry_period)] =
 		IntervalPGetDatum(&updated_job->fd.retry_period);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_retry_period)] = true;
+	doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_retry_period)] = true;
 
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_scheduled)] =
 		BoolGetDatum(updated_job->fd.scheduled);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_scheduled)] = true;
+	doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_scheduled)] = true;
 
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_config)] = true;
+	doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_config)] = true;
 
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_check_schema)] =
 		NameGetDatum(&updated_job->fd.check_schema);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_check_schema)] = true;
+	doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_check_schema)] = true;
 
 	values[AttrNumberGetAttrOffset(Anum_bgw_job_check_name)] =
 		NameGetDatum(&updated_job->fd.check_name);
-	repl[AttrNumberGetAttrOffset(Anum_bgw_job_check_name)] = true;
+	doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_check_name)] = true;
 
 	if (strlen(NameStr(updated_job->fd.check_name)) == 0)
 	{
@@ -867,12 +867,12 @@ bgw_job_tuple_update_by_id(TupleInfo *ti, void *const data)
 	{
 		values[AttrNumberGetAttrOffset(Anum_bgw_job_hypertable_id)] =
 			Int32GetDatum(updated_job->fd.hypertable_id);
-		repl[AttrNumberGetAttrOffset(Anum_bgw_job_hypertable_id)] = true;
+		doReplace[AttrNumberGetAttrOffset(Anum_bgw_job_hypertable_id)] = true;
 	}
 	else
 		isnull[AttrNumberGetAttrOffset(Anum_bgw_job_hypertable_id)] = true;
 
-	new_tuple = heap_modify_tuple(tuple, ts_scanner_get_tupledesc(ti), values, isnull, repl);
+	new_tuple = heap_modify_tuple(tuple, ts_scanner_get_tupledesc(ti), values, isnull, doReplace);
 
 	ts_catalog_update(ti->scanrel, new_tuple);
 

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -957,7 +957,7 @@ ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name, const char
 	ts_scanner_foreach(&iterator)
 	{
 		bool nulls[Natts_chunk_index];
-		bool repl[Natts_chunk_index] = { false };
+		bool doReplace[Natts_chunk_index] = { false };
 		Datum values[Natts_chunk_index];
 		bool should_free;
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
@@ -968,11 +968,12 @@ ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name, const char
 
 		values[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_index_name)] =
 			CStringGetDatum(ht_index_name);
-		repl[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_index_name)] = true;
+		doReplace[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_index_name)] = true;
 		values[AttrNumberGetAttrOffset(Anum_chunk_index_index_name)] = CStringGetDatum(newname);
-		repl[AttrNumberGetAttrOffset(Anum_chunk_index_index_name)] = true;
+		doReplace[AttrNumberGetAttrOffset(Anum_chunk_index_index_name)] = true;
 
-		new_tuple = heap_modify_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls, repl);
+		new_tuple =
+			heap_modify_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls, doReplace);
 
 		ts_catalog_update(ti->scanrel, new_tuple);
 		heap_freetuple(new_tuple);

--- a/src/dimension_vector.c
+++ b/src/dimension_vector.c
@@ -23,7 +23,7 @@ cmp_slices_reverse(const void *left, const void *right)
 	const DimensionSlice *left_slice = *((DimensionSlice **) left);
 	const DimensionSlice *right_slice = *((DimensionSlice **) right);
 
-	return ts_dimension_slice_cmp(right_slice, left_slice);
+	return -ts_dimension_slice_cmp(left_slice, right_slice);
 }
 
 static int

--- a/src/ts_catalog/hypertable_compression.c
+++ b/src/ts_catalog/hypertable_compression.c
@@ -245,7 +245,7 @@ ts_hypertable_compression_rename_column(int32 htid, char *old_column_name, char 
 		{
 			Datum values[Natts_hypertable_compression];
 			bool isnulls[Natts_hypertable_compression];
-			bool repl[Natts_hypertable_compression] = { false };
+			bool doReplace[Natts_hypertable_compression] = { false };
 			bool should_free;
 			HeapTuple tuple, new_tuple;
 			TupleDesc tupdesc = ts_scanner_get_tupledesc(ti);
@@ -256,8 +256,8 @@ ts_hypertable_compression_rename_column(int32 htid, char *old_column_name, char 
 			namestrcpy(&name_new_column_name, new_column_name);
 			values[AttrNumberGetAttrOffset(Anum_hypertable_compression_attname)] =
 				NameGetDatum(&name_new_column_name);
-			repl[AttrNumberGetAttrOffset(Anum_hypertable_compression_attname)] = true;
-			new_tuple = heap_modify_tuple(tuple, tupdesc, values, isnulls, repl);
+			doReplace[AttrNumberGetAttrOffset(Anum_hypertable_compression_attname)] = true;
+			new_tuple = heap_modify_tuple(tuple, tupdesc, values, isnulls, doReplace);
 			ts_catalog_update(ti->scanrel, new_tuple);
 
 			if (should_free)

--- a/src/ts_catalog/metadata.c
+++ b/src/ts_catalog/metadata.c
@@ -132,7 +132,7 @@ ts_metadata_get_value(const char *metadata_key, Oid value_type, bool *isnull)
  *  the existing value if nothing was inserted.
  */
 Datum
-ts_metadata_insert(const char *metadata_key, Datum metadata_value, Oid value_type,
+ts_metadata_insert(const char *metadata_key, Datum metadata_value, Oid type,
 				   bool include_in_telemetry)
 {
 	Datum existing_value;
@@ -147,7 +147,7 @@ ts_metadata_insert(const char *metadata_key, Datum metadata_value, Oid value_typ
 
 	/* Check for row existence while we have the lock */
 	existing_value =
-		metadata_get_value_internal(metadata_key, value_type, &isnull, ShareRowExclusiveLock);
+		metadata_get_value_internal(metadata_key, type, &isnull, ShareRowExclusiveLock);
 
 	if (!isnull)
 	{
@@ -162,7 +162,7 @@ ts_metadata_insert(const char *metadata_key, Datum metadata_value, Oid value_typ
 	/* Insert into the catalog table for persistence */
 	values[AttrNumberGetAttrOffset(Anum_metadata_key)] = CStringGetDatum(key_data);
 	values[AttrNumberGetAttrOffset(Anum_metadata_value)] =
-		convert_type_to_text(metadata_value, value_type);
+		convert_type_to_text(metadata_value, type);
 	values[AttrNumberGetAttrOffset(Anum_metadata_include_in_telemetry)] =
 		BoolGetDatum(include_in_telemetry);
 

--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -41,7 +41,7 @@ update_materialized_only(ContinuousAgg *agg, bool materialized_only)
 		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
 		bool nulls[Natts_continuous_agg];
 		Datum values[Natts_continuous_agg];
-		bool repl[Natts_continuous_agg] = { false };
+		bool doReplace[Natts_continuous_agg] = { false };
 		bool should_free;
 		HeapTuple tuple = ts_scan_iterator_fetch_heap_tuple(&iterator, false, &should_free);
 		HeapTuple new_tuple;
@@ -49,11 +49,11 @@ update_materialized_only(ContinuousAgg *agg, bool materialized_only)
 
 		heap_deform_tuple(tuple, tupdesc, values, nulls);
 
-		repl[AttrNumberGetAttrOffset(Anum_continuous_agg_materialize_only)] = true;
+		doReplace[AttrNumberGetAttrOffset(Anum_continuous_agg_materialize_only)] = true;
 		values[AttrNumberGetAttrOffset(Anum_continuous_agg_materialize_only)] =
 			BoolGetDatum(materialized_only);
 
-		new_tuple = heap_modify_tuple(tuple, tupdesc, values, nulls, repl);
+		new_tuple = heap_modify_tuple(tuple, tupdesc, values, nulls, doReplace);
 
 		ts_catalog_update(ti->scanrel, new_tuple);
 		heap_freetuple(new_tuple);


### PR DESCRIPTION
Helps find accidentally swapped arguments, like in the recent epoll_ctl() error.

Disable-check: commit-count