### PR TITLE
Add clang-tidy warning readability-inconsistent-declaration-parameter…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if(LINTER)
     message(STATUS "Linter support (clang-tidy) enabled")
     if(LINTER_STRICT)
       set(CMAKE_C_CLANG_TIDY
-          "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses,readability-suspicious-call-argument,readability-misleading-indentation;--warnings-as-errors=*"
+          "${CLANG_TIDY};--checks=clang-diagnostic-*,clang-analyzer-*,-*,clang-analyzer-core.*,clang-diagnostic-*,readability-redundant-control-flow,bugprone-argument-comment,bugprone-macro-parentheses,readability-suspicious-call-argument,readability-misleading-indentation,readability-inconsistent-declaration-parameter-name;--warnings-as-errors=*"
       )
     else()
       set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY};--quiet")

--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -58,7 +58,7 @@ extern void ts_bgw_job_set_scheduler_test_hook(scheduler_test_hook_type hook);
 extern void ts_bgw_job_set_job_entrypoint_function_name(char *func_name);
 extern bool ts_bgw_job_run_and_set_next_start(BgwJob *job, job_main_func func, int64 initial_runs,
 											  Interval *next_interval);
-extern TSDLLEXPORT bool ts_job_errors_insert_tuple(const FormData_job_error *jerr);
+extern TSDLLEXPORT bool ts_job_errors_insert_tuple(const FormData_job_error *job_err);
 extern TSDLLEXPORT void ts_bgw_job_validate_schedule_interval(Interval *schedule_interval);
 extern TSDLLEXPORT char *ts_bgw_job_validate_timezone(Datum timezone);
 #endif /* BGW_JOB_H */

--- a/src/bgw/job_stat.h
+++ b/src/bgw/job_stat.h
@@ -40,7 +40,7 @@ extern TSDLLEXPORT void ts_bgw_job_stat_upsert_next_start(int32 bgw_job_id, Time
 extern bool ts_bgw_job_stat_should_execute(BgwJobStat *jobstat, BgwJob *job);
 
 extern TimestampTz ts_bgw_job_stat_next_start(BgwJobStat *jobstat, BgwJob *job,
-											  int32 consecutive_failed_starts);
+											  int32 consecutive_failed_launches);
 extern TSDLLEXPORT void ts_bgw_job_stat_mark_crash_reported(int32 bgw_job_id);
 
 #endif /* BGW_JOB_STAT_H */

--- a/src/bgw_policy/chunk_stats.h
+++ b/src/bgw_policy/chunk_stats.h
@@ -15,7 +15,7 @@ typedef struct BgwPolicyChunkStats
 	FormData_bgw_policy_chunk_stats fd;
 } BgwPolicyChunkStats;
 
-extern TSDLLEXPORT void ts_bgw_policy_chunk_stats_insert(BgwPolicyChunkStats *stat);
+extern TSDLLEXPORT void ts_bgw_policy_chunk_stats_insert(BgwPolicyChunkStats *chunk_stats);
 extern BgwPolicyChunkStats *ts_bgw_policy_chunk_stats_find(int32 job_id, int32 chunk_id);
 extern void ts_bgw_policy_chunk_stats_delete_row_only_by_job_id(int32 job_id);
 extern void ts_bgw_policy_chunk_stats_delete_by_chunk_id(int32 chunk_id);

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -36,9 +36,9 @@ typedef struct Hypercube Hypercube;
 typedef struct ChunkScanCtx ChunkScanCtx;
 
 extern TSDLLEXPORT ChunkConstraints *ts_chunk_constraints_alloc(int size_hint, MemoryContext mctx);
-extern ChunkConstraints *ts_chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size count_hint,
-															  MemoryContext mctx);
-extern ChunkConstraints *ts_chunk_constraints_copy(ChunkConstraints *constraints);
+extern ChunkConstraints *
+ts_chunk_constraint_scan_by_chunk_id(int32 chunk_id, Size num_constraints_hint, MemoryContext mctx);
+extern ChunkConstraints *ts_chunk_constraints_copy(ChunkConstraints *chunk_constraints);
 extern int ts_chunk_constraint_scan_by_dimension_slice(const DimensionSlice *slice,
 													   ChunkScanCtx *ctx, MemoryContext mctx);
 extern int ts_chunk_constraint_scan_by_dimension_slice_to_list(const DimensionSlice *slice,
@@ -73,10 +73,10 @@ extern int ts_chunk_constraint_delete_by_constraint_name(int32 chunk_id,
 														 bool delete_metadata,
 														 bool drop_constraint);
 extern void ts_chunk_constraint_recreate(const ChunkConstraint *cc, Oid chunk_oid);
-extern int ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname,
-															const char *newname);
+extern int ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *old_name,
+															const char *new_name);
 extern int ts_chunk_constraint_adjust_meta(int32 chunk_id, const char *ht_constraint_name,
-										   const char *oldname, const char *newname);
+										   const char *old_name, const char *new_name);
 
 extern char *
 ts_chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid,

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -945,14 +945,14 @@ init_scan_by_chunk_id_index_name(ScanIterator *iterator, int32 chunk_id, const c
  * Adjust internal metadata after index/constraint rename
  */
 int
-ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name, const char *oldname,
-						   const char *newname)
+ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name, const char *old_name,
+						   const char *new_name)
 {
 	ScanIterator iterator =
 		ts_scan_iterator_create(CHUNK_INDEX, RowExclusiveLock, CurrentMemoryContext);
 	int count = 0;
 
-	init_scan_by_chunk_id_index_name(&iterator, chunk_id, oldname);
+	init_scan_by_chunk_id_index_name(&iterator, chunk_id, old_name);
 
 	ts_scanner_foreach(&iterator)
 	{
@@ -969,7 +969,7 @@ ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name, const char
 		values[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_index_name)] =
 			CStringGetDatum(ht_index_name);
 		doReplace[AttrNumberGetAttrOffset(Anum_chunk_index_hypertable_index_name)] = true;
-		values[AttrNumberGetAttrOffset(Anum_chunk_index_index_name)] = CStringGetDatum(newname);
+		values[AttrNumberGetAttrOffset(Anum_chunk_index_index_name)] = CStringGetDatum(new_name);
 		doReplace[AttrNumberGetAttrOffset(Anum_chunk_index_index_name)] = true;
 
 		new_tuple =
@@ -987,13 +987,13 @@ ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name, const char
 }
 
 int
-ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname)
+ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *new_name)
 {
 	ScanKeyData scankey[2];
 	const char *indexname = get_rel_name(chunk_indexrelid);
 	ChunkIndexRenameInfo renameinfo = {
 		.oldname = indexname,
-		.newname = newname,
+		.newname = new_name,
 	};
 
 	ScanKeyInit(&scankey[0],
@@ -1016,13 +1016,13 @@ ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname)
 }
 
 int
-ts_chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *newname)
+ts_chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid, const char *new_name)
 {
 	ScanKeyData scankey[2];
 	const char *indexname = get_rel_name(hypertable_indexrelid);
 	ChunkIndexRenameInfo renameinfo = {
 		.oldname = indexname,
-		.newname = newname,
+		.newname = new_name,
 		.isparent = true,
 	};
 

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -41,9 +41,9 @@ extern int ts_chunk_index_delete(int32 chunk_id, const char *indexname, bool dro
 extern int ts_chunk_index_delete_by_chunk_id(int32 chunk_id, bool drop_index);
 extern void ts_chunk_index_delete_by_name(const char *schema, const char *index_name,
 										  bool drop_index);
-extern int ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *newname);
+extern int ts_chunk_index_rename(Chunk *chunk, Oid chunk_indexrelid, const char *new_name);
 extern int ts_chunk_index_rename_parent(Hypertable *ht, Oid hypertable_indexrelid,
-										const char *newname);
+										const char *new_name);
 extern int ts_chunk_index_adjust_meta(int32 chunk_id, const char *ht_index_name,
 									  const char *old_name, const char *new_name);
 extern int ts_chunk_index_set_tablespace(Hypertable *ht, Oid hypertable_indexrelid,

--- a/src/chunk_scan.h
+++ b/src/chunk_scan.h
@@ -11,6 +11,6 @@
 #include "hypertable.h"
 
 extern Chunk **ts_chunk_scan_by_chunk_ids(const Hyperspace *hs, const List *chunk_ids,
-										  unsigned int *numchunks);
+										  unsigned int *num_chunks);
 
 #endif /* TIMESCALEDB_CHUNK_SCAN_H */

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -140,7 +140,7 @@ extern TSDLLEXPORT DimensionInfo *ts_dimension_info_create_closed(Oid table_reli
 
 extern void ts_dimension_info_validate(DimensionInfo *info);
 extern int32 ts_dimension_add_from_info(DimensionInfo *info);
-extern void ts_dimensions_rename_schema_name(const char *oldname, const char *newname);
+extern void ts_dimensions_rename_schema_name(const char *old_name, const char *new_name);
 extern TSDLLEXPORT void ts_dimension_update(const Hypertable *ht, const NameData *dimname,
 											DimensionType dimtype, Datum *interval,
 											Oid *intervaltype, int16 *num_slices,

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -45,7 +45,8 @@ typedef struct Hypercube Hypercube;
 extern DimensionVec *ts_dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit,
 												   const ScanTupLock *tuplock);
 
-extern void ts_dimension_slice_scan_list(int32 dimension_id, int64 coordinate, List **dest);
+extern void ts_dimension_slice_scan_list(int32 dimension_id, int64 coordinate,
+										 List **matching_dimension_slices);
 
 extern DimensionVec *
 ts_dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy,

--- a/src/jsonb_utils.h
+++ b/src/jsonb_utils.h
@@ -17,7 +17,7 @@ extern TSDLLEXPORT void ts_jsonb_add_bool(JsonbParseState *state, const char *ke
 extern TSDLLEXPORT void ts_jsonb_add_str(JsonbParseState *state, const char *key,
 										 const char *value);
 extern TSDLLEXPORT void ts_jsonb_add_interval(JsonbParseState *state, const char *key,
-											  Interval *value);
+											  Interval *interval);
 extern TSDLLEXPORT void ts_jsonb_add_int32(JsonbParseState *state, const char *key,
 										   const int32 value);
 extern TSDLLEXPORT void ts_jsonb_add_int64(JsonbParseState *state, const char *key,

--- a/src/nodes/chunk_append/exec.c
+++ b/src/nodes/chunk_append/exec.c
@@ -119,7 +119,7 @@ static void choose_next_subplan_non_parallel(ChunkAppendState *state);
 static void choose_next_subplan_for_worker(ChunkAppendState *state);
 
 static List *constify_restrictinfos(PlannerInfo *root, List *restrictinfos);
-static bool can_exclude_chunk(List *constraints, List *restrictinfos);
+static bool can_exclude_chunk(List *constraints, List *baserestrictinfo);
 static void do_startup_exclusion(ChunkAppendState *state);
 static Node *constify_param_mutator(Node *node, void *context);
 static List *constify_restrictinfo_params(PlannerInfo *root, EState *state, List *restrictinfos);

--- a/src/nodes/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch.c
@@ -95,9 +95,9 @@ ts_chunk_dispatch_get_cmd_type(const ChunkDispatch *dispatch)
 }
 
 void
-ts_chunk_dispatch_destroy(ChunkDispatch *cd)
+ts_chunk_dispatch_destroy(ChunkDispatch *chunk_dispatch)
 {
-	ts_subspace_store_free(cd->cache);
+	ts_subspace_store_free(chunk_dispatch->cache);
 }
 
 static void

--- a/src/nodes/chunk_dispatch.h
+++ b/src/nodes/chunk_dispatch.h
@@ -45,7 +45,7 @@ typedef struct Point Point;
 typedef void (*on_chunk_changed_func)(ChunkInsertState *state, void *data);
 
 extern ChunkDispatch *ts_chunk_dispatch_create(Hypertable *ht, EState *estate, int eflags);
-extern void ts_chunk_dispatch_destroy(ChunkDispatch *dispatch);
+extern void ts_chunk_dispatch_destroy(ChunkDispatch *chunk_dispatch);
 extern ChunkInsertState *
 ts_chunk_dispatch_get_chunk_insert_state(ChunkDispatch *dispatch, Point *p,
 										 const on_chunk_changed_func on_chunk_changed, void *data);

--- a/src/nodes/chunk_dispatch_state.h
+++ b/src/nodes/chunk_dispatch_state.h
@@ -38,7 +38,8 @@ typedef struct ChunkDispatchState
 } ChunkDispatchState;
 
 extern TSDLLEXPORT bool ts_is_chunk_dispatch_state(PlanState *state);
-extern ChunkDispatchState *ts_chunk_dispatch_state_create(Oid hypertable_oid, Plan *plan);
-extern void ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state, ModifyTableState *parent);
+extern ChunkDispatchState *ts_chunk_dispatch_state_create(Oid hypertable_relid, Plan *plan);
+extern void ts_chunk_dispatch_state_set_parent(ChunkDispatchState *state,
+											   ModifyTableState *mtstate);
 
 #endif /* TIMESCALEDB_CHUNK_DISPATCH_STATE_H */

--- a/src/planner/agg_bookend.c
+++ b/src/planner/agg_bookend.c
@@ -77,8 +77,8 @@ typedef struct MutatorContext
 } MutatorContext;
 
 static bool find_first_last_aggs_walker(Node *node, List **context);
-static bool build_first_last_path(PlannerInfo *root, FirstLastAggInfo *flinfo, Oid eqop, Oid sortop,
-								  bool nulls_first);
+static bool build_first_last_path(PlannerInfo *root, FirstLastAggInfo *fl_info, Oid eqop,
+								  Oid sortop, bool nulls_first);
 static void first_last_qp_callback(PlannerInfo *root, void *extra);
 static Node *mutate_aggref_node(Node *node, MutatorContext *context);
 static void replace_aggref_in_tlist(MinMaxAggPath *minmaxagg_path);

--- a/src/subspace_store.h
+++ b/src/subspace_store.h
@@ -23,14 +23,14 @@ extern SubspaceStore *ts_subspace_store_init(const Hyperspace *space, MemoryCont
 											 int16 max_items);
 
 /* Store an object associate with the subspace represented by a hypercube */
-extern void ts_subspace_store_add(SubspaceStore *cache, const Hypercube *hc, void *object,
-								  void (*object_free)(void *));
+extern void ts_subspace_store_add(SubspaceStore *subspace_store, const Hypercube *hypercube,
+								  void *object, void (*object_free)(void *));
 
 /* Get the object stored for the subspace that a point is in.
  * Return the object stored or NULL if this subspace is not in the store.
  */
-extern void *ts_subspace_store_get(const SubspaceStore *cache, const Point *target);
-extern void ts_subspace_store_free(SubspaceStore *cache);
-extern MemoryContext ts_subspace_store_mcxt(const SubspaceStore *cache);
+extern void *ts_subspace_store_get(const SubspaceStore *subspace_store, const Point *target);
+extern void ts_subspace_store_free(SubspaceStore *subspace_store);
+extern MemoryContext ts_subspace_store_mcxt(const SubspaceStore *subspace_store);
 
 #endif /* TIMESCALEDB_SUBSPACE_STORE_H */

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -171,7 +171,7 @@ TSDLLEXPORT void ts_create_arrays_from_caggs_info(const CaggsInfo *all_caggs,
 extern TSDLLEXPORT ContinuousAgg *
 ts_continuous_agg_find_by_mat_hypertable_id(int32 mat_hypertable_id);
 
-extern TSDLLEXPORT void ts_materialization_invalidation_log_delete_inner(int32 materialization_id);
+extern TSDLLEXPORT void ts_materialization_invalidation_log_delete_inner(int32 mat_hypertable_id);
 
 extern TSDLLEXPORT ContinuousAggHypertableStatus
 ts_continuous_agg_hypertable_status(int32 hypertable_id);

--- a/src/ts_catalog/tablespace.c
+++ b/src/ts_catalog/tablespace.c
@@ -40,18 +40,19 @@ tablespaces_alloc(int capacity)
 }
 
 Tablespace *
-ts_tablespaces_add(Tablespaces *tspcs, const FormData_tablespace *form, Oid tspc_oid)
+ts_tablespaces_add(Tablespaces *tablespaces, const FormData_tablespace *form, Oid tspc_oid)
 {
 	Tablespace *tspc;
 
-	if (tspcs->num_tablespaces >= tspcs->capacity)
+	if (tablespaces->num_tablespaces >= tablespaces->capacity)
 	{
-		tspcs->capacity += TABLESPACE_DEFAULT_CAPACITY;
-		Assert(tspcs->tablespaces); /* repalloc() does not work with NULL argument */
-		tspcs->tablespaces = repalloc(tspcs->tablespaces, sizeof(Tablespace) * tspcs->capacity);
+		tablespaces->capacity += TABLESPACE_DEFAULT_CAPACITY;
+		Assert(tablespaces->tablespaces); /* repalloc() does not work with NULL argument */
+		tablespaces->tablespaces =
+			repalloc(tablespaces->tablespaces, sizeof(Tablespace) * tablespaces->capacity);
 	}
 
-	tspc = &tspcs->tablespaces[tspcs->num_tablespaces++];
+	tspc = &tablespaces->tablespaces[tablespaces->num_tablespaces++];
 	memcpy(&tspc->fd, form, sizeof(FormData_tablespace));
 	tspc->tablespace_oid = tspc_oid;
 
@@ -59,12 +60,12 @@ ts_tablespaces_add(Tablespaces *tspcs, const FormData_tablespace *form, Oid tspc
 }
 
 bool
-ts_tablespaces_contain(const Tablespaces *tspcs, Oid tspc_oid)
+ts_tablespaces_contain(const Tablespaces *tablespaces, Oid tspc_oid)
 {
 	int i;
 
-	for (i = 0; i < tspcs->num_tablespaces; i++)
-		if (tspc_oid == tspcs->tablespaces[i].tablespace_oid)
+	for (i = 0; i < tablespaces->num_tablespaces; i++)
+		if (tspc_oid == tablespaces->tablespaces[i].tablespace_oid)
 			return true;
 
 	return false;

--- a/src/ts_catalog/tablespace.h
+++ b/src/ts_catalog/tablespace.h
@@ -26,7 +26,7 @@ typedef struct Tablespaces
 
 extern Tablespace *ts_tablespaces_add(Tablespaces *tablespaces, const FormData_tablespace *form,
 									  Oid tspc_oid);
-extern bool ts_tablespaces_contain(const Tablespaces *tspcs, Oid tspc_oid);
+extern bool ts_tablespaces_contain(const Tablespaces *tablespaces, Oid tspc_oid);
 extern Tablespaces *ts_tablespace_scan(int32 hypertable_id);
 extern TSDLLEXPORT void ts_tablespace_attach_internal(Name tspcname, Oid hypertable_oid,
 													  bool if_not_attached);

--- a/test/src/net/conn_mock.h
+++ b/test/src/net/conn_mock.h
@@ -10,6 +10,6 @@
 
 typedef struct Connection Connection;
 
-extern ssize_t ts_connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buflen);
+extern ssize_t ts_connection_mock_set_recv_buf(Connection *conn, char *buf, size_t buf_len);
 
 #endif /* TIMESCALEDB_CONN_MOCK_H */

--- a/tsl/src/bgw_policy/policy_utils.h
+++ b/tsl/src/bgw_policy/policy_utils.h
@@ -13,7 +13,7 @@ bool policy_config_check_hypertable_lag_equality(Jsonb *config, const char *json
 												 Oid dim_type, Oid lag_type, Datum lag_datum);
 int64 subtract_integer_from_now_internal(int64 interval, Oid time_dim_type, Oid now_func,
 										 bool *overflow);
-Datum subtract_interval_from_now(Interval *interval, Oid time_dim_type);
+Datum subtract_interval_from_now(Interval *lag, Oid time_dim_type);
 const Dimension *get_open_dimension_for_hypertable(const Hypertable *ht);
 bool policy_get_verbose_log(const Jsonb *config);
 #endif /* TIMESCALEDB_TSL_BGW_POLICY_UTILS_H */

--- a/tsl/src/chunk_api.h
+++ b/tsl/src/chunk_api.h
@@ -20,7 +20,7 @@ extern void chunk_api_create_on_data_nodes(const Chunk *chunk, const Hypertable 
 										   const char *remote_chunk_name, List *data_nodes);
 extern Datum chunk_api_get_chunk_relstats(PG_FUNCTION_ARGS);
 extern Datum chunk_api_get_chunk_colstats(PG_FUNCTION_ARGS);
-extern void chunk_api_update_distributed_hypertable_stats(Oid relid);
+extern void chunk_api_update_distributed_hypertable_stats(Oid table_id);
 extern Datum chunk_create_empty_table(PG_FUNCTION_ARGS);
 extern void chunk_api_call_create_empty_chunk_table(const Hypertable *ht, const Chunk *chunk,
 													const char *node_name);

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -156,7 +156,7 @@ static Tuplesortstate *compress_chunk_sort_relation(Relation in_rel, int n_keys,
 static void row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_desc,
 								Relation compressed_table, int num_compression_infos,
 								const ColumnCompressionInfo **column_compression_info,
-								int16 *column_offsets, int16 num_compressed_columns,
+								int16 *column_offsets, int16 num_columns_in_compressed_table,
 								bool need_bistate);
 static void row_compressor_append_sorted_rows(RowCompressor *row_compressor,
 											  Tuplesortstate *sorted_rel, TupleDesc sorted_desc);

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -145,7 +145,7 @@ pg_attribute_unused() assert_num_compression_algorithms_sane(void)
 extern CompressionStorage compression_get_toast_storage(CompressionAlgorithms algo);
 extern CompressionStats compress_chunk(Oid in_table, Oid out_table,
 									   const ColumnCompressionInfo **column_compression_info,
-									   int num_columns);
+									   int num_compression_infos);
 extern void decompress_chunk(Oid in_table, Oid out_table);
 
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(

--- a/tsl/src/compression/create.h
+++ b/tsl/src/compression/create.h
@@ -21,7 +21,7 @@ bool tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 void tsl_process_compress_table_add_column(Hypertable *ht, ColumnDef *orig_def);
 void tsl_process_compress_table_drop_column(Hypertable *ht, char *name);
 void tsl_process_compress_table_rename_column(Hypertable *ht, const RenameStmt *stmt);
-Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_oid);
+Chunk *create_compress_chunk(Hypertable *compress_ht, Chunk *src_chunk, Oid table_id);
 
 char *compression_column_segment_min_name(const FormData_hypertable_compression *fd);
 char *compression_column_segment_max_name(const FormData_hypertable_compression *fd);

--- a/tsl/src/compression/datum_serialize.h
+++ b/tsl/src/compression/datum_serialize.h
@@ -28,23 +28,23 @@ BinaryStringEncoding datum_serializer_binary_string_encoding(DatumSerializer *se
 /* serialize to bytes in memory. */
 Size datum_get_bytes_size(DatumSerializer *serializer, Size start_offset, Datum val);
 char *datum_to_bytes_and_advance(DatumSerializer *serializer, char *start, Size *max_size,
-								 Datum val);
+								 Datum datum);
 
 /* serialize to a binary string (for send functions) */
-void type_append_to_binary_string(Oid type_oid, StringInfo data);
+void type_append_to_binary_string(Oid type_oid, StringInfo buffer);
 void datum_append_to_binary_string(DatumSerializer *serializer, BinaryStringEncoding encoding,
-								   StringInfo data, Datum datum);
+								   StringInfo buffer, Datum datum);
 
 /* DESERIALIZATION */
 typedef struct DatumDeserializer DatumDeserializer;
 DatumDeserializer *create_datum_deserializer(Oid type);
 
 /* deserialization from bytes in memory */
-Datum bytes_to_datum_and_advance(DatumDeserializer *deserializer, const char **bytes);
+Datum bytes_to_datum_and_advance(DatumDeserializer *deserializer, const char **ptr);
 
 /* deserialization from binary strings (for recv functions) */
 Datum binary_string_to_datum(DatumDeserializer *deserializer, BinaryStringEncoding encoding,
-							 StringInfo data);
-Oid binary_string_get_type(StringInfo data);
+							 StringInfo buffer);
+Oid binary_string_get_type(StringInfo buffer);
 
 #endif

--- a/tsl/src/compression/dictionary.h
+++ b/tsl/src/compression/dictionary.h
@@ -31,13 +31,13 @@ extern void *dictionary_compressor_finish(DictionaryCompressor *compressor);
 
 extern DecompressionIterator *
 tsl_dictionary_decompression_iterator_from_datum_forward(Datum dictionary_compressed,
-														 Oid element_oid);
+														 Oid element_type);
 extern DecompressResult
 dictionary_decompression_iterator_try_next_forward(DecompressionIterator *iter);
 
 extern DecompressionIterator *
 tsl_dictionary_decompression_iterator_from_datum_reverse(Datum dictionary_compressed,
-														 Oid element_oid);
+														 Oid element_type);
 extern DecompressResult
 dictionary_decompression_iterator_try_next_reverse(DecompressionIterator *iter);
 

--- a/tsl/src/compression/gorilla.h
+++ b/tsl/src/compression/gorilla.h
@@ -79,7 +79,7 @@ extern void gorilla_compressor_append_value(GorillaCompressor *compressor, uint6
 extern void *gorilla_compressor_finish(GorillaCompressor *compressor);
 
 extern DecompressionIterator *
-gorilla_decompression_iterator_from_datum_forward(Datum dictionary_compressed, Oid element_type);
+gorilla_decompression_iterator_from_datum_forward(Datum gorilla_compressed, Oid element_type);
 extern DecompressResult
 gorilla_decompression_iterator_try_next_forward(DecompressionIterator *iter);
 
@@ -88,7 +88,7 @@ gorilla_decompression_iterator_from_datum_reverse(Datum gorilla_compressed, Oid 
 extern DecompressResult
 gorilla_decompression_iterator_try_next_reverse(DecompressionIterator *iter);
 
-extern void gorilla_compressed_send(CompressedDataHeader *compressed, StringInfo buffer);
+extern void gorilla_compressed_send(CompressedDataHeader *header, StringInfo buffer);
 extern Datum gorilla_compressed_recv(StringInfo buf);
 
 extern Datum tsl_gorilla_compressor_append(PG_FUNCTION_ARGS);

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -200,7 +200,7 @@ static int32 mattablecolumninfo_create_materialization_table(
 	MatTableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
 	CAggTimebucketInfo *origquery_tblinfo, bool create_addl_index, char *tablespacename,
 	char *table_access_method, ObjectAddress *mataddress);
-static Query *mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *matcolinfo,
+static Query *mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *mattblinfo,
 														  Query *userview_query, bool finalized);
 
 static void caggtimebucketinfo_init(CAggTimebucketInfo *src, int32 hypertable_id,

--- a/tsl/src/continuous_aggs/create.h
+++ b/tsl/src/continuous_aggs/create.h
@@ -13,7 +13,7 @@
 
 #define CONTINUOUS_AGG_CHUNK_ID_COL_NAME "chunk_id"
 
-DDLResult tsl_process_continuous_agg_viewstmt(Node *stmt, const char *query_string, void *pstmt,
+DDLResult tsl_process_continuous_agg_viewstmt(Node *node, const char *query_string, void *pstmt,
 											  WithClauseResult *with_clause_options);
 
 extern void cagg_flip_realtime_view_definition(ContinuousAgg *agg, Hypertable *mat_ht);

--- a/tsl/src/deparse.h
+++ b/tsl/src/deparse.h
@@ -48,7 +48,7 @@ const char *deparse_get_tabledef_commands_concat(Oid relid);
 
 DeparsedHypertableCommands *deparse_get_distributed_hypertable_create_command(Hypertable *ht);
 
-const char *deparse_func_call(FunctionCallInfo finfo);
+const char *deparse_func_call(FunctionCallInfo fcinfo);
 const char *deparse_oid_function_call_coll(Oid funcid, Oid collation, unsigned int num_args, ...);
 const char *deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname);
 const char *deparse_create_trigger(CreateTrigStmt *stmt);

--- a/tsl/src/dist_util.c
+++ b/tsl/src/dist_util.c
@@ -31,7 +31,7 @@ static Datum dist_util_remote_srf_query(FunctionCallInfo fcinfo, const char *nod
 /* UUID associated with remote connection */
 static pg_uuid_t *peer_dist_id = NULL;
 
-static bool dist_util_set_id_with_uuid_check(Datum dist_uuid, bool check_uuid);
+static bool dist_util_set_id_with_uuid_check(Datum dist_id, bool check_uuid);
 
 /* Requires non-null arguments */
 static bool

--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -200,7 +200,7 @@ static void deparseReturningList(StringInfo buf, RangeTblEntry *rte, Index rtind
 static void deparseColumnRef(StringInfo buf, int varno, int varattno, RangeTblEntry *rte,
 							 bool qualify_col);
 static void deparseRelation(StringInfo buf, Relation rel);
-static void deparseExpr(Expr *expr, deparse_expr_cxt *context);
+static void deparseExpr(Expr *node, deparse_expr_cxt *context);
 static void deparseVar(Var *node, deparse_expr_cxt *context);
 static void deparseConst(Const *node, deparse_expr_cxt *context, int showtype);
 static void deparseParam(Param *node, deparse_expr_cxt *context);

--- a/tsl/src/fdw/deparse.h
+++ b/tsl/src/fdw/deparse.h
@@ -49,7 +49,7 @@ extern List *build_tlist_to_deparse(RelOptInfo *foreignrel);
 extern void deparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel, List *tlist,
 									List *remote_where, List *remote_having, List *pathkeys,
 									bool is_subquery, List **retrieved_attrs, List **params_list,
-									DataNodeChunkAssignment *swa);
+									DataNodeChunkAssignment *sca);
 
 extern const char *get_jointype_name(JoinType jointype);
 extern void deparseStringLiteral(StringInfo buf, const char *val);

--- a/tsl/src/fdw/option.h
+++ b/tsl/src/fdw/option.h
@@ -9,7 +9,7 @@
 #include <postgres.h>
 
 extern void option_validate(List *options_list, Oid catalog);
-extern List *option_extract_extension_list(const char *extensionsString, bool warn_on_missing);
+extern List *option_extract_extension_list(const char *extensions_string, bool warn_on_missing);
 extern bool option_get_from_options_list_int(List *options, const char *optionname, int *value);
 
 #endif /* TIMESCALEDB_TSL_FDW_OPTION_H */

--- a/tsl/src/nodes/async_append.h
+++ b/tsl/src/nodes/async_append.h
@@ -32,6 +32,6 @@ typedef struct AsyncScanState
 	void (*fetch_data)(struct AsyncScanState *state);
 } AsyncScanState;
 
-extern void async_append_add_paths(PlannerInfo *root, RelOptInfo *hyper_rel);
+extern void async_append_add_paths(PlannerInfo *root, RelOptInfo *final_rel);
 
 #endif

--- a/tsl/src/remote/async.h
+++ b/tsl/src/remote/async.h
@@ -92,7 +92,7 @@ extern AsyncRequest *async_request_send_with_stmt_params_elevel_res_format(
 extern AsyncRequest *async_request_send_prepare(TSConnection *conn, const char *sql_statement,
 												int n_params);
 extern AsyncRequest *async_request_send_prepared_stmt(PreparedStmt *stmt,
-													  const char *const *paramValues);
+													  const char *const *param_values);
 extern AsyncRequest *async_request_send_prepared_stmt_with_params(PreparedStmt *stmt,
 																  StmtParams *params,
 																  int res_format);
@@ -107,7 +107,7 @@ extern AsyncResponseResult *async_request_wait_any_result(AsyncRequest *request)
 extern AsyncResponse *async_request_cleanup_result(AsyncRequest *req, TimestampTz endtime);
 
 /* Returns on successful commands, throwing errors otherwise */
-extern void async_request_wait_ok_command(AsyncRequest *set);
+extern void async_request_wait_ok_command(AsyncRequest *req);
 extern PreparedStmt *async_request_wait_prepared_statement(AsyncRequest *request);
 
 /* Async Response */

--- a/tsl/src/remote/dist_commands.h
+++ b/tsl/src/remote/dist_commands.h
@@ -22,7 +22,7 @@ typedef struct DistCmdDescr
 extern DistCmdResult *ts_dist_multi_cmds_params_invoke_on_data_nodes(List *cmd_descriptors,
 																	 List *data_nodes,
 																	 bool transactional);
-extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes(const char *sql, List *node_names,
+extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes(const char *sql, List *data_nodes,
 													   bool transactional);
 extern DistCmdResult *ts_dist_cmd_params_invoke_on_data_nodes(const char *sql, StmtParams *params,
 															  List *data_nodes, bool transactional);

--- a/tsl/src/remote/txn.h
+++ b/tsl/src/remote/txn.h
@@ -24,7 +24,7 @@ typedef enum
 /* actions */
 extern void remote_txn_init(RemoteTxn *entry, TSConnection *conn);
 extern RemoteTxn *remote_txn_begin_on_connection(TSConnection *conn);
-extern void remote_txn_begin(RemoteTxn *entry, int txnlevel);
+extern void remote_txn_begin(RemoteTxn *entry, int curlevel);
 extern bool remote_txn_abort(RemoteTxn *entry);
 extern void remote_txn_write_persistent_record(RemoteTxn *entry);
 extern void remote_txn_deallocate_prepared_stmts_if_needed(RemoteTxn *entry);
@@ -49,7 +49,7 @@ extern void remote_txn_report_prepare_transaction_result(RemoteTxn *txn, bool su
 
 /* Persitent record */
 extern RemoteTxnId *remote_txn_persistent_record_write(TSConnectionId id);
-extern bool remote_txn_persistent_record_exists(const RemoteTxnId *gid);
+extern bool remote_txn_persistent_record_exists(const RemoteTxnId *parsed);
 extern int remote_txn_persistent_record_delete_for_data_node(Oid foreign_server_oid,
 															 const char *gid);
 


### PR DESCRIPTION
…-name

Mostly cosmetic stuff. Matched to definition automatically with --fix-notes.