### PR TITLE
Bump codecov github action version

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -130,7 +130,7 @@ jobs:
 
     - name: Upload coverage report
       if: matrix.coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./build/codecov/timescaledb-codecov.info
 


### PR DESCRIPTION
Leftover from previous commit 8950ab where we bumped some github action versions to run on Node16 instead of Node12 (in deprecation).