### PR TITLE
Chunk exclusion by time_bucket with timezone

### DIFF
--- a/test/expected/plan_expand_hypertable-12.out
+++ b/test/expected/plan_expand_hypertable-12.out
@@ -1353,6 +1353,52 @@ time_bucket exclusion with timestamptz
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
 (8 rows)
 
+\qecho time_bucket exclusion with timestamptz and timezone
+time_bucket exclusion with timestamptz and timezone
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') < '2000-01-03' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
+\qecho time_bucket exclusion with timestamptz, timezone and offset
+time_bucket exclusion with timestamptz, timezone and offset
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') < '2000-01-03' ORDER BY time;
+                                                                                      QUERY PLAN                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
 \qecho time_bucket exclusion with timestamptz and day interval
 time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;

--- a/test/expected/plan_expand_hypertable-13.out
+++ b/test/expected/plan_expand_hypertable-13.out
@@ -1353,6 +1353,52 @@ time_bucket exclusion with timestamptz
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
 (8 rows)
 
+\qecho time_bucket exclusion with timestamptz and timezone
+time_bucket exclusion with timestamptz and timezone
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') < '2000-01-03' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
+\qecho time_bucket exclusion with timestamptz, timezone and offset
+time_bucket exclusion with timestamptz, timezone and offset
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') < '2000-01-03' ORDER BY time;
+                                                                                      QUERY PLAN                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
 \qecho time_bucket exclusion with timestamptz and day interval
 time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;

--- a/test/expected/plan_expand_hypertable-14.out
+++ b/test/expected/plan_expand_hypertable-14.out
@@ -1353,6 +1353,52 @@ time_bucket exclusion with timestamptz
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
 (8 rows)
 
+\qecho time_bucket exclusion with timestamptz and timezone
+time_bucket exclusion with timestamptz and timezone
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') < '2000-01-03' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
+\qecho time_bucket exclusion with timestamptz, timezone and offset
+time_bucket exclusion with timestamptz, timezone and offset
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') < '2000-01-03' ORDER BY time;
+                                                                                      QUERY PLAN                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
 \qecho time_bucket exclusion with timestamptz and day interval
 time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;

--- a/test/expected/plan_expand_hypertable-15.out
+++ b/test/expected/plan_expand_hypertable-15.out
@@ -1353,6 +1353,52 @@ time_bucket exclusion with timestamptz
          Filter: ((time_bucket('@ 6 hours'::interval, "time") >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time") <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
 (8 rows)
 
+\qecho time_bucket exclusion with timestamptz and timezone
+time_bucket exclusion with timestamptz and timezone
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') < '2000-01-03' ORDER BY time;
+                                                                                   QUERY PLAN                                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
+\qecho time_bucket exclusion with timestamptz, timezone and offset
+time_bucket exclusion with timestamptz, timezone and offset
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') < '2000-01-03' ORDER BY time;
+                                                                                      QUERY PLAN                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+   Index Cond: ("time" < 'Mon Jan 03 06:00:00 2000 PST'::timestamp with time zone)
+   Filter: (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) < 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone)
+(3 rows)
+
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ChunkAppend) on metrics_timestamptz
+   Order: metrics_timestamptz."time"
+   ->  Index Only Scan Backward using _hyper_6_160_chunk_metrics_timestamptz_time_idx on _hyper_6_160_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+   ->  Index Only Scan Backward using _hyper_6_161_chunk_metrics_timestamptz_time_idx on _hyper_6_161_chunk
+         Index Cond: (("time" >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND ("time" <= 'Mon Jan 10 06:00:00 2000 PST'::timestamp with time zone))
+         Filter: ((time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, '@ 1 hour'::interval) >= 'Mon Jan 03 00:00:00 2000 PST'::timestamp with time zone) AND (time_bucket('@ 6 hours'::interval, "time", 'UTC'::text, NULL::timestamp with time zone, NULL::interval) <= 'Mon Jan 10 00:00:00 2000 PST'::timestamp with time zone))
+(8 rows)
+
 \qecho time_bucket exclusion with timestamptz and day interval
 time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;

--- a/test/sql/include/plan_expand_hypertable_query.sql
+++ b/test/sql/include/plan_expand_hypertable_query.sql
@@ -197,6 +197,14 @@ SELECT * FROM cte ORDER BY value;
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time) < '2000-01-03' ORDER BY time;
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time) >= '2000-01-03' AND time_bucket('6h',time) <= '2000-01-10' ORDER BY time;
 
+\qecho time_bucket exclusion with timestamptz and timezone
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') < '2000-01-03' ORDER BY time;
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+
+\qecho time_bucket exclusion with timestamptz, timezone and offset
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') < '2000-01-03' ORDER BY time;
+:PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('6h',time,'UTC',NULL,'1h') >= '2000-01-03' AND time_bucket('6h',time,'UTC') <= '2000-01-10' ORDER BY time;
+
 \qecho time_bucket exclusion with timestamptz and day interval
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('1d',time) < '2000-01-03' ORDER BY time;
 :PREFIX SELECT time FROM metrics_timestamptz WHERE time_bucket('1d',time) >= '2000-01-03' AND time_bucket('1d',time) <= '2000-01-10' ORDER BY time;


### PR DESCRIPTION
Added the ability to chunk exclusion happen when using
time_bucket(width, ts, tzname, origin, offset) variation.

Disable-check: force-changelog-changed

Fixes #4547 #4825