### PR TITLE
Add telemetry for fixed schedule jobs

### DIFF
--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -59,6 +59,11 @@
 #define REQ_BUILD_ARCHITECTURE "build_architecture"
 #define REQ_DATA_VOLUME "data_volume"
 
+#define REQ_NUM_POLICY_CAGG_FIXED "num_continuous_aggs_policies_fixed"
+#define REQ_NUM_POLICY_COMPRESSION_FIXED "num_compression_policies_fixed"
+#define REQ_NUM_POLICY_REORDER_FIXED "num_reorder_policies_fixed"
+#define REQ_NUM_POLICY_RETENTION_FIXED "num_retention_policies_fixed"
+#define REQ_NUM_USER_DEFINED_ACTIONS_FIXED "num_user_defined_actions_fixed"
 #define REQ_NUM_POLICY_CAGG "num_continuous_aggs_policies"
 #define REQ_NUM_POLICY_COMPRESSION "num_compression_policies"
 #define REQ_NUM_POLICY_REORDER "num_reorder_policies"
@@ -101,19 +106,42 @@ bgw_job_type_counts()
 		if (namestrcmp(&job->fd.proc_schema, INTERNAL_SCHEMA_NAME) == 0)
 		{
 			if (namestrcmp(&job->fd.proc_name, "policy_refresh_continuous_aggregate") == 0)
-				counts.policy_cagg++;
+			{
+				if (job->fd.fixed_schedule)
+					counts.policy_cagg_fixed++;
+				else
+					counts.policy_cagg++;
+			}
 			else if (namestrcmp(&job->fd.proc_name, "policy_compression") == 0)
-				counts.policy_compression++;
+			{
+				if (job->fd.fixed_schedule)
+					counts.policy_compression_fixed++;
+				else
+					counts.policy_compression++;
+			}
 			else if (namestrcmp(&job->fd.proc_name, "policy_reorder") == 0)
-				counts.policy_reorder++;
+			{
+				if (job->fd.fixed_schedule)
+					counts.policy_reorder_fixed++;
+				else
+					counts.policy_reorder++;
+			}
 			else if (namestrcmp(&job->fd.proc_name, "policy_retention") == 0)
-				counts.policy_retention++;
+			{
+				if (job->fd.fixed_schedule)
+					counts.policy_retention_fixed++;
+				else
+					counts.policy_retention++;
+			}
 			else if (namestrcmp(&job->fd.proc_name, "policy_telemetry") == 0)
 				counts.policy_telemetry++;
 		}
 		else
 		{
-			counts.user_defined_action++;
+			if (job->fd.fixed_schedule)
+				counts.user_defined_action_fixed++;
+			else
+				counts.user_defined_action++;
 		}
 	}
 
@@ -226,10 +254,15 @@ add_job_counts(JsonbParseState *state)
 	BgwJobTypeCount counts = bgw_job_type_counts();
 
 	ts_jsonb_add_int32(state, REQ_NUM_POLICY_CAGG, counts.policy_cagg);
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_CAGG_FIXED, counts.policy_cagg_fixed);
 	ts_jsonb_add_int32(state, REQ_NUM_POLICY_COMPRESSION, counts.policy_compression);
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_COMPRESSION_FIXED, counts.policy_compression_fixed);
 	ts_jsonb_add_int32(state, REQ_NUM_POLICY_REORDER, counts.policy_reorder);
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_REORDER_FIXED, counts.policy_reorder_fixed);
 	ts_jsonb_add_int32(state, REQ_NUM_POLICY_RETENTION, counts.policy_retention);
+	ts_jsonb_add_int32(state, REQ_NUM_POLICY_RETENTION_FIXED, counts.policy_retention_fixed);
 	ts_jsonb_add_int32(state, REQ_NUM_USER_DEFINED_ACTIONS, counts.user_defined_action);
+	ts_jsonb_add_int32(state, REQ_NUM_USER_DEFINED_ACTIONS_FIXED, counts.user_defined_action_fixed);
 }
 
 static int64

--- a/src/telemetry/telemetry.h
+++ b/src/telemetry/telemetry.h
@@ -27,11 +27,16 @@
 typedef struct BgwJobTypeCount
 {
 	int32 policy_cagg;
+	int32 policy_cagg_fixed;
 	int32 policy_compression;
+	int32 policy_compression_fixed;
 	int32 policy_reorder;
+	int32 policy_reorder_fixed;
 	int32 policy_retention;
+	int32 policy_retention_fixed;
 	int32 policy_telemetry;
 	int32 user_defined_action;
+	int32 user_defined_action_fixed;
 } BgwJobTypeCount;
 
 typedef struct VersionResult

--- a/test/expected/telemetry.out
+++ b/test/expected/telemetry.out
@@ -364,8 +364,8 @@ WARNING:  telemetry could not connect to "noservice.timescale.com"
 SET timescaledb.telemetry_level=basic;
 SELECT * FROM jsonb_object_keys(get_telemetry_report()) AS key
 WHERE key != 'os_name_pretty';
-             key              
-------------------------------
+                key                 
+------------------------------------
  db_uuid
  license
  os_name
@@ -393,9 +393,14 @@ WHERE key != 'os_name_pretty';
  num_retention_policies
  num_compression_policies
  num_user_defined_actions
+ num_reorder_policies_fixed
  build_architecture_bit_size
  num_continuous_aggs_policies
-(29 rows)
+ num_retention_policies_fixed
+ num_compression_policies_fixed
+ num_user_defined_actions_fixed
+ num_continuous_aggs_policies_fixed
+(34 rows)
 
 CREATE MATERIALIZED VIEW telemetry_report AS
 SELECT t FROM get_telemetry_report() t;

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -956,6 +956,87 @@ FROM relations;
  }
 (1 row)
 
+-- check telemetry for fixed schedule jobs works
+create or replace procedure job_test_fixed(jobid int, config jsonb) language plpgsql as $$
+begin
+raise log 'this is job_test_fixed';
+end
+$$;
+create or replace procedure job_test_drifting(jobid int, config jsonb) language plpgsql as $$
+begin
+raise log 'this is job_test_drifting';
+end
+$$;
+-- before adding the jobs
+select get_telemetry_report()->'num_user_defined_actions_fixed';
+ ?column? 
+----------
+ 0
+(1 row)
+
+select get_telemetry_report()->'num_user_defined_actions';
+ ?column? 
+----------
+ 0
+(1 row)
+
+select add_job('job_test_fixed', '1 week');
+ add_job 
+---------
+    1000
+(1 row)
+
+select add_job('job_test_drifting', '1 week', fixed_schedule => false);
+ add_job 
+---------
+    1001
+(1 row)
+
+-- add continuous aggregate refresh policy for contagg
+select add_continuous_aggregate_policy('contagg', interval '3 weeks', NULL, interval '3 weeks'); -- drifting
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1002
+(1 row)
+
+select add_continuous_aggregate_policy('contagg_old', interval '3 weeks', NULL, interval '3 weeks', initial_start => now()); -- fixed
+ add_continuous_aggregate_policy 
+---------------------------------
+                            1003
+(1 row)
+
+-- add retention policy, fixed
+select add_retention_policy('hyper', interval '1 year', initial_start => now());
+ add_retention_policy 
+----------------------
+                 1004
+(1 row)
+
+-- add compression policy
+select add_compression_policy('hyper', interval '3 weeks', initial_start => now());
+ add_compression_policy 
+------------------------
+                   1005
+(1 row)
+
+select r->'num_user_defined_actions_fixed' as UDA_fixed, r->'num_user_defined_actions' AS UDA_drifting FROM get_telemetry_report() r;
+ uda_fixed | uda_drifting 
+-----------+--------------
+ 1         | 1
+(1 row)
+
+select r->'num_continuous_aggs_policies_fixed' as contagg_fixed, r->'num_continuous_aggs_policies' as contagg_drifting FROM get_telemetry_report() r;
+ contagg_fixed | contagg_drifting 
+---------------+------------------
+ 1             | 1
+(1 row)
+
+select r->'num_compression_policies_fixed' as compress_fixed, r->'num_retention_policies_fixed' as retention_fixed FROM get_telemetry_report() r;
+ compress_fixed | retention_fixed 
+----------------+-----------------
+ 1              | 1
+(1 row)
+
 DROP VIEW relations;
 DROP MATERIALIZED VIEW telemetry_report;
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER


### PR DESCRIPTION
Previous commit #4664 introduced the ability to execute background jobs on a fixed schedule.
This commit updates our telemetry data to include the number of jobs scheduled to execute on a fixed schedule vs the number registered to execute on a drifting schedule.