### PR TITLE
Fix GitHub output action

### DIFF
--- a/.github/gh_config_reader.py
+++ b/.github/gh_config_reader.py
@@ -4,11 +4,13 @@
 #  Please see the included NOTICE for copyright information and
 #  LICENSE-APACHE for a copy of the license.
 
-import json
 import ci_settings
+import json
+import os
 
 # generate commands to set github action variables
 for key in dir(ci_settings):
     if not key.startswith("__"):
         value = getattr(ci_settings, key)
-        print(str.format("::set-output name={0}::{1}", key, json.dumps(value)))
+        with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+            print(str.format("{0}={1}", key, json.dumps(value)), file=output)

--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -16,6 +16,7 @@
 # if a job was actually run.
 
 import json
+import os
 import sys
 from ci_settings import PG12_EARLIEST, PG12_LATEST, PG13_EARLIEST, PG13_LATEST, PG14_EARLIEST, PG14_LATEST
 
@@ -181,5 +182,6 @@ if event_type != "pull_request":
   m["include"].append(build_debug_config({"pg":14,"snapshot":"snapshot", "installcheck_args": "IGNORES='dist_gapfill_pushdown-14 memoize'"}))
 
 # generate command to set github action variable
-print(str.format("::set-output name=matrix::{0}",json.dumps(m)))
+with open(os.environ['GITHUB_OUTPUT'], "a") as output:
+  print(str.format("matrix={0}",json.dumps(m)), file=output)
 

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -108,7 +108,7 @@ jobs:
         sudo chmod a+rw .
         sudo find . -name regression.diffs -exec cat {} + > regression.log
         sudo find . -name postmaster.log -exec cat {} + > postgres.log
-        if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
+        if [[ -s regression.log ]]; then echo "regression_diff=true" >>$GITHUB_OUTPUT; fi
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
         cat regression.log
 

--- a/.github/workflows/apt-arm-packages.yaml
+++ b/.github/workflows/apt-arm-packages.yaml
@@ -70,7 +70,7 @@ jobs:
         else
           version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
         fi
-        echo "::set-output name=version::${version}"
+        echo "version=${version}" >>$GITHUB_OUTPUT
 
     - name: Test Installation
       run: |

--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -66,7 +66,7 @@ jobs:
         else
           version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
         fi
-        echo "::set-output name=version::${version}"
+        echo "version=${version}" >>$GITHUB_OUTPUT
 
     - name: Test Installation
       run: |

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -83,7 +83,7 @@ jobs:
         find . -name regression.diffs -exec cat {} + > regression.log
         find . -name postmaster.log -exec cat {} + > postgres.log
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
-        if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
+        if [[ -s regression.log ]]; then echo "regression_diff=true"; fi >>$GITHUB_OUTPUT
         cat regression.log
 
     - name: Coredumps
@@ -101,7 +101,7 @@ jobs:
               bt full
         EOT
           done
-          echo "::set-output name=coredumps::true"
+          echo "coredumps=true" >>$GITHUB_OUTPUT
           exit 1
         fi
 

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -143,11 +143,11 @@ jobs:
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           # wait in case there are in-progress coredumps
           sleep 10
-          if coredumpctl -q list >/dev/null; then echo "::set-output name=coredumps::true"; fi
+          if coredumpctl -q list >/dev/null; then echo "coredumps=true" >>$GITHUB_OUTPUT; fi
           # print OOM killer information
           sudo journalctl --system -q --facility=kern --grep "Killed process" || true
         fi
-        if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
+        if [[ -s regression.log ]]; then echo "regression_diff=true" >>$GITHUB_OUTPUT; fi
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
         cat regression.log
 

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -71,7 +71,7 @@ jobs:
         else
           version=$(grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!')
         fi
-        echo "::set-output name=version::${version}"
+        echo "version=${version}" >>$GITHUB_OUTPUT
 
     - name: Test Installation
       run: |

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -117,11 +117,11 @@ jobs:
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           # wait in case there are in-progress coredumps
           sleep 10
-          if coredumpctl -q list >/dev/null; then echo "::set-output name=coredumps::true"; fi
+          if coredumpctl -q list >/dev/null; then echo "coredumps=true" >>$GITHUB_OUTPUT; fi
           # print OOM killer information
           sudo journalctl --system -q --facility=kern --grep "Killed process" || true
         fi
-        if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
+        if [[ -s regression.log ]]; then echo "regression_diff=true" >>$GITHUB_OUTPUT; fi
         grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
         cat regression.log
 

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -106,7 +106,7 @@ jobs:
         # wait for in progress coredumps
         sleep 10
         if coredumpctl list; then
-          echo "::set-output name=coredumps::true"
+          echo "coredumps=true" >>$GITHUB_OUTPUT
           false
         fi
 

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -27,9 +27,9 @@ jobs:
       id: build_type
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          echo "::set-output name=build_type::['Debug']"
+          echo "build_type=['Debug']" >>$GITHUB_OUTPUT
         else
-          echo "::set-output name=build_type::['Debug','Release']"
+          echo "build_type=['Debug','Release']" >>$GITHUB_OUTPUT
         fi
 
   build:
@@ -176,14 +176,24 @@ jobs:
 
     - name: Show regression diffs
       if: always() && matrix.pg != '12'
+      shell: python
       id: collectlogs
-      shell: wsl-bash {0}
       run: |
-        find build_wsl -name regression.out -exec cat {} + > installcheck.log
-        find build_wsl -name regression.diffs -exec cat {} + > regression.log
-        if [[ -s regression.log ]]; then echo "::set-output name=regression_diff::true"; fi
-        grep -e 'FAILED' -e 'failed (ignored)' installcheck.log || true
-        cat regression.log
+        import re
+        import os
+        from pathlib import Path
+
+        for path in Path('build_wsl').rglob('regression.out'):
+          for line in path.open():
+            if re.search('failed', line, re.IGNORECASE):
+              print(line, end='')
+
+        for path in Path('build_wsl').rglob('regression.diffs'):
+          for line in path.open():
+            print(line, end='')
+        
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+          print('regression_diff=true', file=output)
 
     - name: Save regression diffs
       if: always() && matrix.pg != '12' && steps.collectlogs.outputs.regression_diff == 'true'
@@ -191,4 +201,3 @@ jobs:
       with:
         name: Regression diff ${{ matrix.os }} ${{ matrix.name }} ${{ matrix.pg }}
         path: regression.log
-

--- a/.github/workflows/windows-packages.yaml
+++ b/.github/workflows/windows-packages.yaml
@@ -75,7 +75,7 @@ jobs:
         } else {
           $version=grep '^update_from_version = ' version.config | sed -e 's!^update_from_version = !!'
         }
-        echo "::set-output name=version::${version}"
+        echo "version=${version}" >>$GITHUB_OUTPUT
 
     - name: Install PostgreSQL ${{ matrix.pg }}
       run: |


### PR DESCRIPTION
To avoid untrusted logged data to use `set-state` and `set-output` workflow
commands without the intention of the workflow author GitHub have
introduced a new set of environment files to manage state and output.

This commit changes the existing uses of `set-output` to use the new
environment files instead.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
