### PR TITLE
Remove an unused function in the copy code

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -271,15 +271,6 @@ TSCopyMultiInsertInfoIsFull(TSCopyMultiInsertInfo *miinfo)
 }
 
 /*
- * Returns true if we have no buffered tuples.
- */
-static inline bool
-TSCopyMultiInsertInfoIsEmpty(TSCopyMultiInsertInfo *miinfo)
-{
-	return miinfo->bufferedTuples == 0;
-}
-
-/*
  * Write the tuples stored in 'buffer' out to the table.
  */
 static inline int


### PR DESCRIPTION
Since e555eea9dbc05f4c09cf0d7e23b814054a459d19 the function TSCopyMultiInsertInfoIsEmpty is no longer used. This patch removes the unused code from src/copy.c.