### PR TITLE
Fix flaky copy_memory_usage tests

### DIFF
--- a/test/expected/copy_memory_usage.out
+++ b/test/expected/copy_memory_usage.out
@@ -50,16 +50,10 @@ select count(*) from portal_memory_log;
      5
 (1 row)
 
---- Check the memory usage of the PortalContext. Ensure that the copy commands do
---- not allocate memory in this context and the context does not grow. Allow 10%
---- change of memory usage to account for some randomness.
-select bytes as bytes_begin from portal_memory_log order by id asc limit 1 \gset
-select bytes as bytes_end from portal_memory_log order by id desc limit 1 \gset
--- We'll only compare the biggest runs, because the smaller ones have variance
--- due to new chunks being created and other unknown reasons. Allow 10% change of
--- memory usage to account for some randomness.
+-- Check that the memory doesn't increase with file size by using linear regression.
 select * from portal_memory_log where (
-   select abs(:bytes_begin - :bytes_end) / :bytes_begin::float > 0.1
+    select regr_slope(bytes, id - 1) / regr_intercept(bytes, id - 1)::float > 0.05
+        from portal_memory_log
 );
  id | bytes 
 ----+-------


### PR DESCRIPTION
The changes from e555eea lead to flakiness. They are a leftover of earlier version and probably not needed anymore.