### PR TITLE
Do not cache the classify_relation result

### DIFF
--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -1394,13 +1394,9 @@ ts_plan_expand_hypertable_chunks(Hypertable *ht, PlannerInfo *root, RelOptInfo *
 
 		/*
 		 * Add the information about chunks to the baserel info cache for
-		 * classify_relation(). The relation type is TS_REL_CHUNK_CHILD -- chunk
-		 * added as a result of expanding a hypertable.
+		 * classify_relation().
 		 */
-		add_baserel_cache_entry_for_chunk(chunks[i]->table_id,
-										  chunks[i]->fd.status,
-										  ht,
-										  TS_REL_CHUNK_CHILD);
+		add_baserel_cache_entry_for_chunk(chunks[i]->table_id, chunks[i]->fd.status, ht);
 	}
 
 	/* nothing to do here if we have no chunks and no data nodes */

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -75,7 +75,7 @@ ts_get_private_reloptinfo(RelOptInfo *rel)
 typedef enum TsRelType
 {
 	TS_REL_HYPERTABLE,		 /* A hypertable with no parent */
-	TS_REL_CHUNK,			 /* Chunk with no parent (i.e., it's part of the
+	TS_REL_CHUNK_STANDALONE, /* Chunk with no parent (i.e., it's part of the
 							  * plan as a standalone table. For example,
 							  * querying the chunk directly and not via the
 							  * parent hypertable). */
@@ -107,6 +107,6 @@ extern void ts_planner_constraint_cleanup(PlannerInfo *root, RelOptInfo *rel);
 extern Node *ts_add_space_constraints(PlannerInfo *root, List *rtable, Node *node);
 
 extern void add_baserel_cache_entry_for_chunk(Oid chunk_reloid, uint32 chunk_status,
-											  Hypertable *hypertable, TsRelType chunk_reltype);
+											  Hypertable *hypertable);
 
 #endif /* TIMESCALEDB_PLANNER_H */

--- a/tsl/test/shared/expected/classify_relation.out
+++ b/tsl/test/shared/expected/classify_relation.out
@@ -1,0 +1,11 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Test the case where the chunk is present both as a separate table and as a
+-- child of a hypertable. #4708
+select show_chunks('metrics_compressed') chunk order by 1 limit 1 \gset
+select * from metrics_compressed inner join :chunk on (false);
+ time | device_id | v0 | v1 | v2 | v3 | time | device_id | v0 | v1 | v2 | v3 
+------+-----------+----+----+----+----+------+-----------+----+----+----+----
+(0 rows)
+

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_FILES_SHARED
     cagg_compression.sql
+    classify_relation.sql
     constify_timestamptz_op_interval.sql
     constraint_exclusion_prepared.sql
     decompress_placeholdervar.sql

--- a/tsl/test/shared/sql/classify_relation.sql
+++ b/tsl/test/shared/sql/classify_relation.sql
@@ -1,0 +1,9 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Test the case where the chunk is present both as a separate table and as a
+-- child of a hypertable. #4708
+
+select show_chunks('metrics_compressed') chunk order by 1 limit 1 \gset
+select * from metrics_compressed inner join :chunk on (false);


### PR DESCRIPTION
It depends on the context, not only on the relation id. The same chunk can be expanded both as a child of hypertable and as an independent table.

Fixes https://github.com/timescale/timescaledb/issues/4708