### PR TITLE
Fix ereport call in job schedule for PG 12.0

### DIFF
--- a/src/bgw/job.c
+++ b/src/bgw/job.c
@@ -1397,10 +1397,10 @@ ts_bgw_job_validate_schedule_interval(Interval *schedule_interval)
 
 	if (has_month && (has_day || has_time))
 		ereport(ERROR,
-				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				errmsg("month intervals cannot have day or time component"),
-				errdetail("Fixed schedule jobs do not support such schedule intervals."),
-				errhint("Express the interval in terms of days or time instead."));
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("month intervals cannot have day or time component"),
+				 errdetail("Fixed schedule jobs do not support such schedule intervals."),
+				 errhint("Express the interval in terms of days or time instead.")));
 }
 
 char *


### PR DESCRIPTION
Since PG 12.3 the `ereport` syntax changed and the commit 54ed0d introduced and `ereport` call that works just using newer PG versions.

Changed the `ereport` call a PG 12.0 compatible syntax.

CI failure: https://github.com/timescale/timescaledb/actions/runs/3292571583/jobs/5428090238

Related PRs: #4733, #4809