### PR TITLE
Add a Coccinelle test for PG 12.3+ ereport syntax

### DIFF
--- a/coccinelle/ereport_pg12.cocci
+++ b/coccinelle/ereport_pg12.cocci
@@ -1,0 +1,16 @@
+// Since PG 12.3 the ereport syntax changed. This coccinelle patch checks that the used 
+// ereport calls work with PG < 12.3. 
+//
+// See postgres/postgres@a86715451653c730d637847b403b0420923956f7
+//
+
+@rule_1@
+constant K1;
+expression E1, E2;
+@@
+
+// We pass two or more expressions to ereport
+
++ /* ereport uses PG 12.3+ syntax */
+ereport(K1, E1, E2, ...);
+


### PR DESCRIPTION
This PR adds a Coccinelle test for ereport(..) calls that use the PG 12.3+ syntax
(postgres/postgres@a86715451653c730d637847b403b0420923956f7). We had some of these calls in the past, which we had to fix afterward (see #4733, #4809, #4871). This Coccinelle patch detects such calls and reports them in the CI run.