### PR TITLE
Allow joins in continuous aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This release also includes several bug fixes.
 * #4786 Extend the now() optimization to also apply to CURRENT_TIMESTAMP
 * #4820 Support parameterized data node scans in joins
 * #4830 Add function to change configuration of a data nodes
+* #4874 Allow joins in continuous aggregates
 * #4966 Handle DML activity when datanode is not available
 * #4971 Add function to drop stale chunks on a datanode
 
@@ -355,7 +356,7 @@ This release adds major new features since the 2.5.2 release, including:
 * Experimental support for timezones in continuous aggregates
 * Experimental support for monthly buckets in continuous aggregates
 
-The release also includes several bug fixes. Telemetry reports now include new and more detailed statistics on regular tables and views, compression, distributed hypertables, and continuous aggregates, which will help us improve TimescaleDB.  
+The release also includes several bug fixes. Telemetry reports now include new and more detailed statistics on regular tables and views, compression, distributed hypertables, and continuous aggregates, which will help us improve TimescaleDB.
 
 **Features**
 * #3768 Allow ALTER TABLE ADD COLUMN with DEFAULT on compressed hypertable
@@ -537,22 +538,22 @@ The experimental features in this release are:
 * APIs for chunk manipulation across data nodes in a distributed
 hypertable setup. This includes the ability to add a data node and move
 chunks to the new data node for cluster rebalancing.
-* The `time_bucket_ng` function, a newer version of `time_bucket`. This 
+* The `time_bucket_ng` function, a newer version of `time_bucket`. This
 function supports years, months, days, hours, minutes, and seconds.
- 
+
 We’re committed to developing these experiments, giving the community
  a chance to provide early feedback and influence the direction of
-TimescaleDB’s development. We’ll travel faster with your input! 
-	
-Please create your feedback as a GitHub issue (using the 
-experimental-schema label), describe what you found, and tell us the 
+TimescaleDB’s development. We’ll travel faster with your input!
+
+Please create your feedback as a GitHub issue (using the
+experimental-schema label), describe what you found, and tell us the
 steps or share the code snip to recreate it.
 
-This release also includes several bug fixes. 
+This release also includes several bug fixes.
 
 PostgreSQL 11 deprecation announcement
-Timescale is working hard on our next exciting features. To make that 
-possible, we require functionality that is available in Postgres 12 and 
+Timescale is working hard on our next exciting features. To make that
+possible, we require functionality that is available in Postgres 12 and
 above. Postgres 11 is not supported with TimescaleDB 2.4.
 
 **Experimental Features**
@@ -614,7 +615,7 @@ This release adds major new features since the 2.2.1 release.
 We deem it moderate priority for upgrading.
 
 This release adds support for inserting data into compressed chunks
-and improves performance when inserting data into distributed hypertables. 
+and improves performance when inserting data into distributed hypertables.
 Distributed hypertables now also support triggers and compression policies.
 
 The bug fixes in this release address issues related to the handling
@@ -670,7 +671,7 @@ of indexes, in compression, and in policies.
 * #3151 Fix `fdw_relinfo_get` assertion failure on `DELETE`
 * #3155 Inherit `CFLAGS` from PostgreSQL
 * #3169 Fix incorrect type cast in compression policy
-* #3183 Fix segfault in calculate_chunk_interval 
+* #3183 Fix segfault in calculate_chunk_interval
 * #3185 Fix wrong datatype for integer based retention policy
 
 **Thanks**
@@ -685,27 +686,27 @@ of indexes, in compression, and in policies.
 This release adds major new features since the 2.1.1 release.
 We deem it moderate priority for upgrading.
 
-This release adds the Skip Scan optimization, which significantly 
-improves the performance of queries with DISTINCT ON. This 
-optimization is not yet available for queries on distributed 
+This release adds the Skip Scan optimization, which significantly
+improves the performance of queries with DISTINCT ON. This
+optimization is not yet available for queries on distributed
 hypertables.
 
-This release also adds a function to create a distributed 
-restore point, which allows performing a consistent restore of a 
+This release also adds a function to create a distributed
+restore point, which allows performing a consistent restore of a
 multi-node cluster from a backup.
 
-The bug fixes in this release address issues with size and stats 
-functions, high memory usage in distributed inserts, slow distributed 
-ORDER BY queries, indexes involving INCLUDE, and single chunk query 
+The bug fixes in this release address issues with size and stats
+functions, high memory usage in distributed inserts, slow distributed
+ORDER BY queries, indexes involving INCLUDE, and single chunk query
 planning.
 
 **PostgreSQL 11 deprecation announcement**
 
-Timescale is working hard on our next exciting features. To make that 
-possible, we require functionality that is unfortunately absent on 
-PostgreSQL 11. For this reason, we will continue supporting PostgreSQL 
-11 until mid-June 2021. Sooner to that time, we will announce the 
-specific version of TimescaleDB in which PostgreSQL 11 support will 
+Timescale is working hard on our next exciting features. To make that
+possible, we require functionality that is unfortunately absent on
+PostgreSQL 11. For this reason, we will continue supporting PostgreSQL
+11 until mid-June 2021. Sooner to that time, we will announce the
+specific version of TimescaleDB in which PostgreSQL 11 support will
 not be included going forward.
 
 **Major Features**
@@ -734,10 +735,10 @@ not be included going forward.
 This maintenance release contains bugfixes since the 2.1.0 release. We
 deem it high priority for upgrading.
 
-The bug fixes in this release address issues with CREATE INDEX and 
+The bug fixes in this release address issues with CREATE INDEX and
 UPSERT for hypertables, custom jobs, and gapfill queries.
 
-This release marks TimescaleDB as a trusted extension in PG13, so that 
+This release marks TimescaleDB as a trusted extension in PG13, so that
 superuser privileges are not required anymore to install the extension.
 
 **Minor features**
@@ -822,7 +823,7 @@ and when upgrading from previous versions.
 **Bugfixes**
 * #2502 Replace check function when updating
 * #2558 Repair dimension slice table on update
-* #2619 Fix segfault in decompress_chunk for chunks with dropped 
+* #2619 Fix segfault in decompress_chunk for chunks with dropped
   columns
 * #2664 Fix support for complex aggregate expression
 * #2800 Lock dimension slices when creating new chunk
@@ -883,46 +884,46 @@ and when upgrading from previous versions.
 
 ## 2.0.0 (2020-12-18)
 
-With this release, we are officially moving TimescaleDB 2.0 to GA, 
+With this release, we are officially moving TimescaleDB 2.0 to GA,
 concluding several release candidates.
 
-TimescaleDB 2.0 adds the much-anticipated support for distributed 
-hypertables (multi-node TimescaleDB), as well as new features and 
-enhancements to core functionality to give users better clarity and 
+TimescaleDB 2.0 adds the much-anticipated support for distributed
+hypertables (multi-node TimescaleDB), as well as new features and
+enhancements to core functionality to give users better clarity and
 more control and flexibility over their data.
 
-Multi-node architecture:  In particular, with TimescaleDB 2.0, users 
-can now create distributed hypertables across multiple instances of 
-TimescaleDB, configured so that one instance serves as an access node 
-and multiple others as data nodes. All queries for a distributed 
+Multi-node architecture:  In particular, with TimescaleDB 2.0, users
+can now create distributed hypertables across multiple instances of
+TimescaleDB, configured so that one instance serves as an access node
+and multiple others as data nodes. All queries for a distributed
 hypertable are issued to the access node, but inserted data and queries
 are pushed down across data nodes for greater scale and performance.
 
-Multi-node TimescaleDB can be self managed or, for easier operation, 
+Multi-node TimescaleDB can be self managed or, for easier operation,
 launched within Timescale's fully-managed cloud services.
 
 This release also adds:
 
-* Support for user-defined actions, allowing users to define, 
-  customize, and schedule automated tasks, which can be run by the 
+* Support for user-defined actions, allowing users to define,
+  customize, and schedule automated tasks, which can be run by the
   built-in jobs scheduling framework now exposed to users.
-* Significant changes to continuous aggregates, which now separate the 
-  view creation from the policy.  Users can now refresh individual 
-  regions of the continuous aggregate materialized view, or schedule 
+* Significant changes to continuous aggregates, which now separate the
+  view creation from the policy.  Users can now refresh individual
+  regions of the continuous aggregate materialized view, or schedule
   automated refreshing via  policy.
-* Redesigned informational views, including new (and more general) 
-  views for information about hypertable's dimensions and chunks, 
-  policies and user-defined actions, as well as support for multi-node 
+* Redesigned informational views, including new (and more general)
+  views for information about hypertable's dimensions and chunks,
+  policies and user-defined actions, as well as support for multi-node
   TimescaleDB.
-* Moving all formerly enterprise features into our Community Edition, 
-  and updating Timescale License, which now provides additional (more 
+* Moving all formerly enterprise features into our Community Edition,
+  and updating Timescale License, which now provides additional (more
   permissive) rights to users and developers.
 
-Some of the changes above (e.g., continuous aggregates, updated 
-informational views) do introduce breaking changes to APIs and are not 
-backwards compatible. While the update scripts in TimescaleDB 2.0 will 
-upgrade databases running TimescaleDB 1.x automatically, some of these 
-API and feature changes may require changes to clients and/or upstream 
+Some of the changes above (e.g., continuous aggregates, updated
+informational views) do introduce breaking changes to APIs and are not
+backwards compatible. While the update scripts in TimescaleDB 2.0 will
+upgrade databases running TimescaleDB 1.x automatically, some of these
+API and feature changes may require changes to clients and/or upstream
 scripts that rely on the previous APIs.  Before upgrading, we recommend
 reviewing upgrade documentation at docs.timescale.com for more details.
 
@@ -945,7 +946,7 @@ TimescaleDB 2.0 moves the following major features to GA:
 
 **Minor Features**
 
-Since the last release candidate 4, there are several minor 
+Since the last release candidate 4, there are several minor
 improvements:
 * #2746 Optimize locking for create chunk API
 * #2705 Block tableoid access on distributed hypertable
@@ -955,7 +956,7 @@ improvements:
 **Bugfixes**
 
 Since the last release candidate 4, there are several bugfixes:
-* #2719 Support disabling compression on distributed hypertables 
+* #2719 Support disabling compression on distributed hypertables
 * #2742 Fix compression status in chunks view for distributed chunks
 * #2751 Fix crash and cancel when adding data node
 * #2763 Fix check constraint on hypertable metadata table
@@ -966,30 +967,30 @@ Thanks to all contributors for the TimescaleDB 2.0 release:
 * @airton-neto for reporting a bug in executing some queries with UNION
 * @nshah14285 for reporting an issue with propagating privileges
 * @kalman5 for reporting an issue with renaming constraints
-* @LbaNeXte for reporting a bug in decompression for queries with 
+* @LbaNeXte for reporting a bug in decompression for queries with
   subqueries
-* @semtexzv for reporting an issue with continuous aggregates on 
+* @semtexzv for reporting an issue with continuous aggregates on
   int-based hypertables
 * @mr-ns for reporting an issue with privileges for creating chunks
-* @cloud-rocket for reporting an issue with setting an owner on 
+* @cloud-rocket for reporting an issue with setting an owner on
   continuous aggregate
 * @jocrau for reporting a bug during creating an index with transaction
   per chunk
 * @fvannee for reporting an issue with custom time types
-* @ArtificialPB for reporting a bug in executing queries with 
+* @ArtificialPB for reporting a bug in executing queries with
   conditional ordering on compressed hypertable
 * @dutchgecko for reporting an issue with continuous aggregate datatype
   handling
-* @lambdaq for suggesting to improve error message in continuous 
+* @lambdaq for suggesting to improve error message in continuous
   aggregate creation
 * @francesco11112 for reporting memory issue on COPY
-* @Netskeh for reporting bug on time_bucket problem in continuous 
+* @Netskeh for reporting bug on time_bucket problem in continuous
   aggregates
 * @mr-ns for reporting the issue with CTEs on distributed hypertables
 * @akamensky for reporting an issue with recursive cache invalidation
-* @ryanbooz for reporting slow queries with real-time aggregation on 
+* @ryanbooz for reporting slow queries with real-time aggregation on
   continuous aggregates
-* @cevian for reporting an issue with disabling compression on 
+* @cevian for reporting an issue with disabling compression on
   distributed hypertables
 
 ## 2.0.0-rc4 (2020-12-02)
@@ -997,7 +998,7 @@ Thanks to all contributors for the TimescaleDB 2.0 release:
 This release candidate contains bugfixes since the previous release
 candidate, as well as additional minor features. It improves
 validation of configuration changes for background jobs, adds support
-for gapfill on distributed tables, contains improvements to the memory 
+for gapfill on distributed tables, contains improvements to the memory
 handling for large COPY, and contains improvements to compression for
 distributed hypertables.
 
@@ -1038,16 +1039,16 @@ chunks.
 **Bugfixes**
 * #2560 Fix SCHEMA DROP CASCADE with continuous aggregates
 * #2593 Set explicitly all lock parameters in alter_job
-* #2604 Fix chunk creation on hypertables with foreign key constraints 
+* #2604 Fix chunk creation on hypertables with foreign key constraints
 * #2610 Support analyze of internal compression table
 * #2612 Optimize internal cagg_watermark function
 * #2613 Refresh correct partial during refresh on drop
 * #2617 Fix validation of available extensions on data node
-* #2619 Fix segfault in decompress_chunk for chunks with dropped columns 
-* #2620 Fix DROP CASCADE for continuous aggregate 
+* #2619 Fix segfault in decompress_chunk for chunks with dropped columns
+* #2620 Fix DROP CASCADE for continuous aggregate
 * #2625 Fix subquery errors when using AsyncAppend
 * #2626 Fix incorrect total_table_pages setting for compressed scan
-* #2628 Stop recursion in cache invalidation 
+* #2628 Stop recursion in cache invalidation
 
 **Thanks**
 * @mr-ns for reporting the issue with CTEs on distributed hypertables
@@ -1142,17 +1143,17 @@ _before_ upgrading.
 **For beta releases**, upgrading from an earlier version of the
 extension (including previous beta releases) is not supported.
 
-This beta release includes breaking changes to APIs. The most 
-notable changes since the beta-5 release are the following, which will 
+This beta release includes breaking changes to APIs. The most
+notable changes since the beta-5 release are the following, which will
 be reflected in forthcoming documentation for the 2.0 release.
 
-* Existing information views were reorganized. Retrieving information 
-about sizes and statistics was moved to functions. New views were added 
+* Existing information views were reorganized. Retrieving information
+about sizes and statistics was moved to functions. New views were added
 to expose information, which was previously available only internally.
 * New ability to create custom jobs was added.
-* Continuous aggregate API was redesigned. Its policy creation is separated 
+* Continuous aggregate API was redesigned. Its policy creation is separated
 from the view creation.
-* compress_chunk_policy and drop_chunk_policy were renamed to compression_policy and 
+* compress_chunk_policy and drop_chunk_policy were renamed to compression_policy and
 retention_policy.
 
 ## 1.7.4 (2020-09-07)

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -148,6 +148,7 @@ extern TSDLLEXPORT void ts_dimension_update(const Hypertable *ht, const NameData
 											Oid *integer_now_func);
 extern TSDLLEXPORT List *ts_dimension_get_partexprs(const Dimension *dim, Index hyper_varno);
 extern TSDLLEXPORT Point *ts_point_create(int16 num_dimensions);
+extern TSDLLEXPORT bool ts_is_equality_operator(Oid opno, Oid left, Oid right);
 
 #define hyperspace_get_open_dimension(space, i)                                                    \
 	ts_hyperspace_get_dimension(space, DIMENSION_TYPE_OPEN, i)

--- a/src/planner/space_constraint.c
+++ b/src/planner/space_constraint.c
@@ -48,8 +48,8 @@ get_space_dimension(Oid relid, AttrNumber varattno)
  * the space dimension. This is the equality operator between
  * left and right in the btree operator family.
  */
-static bool
-is_valid_space_operator(Oid opno, Oid left, Oid right)
+bool
+ts_is_equality_operator(Oid opno, Oid left, Oid right)
 {
 	TypeCacheEntry *tce;
 
@@ -96,7 +96,7 @@ is_valid_space_constraint(OpExpr *op, List *rtable)
 		return false;
 
 	Const *value = lsecond_node(Const, op->args);
-	if (!is_valid_space_operator(op->opno, var->vartype, value->consttype))
+	if (!ts_is_equality_operator(op->opno, var->vartype, value->consttype))
 		return false;
 
 	/*
@@ -130,7 +130,7 @@ is_valid_scalar_space_constraint(ScalarArrayOpExpr *op, List *rtable)
 	if (arr->multidims || !op->useOr || var->varlevelsup != 0)
 		return false;
 
-	if (!is_valid_space_operator(op->opno, var->vartype, arr->element_typeid))
+	if (!ts_is_equality_operator(op->opno, var->vartype, arr->element_typeid))
 		return false;
 
 	/*

--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -56,6 +56,7 @@
 #include <utils/ruleutils.h>
 #include <utils/syscache.h>
 #include <utils/typcache.h>
+#include <optimizer/prep.h>
 
 #include "create.h"
 
@@ -90,6 +91,7 @@
 #define INTERNAL_TO_DATE_FUNCTION "to_date"
 #define INTERNAL_TO_TSTZ_FUNCTION "to_timestamp"
 #define INTERNAL_TO_TS_FUNCTION "to_timestamp_without_timezone"
+#define CONTINUOUS_AGG_MAX_JOIN_RELATIONS 2
 
 #define PRINT_MATCOLNAME(colbuf, type, original_query_resno, colno)                                \
 	do                                                                                             \
@@ -126,6 +128,7 @@
 		(selquery)->resultRelation = 0;                                                            \
 		(selquery)->hasAggs = true;                                                                \
 		(selquery)->hasRowSecurity = false;                                                        \
+		(selquery)->rtable = NULL;                                                                 \
 	} while (0);
 
 typedef struct MatTableColumnInfo
@@ -196,8 +199,7 @@ static void mattablecolumninfo_init(MatTableColumnInfo *matcolinfo, List *groupl
 static Var *mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input,
 										int original_query_resno, bool finalized,
 										bool *skip_adding);
-static void mattablecolumninfo_addinternal(MatTableColumnInfo *matcolinfo,
-										   RangeTblEntry *usertbl_rte, int32 usertbl_htid);
+static void mattablecolumninfo_addinternal(MatTableColumnInfo *matcolinfo);
 static int32 mattablecolumninfo_create_materialization_table(
 	MatTableColumnInfo *matcolinfo, int32 hypertable_id, RangeVar *mat_rel,
 	CAggTimebucketInfo *origquery_tblinfo, bool create_addl_index, char *tablespacename,
@@ -215,7 +217,7 @@ static void caggtimebucket_validate(CAggTimebucketInfo *tbinfo, List *groupClaus
 static void finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query,
 							   MatTableColumnInfo *mattblinfo);
 static Query *finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
-											 ObjectAddress *mattbladdress);
+											 ObjectAddress *mattbladdress, char *relname);
 static bool function_allowed_in_cagg_definition(Oid funcid);
 
 static Const *cagg_boundary_make_lower_bound(Oid type);
@@ -639,7 +641,7 @@ mattablecolumninfo_get_partial_select_query(MatTableColumnInfo *mattblinfo, Quer
 	return partial_selquery;
 }
 
-/* create a  view for the query using the SELECt stmt sqlquery
+/* create a view for the query using the SELECt stmt sqlquery
  * and view name from RangeVar viewrel
  */
 static ObjectAddress
@@ -1155,14 +1157,17 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 	CAggTimebucketInfo bucket_info, bucket_info_parent;
 	Cache *hcache;
 	Hypertable *ht = NULL, *ht_parent = NULL;
-	RangeTblRef *rtref = NULL;
-	RangeTblEntry *rte;
-	List *fromList;
+	RangeTblRef *rtref = NULL, *rtref_other = NULL;
+	RangeTblEntry *rte = NULL, *rte_other = NULL;
+	JoinType jointype = JOIN_FULL;
+	OpExpr *op = NULL;
+	List *fromList = NIL;
 	StringInfo hint = makeStringInfo();
 	StringInfo detail = makeStringInfo();
 	bool is_nested = false;
 	Query *prev_query = NULL;
 	ContinuousAgg *cagg_parent = NULL;
+	Oid normal_table_id = InvalidOid;
 
 	if (!cagg_query_supported(query, hint, detail, finalized))
 	{
@@ -1180,25 +1185,141 @@ cagg_validate_query(const Query *query, const bool finalized, const char *cagg_s
 		cagg_agg_validate((Node *) query->targetList, NULL);
 		cagg_agg_validate((Node *) query->havingQual, NULL);
 	}
-
+	/* Check if there are only two tables in the from list */
 	fromList = query->jointree->fromlist;
-	if (list_length(fromList) != 1 || !IsA(linitial(fromList), RangeTblRef))
+	if (list_length(fromList) > CONTINUOUS_AGG_MAX_JOIN_RELATIONS)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("only one hypertable allowed in continuous aggregate view")));
+				 errmsg("only two tables with one hypertable and one normal table"
+						"are  allowed in continuous aggregate view")));
 	}
-	/* check if we have a hypertable in the FROM clause */
-	rtref = linitial_node(RangeTblRef, query->jointree->fromlist);
-	rte = list_nth(query->rtable, rtref->rtindex - 1);
-
-	/* FROM only <tablename> sets rte->inh to false */
-	if ((rte->relkind != RELKIND_RELATION && rte->relkind != RELKIND_VIEW) || rte->tablesample ||
-		rte->inh == false)
+	/* Extra checks for joins in Caggs */
+	if (list_length(fromList) == CONTINUOUS_AGG_MAX_JOIN_RELATIONS ||
+		!IsA(linitial(query->jointree->fromlist), RangeTblRef))
 	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("invalid continuous aggregate view")));
+		/* Using old format caggs is not supported */
+		if (!finalized)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("old format of continuous aggregate is not supported with joins"),
+					 errhint("set timescaledb.finalized to TRUE")));
+
+		if (list_length(fromList) == CONTINUOUS_AGG_MAX_JOIN_RELATIONS)
+		{
+			if (!IsA(linitial(fromList), RangeTblRef) || !IsA(lsecond(fromList), RangeTblRef))
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("invalid continuous aggregate view"),
+						 errdetail(
+							 "from clause can only have one hypertable and one normal table")));
+
+			rtref = linitial_node(RangeTblRef, query->jointree->fromlist);
+			rte = list_nth(query->rtable, rtref->rtindex - 1);
+			rtref_other = lsecond_node(RangeTblRef, query->jointree->fromlist);
+			rte_other = list_nth(query->rtable, rtref_other->rtindex - 1);
+			jointype = rte->jointype || rte_other->jointype;
+
+			if (query->jointree->quals != NULL && IsA(query->jointree->quals, OpExpr))
+				op = (OpExpr *) query->jointree->quals;
+		}
+		else
+		{
+			ListCell *l;
+			foreach (l, query->jointree->fromlist)
+			{
+				Node *jtnode = (Node *) lfirst(l);
+				JoinExpr *join = NULL;
+				if (IsA(jtnode, JoinExpr))
+				{
+					join = castNode(JoinExpr, jtnode);
+#if PG13_LT
+					if (join->usingClause != NULL)
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("invalid continuous aggregate view"),
+								 errdetail(
+									 "joins with using clause in continuous aggregate definition"
+									 " work for Postgres versions 13 and above")));
+#endif
+					jointype = join->jointype;
+					op = (OpExpr *) join->quals;
+					rte = list_nth(query->rtable, ((RangeTblRef *) join->larg)->rtindex - 1);
+					rte_other = list_nth(query->rtable, ((RangeTblRef *) join->rarg)->rtindex - 1);
+				}
+			}
+		}
+
+		/*
+		 * Cagg with joins does not support hierarchical caggs in from clause.
+		 */
+		if (rte->relkind == RELKIND_VIEW || rte_other->relkind == RELKIND_VIEW)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("joins for hierarchical continuous aggregates are not supported")));
+
+		/*
+		 * Error out if there is aynthing else than one normal table and one hypertable
+		 * in the from clause, e.g. sub-query
+		 */
+		if (((rte->relkind != RELKIND_RELATION && rte->relkind != RELKIND_VIEW) ||
+			 rte->tablesample || rte->inh == false) ||
+			((rte_other->relkind != RELKIND_RELATION && rte_other->relkind != RELKIND_VIEW) ||
+			 rte_other->tablesample || rte_other->inh == false) ||
+			(ts_is_hypertable(rte->relid) == ts_is_hypertable(rte_other->relid)))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid continuous aggregate view"),
+					 errdetail("from clause can only have one hypertable and one normal table")));
+
+		/* Only inner joins are allowed */
+		if (jointype != JOIN_INNER)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("only inner joins are supported in continuous aggregates")));
+
+		/* Only equality conditions are permitted on joins */
+		if (op && IsA(op, OpExpr) &&
+			list_length(castNode(OpExpr, op)->args) == CONTINUOUS_AGG_MAX_JOIN_RELATIONS)
+		{
+			Oid left_type = exprType(linitial(op->args));
+			Oid right_type = exprType(lsecond(op->args));
+			if (!ts_is_equality_operator(op->opno, left_type, right_type))
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("invalid continuous aggregate view"),
+						 errdetail(
+							 "only equality conditions are supported in continuous aggregates")));
+		}
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid continuous aggregate view"),
+					 errdetail("unsupported expression in join clause"),
+					 errhint("only equality condition is supported")));
+		/*
+		 * Record the table oid of the normal table, this is required so
+		 * that we know which one is hypertable to carry out the related
+		 * processing in later parts of code.
+		 */
+		normal_table_id = ts_is_hypertable(rte->relid) ? rte_other->relid : rte->relid;
+		if (normal_table_id == rte->relid)
+			rte = rte_other;
+	}
+	else
+	{
+		/* check if we have a hypertable in the FROM clause */
+		rtref = linitial_node(RangeTblRef, query->jointree->fromlist);
+		rte = list_nth(query->rtable, rtref->rtindex - 1);
+	}
+	/* FROM only <tablename> sets rte->inh to false */
+	if (rte->rtekind != RTE_JOIN)
+	{
+		if ((rte->relkind != RELKIND_RELATION && rte->relkind != RELKIND_VIEW) ||
+			rte->tablesample || rte->inh == false)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("invalid continuous aggregate view")));
 	}
 
 	if (rte->relkind == RELKIND_RELATION || rte->relkind == RELKIND_VIEW)
@@ -1852,8 +1973,7 @@ mattablecolumninfo_addentry(MatTableColumnInfo *out, Node *input, int original_q
 
 /* add internal columns for the materialization table */
 static void
-mattablecolumninfo_addinternal(MatTableColumnInfo *matcolinfo, RangeTblEntry *usertbl_rte,
-							   int32 usertbl_htid)
+mattablecolumninfo_addinternal(MatTableColumnInfo *matcolinfo)
 {
 	Index maxRef;
 	int colno = list_length(matcolinfo->partial_seltlist) + 1;
@@ -2238,20 +2358,39 @@ finalizequery_init(FinalizeQueryInfo *inp, Query *orig_query, MatTableColumnInfo
  * for the materialization table
  * matcollist - column list for mat table
  * mattbladdress - materialization table ObjectAddress
+ * This is the function responsible for creating the final
+ * structures for selecting from the materialized hypertable
+ * created for the Cagg which is
+ * select * from _timescaldeb_internal._matrialized_hypertable_<xxx>
  */
 static Query *
 finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
-							   ObjectAddress *mattbladdress)
+							   ObjectAddress *mattbladdress, char *relname)
 {
 	Query *final_selquery = NULL;
 	ListCell *lc;
+	FromExpr *fromexpr;
+	RangeTblEntry *rte;
+
 	/*
 	 * for initial cagg creation rtable will have only 1 entry,
 	 * for alter table rtable will have multiple entries with our
 	 * RangeTblEntry as last member.
+	 * For cagg with joins, we need to create a new RTE and jointree
+	 * which contains the information of the materialised hypertable
+	 * that is created for this cagg.
 	 */
-	RangeTblEntry *rte = llast_node(RangeTblEntry, inp->final_userquery->rtable);
-	FromExpr *fromexpr;
+	if (list_length(inp->final_userquery->jointree->fromlist) >= CONTINUOUS_AGG_MAX_JOIN_RELATIONS)
+	{
+		rte = makeNode(RangeTblEntry);
+		rte->alias = makeAlias(relname, NIL);
+		rte->inFromCl = true;
+		rte->inh = true;
+		rte->rellockmode = 1;
+		rte->eref = copyObject(rte->alias);
+	}
+	else
+		rte = llast_node(RangeTblEntry, inp->final_userquery->rtable);
 	rte->relid = mattbladdress->objectId;
 	rte->rtekind = RTE_RELATION;
 	rte->relkind = RELKIND_RELATION;
@@ -2284,13 +2423,31 @@ finalizequery_get_select_query(FinalizeQueryInfo *inp, List *matcollist,
 
 	CAGG_MAKEQUERY(final_selquery, inp->final_userquery);
 	final_selquery->hasAggs = !inp->finalized;
-	final_selquery->rtable = inp->final_userquery->rtable; /* fixed up above */
-	/* fixup from list. No quals on original table should be
-	 * present here - they should be on the query that populates the mattable (partial_selquery)
+	if (list_length(inp->final_userquery->jointree->fromlist) >= CONTINUOUS_AGG_MAX_JOIN_RELATIONS)
+	{
+		RangeTblRef *rtr;
+		final_selquery->rtable = list_make1(rte);
+		rtr = makeNode(RangeTblRef);
+		rtr->rtindex = 1;
+		fromexpr = makeFromExpr(list_make1(rtr), NULL);
+	}
+	else
+	{
+		final_selquery->rtable = inp->final_userquery->rtable;
+		fromexpr = inp->final_userquery->jointree;
+		fromexpr->quals = NULL;
+	}
+
+	/*
+	 * fixup from list. No quals on original table should be
+	 * present here - they should be on the query that populates
+	 * the mattable (partial_selquery). For the Cagg with join,
+	 * we can not copy the fromlist from inp->final_userquery as
+	 * it has two tables in this case.
 	 */
-	Assert(list_length(inp->final_userquery->jointree->fromlist) == 1);
-	fromexpr = inp->final_userquery->jointree;
-	fromexpr->quals = NULL;
+	Assert(list_length(inp->final_userquery->jointree->fromlist) <=
+		   CONTINUOUS_AGG_MAX_JOIN_RELATIONS);
+
 	final_selquery->jointree = fromexpr;
 	final_selquery->targetList = inp->final_seltlist;
 	final_selquery->sortClause = inp->final_userquery->sortClause;
@@ -2410,6 +2567,14 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	bool finalized = DatumGetBool(with_clause_options[ContinuousViewOptionFinalized].parsed);
 
 	finalqinfo.finalized = finalized;
+	if (list_length(panquery->jointree->fromlist) >= CONTINUOUS_AGG_MAX_JOIN_RELATIONS &&
+		!materialized_only)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("real-time continuous aggregates are not supported with joins"),
+				 errhint("set materialized_only to true")));
+	}
 
 	/*
 	 * Assign the column_name aliases in CREATE VIEW to the query. No other modifications to
@@ -2430,10 +2595,7 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	 *         on the user query's table
 	 */
 	if (!finalized)
-	{
-		RangeTblEntry *usertbl_rte = list_nth(panquery->rtable, 0);
-		mattablecolumninfo_addinternal(&mattblinfo, usertbl_rte, origquery_ht->htid);
-	}
+		mattablecolumninfo_addinternal(&mattblinfo);
 
 	/* Step 1: create the materialization table */
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
@@ -2454,8 +2616,10 @@ cagg_create(const CreateTableAsStmt *create_stmt, ViewStmt *stmt, Query *panquer
 	/* Step 2: create view with select finalize from materialization
 	 * table
 	 */
-	final_selquery =
-		finalizequery_get_select_query(&finalqinfo, mattblinfo.matcollist, &mataddress);
+	final_selquery = finalizequery_get_select_query(&finalqinfo,
+													mattblinfo.matcollist,
+													&mataddress,
+													mat_rel->relname);
 
 	if (!materialized_only)
 		final_selquery = build_union_query(origquery_ht,
@@ -2702,10 +2866,10 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 	fqi.finalized = finalized;
 	finalizequery_init(&fqi, direct_query, &mattblinfo);
 
-	RangeTblEntry *usertbl_rte = list_nth(direct_query->rtable, 0);
-	mattablecolumninfo_addinternal(&mattblinfo, usertbl_rte, 0);
+	mattablecolumninfo_addinternal(&mattblinfo);
 
-	Query *view_query = finalizequery_get_select_query(&fqi, mattblinfo.matcollist, &mataddress);
+	Query *view_query =
+		finalizequery_get_select_query(&fqi, mattblinfo.matcollist, &mataddress, relname);
 
 	if (!agg->data.materialized_only)
 		view_query = build_union_query(&timebucket_exprinfo,

--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -32,27 +32,6 @@ select * from conditions , mat_t1 WITH NO DATA;
 ERROR:  unsupported combination of storage parameters
 DETAIL:  A continuous aggregate does not support standard storage parameters.
 HINT:  Use only parameters with the "timescaledb." prefix when creating a continuous aggregate.
--- join multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
-as
-select location, count(*) from conditions , mat_t1
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
--- join multiple tables WITH explicit JOIN
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
-as
-select location, count(*) from conditions JOIN mat_t1 ON true
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
--- LATERAL multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
-as
-select location, count(*) from conditions,
-LATERAL (Select * from mat_t1 where c = conditions.location) q
-group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
 --non-hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
 as

--- a/tsl/test/expected/cagg_errors_deprecated.out
+++ b/tsl/test/expected/cagg_errors_deprecated.out
@@ -32,27 +32,6 @@ select * from conditions , mat_t1 WITH NO DATA;
 ERROR:  unsupported combination of storage parameters
 DETAIL:  A continuous aggregate does not support standard storage parameters.
 HINT:  Use only parameters with the "timescaledb." prefix when creating a continuous aggregate.
--- join multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
-as
-select location, count(*) from conditions , mat_t1
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
--- join multiple tables WITH explicit JOIN
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
-as
-select location, count(*) from conditions JOIN mat_t1 ON true
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
--- LATERAL multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
-as
-select location, count(*) from conditions,
-LATERAL (Select * from mat_t1 where c = conditions.location) q
-group by location WITH NO DATA;
-ERROR:  only one hypertable allowed in continuous aggregate view
 --non-hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as

--- a/tsl/test/expected/cagg_joins-12.out
+++ b/tsl/test/expected/cagg_joins-12.out
@@ -1,0 +1,359 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+CREATE TABLE conditions(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+device_id int NOT NULL);
+SELECT create_hypertable(
+  'conditions', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-14', 'Moscow', 26,1),
+  ('2021-06-15', 'Moscow', 22,2),
+  ('2021-06-16', 'Moscow', 24,3),
+  ('2021-06-17', 'Moscow', 24,4),
+  ('2021-06-18', 'Moscow', 27,4),
+  ('2021-06-19', 'Moscow', 28,4),
+  ('2021-06-20', 'Moscow', 30,1),
+  ('2021-06-21', 'Moscow', 31,1),
+  ('2021-06-22', 'Moscow', 34,1),
+  ('2021-06-23', 'Moscow', 34,2),
+  ('2021-06-24', 'Moscow', 34,2),
+  ('2021-06-25', 'Moscow', 32,3),
+  ('2021-06-26', 'Moscow', 32,3),
+  ('2021-06-27', 'Moscow', 31,3);
+CREATE TABLE conditions_dup AS SELECT * FROM conditions;
+SELECT create_hypertable(
+  'conditions_dup', 'day',
+  chunk_time_interval => INTERVAL '1 day',
+  migrate_data => true
+);
+NOTICE:  adding not-null constraint to column "day"
+DETAIL:  Time dimensions cannot have NULL values.
+NOTICE:  migrating data to chunks
+DETAIL:  Migration might take a while depending on the amount of data.
+      create_hypertable      
+-----------------------------
+ (2,public,conditions_dup,t)
+(1 row)
+
+CREATE TABLE devices ( device_id int not null, name text, location text);
+INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+CREATE TABLE devices_dup AS SELECT * FROM devices;
+CREATE VIEW devices_view AS SELECT * FROM devices;
+--Create a cagg with join between a hypertable and a normal table
+-- with equality condition on inner join type
+CREATE MATERIALIZED VIEW conditions_summary_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_reorder
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices, conditions
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_2"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  time bucket function must reference a hypertable dimension column
+CREATE MATERIALIZED VIEW conditions_summary_daily_3
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions USING (device_id)
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  joins with using clause in continuous aggregate definition work for Postgres versions 13 and above
+CREATE MATERIALIZED VIEW conditions_summary_daily_3_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices USING (device_id)
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  joins with using clause in continuous aggregate definition work for Postgres versions 13 and above
+--Error out for old format cagg definition
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
+-- Error out LATERAL multiple tables old format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+-- Error out for LATERAL multiple tables in new format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out if from clause has view
+CREATE MATERIALIZED VIEW conditions_summary_daily_view
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+-- Nested CAgg over a CAgg with join
+CREATE MATERIALIZED VIEW cagg_on_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM conditions_summary_daily
+GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_on_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+DROP MATERIALIZED VIEW cagg_on_cagg CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_6_35_chunk
+drop cascades to table _timescaledb_internal._hyper_6_36_chunk
+--Error out when real time aggregation is enabled
+CREATE MATERIALIZED VIEW conditions_summary_daily_realtime
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  real-time continuous aggregates are not supported with joins
+HINT:  set materialized_only to true
+CREATE TABLE cities(name text, currency text);
+INSERT INTO cities VALUES ('Berlin', 'EUR'), ('London', 'PND');
+--Error out when from clause has sub selects
+CREATE MATERIALIZED VIEW conditions_summary_subselect
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+DROP TABLE cities CASCADE;
+--Error out when join is between two hypertables
+CREATE MATERIALIZED VIEW conditions_summary_daily_ht
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   MAX(conditions.temperature),
+   MIN(conditions.temperature)
+FROM conditions, conditions_dup
+WHERE conditions.device_id = conditions_dup.device_id
+GROUP BY bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is between two normal tables
+CREATE MATERIALIZED VIEW conditions_summary_daily_nt
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT AVG(devices.device_id),
+   MAX(devices.device_id),
+   MIN(devices.device_id),
+   devices.name,
+   devices.location
+FROM devices, devices_dup
+WHERE devices.device_id = devices_dup.device_id
+GROUP BY devices.name, devices.location;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is on non-equality condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id <> devices.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  only equality conditions are supported in continuous aggregates
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id AND
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id OR
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Error out when join type is not inner
+CREATE MATERIALIZED VIEW conditions_summary_daily_outer
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions FULL JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  only inner joins are supported in continuous aggregates
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+--Errors out for join between cagg and normal table
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   devices.name
+FROM conditions_summary_daily_cagg cagg, devices
+WHERE cagg.device_id = devices.device_id
+GROUP BY devices.name, bucket;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+--Error out for join between cagg and hypertable
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   cagg.name,
+   conditions.temperature
+FROM conditions_summary_daily_cagg cagg, conditions
+WHERE cagg.device_id = conditions.device_id
+GROUP BY conditions.temperature, bucket, cagg.name;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 9 other objects
+DETAIL:  drop cascades to view _timescaledb_internal._partial_view_3
+drop cascades to view _timescaledb_internal._direct_view_3
+drop cascades to view _timescaledb_internal._partial_view_4
+drop cascades to view _timescaledb_internal._direct_view_4
+drop cascades to view conditions_summary_daily_2
+drop cascades to view _timescaledb_internal._partial_view_5
+drop cascades to view _timescaledb_internal._direct_view_5
+drop cascades to view _timescaledb_internal._partial_view_7
+drop cascades to view _timescaledb_internal._direct_view_7
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_3_29_chunk
+drop cascades to table _timescaledb_internal._hyper_3_30_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_4_31_chunk
+drop cascades to table _timescaledb_internal._hyper_4_32_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_5_33_chunk
+drop cascades to table _timescaledb_internal._hyper_5_34_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_7_37_chunk
+drop cascades to table _timescaledb_internal._hyper_7_38_chunk
+DROP TABLE devices CASCADE;
+NOTICE:  drop cascades to view devices_view
+DROP TABLE conditions_dup CASCADE;
+DROP TABLE devices_dup CASCADE;

--- a/tsl/test/expected/cagg_joins-13.out
+++ b/tsl/test/expected/cagg_joins-13.out
@@ -1,0 +1,378 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+CREATE TABLE conditions(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+device_id int NOT NULL);
+SELECT create_hypertable(
+  'conditions', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-14', 'Moscow', 26,1),
+  ('2021-06-15', 'Moscow', 22,2),
+  ('2021-06-16', 'Moscow', 24,3),
+  ('2021-06-17', 'Moscow', 24,4),
+  ('2021-06-18', 'Moscow', 27,4),
+  ('2021-06-19', 'Moscow', 28,4),
+  ('2021-06-20', 'Moscow', 30,1),
+  ('2021-06-21', 'Moscow', 31,1),
+  ('2021-06-22', 'Moscow', 34,1),
+  ('2021-06-23', 'Moscow', 34,2),
+  ('2021-06-24', 'Moscow', 34,2),
+  ('2021-06-25', 'Moscow', 32,3),
+  ('2021-06-26', 'Moscow', 32,3),
+  ('2021-06-27', 'Moscow', 31,3);
+CREATE TABLE conditions_dup AS SELECT * FROM conditions;
+SELECT create_hypertable(
+  'conditions_dup', 'day',
+  chunk_time_interval => INTERVAL '1 day',
+  migrate_data => true
+);
+NOTICE:  adding not-null constraint to column "day"
+DETAIL:  Time dimensions cannot have NULL values.
+NOTICE:  migrating data to chunks
+DETAIL:  Migration might take a while depending on the amount of data.
+      create_hypertable      
+-----------------------------
+ (2,public,conditions_dup,t)
+(1 row)
+
+CREATE TABLE devices ( device_id int not null, name text, location text);
+INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+CREATE TABLE devices_dup AS SELECT * FROM devices;
+CREATE VIEW devices_view AS SELECT * FROM devices;
+--Create a cagg with join between a hypertable and a normal table
+-- with equality condition on inner join type
+CREATE MATERIALIZED VIEW conditions_summary_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_reorder
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices, conditions
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_2"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_2_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_3
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions USING (device_id)
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_3"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_3_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices USING (device_id)
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_3_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+--Error out for old format cagg definition
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
+-- Error out LATERAL multiple tables old format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+-- Error out for LATERAL multiple tables in new format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out if from clause has view
+CREATE MATERIALIZED VIEW conditions_summary_daily_view
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+-- Nested CAgg over a CAgg with join
+CREATE MATERIALIZED VIEW cagg_on_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM conditions_summary_daily
+GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_on_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+DROP MATERIALIZED VIEW cagg_on_cagg CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_9_41_chunk
+drop cascades to table _timescaledb_internal._hyper_9_42_chunk
+--Error out when real time aggregation is enabled
+CREATE MATERIALIZED VIEW conditions_summary_daily_realtime
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  real-time continuous aggregates are not supported with joins
+HINT:  set materialized_only to true
+CREATE TABLE cities(name text, currency text);
+INSERT INTO cities VALUES ('Berlin', 'EUR'), ('London', 'PND');
+--Error out when from clause has sub selects
+CREATE MATERIALIZED VIEW conditions_summary_subselect
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+DROP TABLE cities CASCADE;
+--Error out when join is between two hypertables
+CREATE MATERIALIZED VIEW conditions_summary_daily_ht
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   MAX(conditions.temperature),
+   MIN(conditions.temperature)
+FROM conditions, conditions_dup
+WHERE conditions.device_id = conditions_dup.device_id
+GROUP BY bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is between two normal tables
+CREATE MATERIALIZED VIEW conditions_summary_daily_nt
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT AVG(devices.device_id),
+   MAX(devices.device_id),
+   MIN(devices.device_id),
+   devices.name,
+   devices.location
+FROM devices, devices_dup
+WHERE devices.device_id = devices_dup.device_id
+GROUP BY devices.name, devices.location;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is on non-equality condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id <> devices.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  only equality conditions are supported in continuous aggregates
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id AND
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id OR
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Error out when join type is not inner
+CREATE MATERIALIZED VIEW conditions_summary_daily_outer
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions FULL JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  only inner joins are supported in continuous aggregates
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+--Errors out for join between cagg and normal table
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   devices.name
+FROM conditions_summary_daily_cagg cagg, devices
+WHERE cagg.device_id = devices.device_id
+GROUP BY devices.name, bucket;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+--Error out for join between cagg and hypertable
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   cagg.name,
+   conditions.temperature
+FROM conditions_summary_daily_cagg cagg, conditions
+WHERE cagg.device_id = conditions.device_id
+GROUP BY conditions.temperature, bucket, cagg.name;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 18 other objects
+DETAIL:  drop cascades to view _timescaledb_internal._partial_view_3
+drop cascades to view _timescaledb_internal._direct_view_3
+drop cascades to view _timescaledb_internal._partial_view_4
+drop cascades to view _timescaledb_internal._direct_view_4
+drop cascades to view conditions_summary_daily_2
+drop cascades to view _timescaledb_internal._partial_view_5
+drop cascades to view _timescaledb_internal._direct_view_5
+drop cascades to view conditions_summary_daily_2_reorder
+drop cascades to view _timescaledb_internal._partial_view_6
+drop cascades to view _timescaledb_internal._direct_view_6
+drop cascades to view conditions_summary_daily_3
+drop cascades to view _timescaledb_internal._partial_view_7
+drop cascades to view _timescaledb_internal._direct_view_7
+drop cascades to view conditions_summary_daily_3_reorder
+drop cascades to view _timescaledb_internal._partial_view_8
+drop cascades to view _timescaledb_internal._direct_view_8
+drop cascades to view _timescaledb_internal._partial_view_10
+drop cascades to view _timescaledb_internal._direct_view_10
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_3_29_chunk
+drop cascades to table _timescaledb_internal._hyper_3_30_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_4_31_chunk
+drop cascades to table _timescaledb_internal._hyper_4_32_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_5_33_chunk
+drop cascades to table _timescaledb_internal._hyper_5_34_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_6_35_chunk
+drop cascades to table _timescaledb_internal._hyper_6_36_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_7_37_chunk
+drop cascades to table _timescaledb_internal._hyper_7_38_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_8_39_chunk
+drop cascades to table _timescaledb_internal._hyper_8_40_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_10_43_chunk
+drop cascades to table _timescaledb_internal._hyper_10_44_chunk
+DROP TABLE devices CASCADE;
+NOTICE:  drop cascades to view devices_view
+DROP TABLE conditions_dup CASCADE;
+DROP TABLE devices_dup CASCADE;

--- a/tsl/test/expected/cagg_joins-14.out
+++ b/tsl/test/expected/cagg_joins-14.out
@@ -1,0 +1,378 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+CREATE TABLE conditions(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+device_id int NOT NULL);
+SELECT create_hypertable(
+  'conditions', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-14', 'Moscow', 26,1),
+  ('2021-06-15', 'Moscow', 22,2),
+  ('2021-06-16', 'Moscow', 24,3),
+  ('2021-06-17', 'Moscow', 24,4),
+  ('2021-06-18', 'Moscow', 27,4),
+  ('2021-06-19', 'Moscow', 28,4),
+  ('2021-06-20', 'Moscow', 30,1),
+  ('2021-06-21', 'Moscow', 31,1),
+  ('2021-06-22', 'Moscow', 34,1),
+  ('2021-06-23', 'Moscow', 34,2),
+  ('2021-06-24', 'Moscow', 34,2),
+  ('2021-06-25', 'Moscow', 32,3),
+  ('2021-06-26', 'Moscow', 32,3),
+  ('2021-06-27', 'Moscow', 31,3);
+CREATE TABLE conditions_dup AS SELECT * FROM conditions;
+SELECT create_hypertable(
+  'conditions_dup', 'day',
+  chunk_time_interval => INTERVAL '1 day',
+  migrate_data => true
+);
+NOTICE:  adding not-null constraint to column "day"
+DETAIL:  Time dimensions cannot have NULL values.
+NOTICE:  migrating data to chunks
+DETAIL:  Migration might take a while depending on the amount of data.
+      create_hypertable      
+-----------------------------
+ (2,public,conditions_dup,t)
+(1 row)
+
+CREATE TABLE devices ( device_id int not null, name text, location text);
+INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+CREATE TABLE devices_dup AS SELECT * FROM devices;
+CREATE VIEW devices_view AS SELECT * FROM devices;
+--Create a cagg with join between a hypertable and a normal table
+-- with equality condition on inner join type
+CREATE MATERIALIZED VIEW conditions_summary_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_reorder
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices, conditions
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_2"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_2_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_3
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions USING (device_id)
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_3"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_3_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices USING (device_id)
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_3_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+--Error out for old format cagg definition
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
+-- Error out LATERAL multiple tables old format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+-- Error out for LATERAL multiple tables in new format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out if from clause has view
+CREATE MATERIALIZED VIEW conditions_summary_daily_view
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+-- Nested CAgg over a CAgg with join
+CREATE MATERIALIZED VIEW cagg_on_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM conditions_summary_daily
+GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_on_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+DROP MATERIALIZED VIEW cagg_on_cagg CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_9_41_chunk
+drop cascades to table _timescaledb_internal._hyper_9_42_chunk
+--Error out when real time aggregation is enabled
+CREATE MATERIALIZED VIEW conditions_summary_daily_realtime
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  real-time continuous aggregates are not supported with joins
+HINT:  set materialized_only to true
+CREATE TABLE cities(name text, currency text);
+INSERT INTO cities VALUES ('Berlin', 'EUR'), ('London', 'PND');
+--Error out when from clause has sub selects
+CREATE MATERIALIZED VIEW conditions_summary_subselect
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+DROP TABLE cities CASCADE;
+--Error out when join is between two hypertables
+CREATE MATERIALIZED VIEW conditions_summary_daily_ht
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   MAX(conditions.temperature),
+   MIN(conditions.temperature)
+FROM conditions, conditions_dup
+WHERE conditions.device_id = conditions_dup.device_id
+GROUP BY bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is between two normal tables
+CREATE MATERIALIZED VIEW conditions_summary_daily_nt
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT AVG(devices.device_id),
+   MAX(devices.device_id),
+   MIN(devices.device_id),
+   devices.name,
+   devices.location
+FROM devices, devices_dup
+WHERE devices.device_id = devices_dup.device_id
+GROUP BY devices.name, devices.location;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is on non-equality condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id <> devices.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  only equality conditions are supported in continuous aggregates
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id AND
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id OR
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Error out when join type is not inner
+CREATE MATERIALIZED VIEW conditions_summary_daily_outer
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions FULL JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  only inner joins are supported in continuous aggregates
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+--Errors out for join between cagg and normal table
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   devices.name
+FROM conditions_summary_daily_cagg cagg, devices
+WHERE cagg.device_id = devices.device_id
+GROUP BY devices.name, bucket;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+--Error out for join between cagg and hypertable
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   cagg.name,
+   conditions.temperature
+FROM conditions_summary_daily_cagg cagg, conditions
+WHERE cagg.device_id = conditions.device_id
+GROUP BY conditions.temperature, bucket, cagg.name;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 18 other objects
+DETAIL:  drop cascades to view _timescaledb_internal._partial_view_3
+drop cascades to view _timescaledb_internal._direct_view_3
+drop cascades to view _timescaledb_internal._partial_view_4
+drop cascades to view _timescaledb_internal._direct_view_4
+drop cascades to view conditions_summary_daily_2
+drop cascades to view _timescaledb_internal._partial_view_5
+drop cascades to view _timescaledb_internal._direct_view_5
+drop cascades to view conditions_summary_daily_2_reorder
+drop cascades to view _timescaledb_internal._partial_view_6
+drop cascades to view _timescaledb_internal._direct_view_6
+drop cascades to view conditions_summary_daily_3
+drop cascades to view _timescaledb_internal._partial_view_7
+drop cascades to view _timescaledb_internal._direct_view_7
+drop cascades to view conditions_summary_daily_3_reorder
+drop cascades to view _timescaledb_internal._partial_view_8
+drop cascades to view _timescaledb_internal._direct_view_8
+drop cascades to view _timescaledb_internal._partial_view_10
+drop cascades to view _timescaledb_internal._direct_view_10
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_3_29_chunk
+drop cascades to table _timescaledb_internal._hyper_3_30_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_4_31_chunk
+drop cascades to table _timescaledb_internal._hyper_4_32_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_5_33_chunk
+drop cascades to table _timescaledb_internal._hyper_5_34_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_6_35_chunk
+drop cascades to table _timescaledb_internal._hyper_6_36_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_7_37_chunk
+drop cascades to table _timescaledb_internal._hyper_7_38_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_8_39_chunk
+drop cascades to table _timescaledb_internal._hyper_8_40_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_10_43_chunk
+drop cascades to table _timescaledb_internal._hyper_10_44_chunk
+DROP TABLE devices CASCADE;
+NOTICE:  drop cascades to view devices_view
+DROP TABLE conditions_dup CASCADE;
+DROP TABLE devices_dup CASCADE;

--- a/tsl/test/expected/cagg_joins-15.out
+++ b/tsl/test/expected/cagg_joins-15.out
@@ -1,0 +1,378 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+CREATE TABLE conditions(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+device_id int NOT NULL);
+SELECT create_hypertable(
+  'conditions', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+    create_hypertable    
+-------------------------
+ (1,public,conditions,t)
+(1 row)
+
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-14', 'Moscow', 26,1),
+  ('2021-06-15', 'Moscow', 22,2),
+  ('2021-06-16', 'Moscow', 24,3),
+  ('2021-06-17', 'Moscow', 24,4),
+  ('2021-06-18', 'Moscow', 27,4),
+  ('2021-06-19', 'Moscow', 28,4),
+  ('2021-06-20', 'Moscow', 30,1),
+  ('2021-06-21', 'Moscow', 31,1),
+  ('2021-06-22', 'Moscow', 34,1),
+  ('2021-06-23', 'Moscow', 34,2),
+  ('2021-06-24', 'Moscow', 34,2),
+  ('2021-06-25', 'Moscow', 32,3),
+  ('2021-06-26', 'Moscow', 32,3),
+  ('2021-06-27', 'Moscow', 31,3);
+CREATE TABLE conditions_dup AS SELECT * FROM conditions;
+SELECT create_hypertable(
+  'conditions_dup', 'day',
+  chunk_time_interval => INTERVAL '1 day',
+  migrate_data => true
+);
+NOTICE:  adding not-null constraint to column "day"
+DETAIL:  Time dimensions cannot have NULL values.
+NOTICE:  migrating data to chunks
+DETAIL:  Migration might take a while depending on the amount of data.
+      create_hypertable      
+-----------------------------
+ (2,public,conditions_dup,t)
+(1 row)
+
+CREATE TABLE devices ( device_id int not null, name text, location text);
+INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+CREATE TABLE devices_dup AS SELECT * FROM devices;
+CREATE VIEW devices_view AS SELECT * FROM devices;
+--Create a cagg with join between a hypertable and a normal table
+-- with equality condition on inner join type
+CREATE MATERIALIZED VIEW conditions_summary_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_reorder
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices, conditions
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_2"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_2_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_2_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_3
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions USING (device_id)
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_3"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+CREATE MATERIALIZED VIEW conditions_summary_daily_3_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices USING (device_id)
+GROUP BY name, bucket;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_3_reorder"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+--Error out for old format cagg definition
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
+-- Error out LATERAL multiple tables old format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  old format of continuous aggregate is not supported with joins
+HINT:  set timescaledb.finalized to TRUE
+-- Error out for LATERAL multiple tables in new format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out if from clause has view
+CREATE MATERIALIZED VIEW conditions_summary_daily_view
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+-- Nested CAgg over a CAgg with join
+CREATE MATERIALIZED VIEW cagg_on_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM conditions_summary_daily
+GROUP BY 1;
+NOTICE:  refreshing continuous aggregate "cagg_on_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+DROP MATERIALIZED VIEW cagg_on_cagg CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_9_41_chunk
+drop cascades to table _timescaledb_internal._hyper_9_42_chunk
+--Error out when real time aggregation is enabled
+CREATE MATERIALIZED VIEW conditions_summary_daily_realtime
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  real-time continuous aggregates are not supported with joins
+HINT:  set materialized_only to true
+CREATE TABLE cities(name text, currency text);
+INSERT INTO cities VALUES ('Berlin', 'EUR'), ('London', 'PND');
+--Error out when from clause has sub selects
+CREATE MATERIALIZED VIEW conditions_summary_subselect
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+DROP TABLE cities CASCADE;
+--Error out when join is between two hypertables
+CREATE MATERIALIZED VIEW conditions_summary_daily_ht
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   MAX(conditions.temperature),
+   MIN(conditions.temperature)
+FROM conditions, conditions_dup
+WHERE conditions.device_id = conditions_dup.device_id
+GROUP BY bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is between two normal tables
+CREATE MATERIALIZED VIEW conditions_summary_daily_nt
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT AVG(devices.device_id),
+   MAX(devices.device_id),
+   MIN(devices.device_id),
+   devices.name,
+   devices.location
+FROM devices, devices_dup
+WHERE devices.device_id = devices_dup.device_id
+GROUP BY devices.name, devices.location;
+ERROR:  invalid continuous aggregate view
+DETAIL:  from clause can only have one hypertable and one normal table
+--Error out when join is on non-equality condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id <> devices.device_id
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  only equality conditions are supported in continuous aggregates
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id AND
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id OR
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+ERROR:  invalid continuous aggregate view
+DETAIL:  unsupported expression in join clause
+HINT:  only equality condition is supported
+--Error out when join type is not inner
+CREATE MATERIALIZED VIEW conditions_summary_daily_outer
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions FULL JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+ERROR:  only inner joins are supported in continuous aggregates
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+NOTICE:  refreshing continuous aggregate "conditions_summary_daily_cagg"
+HINT:  Use WITH NO DATA if you do not want to refresh the continuous aggregate on creation.
+--Errors out for join between cagg and normal table
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   devices.name
+FROM conditions_summary_daily_cagg cagg, devices
+WHERE cagg.device_id = devices.device_id
+GROUP BY devices.name, bucket;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+--Error out for join between cagg and hypertable
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   cagg.name,
+   conditions.temperature
+FROM conditions_summary_daily_cagg cagg, conditions
+WHERE cagg.device_id = conditions.device_id
+GROUP BY conditions.temperature, bucket, cagg.name;
+ERROR:  joins for hierarchical continuous aggregates are not supported
+DROP TABLE conditions CASCADE;
+NOTICE:  drop cascades to 18 other objects
+DETAIL:  drop cascades to view _timescaledb_internal._partial_view_3
+drop cascades to view _timescaledb_internal._direct_view_3
+drop cascades to view _timescaledb_internal._partial_view_4
+drop cascades to view _timescaledb_internal._direct_view_4
+drop cascades to view conditions_summary_daily_2
+drop cascades to view _timescaledb_internal._partial_view_5
+drop cascades to view _timescaledb_internal._direct_view_5
+drop cascades to view conditions_summary_daily_2_reorder
+drop cascades to view _timescaledb_internal._partial_view_6
+drop cascades to view _timescaledb_internal._direct_view_6
+drop cascades to view conditions_summary_daily_3
+drop cascades to view _timescaledb_internal._partial_view_7
+drop cascades to view _timescaledb_internal._direct_view_7
+drop cascades to view conditions_summary_daily_3_reorder
+drop cascades to view _timescaledb_internal._partial_view_8
+drop cascades to view _timescaledb_internal._direct_view_8
+drop cascades to view _timescaledb_internal._partial_view_10
+drop cascades to view _timescaledb_internal._direct_view_10
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_3_29_chunk
+drop cascades to table _timescaledb_internal._hyper_3_30_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_4_31_chunk
+drop cascades to table _timescaledb_internal._hyper_4_32_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_5_33_chunk
+drop cascades to table _timescaledb_internal._hyper_5_34_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_6_35_chunk
+drop cascades to table _timescaledb_internal._hyper_6_36_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_7_37_chunk
+drop cascades to table _timescaledb_internal._hyper_7_38_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_8_39_chunk
+drop cascades to table _timescaledb_internal._hyper_8_40_chunk
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table _timescaledb_internal._hyper_10_43_chunk
+drop cascades to table _timescaledb_internal._hyper_10_44_chunk
+DROP TABLE devices CASCADE;
+NOTICE:  drop cascades to view devices_view
+DROP TABLE conditions_dup CASCADE;
+DROP TABLE devices_dup CASCADE;

--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -20,3 +20,4 @@
 /telemetry_stats-*.sql
 /transparent_decompression-*.sql
 /transparent_decompression_ordered_index-*.sql
+/cagg_joins-*.sql

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -150,7 +150,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     dist_partial_agg.sql.in
     dist_query.sql.in
     cagg_invalidation_dist_ht.sql.in
-    continuous_aggs.sql.in)
+    continuous_aggs.sql.in
+    cagg_joins.sql.in)
   if(USE_TELEMETRY)
     list(APPEND TEST_TEMPLATES telemetry_stats.sql.in)
   endif()

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -29,27 +29,6 @@ CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous, check_option = LO
 as
 select * from conditions , mat_t1 WITH NO DATA;
 
--- join multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
-as
-select location, count(*) from conditions , mat_t1
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-
--- join multiple tables WITH explicit JOIN
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
-as
-select location, count(*) from conditions JOIN mat_t1 ON true
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-
--- LATERAL multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)
-as
-select location, count(*) from conditions,
-LATERAL (Select * from mat_t1 where c = conditions.location) q
-group by location WITH NO DATA;
-
 
 --non-hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH ( timescaledb.continuous)

--- a/tsl/test/sql/cagg_errors_deprecated.sql
+++ b/tsl/test/sql/cagg_errors_deprecated.sql
@@ -29,27 +29,6 @@ CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finali
 as
 select * from conditions , mat_t1 WITH NO DATA;
 
--- join multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
-as
-select location, count(*) from conditions , mat_t1
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-
--- join multiple tables WITH explicit JOIN
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
-as
-select location, count(*) from conditions JOIN mat_t1 ON true
-where conditions.location = mat_t1.c
-group by location WITH NO DATA;
-
--- LATERAL multiple tables
-CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
-as
-select location, count(*) from conditions,
-LATERAL (Select * from mat_t1 where c = conditions.location) q
-group by location WITH NO DATA;
-
 --non-hypertable
 CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
 as

--- a/tsl/test/sql/cagg_joins.sql.in
+++ b/tsl/test/sql/cagg_joins.sql.in
@@ -1,0 +1,308 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+
+CREATE TABLE conditions(
+  day DATE NOT NULL,
+  city text NOT NULL,
+  temperature INT NOT NULL,
+device_id int NOT NULL);
+SELECT create_hypertable(
+  'conditions', 'day',
+  chunk_time_interval => INTERVAL '1 day'
+);
+INSERT INTO conditions (day, city, temperature, device_id) VALUES
+  ('2021-06-14', 'Moscow', 26,1),
+  ('2021-06-15', 'Moscow', 22,2),
+  ('2021-06-16', 'Moscow', 24,3),
+  ('2021-06-17', 'Moscow', 24,4),
+  ('2021-06-18', 'Moscow', 27,4),
+  ('2021-06-19', 'Moscow', 28,4),
+  ('2021-06-20', 'Moscow', 30,1),
+  ('2021-06-21', 'Moscow', 31,1),
+  ('2021-06-22', 'Moscow', 34,1),
+  ('2021-06-23', 'Moscow', 34,2),
+  ('2021-06-24', 'Moscow', 34,2),
+  ('2021-06-25', 'Moscow', 32,3),
+  ('2021-06-26', 'Moscow', 32,3),
+  ('2021-06-27', 'Moscow', 31,3);
+
+CREATE TABLE conditions_dup AS SELECT * FROM conditions;
+SELECT create_hypertable(
+  'conditions_dup', 'day',
+  chunk_time_interval => INTERVAL '1 day',
+  migrate_data => true
+);
+CREATE TABLE devices ( device_id int not null, name text, location text);
+INSERT INTO devices values (1, 'thermo_1', 'Moscow'), (2, 'thermo_2', 'Berlin'),(3, 'thermo_3', 'London'),(4, 'thermo_4', 'Stockholm');
+
+CREATE TABLE devices_dup AS SELECT * FROM devices;
+CREATE VIEW devices_view AS SELECT * FROM devices;
+
+--Create a cagg with join between a hypertable and a normal table
+-- with equality condition on inner join type
+CREATE MATERIALIZED VIEW conditions_summary_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+
+CREATE MATERIALIZED VIEW conditions_summary_daily_reorder
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices, conditions
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+
+CREATE MATERIALIZED VIEW conditions_summary_daily_2
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+
+CREATE MATERIALIZED VIEW conditions_summary_daily_2_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+
+CREATE MATERIALIZED VIEW conditions_summary_daily_3
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM devices JOIN conditions USING (device_id)
+GROUP BY name, bucket;
+
+CREATE MATERIALIZED VIEW conditions_summary_daily_3_reorder
+WITH (timescaledb.continuous) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN devices USING (device_id)
+GROUP BY name, bucket;
+
+--Error out for old format cagg definition
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE, timescaledb.finalized = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+
+CREATE  TABLE mat_t1( a integer, b integer,c TEXT);
+
+-- Error out LATERAL multiple tables old format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous, timescaledb.finalized = false)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+
+-- Error out for LATERAL multiple tables in new format
+CREATE MATERIALIZED VIEW mat_m1 WITH (timescaledb.continuous)
+as
+select temperature, count(*) from conditions,
+LATERAL (Select * from mat_t1 where a = conditions.temperature) q
+group by temperature WITH NO DATA;
+
+--Error out if from clause has view
+CREATE MATERIALIZED VIEW conditions_summary_daily_view
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices_view.device_id,
+   name
+FROM conditions, devices_view
+WHERE conditions.device_id = devices_view.device_id
+GROUP BY name, bucket, devices_view.device_id;
+
+-- Nested CAgg over a CAgg with join
+CREATE MATERIALIZED VIEW cagg_on_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT time_bucket(INTERVAL '1 day', bucket) AS bucket,
+       SUM(avg) AS temperature
+FROM conditions_summary_daily
+GROUP BY 1;
+
+DROP MATERIALIZED VIEW cagg_on_cagg CASCADE;
+
+--Error out when real time aggregation is enabled
+CREATE MATERIALIZED VIEW conditions_summary_daily_realtime
+WITH (timescaledb.continuous, timescaledb.materialized_only = FALSE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+
+CREATE TABLE cities(name text, currency text);
+INSERT INTO cities VALUES ('Berlin', 'EUR'), ('London', 'PND');
+
+--Error out when from clause has sub selects
+CREATE MATERIALIZED VIEW conditions_summary_subselect
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions JOIN (SELECT * FROM devices WHERE location in (SELECT name from cities where currency = 'EUR')) dev ON conditions.device_id = dev.device_id
+GROUP BY name, bucket;
+
+DROP TABLE cities CASCADE;
+
+--Error out when join is between two hypertables
+CREATE MATERIALIZED VIEW conditions_summary_daily_ht
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', conditions.day) AS bucket,
+   AVG(conditions.temperature),
+   MAX(conditions.temperature),
+   MIN(conditions.temperature)
+FROM conditions, conditions_dup
+WHERE conditions.device_id = conditions_dup.device_id
+GROUP BY bucket;
+
+--Error out when join is between two normal tables
+CREATE MATERIALIZED VIEW conditions_summary_daily_nt
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT AVG(devices.device_id),
+   MAX(devices.device_id),
+   MIN(devices.device_id),
+   devices.name,
+   devices.location
+FROM devices, devices_dup
+WHERE devices.device_id = devices_dup.device_id
+GROUP BY devices.name, devices.location;
+
+--Error out when join is on non-equality condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id <> devices.device_id
+GROUP BY name, bucket;
+
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id AND
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+
+--Unsupported join condition
+CREATE MATERIALIZED VIEW conditions_summary_daily_unequal
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id OR
+      conditions.city like '%cow*'
+GROUP BY name, bucket;
+
+--Error out when join type is not inner
+CREATE MATERIALIZED VIEW conditions_summary_daily_outer
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   name
+FROM conditions FULL JOIN devices
+ON conditions.device_id = devices.device_id
+GROUP BY name, bucket;
+
+CREATE MATERIALIZED VIEW conditions_summary_daily_cagg
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', day) AS bucket,
+   AVG(temperature),
+   MAX(temperature),
+   MIN(temperature),
+   devices.device_id device_id,
+   name
+FROM conditions, devices
+WHERE conditions.device_id = devices.device_id
+GROUP BY name, bucket, devices.device_id;
+
+--Errors out for join between cagg and normal table
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   devices.name
+FROM conditions_summary_daily_cagg cagg, devices
+WHERE cagg.device_id = devices.device_id
+GROUP BY devices.name, bucket;
+
+--Error out for join between cagg and hypertable
+CREATE MATERIALIZED VIEW conditions_summary_daily_nested
+WITH (timescaledb.continuous, timescaledb.materialized_only = TRUE) AS
+SELECT time_bucket(INTERVAL '1 day', cagg.bucket) AS bucket,
+   cagg.name,
+   conditions.temperature
+FROM conditions_summary_daily_cagg cagg, conditions
+WHERE cagg.device_id = conditions.device_id
+GROUP BY conditions.temperature, bucket, cagg.name;
+
+DROP TABLE conditions CASCADE;
+DROP TABLE devices CASCADE;
+DROP TABLE conditions_dup CASCADE;
+DROP TABLE devices_dup CASCADE;


### PR DESCRIPTION
Enable the support of having join in the query used for creating the continuous aggregates. It has follwoing restrictions-
1. Join can involve only one hypertable and one normal table
2. Join should be a left inner join
3. Join condition can only be equality