### PR TITLE
Fix postgres version assert in telemetry

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -21,6 +21,8 @@
 
 #include "export.h"
 
+#define PG_MAJOR_MIN 12
+
 #define is_supported_pg_version_12(version) ((version >= 120000) && (version < 130000))
 #define is_supported_pg_version_13(version) ((version >= 130002) && (version < 140000))
 #define is_supported_pg_version_14(version) ((version >= 140000) && (version < 150000))

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -306,7 +306,7 @@ get_pgversion_string()
 	major = server_version_num / 10000;
 	patch = server_version_num % 100;
 
-	Assert(major > 10);
+	Assert(major >= PG_MAJOR_MIN);
 	appendStringInfo(buf, "%d.%d", major, patch);
 
 	return buf->data;


### PR DESCRIPTION
The telemetry code that reads the postgres version was not updated when support for older postgres version was dropped so we introduce a new macro PG_MAJOR_MIN which is the oldest pg major version we support.