### PR TITLE
Add hook for chunk creation

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -67,6 +67,7 @@ extern TSDLLEXPORT int64 ts_interval_value_to_internal(Datum time_val, Oid type_
  * Convert a column from the internal time representation into the specified type
  */
 extern TSDLLEXPORT Datum ts_internal_to_time_value(int64 value, Oid type);
+extern TSDLLEXPORT int64 ts_internal_to_time_int64(int64 value, Oid type);
 extern TSDLLEXPORT Datum ts_internal_to_interval_value(int64 value, Oid type);
 extern TSDLLEXPORT char *ts_internal_to_time_string(int64 value, Oid type);
 

--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -27,6 +27,11 @@ GRANT SELECT on chunk_view TO PUBLIC;
 CREATE SCHEMA test1;
 GRANT CREATE ON SCHEMA test1 TO :ROLE_DEFAULT_PERM_USER;
 GRANT USAGE ON SCHEMA test1 TO :ROLE_DEFAULT_PERM_USER;
+--mock hooks for OSM intercation with timescaledb
+CREATE OR REPLACE FUNCTION ts_setup_osm_hook( ) RETURNS VOID
+AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
+CREATE OR REPLACE FUNCTION ts_undo_osm_hook( ) RETURNS VOID
+AS :TSL_MODULE_PATHNAME LANGUAGE C VOLATILE;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE TABLE test1.hyper1 (time bigint, temp float);
 SELECT create_hypertable('test1.hyper1', 'time', chunk_time_interval => 10);
@@ -465,6 +470,25 @@ SELECT * from ht_try WHERE timec > '2020-01-01 01:00' ORDER BY 1;
             timec             | acq_id | value 
 ------------------------------+--------+-------
  Thu May 05 01:00:00 2022 PDT |    222 |   222
+(1 row)
+
+--TEST insert into a OSM chunk fails. actually any insert will fail. But we just need
+-- to mock the hook and make sure the timescaledb code works correctly.
+SELECT ts_setup_osm_hook();
+ ts_setup_osm_hook 
+-------------------
+ 
+(1 row)
+
+\set ON_ERROR_STOP 0
+--the mock hook returns true always. so cannot create a new chunk on the hypertable
+INSERT INTO ht_try VALUES ('2022-06-05 01:00', 222, 222);
+ERROR:  Cannot insert into tiered chunk range of public.ht_try - attempt to create new chunk with range  [Sat Jun 04 17:00:00 2022 PDT Sun Jun 05 17:00:00 2022 PDT] failed
+\set ON_ERROR_STOP 1
+SELECT ts_undo_osm_hook();
+ ts_undo_osm_hook 
+------------------
+ 
 (1 row)
 
 -- TEST error have to be hypertable owner to attach a chunk to it

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -97,7 +97,10 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
-  list(APPEND TEST_FILES modify_exclusion.sql chunk_utils_internal.sql)
+  list(APPEND TEST_FILES modify_exclusion.sql)
+  if(CMAKE_BUILD_TYPE MATCHES Debug)
+    list(APPEND TEST_FILES chunk_utils_internal.sql)
+  endif()
 endif()
 
 set(SOLO_TESTS

--- a/tsl/test/src/test_chunk_stats.c
+++ b/tsl/test/src/test_chunk_stats.c
@@ -34,3 +34,35 @@ ts_test_chunk_stats_insert(PG_FUNCTION_ARGS)
 
 	PG_RETURN_NULL();
 }
+
+static int
+osm_insert_hook_mock(Oid ht_oid, int64 range_start, int64 range_end)
+{
+	/* always return true */
+	return 1;
+}
+
+/*
+ * Dummy function to mock OSM_INSERT hook called at chunk creation for tiered data
+ */
+TS_FUNCTION_INFO_V1(ts_setup_osm_hook);
+Datum
+ts_setup_osm_hook(PG_FUNCTION_ARGS)
+{
+	typedef int (*MOCK_OSM_INSERT_HOOK)(Oid, int64, int64);
+	MOCK_OSM_INSERT_HOOK *var =
+		(MOCK_OSM_INSERT_HOOK *) find_rendezvous_variable("osm_chunk_insert_check_hook");
+	*var = osm_insert_hook_mock;
+	PG_RETURN_NULL();
+}
+
+TS_FUNCTION_INFO_V1(ts_undo_osm_hook);
+Datum
+ts_undo_osm_hook(PG_FUNCTION_ARGS)
+{
+	typedef int (*MOCK_OSM_INSERT_HOOK)(Oid, int64, int64);
+	MOCK_OSM_INSERT_HOOK *var =
+		(MOCK_OSM_INSERT_HOOK *) find_rendezvous_variable("osm_chunk_insert_check_hook");
+	*var = NULL;
+	PG_RETURN_NULL();
+}


### PR DESCRIPTION
After data is tiered using OSM, we cannot insert data into the same range. Need a callback that can be invoked by timescaledb to check for range overlaps before creating a new chunk