### PR TITLE
Remove useless message from tsl_cagg_try_repair

### DIFF
--- a/tsl/src/continuous_aggs/create.c
+++ b/tsl/src/continuous_aggs/create.c
@@ -2421,13 +2421,9 @@ cagg_rebuild_view_definition(ContinuousAgg *agg, Hypertable *mat_ht)
 	}
 
 	if (finalized)
-	{ /* This continuous aggregate does not have partials, do not check for defects. */
+	{
+		/* This continuous aggregate does not have partials, do not check for defects. */
 		relation_close(user_view_rel, NoLock);
-		elog(INFO,
-			 "Skipping check for defects of aggregate without partials "
-			 "\"%s.%s\"",
-			 schema,
-			 relname);
 		return;
 	}
 


### PR DESCRIPTION
The PR #3899 introduced a new function named `tsl_cagg_try_repair` to try to fix buggy Continuous Aggregates that lead to segfault on a select query. It added an INFO message when skipping the check for Continuous Aggregate that don't have partials and it's annoying during the upgrade/downgrade the extension specially if you have many Continuous Aggregate.

Remove this message because it's completely useless.