### PR TITLE
Fix -Wsign-compare with PG 15

### DIFF
--- a/scripts/clang_format_wrapper.sh
+++ b/scripts/clang_format_wrapper.sh
@@ -66,6 +66,7 @@ echo "formatting"
 
 cd ${TEMP_DIR}
 
+${CLANG_FORMAT:-clang-format} --version
 ${CLANG_FORMAT:-clang-format} -Wno-error=unknown ${CLANG_FORMAT_FLAGS} ${FILE_NAMES}
 
 cd ${CURR_DIR}

--- a/src/import/allpaths.c
+++ b/src/import/allpaths.c
@@ -713,7 +713,7 @@ ts_set_append_rel_size(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEn
 				int pndx = parentvar->varattno - rel->min_attr;
 				int32 child_width = 0;
 
-				if (IsA(childvar, Var) && ((Var *) childvar)->varno == childrel->relid)
+				if (IsA(childvar, Var) && (Index) ((Var *) childvar)->varno == childrel->relid)
 				{
 					int cndx = ((Var *) childvar)->varattno - childrel->min_attr;
 

--- a/src/nodes/chunk_append/chunk_append.c
+++ b/src/nodes/chunk_append/chunk_append.c
@@ -142,7 +142,7 @@ ts_chunk_append_path_create(PlannerInfo *root, RelOptInfo *rel, Hypertable *ht, 
 				 * ts_is_partitioning_column would return the correct
 				 * answer for those as well
 				 */
-				if (var->varno == rel->relid && var->varattno > 0 &&
+				if ((Index) var->varno == rel->relid && var->varattno > 0 &&
 					ts_is_partitioning_column(ht, var->varattno))
 				{
 					path->runtime_exclusion_children = true;
@@ -461,11 +461,17 @@ find_equality_join_var(Var *sort_var, Index ht_relid, Oid eq_opr, List *join_con
 			Assert(IsA(left, Var) && IsA(right, Var));
 
 			/* Is this a join condition referencing our hypertable */
-			if ((left->varno == sort_relid && right->varno == ht_relid &&
-				 left->varattno == sort_var->varattno) ||
-				(left->varno == ht_relid && right->varno == sort_relid &&
+			if (((Index) left->varno == sort_relid && (Index) right->varno == ht_relid &&
+				 left->varattno == sort_var->varattno))
+			{
+				return right;
+			}
+
+			if (((Index) left->varno == ht_relid && (Index) right->varno == sort_relid &&
 				 right->varattno == sort_var->varattno))
-				return left->varno == sort_relid ? right : left;
+			{
+				return left;
+			}
 		}
 	}
 

--- a/src/planner/constify_now.c
+++ b/src/planner/constify_now.c
@@ -74,7 +74,7 @@ is_valid_now_expr(OpExpr *op, List *rtable)
 	Var *var = linitial_node(Var, op->args);
 	if (var->varlevelsup != 0)
 		return false;
-	Assert(var->varno <= (Index) list_length(rtable));
+	Assert((int) var->varno <= list_length(rtable));
 	RangeTblEntry *rte = list_nth(rtable, var->varno - 1);
 
 	/*

--- a/src/planner/expand_hypertable.c
+++ b/src/planner/expand_hypertable.c
@@ -856,7 +856,8 @@ collect_join_quals(Node *quals, CollectQualCtx *ctx, bool can_propagate)
 			if (IsA(left, Var) && IsA(right, Var))
 			{
 				Var *ht_var =
-					castNode(Var, castNode(Var, left)->varno == ctx->rel->relid ? left : right);
+					castNode(Var,
+							 (Index) castNode(Var, left)->varno == ctx->rel->relid ? left : right);
 				TypeCacheEntry *tce = lookup_type_cache(ht_var->vartype, TYPECACHE_EQ_OPR);
 
 				if (op->opno == tce->eq_opr)
@@ -1570,12 +1571,12 @@ propagate_join_quals(PlannerInfo *root, RelOptInfo *rel, CollectQualCtx *ctx)
 		 * check this join condition refers to current hypertable
 		 * our Var might be on either side of the expression
 		 */
-		if (linitial_node(Var, op->args)->varno == rel->relid)
+		if ((Index) linitial_node(Var, op->args)->varno == rel->relid)
 		{
 			rel_var = linitial_node(Var, op->args);
 			other_var = lsecond_node(Var, op->args);
 		}
-		else if (lsecond_node(Var, op->args)->varno == rel->relid)
+		else if ((Index) lsecond_node(Var, op->args)->varno == rel->relid)
 		{
 			rel_var = lsecond_node(Var, op->args);
 			other_var = linitial_node(Var, op->args);

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1592,7 +1592,7 @@ cagg_reorder_groupby_clause(RangeTblEntry *subq_rte, Index rtno, List *outer_sor
 			SortGroupClause *outer_sc = (SortGroupClause *) lfirst(lc);
 			TargetEntry *outer_tle = get_sortgroupclause_tle(outer_sc, outer_tlist);
 			not_found = true;
-			if (IsA(outer_tle->expr, Var) && (((Var *) outer_tle->expr)->varno == rtno))
+			if (IsA(outer_tle->expr, Var) && ((Index) ((Var *) outer_tle->expr)->varno == rtno))
 			{
 				int outer_attno = ((Var *) outer_tle->expr)->varattno;
 				TargetEntry *subq_tle = list_nth(subq->targetList, outer_attno - 1);

--- a/src/planner/space_constraint.c
+++ b/src/planner/space_constraint.c
@@ -102,7 +102,7 @@ is_valid_space_constraint(OpExpr *op, List *rtable)
 	/*
 	 * Check that the constraint is actually on a partitioning column.
 	 */
-	Assert(var->varno <= (Index) list_length(rtable));
+	Assert((int) var->varno <= list_length(rtable));
 	RangeTblEntry *rte = list_nth(rtable, var->varno - 1);
 	Dimension *dim = get_space_dimension(rte->relid, var->varattno);
 
@@ -136,7 +136,7 @@ is_valid_scalar_space_constraint(ScalarArrayOpExpr *op, List *rtable)
 	/*
 	 * Check that the constraint is actually on a partitioning column.
 	 */
-	Assert(var->varno <= (Index) list_length(rtable));
+	Assert((int) var->varno <= list_length(rtable));
 	RangeTblEntry *rte = list_nth(rtable, var->varno - 1);
 	Dimension *dim = get_space_dimension(rte->relid, var->varattno);
 

--- a/tsl/src/fdw/deparse.c
+++ b/tsl/src/fdw/deparse.c
@@ -907,7 +907,7 @@ deparseDistinctClause(StringInfo buf, deparse_expr_cxt *context, List *pathkeys)
 				varno_assigned = true;
 			}
 
-			if (varno != var->varno)
+			if (varno != (Index) var->varno)
 				return;
 		}
 		/* We only allow constants apart from vars, but we ignore them */

--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -466,7 +466,8 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 				RestrictInfo *ri = lfirst_node(RestrictInfo, lc_ri);
 
 				if (ri->right_em && IsA(ri->right_em->em_expr, Var) &&
-					castNode(Var, ri->right_em->em_expr)->varno == info->compressed_rel->relid)
+					(Index) castNode(Var, ri->right_em->em_expr)->varno ==
+						info->compressed_rel->relid)
 				{
 					Var *var = castNode(Var, ri->right_em->em_expr);
 					if (is_compressed_column(info, var->varattno))
@@ -476,7 +477,8 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 					}
 				}
 				if (ri->left_em && IsA(ri->left_em->em_expr, Var) &&
-					castNode(Var, ri->left_em->em_expr)->varno == info->compressed_rel->relid)
+					(Index) castNode(Var, ri->left_em->em_expr)->varno ==
+						info->compressed_rel->relid)
 				{
 					Var *var = castNode(Var, ri->left_em->em_expr);
 					if (is_compressed_column(info, var->varattno))
@@ -630,7 +632,7 @@ compressed_rel_setup_reltarget(RelOptInfo *compressed_rel, CompressionInfo *info
 			Var *chunk_var = castNode(Var, lfirst(lc2));
 
 			/* skip vars that aren't from the uncompressed chunk */
-			if (chunk_var->varno != info->chunk_rel->relid)
+			if ((Index) chunk_var->varno != info->chunk_rel->relid)
 			{
 				continue;
 			}
@@ -756,7 +758,7 @@ chunk_joininfo_mutator(Node *node, CompressionInfo *context)
 		char *column_name;
 		AttrNumber compressed_attno;
 		FormData_hypertable_compression *compressioninfo;
-		if (var->varno != context->chunk_rel->relid)
+		if ((Index) var->varno != context->chunk_rel->relid)
 			return (Node *) var;
 
 		column_name = get_attname(context->chunk_rte->relid, var->varattno, false);
@@ -879,7 +881,7 @@ get_compression_info_for_em(Node *node, EMCreationContext *context)
 		FormData_hypertable_compression *col_info;
 		char *column_name;
 		Var *var = castNode(Var, node);
-		if (var->varno != context->uncompressed_relid_idx)
+		if ((Index) var->varno != context->uncompressed_relid_idx)
 			return NULL;
 
 		/* we can't add an EM for system attributes or whole-row refs */
@@ -911,7 +913,7 @@ create_var_for_compressed_equivalence_member(Var *var, const EMCreationContext *
 {
 	/* based on adjust_appendrel_attrs_mutator */
 	Assert(context->current_col_info != NULL);
-	Assert(var->varno == context->uncompressed_relid_idx);
+	Assert((Index) var->varno == context->uncompressed_relid_idx);
 	Assert(var->varattno > 0);
 
 	var = (Var *) copyObject(var);
@@ -956,7 +958,7 @@ add_segmentby_to_equivalence_class(EquivalenceClass *cur_ec, CompressionInfo *in
 
 		var = castNode(Var, cur_em->em_expr);
 
-		if (var->varno != info->chunk_rel->relid)
+		if ((Index) var->varno != info->chunk_rel->relid)
 			continue;
 
 		/* given that the em is a var of the uncompressed chunk, the relid of the chunk should
@@ -1323,7 +1325,7 @@ find_restrictinfo_equality(RelOptInfo *chunk_rel, CompressionInfo *info)
 				else
 					continue;
 
-				if (var->varno != chunk_rel->relid || var->varattno <= 0)
+				if ((Index) var->varno != chunk_rel->relid || var->varattno <= 0)
 					continue;
 
 				if (IsA(other, Const) || IsA(other, Param))

--- a/tsl/src/nodes/decompress_chunk/exec.c
+++ b/tsl/src/nodes/decompress_chunk/exec.c
@@ -208,7 +208,7 @@ constify_tableoid_walker(Node *node, ConstifyTableOidContext *ctx)
 	{
 		Var *var = castNode(Var, node);
 
-		if (var->varno != ctx->chunk_index)
+		if ((Index) var->varno != ctx->chunk_index)
 			return node;
 
 		if (var->varattno == TableOidAttributeNumber)

--- a/tsl/src/nodes/decompress_chunk/planner.c
+++ b/tsl/src/nodes/decompress_chunk/planner.c
@@ -128,7 +128,7 @@ build_decompression_map(DecompressChunkPath *path, List *scan_tlist, Bitmapset *
 		}
 
 		Var *var = (Var *) target->expr;
-		Assert(var->varno == path->info->compressed_rel->relid);
+		Assert((Index) var->varno == path->info->compressed_rel->relid);
 		AttrNumber compressed_attno = var->varattno;
 
 		if (compressed_attno == InvalidAttrNumber)
@@ -274,14 +274,15 @@ replace_compressed_vars(Node *node, CompressionInfo *info)
 		char *colname;
 
 		/* constify tableoid in quals */
-		if (var->varno == info->chunk_rel->relid && var->varattno == TableOidAttributeNumber)
+		if ((Index) var->varno == info->chunk_rel->relid &&
+			var->varattno == TableOidAttributeNumber)
 			return (Node *)
 				makeConst(OIDOID, -1, InvalidOid, 4, (Datum) info->chunk_rte->relid, false, true);
 
 		/* Upper-level Vars should be long gone at this point */
 		Assert(var->varlevelsup == 0);
 		/* If not to be replaced, we can just return the Var unmodified */
-		if (var->varno != info->compressed_rel->relid)
+		if ((Index) var->varno != info->compressed_rel->relid)
 			return node;
 
 		/* Create a decompressed Var to replace the compressed one */
@@ -323,7 +324,7 @@ clause_has_compressed_attrs(Node *node, void *context)
 	{
 		CompressedAttnoContext *cxt = (CompressedAttnoContext *) context;
 		Var *var = (Var *) node;
-		if (var->varno == cxt->compress_relid)
+		if ((Index) var->varno == cxt->compress_relid)
 		{
 			if (bms_is_member(var->varattno, cxt->compressed_attnos))
 				return true;

--- a/tsl/src/nodes/decompress_chunk/qual_pushdown.c
+++ b/tsl/src/nodes/decompress_chunk/qual_pushdown.c
@@ -96,7 +96,7 @@ get_compression_info_from_var(QualPushdownContext *context, Var *var)
 {
 	char *column_name;
 	/* Not on the chunk we expect */
-	if (var->varno != context->chunk_rel->relid)
+	if ((Index) var->varno != context->chunk_rel->relid)
 		return NULL;
 
 	/* ignore system attibutes or whole row references */

--- a/tsl/src/nodes/skip_scan/planner.c
+++ b/tsl/src/nodes/skip_scan/planner.c
@@ -439,7 +439,7 @@ get_distinct_var(PlannerInfo *root, IndexPath *index_path, SkipScanPath *skip_sc
 	/* If we are dealing with a hypertable Var extracted from distinctClause will point to
 	 * the parent hypertable while the IndexPath will be on a Chunk.
 	 * For a normal table they point to the same relation and we are done here. */
-	if (var->varno == rel->relid)
+	if ((Index) var->varno == rel->relid)
 		return var;
 
 	RangeTblEntry *ht_rte = planner_rt_fetch(var->varno, root);
@@ -688,7 +688,7 @@ fix_indexqual(IndexOptInfo *index, RestrictInfo *rinfo, AttrNumber scankey_attno
 	Assert(index->indexkeys[scankey_attno - 1] != 0);
 	Var *node = linitial_node(Var, pull_var_clause(linitial(op->args), 0));
 
-	Assert(((Var *) node)->varno == index->rel->relid &&
+	Assert((Index) ((Var *) node)->varno == index->rel->relid &&
 		   ((Var *) node)->varattno == index->indexkeys[scankey_attno - 1]);
 
 	Var *result = (Var *) copyObject(node);


### PR DESCRIPTION
It changed the type of Var.varno from Index to int. I'm starting to wonder if it was a good idea to enable this warning, but maybe we can give it the last try.