### PR TITLE
pg_dump on PG15 does not log messages with log level set to PG_LOG_INFO.

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -155,11 +155,9 @@ m["include"].append(
             "snapshot": "snapshot",
             "tsdb_build_args": "-DASSERTIONS=ON -DREQUIRE_ALL_TESTS=ON -DEXPERIMENTAL=ON",
             # below tests are tracked as part of #4838
-            "installcheck_args": "SKIPS='003_connections_privs 001_simple_multinode 004_multinode_rdwr_1pc data_node_bootstrap dist_hypertable-15 bgw_custom' "
-            # below tests are tracked as part of #4832
-            "IGNORES='pg_dump_unprivileged cagg_dump metadata pg_dump compression_hypertable "
+            "installcheck_args": "SKIPS='003_connections_privs 001_simple_multinode 004_multinode_rdwr_1pc data_node_bootstrap dist_hypertable-15 bgw_custom cagg_dump' "
             # below tests are tracked as part of #4833
-            "telemetry_stats dist_commands dist_ddl dist_query dist_partial_agg continuous_aggs continuous_aggs_deprecated "
+            "IGNORES='telemetry_stats dist_commands dist_ddl dist_query dist_partial_agg continuous_aggs continuous_aggs_deprecated "
             # below tests are tracked as part of #4834
             "compression compression_dml modify_exclusion rowsecurity-15 "
             # below tests are tracked as part of #4835

--- a/test/expected/metadata.out
+++ b/test/expected/metadata.out
@@ -81,14 +81,6 @@ SELECT _timescaledb_internal.test_install_timestamp() = :'timestamp_1' as timest
 \c postgres :ROLE_SUPERUSER
 \setenv PGOPTIONS '--client-min-messages=warning'
 \! utils/pg_dump_aux_dump.sh dump/instmeta.sql
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
 ALTER DATABASE :TEST_DBNAME SET timescaledb.restoring='on';
 -- Redirect to /dev/null to suppress NOTICE
 \! utils/pg_dump_aux_restore.sh dump/instmeta.sql

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -269,14 +269,6 @@ INSERT INTO _timescaledb_catalog.metadata VALUES ('exported_uuid', 'original_uui
 -- environmental variables that originally called this psql command. Sadly
 -- vars passed to psql do not work in \! commands so we can't do it that way.
 \! utils/pg_dump_aux_dump.sh dump/pg_dump.sql
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
 \c :TEST_DBNAME
 SET client_min_messages = ERROR;
 CREATE EXTENSION timescaledb CASCADE;

--- a/test/expected/pg_dump_unprivileged.out
+++ b/test/expected/pg_dump_unprivileged.out
@@ -9,14 +9,6 @@ CREATE USER dump_unprivileged CREATEDB;
 \c template1 dump_unprivileged
 CREATE database dump_unprivileged;
 \! utils/pg_dump_unprivileged.sh
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
 Database dumped successfully
 \c template1 :ROLE_SUPERUSER
 DROP EXTENSION timescaledb;

--- a/test/sql/utils/pg_dump_aux_dump.sh
+++ b/test/sql/utils/pg_dump_aux_dump.sh
@@ -6,6 +6,6 @@ export PGOPTIONS
 
 # PG12 changed client logging so NOTICE messages are now warning.
 # We adopt this also for older PG versions to make tests compatible.
-${PG_BINDIR}/pg_dump -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -Fc ${TEST_DBNAME} 2>&1 > ${DUMPFILE} | sed 's/NOTICE/warning/g'
+${PG_BINDIR}/pg_dump -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} -Fc ${TEST_DBNAME} > /dev/null 2>&1 -f ${DUMPFILE} | sed 's/NOTICE/warning/g'
 ${PG_BINDIR}/dropdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} ${TEST_DBNAME}
 ${PG_BINDIR}/createdb -h ${PGHOST} -U ${TEST_ROLE_SUPERUSER} ${TEST_DBNAME}

--- a/test/sql/utils/pg_dump_unprivileged.sh
+++ b/test/sql/utils/pg_dump_unprivileged.sh
@@ -3,7 +3,7 @@ PGOPTIONS='--client-min-messages=warning'
 
 # PG12 changed client logging so NOTICE messages are now warning.
 # We adopt this also for older PG versions to make tests compatible.
-${PG_BINDIR}/pg_dump -h ${PGHOST} -U dump_unprivileged dump_unprivileged 2>&1 > /dev/null | sed 's/NOTICE/warning/g'
+${PG_BINDIR}/pg_dump -h ${PGHOST} -U dump_unprivileged dump_unprivileged > /dev/null 2>&1 | sed 's/NOTICE/warning/g'
 
 if [ $? -eq 0 ]; then
   echo "Database dumped successfully"

--- a/tsl/test/expected/cagg_dump.out
+++ b/tsl/test/expected/cagg_dump.out
@@ -133,14 +133,6 @@ SELECT count(*) FROM conditions_after;
 --dump & restore
 \c postgres :ROLE_SUPERUSER
 \! utils/pg_dump_aux_dump.sh dump/pg_dump.sql
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
 \c :TEST_DBNAME
 SET client_min_messages = ERROR;
 CREATE EXTENSION timescaledb CASCADE;

--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -87,14 +87,6 @@ psql:include/compression_test_hypertable.sql:7: NOTICE:  table "original_result"
                27
 (1 row)
 
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
  timescaledb_pre_restore 
 -------------------------
  t
@@ -229,14 +221,6 @@ SELECT 'test2' AS "HYPERTABLE_NAME" \gset
                 5
 (1 row)
 
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
  timescaledb_pre_restore 
 -------------------------
  t
@@ -349,14 +333,6 @@ SELECT 'test4' AS "HYPERTABLE_NAME" \gset
                 1
 (1 row)
 
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
  timescaledb_pre_restore 
 -------------------------
  t
@@ -470,14 +446,6 @@ SELECT 'test5' AS "HYPERTABLE_NAME" \gset
                10
 (1 row)
 
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
  timescaledb_pre_restore 
 -------------------------
  t
@@ -558,14 +526,6 @@ INSERT INTO test6 SELECT t, NULL, customtype_in(t::TEXT::cstring)
                 5
 (1 row)
 
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
  timescaledb_pre_restore 
 -------------------------
  t
@@ -643,14 +603,6 @@ INSERT INTO test7
                 1
 (1 row)
 
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   hypertable
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
-pg_dump: warning: there are circular foreign-key constraints on this table:
-pg_dump:   chunk
-pg_dump: You might not be able to restore the dump without using --disable-triggers or temporarily dropping the constraints.
-pg_dump: Consider using a full dump instead of a --data-only dump to avoid this problem.
  timescaledb_pre_restore 
 -------------------------
  t


### PR DESCRIPTION
Version 15 pg_dump program does not log any messages with log level < PG_LOG_WARNING to stdout. Whereas this check is not present in version 14, thus we see corresponding tests fail with missing log information. This patch fixes by supressing those log information, so that the tests pass on all versions of postgresql.

Fixes #4832