### PR TITLE
Fix failure resuming a CAgg migration

### DIFF
--- a/tsl/test/expected/cagg_migrate_integer.out
+++ b/tsl/test/expected/cagg_migrate_integer.out
@@ -157,14 +157,6 @@ SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg_migrate_plan;
                  3
 (1 row)
 
-\set ON_ERROR_STOP 0
--- should error because plan already exists
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
-psql:include/cagg_migrate_common.sql:156: ERROR:  plan already exists for materialized hypertable 3
-\set ON_ERROR_STOP 1
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |   status    |       type       |                                                                         config                                                                          
 -------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -188,8 +180,42 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      18 | NOT STARTED | ENABLE POLICIES  | 
 (18 rows)
 
-ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:156: WARNING:  resuming the migration of the continuous aggregate "public.conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:156: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      18 | FINISHED | ENABLE POLICIES  | 
+(18 rows)
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:161: ERROR:  plan already exists for materialized hypertable 3
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:162: ERROR:  plan already exists for continuous aggregate public.conditions_summary_daily
+\set ON_ERROR_STOP 1
 -- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
 SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
@@ -227,8 +253,10 @@ AND job_id >= 1000;
 (3 rows)
 
 -- execute the migration
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:185: NOTICE:  drop cascades to 10 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:186: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily');
 psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
@@ -255,13 +283,13 @@ WHERE
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_5.bucket,
-    _materialized_hypertable_5.min,
-    _materialized_hypertable_5.max,
-    _materialized_hypertable_5.avg,
-    _materialized_hypertable_5.sum
-   FROM _timescaledb_internal._materialized_hypertable_5
-  WHERE _materialized_hypertable_5.bucket < COALESCE(_timescaledb_internal.cagg_watermark(5)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.min,
+    _materialized_hypertable_6.max,
+    _materialized_hypertable_6.avg,
+    _materialized_hypertable_6.sum
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -269,7 +297,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(5)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
@@ -279,9 +307,9 @@ AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
  job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
 --------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": 100}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": 400, "hypertable_id": 3}
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": 100}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": 400, "hypertable_id": 3}
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
@@ -334,16 +362,16 @@ SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_5_112_chunk
- _timescaledb_internal._hyper_5_113_chunk
- _timescaledb_internal._hyper_5_114_chunk
- _timescaledb_internal._hyper_5_115_chunk
- _timescaledb_internal._hyper_5_116_chunk
- _timescaledb_internal._hyper_5_117_chunk
- _timescaledb_internal._hyper_5_118_chunk
- _timescaledb_internal._hyper_5_119_chunk
- _timescaledb_internal._hyper_5_120_chunk
- _timescaledb_internal._hyper_5_121_chunk
+ _timescaledb_internal._hyper_6_122_chunk
+ _timescaledb_internal._hyper_6_123_chunk
+ _timescaledb_internal._hyper_6_124_chunk
+ _timescaledb_internal._hyper_6_125_chunk
+ _timescaledb_internal._hyper_6_126_chunk
+ _timescaledb_internal._hyper_6_127_chunk
+ _timescaledb_internal._hyper_6_128_chunk
+ _timescaledb_internal._hyper_6_129_chunk
+ _timescaledb_internal._hyper_6_130_chunk
+ _timescaledb_internal._hyper_6_131_chunk
 (10 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -356,11 +384,11 @@ SELECT * FROM conditions_summary_daily_new;
 
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 10 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -372,13 +400,13 @@ psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditi
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_7.bucket,
-    _materialized_hypertable_7.min,
-    _materialized_hypertable_7.max,
-    _materialized_hypertable_7.avg,
-    _materialized_hypertable_7.sum
-   FROM _timescaledb_internal._materialized_hypertable_7
-  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_8.bucket,
+    _materialized_hypertable_8.min,
+    _materialized_hypertable_8.max,
+    _materialized_hypertable_8.avg,
+    _materialized_hypertable_8.sum
+   FROM _timescaledb_internal._materialized_hypertable_8
+  WHERE _materialized_hypertable_8.bucket < COALESCE(_timescaledb_internal.cagg_watermark(8)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -386,7 +414,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(8)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -421,17 +449,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -443,13 +471,13 @@ psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 10 other obj
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_9.bucket,
-    _materialized_hypertable_9.min,
-    _materialized_hypertable_9.max,
-    _materialized_hypertable_9.avg,
-    _materialized_hypertable_9.sum
-   FROM _timescaledb_internal._materialized_hypertable_9
-  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.min,
+    _materialized_hypertable_10.max,
+    _materialized_hypertable_10.avg,
+    _materialized_hypertable_10.sum
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE _materialized_hypertable_10.bucket < COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -457,22 +485,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 10 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -491,11 +519,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -503,7 +531,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -511,14 +539,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -530,23 +558,23 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
-                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
-                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
-                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      18 | FINISHED | ENABLE POLICIES  | 
+                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                12 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                12 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                12 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 

--- a/tsl/test/expected/cagg_migrate_integer_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_integer_dist_ht.out
@@ -192,14 +192,6 @@ SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg_migrate_plan;
                  3
 (1 row)
 
-\set ON_ERROR_STOP 0
--- should error because plan already exists
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
-psql:include/cagg_migrate_common.sql:156: ERROR:  plan already exists for materialized hypertable 3
-\set ON_ERROR_STOP 1
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |   status    |       type       |                                                                         config                                                                          
 -------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -223,8 +215,42 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      18 | NOT STARTED | ENABLE POLICIES  | 
 (18 rows)
 
-ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:156: WARNING:  resuming the migration of the continuous aggregate "public.conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:156: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      18 | FINISHED | ENABLE POLICIES  | 
+(18 rows)
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:161: ERROR:  plan already exists for materialized hypertable 3
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:162: ERROR:  plan already exists for continuous aggregate public.conditions_summary_daily
+\set ON_ERROR_STOP 1
 -- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
 SELECT add_continuous_aggregate_policy('conditions_summary_daily', '30 days'::interval, '1 day'::interval, '1 hour'::interval);
@@ -262,8 +288,10 @@ AND job_id >= 1000;
 (3 rows)
 
 -- execute the migration
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:185: NOTICE:  drop cascades to 10 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:186: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily');
 psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
@@ -290,13 +318,13 @@ WHERE
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_5.bucket,
-    _materialized_hypertable_5.min,
-    _materialized_hypertable_5.max,
-    _materialized_hypertable_5.avg,
-    _materialized_hypertable_5.sum
-   FROM _timescaledb_internal._materialized_hypertable_5
-  WHERE _materialized_hypertable_5.bucket < COALESCE(_timescaledb_internal.cagg_watermark(5)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.min,
+    _materialized_hypertable_6.max,
+    _materialized_hypertable_6.avg,
+    _materialized_hypertable_6.sum
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -304,7 +332,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(5)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
@@ -314,9 +342,9 @@ AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
  job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
 --------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": 100}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": 400, "hypertable_id": 3}
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": 100}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": 400, "hypertable_id": 3}
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
@@ -369,16 +397,16 @@ SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
               compress_chunk              
 ------------------------------------------
- _timescaledb_internal._hyper_5_112_chunk
- _timescaledb_internal._hyper_5_113_chunk
- _timescaledb_internal._hyper_5_114_chunk
- _timescaledb_internal._hyper_5_115_chunk
- _timescaledb_internal._hyper_5_116_chunk
- _timescaledb_internal._hyper_5_117_chunk
- _timescaledb_internal._hyper_5_118_chunk
- _timescaledb_internal._hyper_5_119_chunk
- _timescaledb_internal._hyper_5_120_chunk
- _timescaledb_internal._hyper_5_121_chunk
+ _timescaledb_internal._hyper_6_122_chunk
+ _timescaledb_internal._hyper_6_123_chunk
+ _timescaledb_internal._hyper_6_124_chunk
+ _timescaledb_internal._hyper_6_125_chunk
+ _timescaledb_internal._hyper_6_126_chunk
+ _timescaledb_internal._hyper_6_127_chunk
+ _timescaledb_internal._hyper_6_128_chunk
+ _timescaledb_internal._hyper_6_129_chunk
+ _timescaledb_internal._hyper_6_130_chunk
+ _timescaledb_internal._hyper_6_131_chunk
 (10 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -391,11 +419,11 @@ SELECT * FROM conditions_summary_daily_new;
 
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 10 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 10 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -407,13 +435,13 @@ psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditi
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_7.bucket,
-    _materialized_hypertable_7.min,
-    _materialized_hypertable_7.max,
-    _materialized_hypertable_7.avg,
-    _materialized_hypertable_7.sum
-   FROM _timescaledb_internal._materialized_hypertable_7
-  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_8.bucket,
+    _materialized_hypertable_8.min,
+    _materialized_hypertable_8.max,
+    _materialized_hypertable_8.avg,
+    _materialized_hypertable_8.sum
+   FROM _timescaledb_internal._materialized_hypertable_8
+  WHERE _materialized_hypertable_8.bucket < COALESCE(_timescaledb_internal.cagg_watermark(8)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -421,7 +449,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(7)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(8)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -456,17 +484,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -478,13 +506,13 @@ psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 10 other obj
  avg    | numeric |           |          |         | main    | 
  sum    | numeric |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_9.bucket,
-    _materialized_hypertable_9.min,
-    _materialized_hypertable_9.max,
-    _materialized_hypertable_9.avg,
-    _materialized_hypertable_9.sum
-   FROM _timescaledb_internal._materialized_hypertable_9
-  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.min,
+    _materialized_hypertable_10.max,
+    _materialized_hypertable_10.avg,
+    _materialized_hypertable_10.sum
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE _materialized_hypertable_10.bucket < COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
 UNION ALL
  SELECT time_bucket(24, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -492,22 +520,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 10 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -526,11 +554,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -538,7 +566,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -546,14 +574,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -565,24 +593,24 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                         config                                                                          
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------
-                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
-                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
-                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                11 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      18 | FINISHED | ENABLE POLICIES  | 
+                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "1008"}
+                12 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                12 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "1008", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "integer"}
+                12 |       5 | FINISHED | COPY DATA        | {"end_ts": "100", "start_ts": "0", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       6 | FINISHED | COPY DATA        | {"end_ts": "200", "start_ts": "100", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       7 | FINISHED | COPY DATA        | {"end_ts": "300", "start_ts": "200", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       8 | FINISHED | COPY DATA        | {"end_ts": "400", "start_ts": "300", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |       9 | FINISHED | COPY DATA        | {"end_ts": "500", "start_ts": "400", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      10 | FINISHED | COPY DATA        | {"end_ts": "600", "start_ts": "500", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      11 | FINISHED | COPY DATA        | {"end_ts": "700", "start_ts": "600", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
+                12 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 
 -- cleanup

--- a/tsl/test/expected/cagg_migrate_timestamp.out
+++ b/tsl/test/expected/cagg_migrate_timestamp.out
@@ -152,14 +152,6 @@ SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg_migrate_plan;
                  3
 (1 row)
 
-\set ON_ERROR_STOP 0
--- should error because plan already exists
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
-psql:include/cagg_migrate_common.sql:156: ERROR:  plan already exists for materialized hypertable 3
-\set ON_ERROR_STOP 1
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |   status    |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -179,8 +171,38 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      14 | NOT STARTED | ENABLE POLICIES  | 
 (14 rows)
 
-ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:156: WARNING:  resuming the migration of the continuous aggregate "public.conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:156: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      14 | FINISHED | ENABLE POLICIES  | 
+(14 rows)
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:161: ERROR:  plan already exists for materialized hypertable 3
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:162: ERROR:  plan already exists for continuous aggregate public.conditions_summary_daily
+\set ON_ERROR_STOP 1
 -- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
  add_retention_policy 
@@ -218,8 +240,10 @@ AND job_id >= 1000;
 (3 rows)
 
 -- execute the migration
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:185: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:186: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily');
 psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
@@ -246,13 +270,13 @@ WHERE
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_5.bucket,
-    _materialized_hypertable_5.min,
-    _materialized_hypertable_5.max,
-    _materialized_hypertable_5.avg,
-    _materialized_hypertable_5.sum
-   FROM _timescaledb_internal._materialized_hypertable_5
-  WHERE _materialized_hypertable_5.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(5)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.min,
+    _materialized_hypertable_6.max,
+    _materialized_hypertable_6.avg,
+    _materialized_hypertable_6.sum
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -260,7 +284,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(5)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
@@ -270,9 +294,9 @@ AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
  job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
 --------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": "@ 30 days", "hypertable_id": 3}
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
@@ -317,12 +341,12 @@ SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_5_60_chunk
- _timescaledb_internal._hyper_5_61_chunk
- _timescaledb_internal._hyper_5_62_chunk
- _timescaledb_internal._hyper_5_63_chunk
- _timescaledb_internal._hyper_5_64_chunk
- _timescaledb_internal._hyper_5_65_chunk
+ _timescaledb_internal._hyper_6_66_chunk
+ _timescaledb_internal._hyper_6_67_chunk
+ _timescaledb_internal._hyper_6_68_chunk
+ _timescaledb_internal._hyper_6_69_chunk
+ _timescaledb_internal._hyper_6_70_chunk
+ _timescaledb_internal._hyper_6_71_chunk
 (6 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -335,11 +359,11 @@ SELECT * FROM conditions_summary_daily_new;
 
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -351,13 +375,13 @@ psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditi
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_7.bucket,
-    _materialized_hypertable_7.min,
-    _materialized_hypertable_7.max,
-    _materialized_hypertable_7.avg,
-    _materialized_hypertable_7.sum
-   FROM _timescaledb_internal._materialized_hypertable_7
-  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_8.bucket,
+    _materialized_hypertable_8.min,
+    _materialized_hypertable_8.max,
+    _materialized_hypertable_8.avg,
+    _materialized_hypertable_8.sum
+   FROM _timescaledb_internal._materialized_hypertable_8
+  WHERE _materialized_hypertable_8.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(8)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -365,7 +389,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(8)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -400,17 +424,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -422,13 +446,13 @@ psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 6 other obje
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_9.bucket,
-    _materialized_hypertable_9.min,
-    _materialized_hypertable_9.max,
-    _materialized_hypertable_9.avg,
-    _materialized_hypertable_9.sum
-   FROM _timescaledb_internal._materialized_hypertable_9
-  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.min,
+    _materialized_hypertable_10.max,
+    _materialized_hypertable_10.avg,
+    _materialized_hypertable_10.sum
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE _materialized_hypertable_10.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(10)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -436,22 +460,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(10)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 6 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -470,11 +494,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -482,7 +506,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -490,14 +514,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -509,19 +533,19 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
-                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
-                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      14 | FINISHED | ENABLE POLICIES  | 
+                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                12 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                12 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                12 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 

--- a/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
@@ -187,14 +187,6 @@ SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg_migrate_plan;
                  3
 (1 row)
 
-\set ON_ERROR_STOP 0
--- should error because plan already exists
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
-psql:include/cagg_migrate_common.sql:156: ERROR:  plan already exists for materialized hypertable 3
-\set ON_ERROR_STOP 1
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
-CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |   status    |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -214,8 +206,38 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      14 | NOT STARTED | ENABLE POLICIES  | 
 (14 rows)
 
-ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
+-- should resume the execution
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:156: WARNING:  resuming the migration of the continuous aggregate "public.conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:156: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
+ mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
+-------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                 3 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      14 | FINISHED | ENABLE POLICIES  | 
+(14 rows)
+
+\set ON_ERROR_STOP 0
+-- should error because plan already exists
+CALL _timescaledb_internal.cagg_migrate_create_plan(:'CAGG_DATA', 'conditions_summary_daily_new');
+psql:include/cagg_migrate_common.sql:161: ERROR:  plan already exists for materialized hypertable 3
+CALL cagg_migrate('conditions_summary_daily');
+psql:include/cagg_migrate_common.sql:162: ERROR:  plan already exists for continuous aggregate public.conditions_summary_daily
+\set ON_ERROR_STOP 1
 -- policies for test
+ALTER MATERIALIZED VIEW conditions_summary_daily SET (timescaledb.compress=true);
 \if :IS_TIME_DIMENSION
 SELECT add_retention_policy('conditions_summary_daily', '30 days'::interval);
  add_retention_policy 
@@ -253,8 +275,10 @@ AND job_id >= 1000;
 (3 rows)
 
 -- execute the migration
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+DROP MATERIALIZED VIEW conditions_summary_daily_new;
+psql:include/cagg_migrate_common.sql:185: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:186: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily');
 psql:include/cagg_migrate_common.sql:187: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 SELECT
@@ -281,13 +305,13 @@ WHERE
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_5.bucket,
-    _materialized_hypertable_5.min,
-    _materialized_hypertable_5.max,
-    _materialized_hypertable_5.avg,
-    _materialized_hypertable_5.sum
-   FROM _timescaledb_internal._materialized_hypertable_5
-  WHERE _materialized_hypertable_5.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(5)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_6.bucket,
+    _materialized_hypertable_6.min,
+    _materialized_hypertable_6.max,
+    _materialized_hypertable_6.avg,
+    _materialized_hypertable_6.sum
+   FROM _timescaledb_internal._materialized_hypertable_6
+  WHERE _materialized_hypertable_6.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -295,7 +319,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(5)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
@@ -305,9 +329,9 @@ AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
  job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
 --------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_5 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_5 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_5 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
+   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
+   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": "@ 30 days", "hypertable_id": 3}
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
@@ -352,12 +376,12 @@ SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily') c ORDER BY
 SELECT compress_chunk(c) FROM show_chunks('conditions_summary_daily_new') c ORDER BY c::regclass::text;
              compress_chunk              
 -----------------------------------------
- _timescaledb_internal._hyper_5_60_chunk
- _timescaledb_internal._hyper_5_61_chunk
- _timescaledb_internal._hyper_5_62_chunk
- _timescaledb_internal._hyper_5_63_chunk
- _timescaledb_internal._hyper_5_64_chunk
- _timescaledb_internal._hyper_5_65_chunk
+ _timescaledb_internal._hyper_6_66_chunk
+ _timescaledb_internal._hyper_6_67_chunk
+ _timescaledb_internal._hyper_6_68_chunk
+ _timescaledb_internal._hyper_6_69_chunk
+ _timescaledb_internal._hyper_6_70_chunk
+ _timescaledb_internal._hyper_6_71_chunk
 (6 rows)
 
 -- check migrated data after compression. should return 0 (zero) rows
@@ -370,11 +394,11 @@ SELECT * FROM conditions_summary_daily_new;
 
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  drop cascades to 6 other objects
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 6 other objects
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -386,13 +410,13 @@ psql:include/cagg_migrate_common.sql:233: NOTICE:  continuous aggregate "conditi
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_7.bucket,
-    _materialized_hypertable_7.min,
-    _materialized_hypertable_7.max,
-    _materialized_hypertable_7.avg,
-    _materialized_hypertable_7.sum
-   FROM _timescaledb_internal._materialized_hypertable_7
-  WHERE _materialized_hypertable_7.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_8.bucket,
+    _materialized_hypertable_8.min,
+    _materialized_hypertable_8.max,
+    _materialized_hypertable_8.avg,
+    _materialized_hypertable_8.sum
+   FROM _timescaledb_internal._materialized_hypertable_8
+  WHERE _materialized_hypertable_8.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(8)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -400,7 +424,7 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(7)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(8)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 -- cagg with the old format because it was overriden
@@ -435,17 +459,17 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:240: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- test migration overriding the new cagg and removing the old
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:246: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:248: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -457,13 +481,13 @@ psql:include/cagg_migrate_common.sql:248: NOTICE:  drop cascades to 6 other obje
  avg    | numeric                  |           |          |         | main    | 
  sum    | numeric                  |           |          |         | main    | 
 View definition:
- SELECT _materialized_hypertable_9.bucket,
-    _materialized_hypertable_9.min,
-    _materialized_hypertable_9.max,
-    _materialized_hypertable_9.avg,
-    _materialized_hypertable_9.sum
-   FROM _timescaledb_internal._materialized_hypertable_9
-  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.min,
+    _materialized_hypertable_10.max,
+    _materialized_hypertable_10.avg,
+    _materialized_hypertable_10.sum
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE _materialized_hypertable_10.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(10)), '-infinity'::timestamp with time zone)
 UNION ALL
  SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
     min(conditions.temperature) AS min,
@@ -471,22 +495,22 @@ UNION ALL
     avg(conditions.temperature) AS avg,
     sum(conditions.temperature) AS sum
    FROM conditions
-  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(9)), '-infinity'::timestamp with time zone)
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(10)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:253: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:255: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
 -- permissions test
-DELETE FROM _timescaledb_catalog.continuous_agg_migrate_plan;
-ALTER SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq RESTART;
+TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 6 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -505,11 +529,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:280: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:284: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -517,7 +541,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:294: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -525,14 +549,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:304: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:313: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -544,20 +568,20 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                11 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
-                11 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
-                11 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                11 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
-                11 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                11 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
-                11 |      14 | FINISHED | ENABLE POLICIES  | 
+                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                12 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
+                12 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
+                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                12 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
+                12 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 
 -- cleanup


### PR DESCRIPTION
Trying to resume a failed Continuous Aggregate raise an exception that the migration plan already exists, but this is wrong and the expected behaviour should be resume the migration and continue from the last failed step.