### PR TITLE
Create index fails if hypertable has foreign table chunk

### DIFF
--- a/tsl/test/expected/chunk_utils_internal.out
+++ b/tsl/test/expected/chunk_utils_internal.out
@@ -861,6 +861,27 @@ FROM _timescaledb_catalog.chunk WHERE table_name = :'COPY_CHUNK_NAME';
 
 -- Copy should work now
 COPY test1.copy_test FROM STDIN DELIMITER ',';
+--Utility functions -check index creation on hypertable with OSM chunk
+-- Indexes are not created on OSM chunks, they are skipped as these are foreign tables
+\c :TEST_DBNAME :ROLE_4
+CREATE INDEX hyper_constr_mid_idx ON hyper_constr( mid, time);
+NOTICE:  skipping index creation for tiered data
+SELECT indexname, tablename FROM pg_indexes WHERE indexname = 'hyper_constr_mid_idx';
+      indexname       |  tablename   
+----------------------+--------------
+ hyper_constr_mid_idx | hyper_constr
+(1 row)
+
+DROP INDEX hyper_constr_mid_idx;
+CREATE INDEX hyper_constr_mid_idx ON hyper_constr(mid, time) WITH (timescaledb.transaction_per_chunk);
+NOTICE:  skipping index creation for tiered data
+SELECT indexname, tablename FROM pg_indexes WHERE indexname = 'hyper_constr_mid_idx';
+      indexname       |  tablename   
+----------------------+--------------
+ hyper_constr_mid_idx | hyper_constr
+(1 row)
+
+DROP INDEX hyper_constr_mid_idx;
 -- clean up databases created
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE postgres_fdw_db;

--- a/tsl/test/sql/chunk_utils_internal.sql
+++ b/tsl/test/sql/chunk_utils_internal.sql
@@ -533,6 +533,17 @@ COPY test1.copy_test FROM STDIN DELIMITER ',';
 2021-01-01 01:10:00+01,1
 \.
 
+--Utility functions -check index creation on hypertable with OSM chunk
+-- Indexes are not created on OSM chunks, they are skipped as these are foreign tables
+\c :TEST_DBNAME :ROLE_4
+CREATE INDEX hyper_constr_mid_idx ON hyper_constr( mid, time);
+SELECT indexname, tablename FROM pg_indexes WHERE indexname = 'hyper_constr_mid_idx';
+DROP INDEX hyper_constr_mid_idx;
+
+CREATE INDEX hyper_constr_mid_idx ON hyper_constr(mid, time) WITH (timescaledb.transaction_per_chunk);
+SELECT indexname, tablename FROM pg_indexes WHERE indexname = 'hyper_constr_mid_idx';
+DROP INDEX hyper_constr_mid_idx;
+
 -- clean up databases created
 \c :TEST_DBNAME :ROLE_SUPERUSER
 DROP DATABASE postgres_fdw_db;


### PR DESCRIPTION
We cannot create indexes on foreign tables. This PR modifies process_index_chunk to skip OSM chunks

Disable-check: force-changelog-changed