### PR TITLE
Swap lookup order for clang-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,7 +389,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${EXT_CONTROL_FILE}
 
 find_program(
   CLANG_FORMAT
-  NAMES clang-format clang-format-14
+  NAMES clang-format-14 clang-format
   PATHS /usr/bin /usr/local/bin /usr/local/opt/ /usr/local/opt/llvm/bin /opt/bin
   DOC "The path to clang-format")
 

--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -1619,6 +1619,12 @@ SELECT time_bucket('1 month', time), avg(a)
 FROM test_table_scheduler
 GROUP BY time_bucket('1 month', time)
 WITH NO DATA;
+SELECT set_chunk_time_interval('_timescaledb_internal._materialized_hypertable_2', interval '36500 days');
+ set_chunk_time_interval 
+-------------------------
+ 
+(1 row)
+
 select show_chunks('test_table_scheduler');
               show_chunks               
 ----------------------------------------
@@ -1694,11 +1700,11 @@ select hypertable_schema, hypertable_name, chunk_schema, chunk_name, is_compress
  _timescaledb_internal | _materialized_hypertable_2 | _timescaledb_internal | _hyper_2_10_chunk | f
 (5 rows)
 
-select avg_a from cagg_scheduler;
+select avg_a from cagg_scheduler ORDER BY 1;
        avg_a        
 --------------------
- 4.0000000000000000
  3.0000000000000000
+ 4.0000000000000000
 (2 rows)
 
 -- test the API for add_job too
@@ -1747,14 +1753,21 @@ select * from _timescaledb_config.bgw_job order by id;
  1031 | Reorder Policy [1031]                      | @ 360 hours       | @ 0         |          -1 | @ 5 mins     | _timescaledb_internal | policy_reorder                      | super_user | t         | t              | Fri Dec 31 16:00:00.015 1999 PST |             1 | {"index_name": "test_table_scheduler_time_idx", "hypertable_id": 1}            | _timescaledb_internal | policy_reorder_check                      | Europe/Berlin
 (6 rows)
 
-select job_id, last_start, last_finish, next_start, last_successful_finish from _timescaledb_internal.bgw_job_stat order by job_id;
- job_id |            last_start            |           last_finish            |            next_start            |      last_successful_finish      
---------+----------------------------------+----------------------------------+----------------------------------+----------------------------------
-   1026 | Fri Dec 31 16:00:00 1999 PST     | Fri Dec 31 16:00:00 1999 PST     | Sat Jan 01 16:00:00 2000 PST     | Fri Dec 31 16:00:00 1999 PST
-   1027 | Fri Dec 31 16:00:00 1999 PST     | Fri Dec 31 16:00:00 1999 PST     | Sat Jan 15 16:00:00 2000 PST     | Fri Dec 31 16:00:00 1999 PST
-   1028 | Fri Dec 31 16:00:00.005 1999 PST | Fri Dec 31 16:00:00.005 1999 PST | Fri Jan 21 16:00:00.005 2000 PST | Fri Dec 31 16:00:00.005 1999 PST
-   1029 | Fri Dec 31 16:00:00.025 1999 PST | Fri Dec 31 16:00:00.025 1999 PST | Mon Jul 31 16:00:00.01 2000 PDT  | Fri Dec 31 16:00:00.025 1999 PST
-   1030 | Fri Dec 31 16:00:00.025 1999 PST | Fri Dec 31 16:00:00.025 1999 PST | Mon Jul 31 16:00:00.01 2000 PDT  | Fri Dec 31 16:00:00.025 1999 PST
-   1031 | Fri Dec 31 16:00:00.025 1999 PST | Fri Dec 31 16:00:00.025 1999 PST | Sat Jan 15 16:00:00.015 2000 PST | Fri Dec 31 16:00:00.025 1999 PST
+SELECT
+  job_id,
+  date_trunc('second',last_start) AS last_start,
+  date_trunc('second',last_finish) AS last_finish,
+  date_trunc('second',next_start) AS next_start,
+  last_successful_finish
+FROM _timescaledb_internal.bgw_job_stat
+ORDER BY job_id;
+ job_id |          last_start          |         last_finish          |          next_start          |      last_successful_finish      
+--------+------------------------------+------------------------------+------------------------------+----------------------------------
+   1026 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | Sat Jan 01 16:00:00 2000 PST | Fri Dec 31 16:00:00 1999 PST
+   1027 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | Sat Jan 15 16:00:00 2000 PST | Fri Dec 31 16:00:00 1999 PST
+   1028 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | Fri Jan 21 16:00:00 2000 PST | Fri Dec 31 16:00:00.005 1999 PST
+   1029 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | Mon Jul 31 16:00:00 2000 PDT | Fri Dec 31 16:00:00.025 1999 PST
+   1030 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | Mon Jul 31 16:00:00 2000 PDT | Fri Dec 31 16:00:00.025 1999 PST
+   1031 | Fri Dec 31 16:00:00 1999 PST | Fri Dec 31 16:00:00 1999 PST | Sat Jan 15 16:00:00 2000 PST | Fri Dec 31 16:00:00.025 1999 PST
 (6 rows)
 


### PR DESCRIPTION
Look for the binary with exact version before looking for the generic name to prevent failure when clang-format is lower then required version but clang-format-14 exists.

Disable-check: commit-count
