### PR TITLE
Fix ts_catalog invalidation

### DIFF
--- a/src/cache_invalidate.c
+++ b/src/cache_invalidate.c
@@ -99,6 +99,10 @@ cache_invalidate_relcache_callback(Datum arg, Oid relid)
 	{
 		ts_bgw_job_cache_invalidate_callback();
 	}
+	else if (ts_extension_is_loaded() && ts_catalog_is_valid() && ts_is_catalog_table(relid))
+	{
+		ts_catalog_reset();
+	}
 }
 
 /* Registration for given cache ids happens in non-TSL code when the extension

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -389,6 +389,12 @@ catalog_database_info_init(CatalogDatabaseInfo *info)
 		elog(ERROR, "OID lookup failed for schema \"%s\"", CATALOG_SCHEMA_NAME);
 }
 
+bool
+ts_catalog_is_valid(void)
+{
+	return catalog_is_valid(&s_catalog);
+}
+
 TSDLLEXPORT CatalogDatabaseInfo *
 ts_catalog_database_info_get()
 {
@@ -529,8 +535,6 @@ ts_catalog_reset(void)
 {
 	s_catalog.initialized = false;
 	database_info.database_id = InvalidOid;
-
-	ts_cache_invalidate_set_proxy_tables(InvalidOid, InvalidOid);
 }
 
 static CatalogTable

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1439,6 +1439,7 @@ extern TSDLLEXPORT CatalogDatabaseInfo *ts_catalog_database_info_get(void);
 extern TSDLLEXPORT Catalog *ts_catalog_get(void);
 extern void ts_catalog_reset(void);
 extern bool ts_is_catalog_table(Oid relid);
+extern bool ts_catalog_is_valid(void);
 
 /* Functions should operate on a passed-in Catalog struct */
 static inline Oid

--- a/test/expected/cache_invalidation.out
+++ b/test/expected/cache_invalidation.out
@@ -1,0 +1,25 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+-- Test that timescale catalog structure is properly invalidated
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE TABLE catalog_invalidation (
+  time        TIMESTAMPTZ       NOT NULL
+);
+SELECT create_hypertable('catalog_invalidation', 'time');
+         create_hypertable         
+-----------------------------------
+ (1,public,catalog_invalidation,t)
+(1 row)
+
+SELECT 1 AS test FROM catalog_invalidation;
+ test 
+------
+(0 rows)
+
+REINDEX SCHEMA CONCURRENTLY _timescaledb_catalog;
+SELECT 1 AS test FROM catalog_invalidation;
+ test 
+------
+(0 rows)
+

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_FILES
     alternate_users.sql
     baserel_cache.sql
     broken_tables.sql
+    cache_invalidation.sql
     chunks.sql
     chunk_adaptive.sql
     chunk_utils.sql

--- a/test/sql/cache_invalidation.sql
+++ b/test/sql/cache_invalidation.sql
@@ -1,0 +1,18 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+-- Test that timescale catalog structure is properly invalidated
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE TABLE catalog_invalidation (
+  time        TIMESTAMPTZ       NOT NULL
+);
+SELECT create_hypertable('catalog_invalidation', 'time');
+
+SELECT 1 AS test FROM catalog_invalidation;
+
+REINDEX SCHEMA CONCURRENTLY _timescaledb_catalog;
+
+SELECT 1 AS test FROM catalog_invalidation;

--- a/test/src/loader/init.c
+++ b/test/src/loader/init.c
@@ -94,6 +94,13 @@ ts_catalog_reset()
 {
 }
 
+/* mock for extension.c */
+void ts_cache_invalidate_set_proxy_tables(Oid hypertable_proxy_oid, Oid bgw_proxy_oid);
+void
+ts_cache_invalidate_set_proxy_tables(Oid hypertable_proxy_oid, Oid bgw_proxy_oid)
+{
+}
+
 /* mock for guc.c */
 void ts_hypertable_cache_invalidate_callback(void);
 void


### PR DESCRIPTION
Since timescale catalog data is stored in per-process (per-backend) memory, it should be properly invalidated when it is changed. Invalidation is now done for other caches but is not done for timescale catalog structure. This, for example, causes errors when ts catalog is initialized before and hypertable is queried after **concurrent** reindex in `_timescaledb_catalog` schema, which changes indexes' OIDs (the same error can be observed in other backends):

```
CREATE TABLE conditions (
  time        TIMESTAMPTZ       NOT NULL,
  location    TEXT              NOT NULL,
  temperature DOUBLE PRECISION  NULL,
  humidity    DOUBLE PRECISION  NULL
);
SELECT create_hypertable('conditions', 'time');

SELECT * FROM conditions;
 time | location | temperature | humidity 
------+----------+-------------+----------
(0 rows)


SELECT relname, indexrelid  FROM pg_index JOIN pg_class ON indexrelid=oid WHERE indrelid='_timescaledb_catalog.chunk'::regclass::oid;
             relname              | indexrelid 
----------------------------------+------------
 chunk_pkey                       |      58861
 chunk_schema_name_table_name_key |      58862
 chunk_hypertable_id_idx          |      58863
 chunk_compressed_chunk_id_idx    |      58864
 chunk_osm_chunk_idx              |      58865
(5 rows)

SELECT relname, indexrelid  FROM pg_index JOIN pg_class ON indexrelid=oid WHERE indrelid='_timescaledb_catalog.hypertable'::regclass::oid;
                            relname                            | indexrelid 
---------------------------------------------------------------+------------
 hypertable_pkey                                               |      58852
 hypertable_associated_schema_name_associated_table_prefix_key |      58853
 hypertable_table_name_schema_name_key                         |      58854
(3 rows)


REINDEX SCHEMA CONCURRENTLY _timescaledb_catalog;


SELECT * FROM conditions;
ERROR:  could not open relation with OID 58862
SELECT * FROM conditions;
ERROR:  could not open relation with OID 58854
\c
SELECT * FROM conditions;
 time | location | temperature | humidity 
------+----------+-------------+----------
(0 rows)
```