### PR TITLE
Take advisory lock for job tuple

### DIFF
--- a/src/bgw/job.h
+++ b/src/bgw/job.h
@@ -33,7 +33,8 @@ extern TSDLLEXPORT List *ts_bgw_job_find_by_proc_and_hypertable_id(const char *p
 																   int32 hypertable_id);
 
 extern bool ts_bgw_job_get_share_lock(int32 bgw_job_id, MemoryContext mctx);
-
+TSDLLEXPORT bool ts_lock_job_id(int32 job_id, LOCKMODE mode, bool session_lock, LOCKTAG *tag,
+								bool block);
 TSDLLEXPORT BgwJob *ts_bgw_job_find(int job_id, MemoryContext mctx, bool fail_if_not_found);
 
 extern bool ts_bgw_job_has_timeout(BgwJob *job);


### PR DESCRIPTION
Job ids are locked using an advisory lock rather than a row lock on the
jobs table, but this lock is not taken in the job API functions
(`alter_job`, `delete_job`, etc.), which appears to cause a race
condition resulting in addition of multiple rows with the same job id.

This commit adds an advisory `RowExclusiveLock` on the job id while
altering it to match the advisory locks taken while performing other
modifications.

Closes #4863