### PR TITLE
Disable llvm on macos

### DIFF
--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -92,7 +92,12 @@ jobs:
         mkdir -p ~/$PG_SRC_DIR
         tar --extract --file postgresql.tar.bz2 --directory ~/$PG_SRC_DIR --strip-components 1
         cd ~/$PG_SRC_DIR
-        ./configure --prefix=$HOME/$PG_INSTALL_DIR --with-llvm LLVM_CONFIG=${{ matrix.llvm_config }} --with-openssl --without-readline --without-zlib --without-libxml ${{ matrix.pg_extra_args }}
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          ./configure --prefix=$HOME/$PG_INSTALL_DIR --with-llvm LLVM_CONFIG=${{ matrix.llvm_config }} --with-openssl --without-readline --without-zlib --without-libxml ${{ matrix.pg_extra_args }}
+        else
+          # the current github macos image has a buggy llvm installation so we build without llvm on mac
+          ./configure --prefix=$HOME/$PG_INSTALL_DIR --with-openssl --without-readline --without-zlib --without-libxml ${{ matrix.pg_extra_args }}
+        fi
         make -j $MAKE_JOBS
         make -j $MAKE_JOBS -C src/test/isolation
         make -j $MAKE_JOBS -C contrib/postgres_fdw


### PR DESCRIPTION
I accidentally re-enabled it when adding the flaky check.