### PR TITLE
Fix orphan jobs after CAgg migration

### DIFF
--- a/tsl/test/expected/cagg_migrate_integer.out
+++ b/tsl/test/expected/cagg_migrate_integer.out
@@ -174,9 +174,9 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      12 | NOT STARTED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      13 | NOT STARTED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      14 | NOT STARTED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      15 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      18 | NOT STARTED | ENABLE POLICIES  | 
 (18 rows)
 
@@ -201,9 +201,9 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      15 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 
@@ -240,16 +240,16 @@ SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
 (1 row)
 
 \endif
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
-   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": 100}
-   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
-   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": 400, "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                            config                             | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": 100}                   |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_compression_check
+   1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": 400, "hypertable_id": 3}                       |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 -- execute the migration
@@ -300,16 +300,16 @@ UNION ALL
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
 AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": 100}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": 400, "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                            config                             | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1005 | Compression Policy [1005]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": 100}                   |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_compression_check
+   1004 | Refresh Continuous Aggregate Policy [1004] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 6} |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1003 | Retention Policy [1003]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": 400, "hypertable_id": 3}                       |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
@@ -329,10 +329,10 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+                 3 |      15 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005, 1002, 1001, 1000]}
 (18 rows)
 
 -- check migrated data. should return 0 (zero) rows
@@ -382,13 +382,27 @@ SELECT * FROM conditions_summary_daily_new;
 --------+-----+-----+-----+-----
 (0 rows)
 
+CREATE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:235: NOTICE:  drop cascades to 10 other objects
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:236: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:239: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -449,17 +463,50 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:246: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1006 | Retention Policy [1006]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             8 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1007 | Refresh Continuous Aggregate Policy [1007] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             8 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 8} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1008 | Compression Policy [1008]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             8 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema |             name             |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+------------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily_old | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily_old | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily_old | 1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- test migration overriding the new cagg and removing the old
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -491,16 +538,37 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:266: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:268: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                             config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+----------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1009 | Retention Policy [1009]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |            10 | {"drop_after": 400, "hypertable_id": 3}                        | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1010 | Refresh Continuous Aggregate Policy [1010] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |            10 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 10} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1011 | Compression Policy [1011]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |            10 | {"hypertable_id": 3, "compress_after": 100}                    | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- permissions test
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:278: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:279: NOTICE:  drop cascades to 10 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -519,11 +587,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:298: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:302: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -531,7 +599,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:312: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -539,14 +607,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:322: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:331: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -572,9 +640,9 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                 12 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                 12 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                 12 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                12 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      15 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      16 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      17 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                 12 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 

--- a/tsl/test/expected/cagg_migrate_integer_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_integer_dist_ht.out
@@ -209,9 +209,9 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      12 | NOT STARTED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      13 | NOT STARTED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      14 | NOT STARTED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      15 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      18 | NOT STARTED | ENABLE POLICIES  | 
 (18 rows)
 
@@ -236,9 +236,9 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      15 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 
@@ -275,16 +275,16 @@ SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
 (1 row)
 
 \endif
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
-   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": 100}
-   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
-   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": 400, "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                            config                             | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": 100}                   |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_compression_check
+   1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": 400, "hypertable_id": 3}                       |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 -- execute the migration
@@ -335,16 +335,16 @@ UNION ALL
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(6)::integer, '-2147483648'::integer)
   GROUP BY (time_bucket(24, conditions."time"));
 
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
 AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                            config                             
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+---------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": 100}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": 400, "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                            config                             | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1005 | Compression Policy [1005]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": 100}                   |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_compression_check
+   1004 | Refresh Continuous Aggregate Policy [1004] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 6} |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1003 | Retention Policy [1003]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": 400, "hypertable_id": 3}                       |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
@@ -364,10 +364,10 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                  3 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                  3 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                 3 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      17 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+                 3 |      15 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      16 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      17 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      18 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005, 1002, 1001, 1000]}
 (18 rows)
 
 -- check migrated data. should return 0 (zero) rows
@@ -417,13 +417,27 @@ SELECT * FROM conditions_summary_daily_new;
 --------+-----+-----+-----+-----
 (0 rows)
 
+CREATE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:235: NOTICE:  drop cascades to 10 other objects
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:236: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:239: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -484,17 +498,50 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:246: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1006 | Retention Policy [1006]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             8 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1007 | Refresh Continuous Aggregate Policy [1007] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             8 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 8} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1008 | Compression Policy [1008]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             8 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema |             name             |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+------------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily_old | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily_old | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily_old | 1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- test migration overriding the new cagg and removing the old
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 10 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                            config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": 400, "hypertable_id": 3}                       | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": 100}                   | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 10 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                   View "public.conditions_summary_daily"
@@ -526,16 +573,37 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:266: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:268: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                             config                             |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+----------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1009 | Retention Policy [1009]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |            10 | {"drop_after": 400, "hypertable_id": 3}                        | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1010 | Refresh Continuous Aggregate Policy [1010] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |            10 | {"end_offset": 1, "start_offset": 50, "mat_hypertable_id": 10} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1011 | Compression Policy [1011]                  | @ 1 day           | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |            10 | {"hypertable_id": 3, "compress_after": 100}                    | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- permissions test
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:278: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 10 other objects
+psql:include/cagg_migrate_common.sql:279: NOTICE:  drop cascades to 10 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -554,11 +622,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:298: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:302: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -566,7 +634,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:312: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -574,14 +642,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:322: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:331: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -607,9 +675,9 @@ SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalo
                 12 |      12 | FINISHED | COPY DATA        | {"end_ts": "800", "start_ts": "700", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                 12 |      13 | FINISHED | COPY DATA        | {"end_ts": "900", "start_ts": "800", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
                 12 |      14 | FINISHED | COPY DATA        | {"end_ts": "1000", "start_ts": "900", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "integer"}
-                12 |      15 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      16 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      17 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      15 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      16 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      17 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                 12 |      18 | FINISHED | ENABLE POLICIES  | 
 (18 rows)
 

--- a/tsl/test/expected/cagg_migrate_timestamp.out
+++ b/tsl/test/expected/cagg_migrate_timestamp.out
@@ -155,19 +155,19 @@ SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |   status    |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED    | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       1 | FINISHED    | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                  3 |       2 | NOT STARTED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                  3 |       3 | NOT STARTED | DISABLE POLICIES | {"policies": null}
-                 3 |       4 | NOT STARTED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       4 | NOT STARTED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                  3 |       5 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       6 | NOT STARTED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       7 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       8 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       9 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |      10 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      11 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      14 | NOT STARTED | ENABLE POLICIES  | 
 (14 rows)
 
@@ -178,19 +178,19 @@ psql:include/cagg_migrate_common.sql:156: NOTICE:  continuous aggregate "conditi
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                  3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                  3 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                  3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      11 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 
@@ -227,16 +227,16 @@ SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
 SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
 SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
 \endif
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
-   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
-   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
-   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                                     config                                     | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+--------------------------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_compression_check
+   1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 3}                                |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 -- execute the migration
@@ -287,35 +287,35 @@ UNION ALL
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
 AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                                     config                                     | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+--------------------------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1005 | Compression Policy [1005]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_compression_check
+   1004 | Refresh Continuous Aggregate Policy [1004] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 6} |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1003 | Retention Policy [1003]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 3}                                |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                  3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                  3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1002, 1000]}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                  3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+                 3 |      11 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005, 1002, 1001, 1000]}
 (14 rows)
 
 -- check migrated data. should return 0 (zero) rows
@@ -357,13 +357,27 @@ SELECT * FROM conditions_summary_daily_new;
 --------+-----+-----+-----+-----
 (0 rows)
 
+CREATE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:235: NOTICE:  drop cascades to 6 other objects
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:236: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:239: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -424,17 +438,50 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:246: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1006 | Retention Policy [1006]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             8 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1007 | Refresh Continuous Aggregate Policy [1007] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             8 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 8} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1008 | Compression Policy [1008]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             8 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema |             name             |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+------------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily_old | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily_old | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily_old | 1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- test migration overriding the new cagg and removing the old
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -466,16 +513,37 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:266: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:268: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1009 | Retention Policy [1009]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |            10 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                 | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1010 | Refresh Continuous Aggregate Policy [1010] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |            10 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 10} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1011 | Compression Policy [1011]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |            10 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                             | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- permissions test
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:278: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:279: NOTICE:  drop cascades to 6 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -494,11 +562,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:298: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:302: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -506,7 +574,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:312: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -514,14 +582,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:322: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:331: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -533,19 +601,19 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                 12 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                 12 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                 12 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                12 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      11 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                 12 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 

--- a/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
+++ b/tsl/test/expected/cagg_migrate_timestamp_dist_ht.out
@@ -190,19 +190,19 @@ SELECT mat_hypertable_id FROM _timescaledb_catalog.continuous_agg_migrate_plan;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |   status    |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+-------------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED    | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       1 | FINISHED    | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                  3 |       2 | NOT STARTED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                  3 |       3 | NOT STARTED | DISABLE POLICIES | {"policies": null}
-                 3 |       4 | NOT STARTED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       4 | NOT STARTED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                  3 |       5 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       6 | NOT STARTED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       7 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       8 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       9 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |      10 | NOT STARTED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      11 | NOT STARTED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | NOT STARTED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | NOT STARTED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      14 | NOT STARTED | ENABLE POLICIES  | 
 (14 rows)
 
@@ -213,19 +213,19 @@ psql:include/cagg_migrate_common.sql:156: NOTICE:  continuous aggregate "conditi
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                  3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                  3 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                  3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      11 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                  3 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 
@@ -262,16 +262,16 @@ SELECT add_retention_policy('conditions_summary_daily', '400'::integer);
 SELECT add_continuous_aggregate_policy('conditions_summary_daily', '50'::integer, '1'::integer, '1 hour'::interval);
 SELECT add_compression_policy('conditions_summary_daily', '100'::integer);
 \endif
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'MAT_SCHEMA_NAME'
 AND hypertable_name = :'MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
-   1002 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
-   1001 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
-   1000 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_3 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                                     config                                     | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+--------------------------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_compression_check
+   1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 3}                                |            |               | _timescaledb_internal | _materialized_hypertable_3 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 -- execute the migration
@@ -322,35 +322,35 @@ UNION ALL
   WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(6)), '-infinity'::timestamp with time zone)
   GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
 
-SELECT job_id, application_name, proc_schema, proc_name, scheduled, hypertable_schema, hypertable_name, config
+SELECT *
 FROM timescaledb_information.jobs
 WHERE hypertable_schema = :'NEW_MAT_SCHEMA_NAME'
 AND hypertable_name = :'NEW_MAT_TABLE_NAME'
 AND job_id >= 1000;
- job_id |              application_name              |      proc_schema      |              proc_name              | scheduled |   hypertable_schema   |      hypertable_name       |                                     config                                     
---------+--------------------------------------------+-----------------------+-------------------------------------+-----------+-----------------------+----------------------------+--------------------------------------------------------------------------------
-   1005 | Compression Policy [1002]                  | _timescaledb_internal | policy_compression                  | t         | _timescaledb_internal | _materialized_hypertable_6 | {"hypertable_id": 3, "compress_after": "@ 45 days"}
-   1004 | Refresh Continuous Aggregate Policy [1001] | _timescaledb_internal | policy_refresh_continuous_aggregate | t         | _timescaledb_internal | _materialized_hypertable_6 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3}
-   1003 | Retention Policy [1000]                    | _timescaledb_internal | policy_retention                    | t         | _timescaledb_internal | _materialized_hypertable_6 | {"drop_after": "@ 30 days", "hypertable_id": 3}
+ job_id |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule |                                     config                                     | next_start | initial_start |   hypertable_schema   |      hypertable_name       |     check_schema      |                check_name                 
+--------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+--------------------------------------------------------------------------------+------------+---------------+-----------------------+----------------------------+-----------------------+-------------------------------------------
+   1005 | Compression Policy [1005]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_compression_check
+   1004 | Refresh Continuous Aggregate Policy [1004] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 6} |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_refresh_continuous_aggregate_check
+   1003 | Retention Policy [1003]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              | {"drop_after": "@ 30 days", "hypertable_id": 3}                                |            |               | _timescaledb_internal | _materialized_hypertable_6 | _timescaledb_internal | policy_retention_check
 (3 rows)
 
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                 3 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                  3 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                  3 |       3 | FINISHED | DISABLE POLICIES | {"policies": [1002, 1000]}
-                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                 3 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                  3 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                  3 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                 3 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      13 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
-                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005]}
+                 3 |      11 | FINISHED | COPY POLICIES    | {"policies": [1002, 1001, 1000], "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                 3 |      14 | FINISHED | ENABLE POLICIES  | {"policies": [1003, 1004, 1005, 1002, 1001, 1000]}
 (14 rows)
 
 -- check migrated data. should return 0 (zero) rows
@@ -392,13 +392,27 @@ SELECT * FROM conditions_summary_daily_new;
 --------+-----+-----+-----+-----
 (0 rows)
 
+CREATE VIEW cagg_jobs AS
+SELECT user_view_schema AS schema, user_view_name AS name, bgw_job.*
+FROM _timescaledb_config.bgw_job
+JOIN _timescaledb_catalog.continuous_agg ON mat_hypertable_id = hypertable_id
+ORDER BY bgw_job.id;
 -- test migration overriding the new cagg and keeping the old
 DROP MATERIALIZED VIEW conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:229: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:235: NOTICE:  drop cascades to 6 other objects
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:230: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:236: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE);
-psql:include/cagg_migrate_common.sql:231: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:239: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -459,17 +473,50 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:238: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:246: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1006 | Retention Policy [1006]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             8 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1007 | Refresh Continuous Aggregate Policy [1007] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             8 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 8} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1008 | Compression Policy [1008]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             8 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return the old cagg jobs
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema |             name             |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+------------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily_old | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily_old | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily_old | 1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- test migration overriding the new cagg and removing the old
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:242: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:243: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 6 other objects
 ALTER MATERIALIZED VIEW conditions_summary_daily_old RENAME TO conditions_summary_daily;
+-- check policies before the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                     |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+--------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1000 | Retention Policy [1000]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |             3 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1001 | Refresh Continuous Aggregate Policy [1001] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |             3 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 3} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1002 | Compression Policy [1002]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |             3 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                            | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
 CALL cagg_migrate('conditions_summary_daily', override => TRUE, drop_old => TRUE);
-psql:include/cagg_migrate_common.sql:245: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
-psql:include/cagg_migrate_common.sql:245: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:261: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:261: NOTICE:  drop cascades to 6 other objects
 -- cagg with the new format because it was overriden
 \d+ conditions_summary_daily
                            View "public.conditions_summary_daily"
@@ -501,16 +548,37 @@ UNION ALL
 \set ON_ERROR_STOP 0
 -- should fail because the cagg was overriden
 SELECT * FROM conditions_summary_daily_new;
-psql:include/cagg_migrate_common.sql:250: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
+psql:include/cagg_migrate_common.sql:266: ERROR:  relation "conditions_summary_daily_new" does not exist at character 15
 -- should fail because the old cagg was removed
 SELECT * FROM conditions_summary_daily_old;
-psql:include/cagg_migrate_common.sql:252: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
+psql:include/cagg_migrate_common.sql:268: ERROR:  relation "conditions_summary_daily_old" does not exist at character 15
 \set ON_ERROR_STOP 1
+-- check policies after the migration
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily';
+ schema |           name           |  id  |              application_name              | schedule_interval | max_runtime | max_retries | retry_period |      proc_schema      |              proc_name              |       owner        | scheduled | fixed_schedule | initial_start | hypertable_id |                                     config                                      |     check_schema      |                check_name                 | timezone 
+--------+--------------------------+------+--------------------------------------------+-------------------+-------------+-------------+--------------+-----------------------+-------------------------------------+--------------------+-----------+----------------+---------------+---------------+---------------------------------------------------------------------------------+-----------------------+-------------------------------------------+----------
+ public | conditions_summary_daily | 1009 | Retention Policy [1009]                    | @ 1 day           | @ 5 mins    |          -1 | @ 5 mins     | _timescaledb_internal | policy_retention                    | cluster_super_user | t         | f              |               |            10 | {"drop_after": "@ 30 days", "hypertable_id": 3}                                 | _timescaledb_internal | policy_retention_check                    | 
+ public | conditions_summary_daily | 1010 | Refresh Continuous Aggregate Policy [1010] | @ 1 hour          | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_refresh_continuous_aggregate | cluster_super_user | t         | f              |               |            10 | {"end_offset": "@ 1 day", "start_offset": "@ 30 days", "mat_hypertable_id": 10} | _timescaledb_internal | policy_refresh_continuous_aggregate_check | 
+ public | conditions_summary_daily | 1011 | Compression Policy [1011]                  | @ 35 days         | @ 0         |          -1 | @ 1 hour     | _timescaledb_internal | policy_compression                  | cluster_super_user | t         | f              |               |            10 | {"hypertable_id": 3, "compress_after": "@ 45 days"}                             | _timescaledb_internal | policy_compression_check                  | 
+(3 rows)
+
+-- should return no rows because the old cagg was removed
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_old';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
+-- should return no rows because the cagg was overwritten
+SELECT * FROM cagg_jobs WHERE schema = 'public' AND name = 'conditions_summary_daily_new';
+ schema | name | id | application_name | schedule_interval | max_runtime | max_retries | retry_period | proc_schema | proc_name | owner | scheduled | fixed_schedule | initial_start | hypertable_id | config | check_schema | check_name | timezone 
+--------+------+----+------------------+-------------------+-------------+-------------+--------------+-------------+-----------+-------+-----------+----------------+---------------+---------------+--------+--------------+------------+----------
+(0 rows)
+
 -- permissions test
 TRUNCATE _timescaledb_catalog.continuous_agg_migrate_plan RESTART IDENTITY CASCADE;
-psql:include/cagg_migrate_common.sql:256: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
+psql:include/cagg_migrate_common.sql:278: NOTICE:  truncate cascades to table "continuous_agg_migrate_plan_step"
 DROP MATERIALIZED VIEW conditions_summary_daily;
-psql:include/cagg_migrate_common.sql:257: NOTICE:  drop cascades to 6 other objects
+psql:include/cagg_migrate_common.sql:279: NOTICE:  drop cascades to 6 other objects
 GRANT ALL ON TABLE conditions TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 CREATE MATERIALIZED VIEW conditions_summary_daily
@@ -529,11 +597,11 @@ FROM
     conditions
 GROUP BY
     bucket;
-psql:include/cagg_migrate_common.sql:276: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
+psql:include/cagg_migrate_common.sql:298: NOTICE:  refreshing continuous aggregate "conditions_summary_daily"
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:280: ERROR:  permission denied for table continuous_agg_migrate_plan
+psql:include/cagg_migrate_common.sql:302: ERROR:  permission denied for table continuous_agg_migrate_plan
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan TO :ROLE_DEFAULT_PERM_USER;
@@ -541,7 +609,7 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step' catalog table
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:290: ERROR:  permission denied for table continuous_agg_migrate_plan_step
+psql:include/cagg_migrate_common.sql:312: ERROR:  permission denied for table continuous_agg_migrate_plan_step
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT SELECT, INSERT, UPDATE ON TABLE _timescaledb_catalog.continuous_agg_migrate_plan_step TO :ROLE_DEFAULT_PERM_USER;
@@ -549,14 +617,14 @@ SET ROLE :ROLE_DEFAULT_PERM_USER;
 \set ON_ERROR_STOP 0
 -- should fail because the lack of permissions on 'continuous_agg_migrate_plan_step_step_id_seq' catalog sequence
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:300: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
+psql:include/cagg_migrate_common.sql:322: ERROR:  permission denied for sequence continuous_agg_migrate_plan_step_step_id_seq
 \set ON_ERROR_STOP 1
 RESET ROLE;
 GRANT USAGE ON SEQUENCE _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq TO :ROLE_DEFAULT_PERM_USER;
 SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- all necessary permissions granted
 CALL cagg_migrate('conditions_summary_daily');
-psql:include/cagg_migrate_common.sql:309: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
+psql:include/cagg_migrate_common.sql:331: NOTICE:  continuous aggregate "conditions_summary_daily_new" is already up-to-date
 -- check migrated data. should return 0 (zero) rows
 SELECT * FROM conditions_summary_daily
 EXCEPT
@@ -568,19 +636,19 @@ SELECT * FROM conditions_summary_daily_new;
 SELECT mat_hypertable_id, step_id, status, type, config FROM _timescaledb_catalog.continuous_agg_migrate_plan_step ORDER BY step_id;
  mat_hypertable_id | step_id |  status  |       type       |                                                                                                          config                                                                                                           
 -------------------+---------+----------+------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sat Dec 31 16:00:00 2022 PST"}
+                12 |       1 | FINISHED | SAVE WATERMARK   | {"watermark": "Sun Jan 01 00:00:00 2023"}
                 12 |       2 | FINISHED | CREATE NEW CAGG  | {"cagg_name_new": "conditions_summary_daily_new"}
                 12 |       3 | FINISHED | DISABLE POLICIES | {"policies": null}
-                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sat Dec 31 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
+                12 |       4 | FINISHED | REFRESH NEW CAGG | {"window_start": "Sun Jan 01 00:00:00 2023", "cagg_name_new": "conditions_summary_daily_new", "window_start_type": "timestamp with time zone"}
                 12 |       5 | FINISHED | COPY DATA        | {"end_ts": "Fri Mar 11 16:00:00 2022 PST", "start_ts": "Fri Dec 31 16:00:00 2021 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       6 | FINISHED | COPY DATA        | {"end_ts": "Fri May 20 16:00:00 2022 PDT", "start_ts": "Fri Mar 11 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       7 | FINISHED | COPY DATA        | {"end_ts": "Fri Jul 29 16:00:00 2022 PDT", "start_ts": "Fri May 20 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       8 | FINISHED | COPY DATA        | {"end_ts": "Fri Oct 07 16:00:00 2022 PDT", "start_ts": "Fri Jul 29 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |       9 | FINISHED | COPY DATA        | {"end_ts": "Fri Dec 16 16:00:00 2022 PST", "start_ts": "Fri Oct 07 16:00:00 2022 PDT", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
                 12 |      10 | FINISHED | COPY DATA        | {"end_ts": "Fri Feb 24 16:00:00 2023 PST", "start_ts": "Fri Dec 16 16:00:00 2022 PST", "cagg_name_new": "conditions_summary_daily_new", "bucket_column_name": "bucket", "bucket_column_type": "timestamp with time zone"}
-                12 |      11 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      12 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
-                12 |      13 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      11 | FINISHED | COPY POLICIES    | {"policies": null, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      12 | FINISHED | OVERRIDE CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
+                12 |      13 | FINISHED | DROP OLD CAGG    | {"drop_old": false, "override": false, "cagg_name_new": "conditions_summary_daily_new"}
                 12 |      14 | FINISHED | ENABLE POLICIES  | 
 (14 rows)
 


### PR DESCRIPTION
When using `override => true` the migration procedure rename the current cagg using the suffix `_old` and rename the new created with suffix `_new` to the original name.

The problem is the `copy polices` step was executed after the `override` step and then we didn't found the new cagg name because it was renamed to the the original name leading the policy orphan (without connection with the materialization hypertable).

Fixed it by reordering the steps executin the `copy policies` before the `override` step. Also made some ajustments to properly copy all `bgw_job` columns even if this catalog table was changed.

Fixes #4885