### PR TITLE
Add printout for multiple jobs with same job_id

### DIFF
--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -547,7 +547,7 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         deptype = 'e' AND
         classid='pg_catalog.pg_class'::pg_catalog.regclass
         AND objid NOT IN (select unnest(extconfig) from pg_extension where extname='timescaledb')
-        ORDER BY objid::regclass::text;
+        ORDER BY objid::regclass::text COLLATE "C";
                        objid                       
 ---------------------------------------------------
  _timescaledb_catalog.chunk_copy_operation

--- a/test/sql/pg_dump.sql
+++ b/test/sql/pg_dump.sql
@@ -170,7 +170,7 @@ WHERE   refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass AND
         deptype = 'e' AND
         classid='pg_catalog.pg_class'::pg_catalog.regclass
         AND objid NOT IN (select unnest(extconfig) from pg_extension where extname='timescaledb')
-        ORDER BY objid::regclass::text;
+        ORDER BY objid::regclass::text COLLATE "C";
 
 -- Make sure we can't run our restoring functions as a normal perm user as that would disable functionality for the whole db
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER


### PR DESCRIPTION
We have a rare condition where a debug build asserts on more than one job with the same job id. Since it is hard to create a reproduction, this commit adds a printout for those conditions and print out all the jobs with that job id in the postgres log.

Part of #4863