### PR TITLE
Improve InvalidOid coccinelle check

### DIFF
--- a/coccinelle/oidisvalid.cocci
+++ b/coccinelle/oidisvalid.cocci
@@ -16,8 +16,8 @@ symbol InvalidOid;
 expression oid;
 @@
 
-/* use OidIsValid() instead of comparing against InvalidOid */
 - (oid != InvalidOid)
++ /* use OidIsValid() instead of comparing against InvalidOid */
 + OidIsValid(oid)
 
 @@
@@ -25,6 +25,25 @@ symbol InvalidOid;
 expression oid;
 @@
 
-/* use OidIsValid() instead of comparing against InvalidOid */
+- (InvalidOid != oid)
++ /* use OidIsValid() instead of comparing against InvalidOid */
++ OidIsValid(oid)
+
+@@
+symbol InvalidOid;
+expression oid;
+@@
+
 - (oid == InvalidOid)
++ /* use OidIsValid() instead of comparing against InvalidOid */
 + !OidIsValid(oid)
+
+@@
+symbol InvalidOid;
+expression oid;
+@@
+
+- (InvalidOid == oid)
++ /* use OidIsValid() instead of comparing against InvalidOid */
++ !OidIsValid(oid)
+

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3339,7 +3339,7 @@ process_altertable_start_table(ProcessUtilityArgs *args)
 				relation = partstmt->name;
 				Assert(NULL != relation);
 
-				if (InvalidOid != ts_hypertable_relid(relation))
+				if (OidIsValid(ts_hypertable_relid(relation)))
 				{
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),


### PR DESCRIPTION
The initial version of the check did not include a detailed message about the code failure in the CI output and did not check for expressions with operands in wrong order.