### PR TITLE
Add new tests to .gitignore list

### DIFF
--- a/test/sql/.gitignore
+++ b/test/sql/.gitignore
@@ -9,6 +9,7 @@
 /delete-*.sql
 /insert-*.sql
 /insert_many-*.sql
+/parallel-*.sql
 /partitioning-*.sql
 /partitionwise-*.sql
 /plan_expand_hypertable-*.sql
@@ -16,5 +17,6 @@
 /plan_hypertable_cache-*.sql
 /plan_hypertable_inline-*.sql
 /plan_ordered_append-*.sql
+/query-*.sql
 /rowsecurity-*.sql
 /update-*.sql

--- a/tsl/test/shared/sql/.gitignore
+++ b/tsl/test/shared/sql/.gitignore
@@ -1,6 +1,7 @@
 /continuous_aggs_compression-*.sql
 /constify_now-*.sql
 /decompress_join-*.sql
+/dist_distinct-*.sql
 /dist_remote_error-*.sql
 /dist_remote_error.text
 /gapfill-*.sql

--- a/tsl/test/sql/.gitignore
+++ b/tsl/test/sql/.gitignore
@@ -6,11 +6,13 @@
 /cagg_union_view-*.sql
 /compression_insert-*.sql
 /compression_permissions-*.sql
+/continuous_aggs-*.sql
 /dist_grant-*.sql
 /dist_hypertable-*.sql
 /dist_partial_agg-*.sql
 /hypertable_distributed-*.sql
 /jit-*.sql
+/modify_exclusion-*.sql
 /plan_skip_scan-*.sql
 /remote-copy-*sv
 /remote_copy-*.sql


### PR DESCRIPTION
Since new tests specific to PG15 were added, these tests which generated .sql files needs to be added to .gitnore