### PR TITLE
Add nothrow codepath to health check

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -251,6 +251,17 @@ create_foreign_server(const char *const node_name, const char *const host, int32
 }
 
 TSConnection *
+data_node_get_connection_nothrow(const char *const data_node, char **errmsg)
+{
+	const ForeignServer *server;
+
+	Assert(data_node != NULL);
+	server = data_node_get_foreign_server(data_node, ACL_NO_CHECK, false, false);
+
+	return remote_connection_open_nothrow(server->serverid, GetUserId(), errmsg);
+}
+
+TSConnection *
 data_node_get_connection(const char *const data_node, RemoteTxnPrepStmtOption const ps_opt,
 						 bool transactional)
 {

--- a/tsl/src/data_node.h
+++ b/tsl/src/data_node.h
@@ -20,6 +20,7 @@ extern ForeignServer *data_node_get_foreign_server(const char *node_name, AclMod
 												   bool fail_on_aclcheck, bool missing_ok);
 extern ForeignServer *data_node_get_foreign_server_by_oid(Oid foreign_server_oid, AclMode mode);
 
+extern TSConnection *data_node_get_connection_nothrow(const char *const data_node, char **errmsg);
 extern TSConnection *data_node_get_connection(const char *const data_node,
 											  RemoteTxnPrepStmtOption const ps_opt,
 											  bool transactional);

--- a/tsl/src/remote/async.h
+++ b/tsl/src/remote/async.h
@@ -104,6 +104,7 @@ extern bool async_request_set_single_row_mode(AsyncRequest *req);
 extern TSConnection *async_request_get_connection(AsyncRequest *req);
 extern AsyncResponseResult *async_request_wait_ok_result(AsyncRequest *request);
 extern AsyncResponseResult *async_request_wait_any_result(AsyncRequest *request);
+extern AsyncResponse *async_request_wait_any_response(AsyncRequest *request);
 extern AsyncResponse *async_request_cleanup_result(AsyncRequest *req, TimestampTz endtime);
 
 /* Returns on successful commands, throwing errors otherwise */
@@ -116,6 +117,7 @@ extern void async_response_report_error(AsyncResponse *res, int elevel);
 extern void async_response_report_error_or_close(AsyncResponse *res, int elevel);
 
 extern AsyncResponseType async_response_get_type(AsyncResponse *res);
+extern char *async_response_get_error_message(AsyncResponse *res, const char **node_name);
 extern void async_response_result_close(AsyncResponseResult *res);
 extern PGresult *async_response_result_get_pg_result(AsyncResponseResult *res);
 extern void *async_response_result_get_user_data(AsyncResponseResult *res);

--- a/tsl/src/remote/dist_commands.c
+++ b/tsl/src/remote/dist_commands.c
@@ -24,6 +24,8 @@
 #include "deparse.h"
 #include "debug_point.h"
 
+#define CONNECTION_CLEANUP_TIME 30000
+
 typedef struct DistPreparedStmt
 {
 	const char *data_node_name;
@@ -34,6 +36,8 @@ typedef struct DistCmdResponse
 {
 	const char *data_node;
 	AsyncResponseResult *result;
+	PGresult *pg_result;
+	const char *errorMessage;
 } DistCmdResponse;
 
 typedef struct DistCmdResult
@@ -46,6 +50,12 @@ typedef struct DistCmdResult
 							  * composite return value */
 	DistCmdResponse responses[FLEXIBLE_ARRAY_MEMBER];
 } DistCmdResult;
+
+typedef struct DistCmdResetCallback
+{
+	TSConnection *conn;
+	PGresult *result;
+} DistCmdResetCallback;
 
 static DistCmdResult *
 ts_dist_cmd_collect_responses(List *requests)
@@ -76,6 +86,288 @@ ts_dist_cmd_collect_responses(List *requests)
 	return results;
 }
 
+static List *
+ts_dist_cmd_sanitize_data_node_list(List *data_nodes)
+{
+	switch (nodeTag(data_nodes))
+	{
+		case T_OidList:
+			data_nodes = data_node_oids_to_node_name_list(data_nodes, ACL_NO_CHECK);
+			break;
+		case T_List:
+			/* Already in the format we want */
+			data_node_name_list_check_acl(data_nodes, ACL_NO_CHECK);
+			break;
+		default:
+			elog(ERROR, "invalid list type %u", nodeTag(data_nodes));
+			break;
+	}
+	return data_nodes;
+}
+
+/*
+ * Callback to manage memory allocated by libpq via malloc
+ *
+ * If a PGresult does not belong to a connection or a connection isn't stored
+ * in the connection cache, all memory associated needs to be handled when the
+ * Memory Context is deleted/reset.
+ */
+static void
+ts_dist_cmd_mctx_reset_callback(void *arg)
+{
+	Assert(arg != NULL);
+	ListCell *lc;
+	List *callback_list = *(List **) arg;
+
+	foreach (lc, callback_list)
+	{
+		DistCmdResetCallback *cb = lfirst(lc);
+		if (cb->result != NULL)
+			PQclear(cb->result);
+		if (cb->conn != NULL)
+			remote_connection_close(cb->conn);
+		pfree(cb);
+	}
+	list_free(callback_list);
+
+	pfree(arg);
+}
+
+/*
+ * Helper function that errors in case of OOM.
+ *
+ */
+static PGresult *
+ts_dist_cmd_make_pg_result(ExecStatusType status)
+{
+	PGresult *pg_result = PQmakeEmptyPGresult(NULL, status);
+	if (pg_result == NULL)
+	{
+		/* If PQmakeEmptyPGresult returns NULL, we are OOM
+		 * There's nothing left to do but to exit now */
+		ereport(ERROR,
+				(errcode(ERRCODE_OUT_OF_MEMORY),
+				 errmsg("out of memory"),
+				 errdetail("Failed to allocate pg_result")));
+	}
+
+	Assert(pg_result != NULL);
+	return pg_result;
+}
+
+static void
+ts_dist_cmd_create_error_response(DistCmdResponse *rsp, const char *err_msg, const char *data_node,
+								  DistCmdResetCallback *cb)
+{
+	Assert(rsp != NULL);
+
+	if (rsp->pg_result == NULL)
+	{
+		Assert(cb != NULL);
+		PGresult *res = ts_dist_cmd_make_pg_result(PGRES_FATAL_ERROR);
+		cb->result = res;
+		rsp->pg_result = res;
+	}
+
+	/* Todo: There is no function to set errorMessage in a pg_result.
+	 * For now, copy errorMessage around in DistCmdResponse */
+	rsp->errorMessage = pstrdup(err_msg);
+	rsp->data_node = pstrdup(data_node);
+}
+
+/*
+ * Invoke SQL statement on the given data nodes without throwing.
+ *
+ * For each broken connection, a PGresult with PGRES_FATAL_ERROR is created.
+ */
+DistCmdResult *
+ts_dist_cmd_invoke_on_data_nodes_no_throw(const char *sql, const char *search_path,
+										  List *data_nodes)
+{
+	ListCell *lc;
+	List *requests = NIL;
+	List **callback_data;
+	DistCmdResult *results;
+	AsyncRequestSet *rs;
+	AsyncResponse *ar;
+	MemoryContextCallback *mcb;
+	bool set_search_path = search_path != NULL;
+
+	if (data_nodes == NIL)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("no data nodes to execute command on"),
+				 errhint("Add data nodes before executing a distributed command.")));
+
+	data_nodes = ts_dist_cmd_sanitize_data_node_list(data_nodes);
+
+	/* Since libpq uses malloc, register a callback that frees results
+	 * on Memory Context Reset/Delete */
+	callback_data = palloc(sizeof(List **));
+	*callback_data = NIL;
+	mcb = palloc0(sizeof(MemoryContextCallback));
+	mcb->func = ts_dist_cmd_mctx_reset_callback;
+	mcb->arg = callback_data;
+	mcb->next = NULL;
+	MemoryContextRegisterResetCallback(CurrentMemoryContext, mcb);
+
+	int i = 0;
+	results = palloc0(sizeof(DistCmdResult) + list_length(data_nodes) * sizeof(DistCmdResponse));
+	rs = async_request_set_create();
+
+	/* Connection, Search Path */
+	foreach (lc, data_nodes)
+	{
+		const char *node_name = lfirst(lc);
+		char *errmsg;
+		AsyncRequest *req;
+		bool error = false;
+		DistCmdResetCallback *cb = palloc0(sizeof(DistCmdResetCallback));
+		DistCmdResponse *response = &results->responses[i];
+		TSConnection *connection = data_node_get_connection_nothrow(node_name, &errmsg);
+
+		if (connection == NULL)
+		{
+			error = true;
+			ts_dist_cmd_create_error_response(response, errmsg, node_name, cb);
+		}
+		else
+			cb->conn = connection;
+		*callback_data = lappend(*callback_data, cb);
+
+		if (set_search_path)
+		{
+			char *set_search_path = psprintf("SET search_path = %s, pg_catalog", search_path);
+			TimestampTz end_time =
+				TimestampTzPlusMilliseconds(GetCurrentTimestamp(), CONNECTION_CLEANUP_TIME);
+
+			ereport(DEBUG2,
+					(errmsg_internal("sending \"%s\" to data node \"%s\"",
+									 search_path,
+									 node_name)));
+
+			req = async_request_send(connection, set_search_path);
+			ar = async_request_wait_any_response(req);
+
+			/* This can not happen, so abort if it does */
+			Assert(ar != NULL);
+
+			/* A node can go down between establishing connection and setting search path */
+			switch (async_response_get_type(ar))
+			{
+				case RESPONSE_RESULT:
+				{
+					PGresult *res = async_response_result_get_pg_result((AsyncResponseResult *) ar);
+					ExecStatusType status = PQresultStatus(res);
+
+					/* Need to set the remote connection to IDLE after a succesful
+					 * search path set. Otherwise no further commands can execute.
+					 * There is a chance that the connection died after a result
+					 * but before closing */
+					async_request_cleanup_result(req, end_time);
+					remote_connection_set_status(connection, CONN_IDLE);
+
+					switch (status)
+					{
+						/* Set search path is succesful */
+						case PGRES_COMMAND_OK:
+							break;
+						/* Unexpected result, propage error and skip data node */
+						default:
+							ts_dist_cmd_create_error_response(response,
+															  PQresultErrorMessage(res),
+															  node_name,
+															  cb);
+							error = true;
+
+							break;
+					}
+
+					break;
+				}
+
+				default:
+					/* We did get an unexpected AsyncResponseResult. */
+					error = true;
+					char *message = async_response_get_error_message(ar, NULL);
+					Assert(message != NULL);
+					ts_dist_cmd_create_error_response(response, message, pstrdup(node_name), cb);
+
+					async_request_cleanup_result(req, end_time);
+					break;
+			}
+
+			async_response_close(ar);
+		}
+
+		if (error)
+		{
+			/* We have encountered an error: skip this data node */
+			++i;
+			continue;
+		}
+		ereport(DEBUG2, (errmsg_internal("sending \"%s\" to data node \"%s\"", sql, node_name)));
+
+		req = async_request_send(connection, sql);
+		async_request_attach_user_data(req, (char *) node_name);
+		async_request_set_add(rs, req);
+	}
+
+	while ((ar = async_request_set_wait_any_response(rs)))
+	{
+		DistCmdResponse *response = &results->responses[i];
+		const char *node_name = NULL;
+		switch (async_response_get_type(ar))
+		{
+			case RESPONSE_RESULT:
+			case RESPONSE_ROW:
+			{
+				node_name = async_response_result_get_user_data((AsyncResponseResult *) ar);
+
+				/* Whatever result we have, simply return it. The caller has
+				 * to handle PGresult errors */
+				PGresult *res = async_response_result_get_pg_result((AsyncResponseResult *) ar);
+				response->result = (AsyncResponseResult *) ar;
+				response->errorMessage = pstrdup(PQresultErrorMessage(res));
+				response->data_node = pstrdup(node_name);
+
+				break;
+			}
+			case RESPONSE_TIMEOUT:
+				/* async_request_set_wait_any_response() does not time out. If we end up
+				 * here, something went very wrong. If a timeout occures, it happened for all
+				 * remaining nodes, so we do not have a specific node to return. */
+				elog(ERROR, "unexpected timeout in async request without timeout");
+
+				break;
+			default:
+			{
+				/* We do not have a PGresult. Make one */
+				DistCmdResetCallback *cb = palloc0(sizeof(DistCmdResetCallback));
+				char *message = async_response_get_error_message(ar, &node_name);
+				ts_dist_cmd_create_error_response(response, message, pstrdup(node_name), cb);
+				*callback_data = lappend(*callback_data, cb);
+			}
+		}
+
+		++i;
+	}
+
+	Assert(i == list_length(data_nodes));
+	results->num_responses = i;
+	list_free(requests);
+
+	return results;
+}
+
+DistCmdResult *
+ts_dist_cmd_invoke_on_all_data_nodes_no_throw(const char *sql, const char *search_path)
+{
+	List *data_nodes = data_node_get_node_name_list();
+
+	return ts_dist_cmd_invoke_on_data_nodes_no_throw(sql, search_path, data_nodes);
+}
+
 /*
  * Invoke multiple SQL statements (commands) on the given data nodes.
  *
@@ -101,19 +393,7 @@ ts_dist_multi_cmds_params_invoke_on_data_nodes(List *cmd_descriptors, List *data
 				 errhint("Add data nodes before executing a distributed command.")));
 
 	Assert(list_length(data_nodes) == list_length(cmd_descriptors));
-	switch (nodeTag(data_nodes))
-	{
-		case T_OidList:
-			data_nodes = data_node_oids_to_node_name_list(data_nodes, ACL_NO_CHECK);
-			break;
-		case T_List:
-			/* Already in the format we want */
-			data_node_name_list_check_acl(data_nodes, ACL_NO_CHECK);
-			break;
-		default:
-			elog(ERROR, "invalid list type %u", nodeTag(data_nodes));
-			break;
-	}
+	data_nodes = ts_dist_cmd_sanitize_data_node_list(data_nodes);
 
 	forboth (lc_data_node, data_nodes, lc_cmd_descr, cmd_descriptors)
 	{
@@ -298,6 +578,18 @@ ts_dist_cmd_func_call_on_data_nodes(FunctionCallInfo fcinfo, List *data_nodes)
 	ts_dist_cmd_close_response(result);
 }
 
+static PGresult *
+ts_dist_cmd_get_response_result(DistCmdResponse *response)
+{
+	PGresult *res;
+
+	if (response->result)
+		res = async_response_result_get_pg_result(response->result);
+	else
+		res = response->pg_result;
+	return res;
+}
+
 PGresult *
 ts_dist_cmd_get_result_by_node_name(DistCmdResult *response, const char *node_name)
 {
@@ -306,9 +598,22 @@ ts_dist_cmd_get_result_by_node_name(DistCmdResult *response, const char *node_na
 		DistCmdResponse *resp = &response->responses[i];
 
 		if (strcmp(node_name, resp->data_node) == 0)
-			return async_response_result_get_pg_result(resp->result);
+			return ts_dist_cmd_get_response_result(resp);
 	}
 	return NULL;
+}
+
+const char *
+ts_dist_cmd_get_error_by_index(DistCmdResult *response, Size index)
+{
+	DistCmdResponse *rsp;
+
+	if (index >= response->num_responses)
+		return NULL;
+
+	rsp = &response->responses[index];
+
+	return rsp->errorMessage;
 }
 
 /*
@@ -333,7 +638,7 @@ ts_dist_cmd_get_result_by_index(DistCmdResult *response, Size index, const char 
 	if (NULL != node_name)
 		*node_name = rsp->data_node;
 
-	return async_response_result_get_pg_result(rsp->result);
+	return ts_dist_cmd_get_response_result(rsp);
 }
 
 /*
@@ -354,7 +659,7 @@ ts_dist_cmd_total_row_count(DistCmdResult *result)
 	{
 		DistCmdResponse *resp = &result->responses[i];
 
-		num_rows += PQntuples(async_response_result_get_pg_result(resp->result));
+		num_rows += PQntuples(ts_dist_cmd_get_response_result(resp));
 	}
 
 	return num_rows;
@@ -432,6 +737,14 @@ ts_dist_cmd_clear_result_by_index(DistCmdResult *response, Size index)
 		pfree((char *) resp->data_node);
 		resp->data_node = NULL;
 	}
+	if (resp->errorMessage != NULL)
+	{
+		pfree((char *) resp->errorMessage);
+		resp->errorMessage = NULL;
+	}
+	/* pg_results are managed by memory context callback */
+	if (resp->pg_result != NULL)
+		resp->pg_result = NULL;
 }
 
 void

--- a/tsl/src/remote/dist_commands.h
+++ b/tsl/src/remote/dist_commands.h
@@ -19,6 +19,13 @@ typedef struct DistCmdDescr
 
 } DistCmdDescr;
 
+extern DistCmdResult *ts_dist_cmd_invoke_on_all_data_nodes_no_throw(const char *sql,
+																	const char *search_path);
+
+extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes_no_throw(const char *sql,
+																const char *search_path,
+																List *data_nodes);
+
 extern DistCmdResult *ts_dist_multi_cmds_params_invoke_on_data_nodes(List *cmd_descriptors,
 																	 List *data_nodes,
 																	 bool transactional);
@@ -32,6 +39,7 @@ extern DistCmdResult *ts_dist_cmd_invoke_on_data_nodes_using_search_path(const c
 																		 const char *search_path,
 																		 List *node_names,
 																		 bool transactional);
+
 extern DistCmdResult *ts_dist_cmd_invoke_on_all_data_nodes(const char *sql);
 extern DistCmdResult *ts_dist_cmd_invoke_func_call_on_all_data_nodes(FunctionCallInfo fcinfo);
 extern DistCmdResult *ts_dist_cmd_invoke_func_call_on_data_nodes(FunctionCallInfo fcinfo,
@@ -39,6 +47,7 @@ extern DistCmdResult *ts_dist_cmd_invoke_func_call_on_data_nodes(FunctionCallInf
 extern Datum ts_dist_cmd_get_single_scalar_result_by_index(DistCmdResult *result, Size index,
 														   bool *isnull, const char **node_name);
 extern void ts_dist_cmd_func_call_on_data_nodes(FunctionCallInfo fcinfo, List *data_nodes);
+extern const char *ts_dist_cmd_get_error_by_index(DistCmdResult *response, Size index);
 extern PGresult *ts_dist_cmd_get_result_by_node_name(DistCmdResult *response,
 													 const char *node_name);
 extern PGresult *ts_dist_cmd_get_result_by_index(DistCmdResult *response, Size index,

--- a/tsl/test/expected/dist_commands.out
+++ b/tsl/test/expected/dist_commands.out
@@ -40,6 +40,10 @@ CREATE FUNCTION _timescaledb_internal.invoke_faulty_distributed_command()
 RETURNS void
 AS :TSL_MODULE_PATHNAME, 'ts_invoke_faulty_distributed_command'
 LANGUAGE C STRICT;
+CREATE FUNCTION _timescaledb_internal.invoke_faulty_distributed_command_nothrow()
+RETURNS void
+AS :TSL_MODULE_PATHNAME, 'ts_invoke_faulty_distributed_command_nothrow'
+LANGUAGE C STRICT;
 GRANT CREATE ON SCHEMA public TO :ROLE_1;
 SET ROLE :ROLE_1;
 SELECT _timescaledb_internal.invoke_distributed_commands();
@@ -50,6 +54,10 @@ INFO:  db_dist_commands_1 result: PGRES_COMMAND_OK
 INFO:  db_dist_commands_2 result: PGRES_COMMAND_OK
 INFO:  db_dist_commands_1 result: PGRES_COMMAND_OK
 INFO:  db_dist_commands_2 result: PGRES_COMMAND_OK
+INFO:  db_dist_commands_1 result: PGRES_TUPLES_OK
+INFO:  db_dist_commands_2 result: PGRES_TUPLES_OK
+INFO:  db_dist_commands_3 result: PGRES_TUPLES_OK
+INFO:  db_dist_commands_1 result: PGRES_TUPLES_OK
  invoke_distributed_commands 
 -----------------------------
  
@@ -117,6 +125,18 @@ SELECT * from disttable2;
  time | device | temp 
 ------+--------+------
 (0 rows)
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- nothrow does not use transactions. Only test that this errors out
+SELECT _timescaledb_internal.invoke_faulty_distributed_command_nothrow();
+INFO:  db_dist_commands_1 error message: ERROR:  column "broken" does not exist
+LINE 1: SELECT broken
+               ^
+
+ invoke_faulty_distributed_command_nothrow 
+-------------------------------------------
+ 
+(1 row)
 
 -- Test connection session identity
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/tsl/test/sql/dist_commands.sql
+++ b/tsl/test/sql/dist_commands.sql
@@ -35,6 +35,11 @@ CREATE FUNCTION _timescaledb_internal.invoke_faulty_distributed_command()
 RETURNS void
 AS :TSL_MODULE_PATHNAME, 'ts_invoke_faulty_distributed_command'
 LANGUAGE C STRICT;
+
+CREATE FUNCTION _timescaledb_internal.invoke_faulty_distributed_command_nothrow()
+RETURNS void
+AS :TSL_MODULE_PATHNAME, 'ts_invoke_faulty_distributed_command_nothrow'
+LANGUAGE C STRICT;
 GRANT CREATE ON SCHEMA public TO :ROLE_1;
 SET ROLE :ROLE_1;
 
@@ -62,6 +67,10 @@ SELECT _timescaledb_internal.invoke_faulty_distributed_command();
 SELECT * from disttable2;
 \c :DATA_NODE_2
 SELECT * from disttable2;
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- nothrow does not use transactions. Only test that this errors out
+SELECT _timescaledb_internal.invoke_faulty_distributed_command_nothrow();
 
 -- Test connection session identity
 \c :TEST_DBNAME :ROLE_SUPERUSER

--- a/tsl/test/src/remote/dist_commands.c
+++ b/tsl/test/src/remote/dist_commands.c
@@ -14,6 +14,7 @@
 
 TS_FUNCTION_INFO_V1(ts_invoke_distributed_commands);
 TS_FUNCTION_INFO_V1(ts_invoke_faulty_distributed_command);
+TS_FUNCTION_INFO_V1(ts_invoke_faulty_distributed_command_nothrow);
 
 #define LOG_PG_STATUS(RESULT, TARGET)                                                              \
 	elog(INFO,                                                                                     \
@@ -26,6 +27,7 @@ ts_invoke_distributed_commands(PG_FUNCTION_ARGS)
 {
 	List *data_nodes = data_node_get_node_name_list_with_aclcheck(ACL_USAGE, true);
 	List *subset_nodes;
+	List *server_oids = NIL;
 	DistCmdResult *results;
 	PreparedDistCmd *prepped_cmd;
 	const char *test_args[3] = { "1976-09-18 00:00:00-07", "47", "103.4" };
@@ -82,6 +84,26 @@ ts_invoke_distributed_commands(PG_FUNCTION_ARGS)
 
 	ts_dist_cmd_close_prepared_command(prepped_cmd);
 
+	results = ts_dist_cmd_invoke_on_all_data_nodes_no_throw("SELECT 1", NULL);
+
+	foreach (lc, data_nodes)
+	{
+		const char *node = lfirst(lc);
+		LOG_PG_STATUS(results, node);
+	}
+
+	ts_dist_cmd_close_response(results);
+
+	/* Test OID to nodename conversion */
+	ForeignServer *server =
+		data_node_get_foreign_server(linitial(data_nodes), ACL_NO_CHECK, false, false);
+	server_oids = lappend_oid(server_oids, server->serverid);
+	results = ts_dist_cmd_invoke_on_all_data_nodes_no_throw("SELECT * from data_nodes",
+															"timescaledb_information");
+	LOG_PG_STATUS(results, server->servername);
+
+	ts_dist_cmd_close_response(results);
+
 	PG_RETURN_VOID();
 }
 
@@ -90,5 +112,40 @@ ts_invoke_faulty_distributed_command(PG_FUNCTION_ARGS)
 {
 	ts_dist_cmd_invoke_on_all_data_nodes(
 		"INSERT INTO public.disttable2 VALUES (CURRENT_TIMESTAMP, 42, 72.5);");
+
+	PG_RETURN_VOID();
+}
+
+Datum
+ts_invoke_faulty_distributed_command_nothrow(PG_FUNCTION_ARGS)
+{
+	List *data_nodes = NIL, *subset_nodes = NIL;
+	DistCmdResult *results;
+
+	TestEnsureError(ts_dist_cmd_invoke_on_data_nodes_no_throw("SELECT broken", NULL, data_nodes));
+
+	data_nodes = data_node_get_node_name_list_with_aclcheck(ACL_USAGE, true);
+	subset_nodes = list_copy(data_nodes);
+	subset_nodes = list_truncate(subset_nodes, list_length(data_nodes) - 2);
+	results = ts_dist_cmd_invoke_on_data_nodes_no_throw("SELECT broken", "public", subset_nodes);
+
+	for (Size i = 0; i < ts_dist_cmd_response_count(results); i++)
+	{
+		const char *node, *errmsg;
+		ts_dist_cmd_get_result_by_index(results, i, &node);
+		errmsg = ts_dist_cmd_get_error_by_index(results, i);
+		elog(INFO, "%s error message: %s", node, errmsg);
+	}
+
+	TestAssertTrue(ts_dist_cmd_get_error_by_index(results, list_length(data_nodes)) == NULL);
+
+	/* Test wrong list kind */
+	list_free(data_nodes);
+	data_nodes = NIL;
+	data_nodes = lappend_int(data_nodes, 123);
+	TestEnsureError(ts_dist_cmd_invoke_on_data_nodes_no_throw("SELECT broken", NULL, data_nodes));
+
+	ts_dist_cmd_close_response(results);
+
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
Add handling for offline nodes in health check
    
_timescaledb_internal.health() must not throw errors when a remote
node is offline. Since the remote connection cache throws, a new
function ts_dist_cmd_invoke_on_data_nodes_no_throw is introduced
to the dist command api.
    
ts_dist_cmd_invoke_on_data_nodes_no_throw establishes a connection
for each dist node and spawns an async request. If a connection can
not be established, it creates a PGresult with PGRES_FATAL_ERROR for
this connection.
    
This function has a couple of trade offs. Since it reuses remote
connection open functions, it needs to make copies of all PGresults.
This is because PGresults are owned by the connection and we register
an event handler which frees all PGresults on connection close. It
also can't create an AsyncResponseResult, since that API is not
accessible in this scope. Therefore struct DistCmdResponse was
changed along with the functions that handle DistCmdResponses.