### PR TITLE
Check for trailing whitespace

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -22,6 +22,7 @@ jobs:
           find src test tsl -name '*.cmake' -exec cmake-format -i {} +
       - name: Check for diff
         run: git diff --exit-code
+
   perl_checks:
     name: Check Perl code in tree
     runs-on: ubuntu-22.04
@@ -30,12 +31,42 @@ jobs:
         run: sudo apt install perltidy
       - name: Checkout source
         uses: actions/checkout@v3
+      - name: Check trailing whitespace
+        if: always()
+        run: |
+          find . -name '*.p[lm]' -exec perl -pi -e 's/[ \t]+$//' {} +
+          git diff --exit-code
       - name: Format Perl files, if needed
-        run: find . -name '*.p[lm]' -exec perltidy -b -bext=/ {} +
-      - name: Check for diff
-        run: git diff --exit-code
+        if: always()
+        run: |
+          find . -name '*.p[lm]' -exec perltidy -b -bext=/ {} +
+          git diff --exit-code
+
+  cc_checks:
+    name: Check code formatting
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+    - name: Check trailing whitespace
+      if: always()
+      run: |
+        find . -name '*.[ch]' -exec perl -pi -e 's/[ \t]+$//' {} +
+        git diff --exit-code
+
+    - name: Check code formatting
+      if: always()
+      run: |
+        sudo apt install clang-format-14
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
+        sudo update-alternatives --set clang-format /usr/bin/clang-format-14
+        ./scripts/clang_format_all.sh
+        git diff --exit-code
+
   misc_checks:
-    name: Check formatting, license, update scripts and git hooks
+    name: Check license, update scripts, and git hooks
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -53,14 +84,6 @@ jobs:
     - name: Check for unreferenced test files
       if: always()
       run: ./scripts/check_unreferenced_files.sh
-    - name: Check code formatting
-      if: always()
-      run: |
-        sudo apt install clang-format-14
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 100
-        sudo update-alternatives --set clang-format /usr/bin/clang-format-14
-        ./scripts/clang_format_all.sh
-        git diff --exit-code
     - name: Check update scripts
       if: always()
       run: ./scripts/check_update_scripts.sh

--- a/tsl/test/t/003_connections_privs.pl
+++ b/tsl/test/t/003_connections_privs.pl
@@ -49,7 +49,7 @@ my ($cmdret, $stdout, $stderr) = $an->psql(
 	SELECT node_name, user_name, invalidated
    	FROM _timescaledb_internal.show_connection_cache()
 	WHERE user_name='alice';
-	
+
 ]);
 
 # Expected output:


### PR DESCRIPTION
As a result of editing, trailing whitespace is often resulting and since some editors automatically remove trailing whitespace this creates diffs with more changed lines than necessary.

Add a check that files do not have trailing whitespace and fail if there are.