### PR TITLE
Remove debian 9 from packages tests.

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Debian images:  9 (stretch), 10 (buster), 11 (bullseye)
+        # Debian images:  10 (buster), 11 (bullseye)
         # Ubuntu images:  18.04 LTS (bionic), 20.04 LTS (focal), 21.10 (impish), 22.04 (jammy)
-        image: [ "debian:9-slim", "debian:10-slim", "debian:11-slim", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy"]
+        image: [ "debian:10-slim", "debian:11-slim", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy"]
         pg: [ 12, 13, 14 ]
         license: [ "TSL", "Apache"]
         include:


### PR DESCRIPTION
Debian 9 is EOL since July 2022 so we won't build packages for it anymore and can remove it from CI.