### PR TITLE
Print correct variables in downgrade test script

### DIFF
--- a/scripts/test_downgrade_from_tag.sh
+++ b/scripts/test_downgrade_from_tag.sh
@@ -264,5 +264,5 @@ docker_pgcmd ${CONTAINER_CLEAN_RESTORE} "ALTER DATABASE dn1 SET timescaledb.rest
 docker_exec ${CONTAINER_CLEAN_RESTORE} "pg_restore -h localhost -U postgres -d dn1 /tmp/dn1.dump"
 docker_pgcmd ${CONTAINER_CLEAN_RESTORE} "ALTER DATABASE dn1 RESET timescaledb.restoring"
 
-echo "Comparing downgraded ($UPDATE_FROM_TAG -> $UPDATE_FROM_TAG) with clean install ($UPDATE_FROM_TAG)"
+echo "Comparing downgraded ($UPDATE_TO_TAG -> $UPDATE_FROM_TAG) with clean install ($UPDATE_TO_TAG)"
 docker_pgdiff_all /src/test/sql/updates/post.${TEST_VERSION}.sql "single"


### PR DESCRIPTION
The downgrade script has printed a message in which the same variable is used for the upgrade and the downgrade version. This patch corrects the output and uses the correct variables.

Wrong CI output:
https://github.com/timescale/timescaledb/actions/runs/3420931335/jobs/5696393173#step:4:2818

Corrected CI output:
https://github.com/timescale/timescaledb/actions/runs/3437207346/jobs/5731676559#step:4:3184