### PR TITLE
Reduce planning memory usage with lots of chunks

### DIFF
--- a/src/import/allpaths.c
+++ b/src/import/allpaths.c
@@ -826,10 +826,11 @@ ts_set_plain_rel_size(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	check_index_predicates(root, rel);
 
 	/* Mark rel with estimated output rows, width, etc */
-	MemoryContext old = MemoryContextSwitchTo(ts_temporary_planner_context);
+	MemoryContext tmp = (MemoryContext) linitial(ts_planner_tmp_mcxt_list);
+	MemoryContext old = MemoryContextSwitchTo(tmp);
 	set_baserel_size_estimates(root, rel);
 	MemoryContextSwitchTo(old);
-	MemoryContextReset(ts_temporary_planner_context);
+	MemoryContextReset(tmp);
 }
 
 /* extracted from the same function in allpaths.c

--- a/src/import/allpaths.c
+++ b/src/import/allpaths.c
@@ -34,6 +34,7 @@
 
 #include "allpaths.h"
 #include "compat/compat.h"
+#include "planner/planner.h"
 
 static void set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntry *rte);
 
@@ -816,7 +817,7 @@ set_tablesample_rel_size(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 
 /* copied from allpaths.c */
 static void
-set_plain_rel_size(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
+ts_set_plain_rel_size(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 {
 	/*
 	 * Test any partial indexes of rel for applicability.  We must do this
@@ -825,7 +826,10 @@ set_plain_rel_size(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	check_index_predicates(root, rel);
 
 	/* Mark rel with estimated output rows, width, etc */
+	MemoryContext old = MemoryContextSwitchTo(ts_temporary_planner_context);
 	set_baserel_size_estimates(root, rel);
+	MemoryContextSwitchTo(old);
+	MemoryContextReset(ts_temporary_planner_context);
 }
 
 /* extracted from the same function in allpaths.c
@@ -882,7 +886,7 @@ ts_set_rel_size(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTblEntry *rt
 				else
 				{
 					/* Plain relation */
-					set_plain_rel_size(root, rel, rte);
+					ts_set_plain_rel_size(root, rel, rte);
 				}
 				break;
 			case RTE_SUBQUERY:

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -11,6 +11,7 @@
 #include <executor/nodeAgg.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
+#include <nodes/pg_list.h>
 #include <nodes/plannodes.h>
 #include <optimizer/appendinfo.h>
 #include <optimizer/clauses.h>

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -449,7 +449,6 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 	 */
 	volatile bool reset_fetcher_type = false;
 	volatile bool reset_baserel_info = false;
-	volatile bool reset_temporary_memory_context = false;
 
 	/*
 	 * If we are in an aborted transaction, reject all queries.

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -575,9 +575,16 @@ timescaledb_planner(Query *parse, int cursor_opts, ParamListInfo bound_params)
 													 /* private_data = */ NULL);
 			}
 
-			ts_planner_tmp_mcxt_list = lcons(
-				AllocSetContextCreate(CurrentMemoryContext, "ts temporary planner context", ALLOCSET_DEFAULT_SIZES),
-				ts_planner_tmp_mcxt_list);
+			/*
+			 * Create a temporary memory context that can optionally be used by
+			 * the planner at this level of timescaledb_planner(). The inner
+			 * recursive invocations of timescaledb_planner() will also create
+			 * their own temporary contexts.
+			 */
+			MemoryContext mcxt = AllocSetContextCreate(CurrentMemoryContext,
+													   "ts temporary planner context",
+													   ALLOCSET_DEFAULT_SIZES);
+			ts_planner_tmp_mcxt_list = lcons(mcxt, ts_planner_tmp_mcxt_list);
 		}
 
 		if (prev_planner_hook != NULL)

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -49,7 +49,7 @@ extern TSDLLEXPORT bool ts_contain_param(Node *node);
 
 extern TSDLLEXPORT DataFetcherType ts_data_node_fetcher_scan_type;
 
-extern TSDLLEXPORT MemoryContext ts_temporary_planner_context;
+extern TSDLLEXPORT List *ts_planner_tmp_mcxt_list;
 
 static inline TimescaleDBPrivate *
 ts_create_private_reloptinfo(RelOptInfo *rel)

--- a/src/planner/planner.h
+++ b/src/planner/planner.h
@@ -49,6 +49,8 @@ extern TSDLLEXPORT bool ts_contain_param(Node *node);
 
 extern TSDLLEXPORT DataFetcherType ts_data_node_fetcher_scan_type;
 
+extern TSDLLEXPORT MemoryContext ts_temporary_planner_context;
+
 static inline TimescaleDBPrivate *
 ts_create_private_reloptinfo(RelOptInfo *rel)
 {


### PR DESCRIPTION
Selectivity functions, like scalararrayinsel, allocate _a lot_ in the top planner context. Use a temporary memory context to call them.

Fixes https://github.com/timescale/timescaledb/issues/4944