### PR TITLE
Bump postgres versions used in CI

### DIFF
--- a/.github/ci_settings.py
+++ b/.github/ci_settings.py
@@ -11,15 +11,15 @@
 # ABI_MIN is the minimum postgres version required when the extension was build against LATEST
 
 PG12_EARLIEST = "12.0"
-PG12_LATEST = "12.12"
+PG12_LATEST = "12.13"
 PG12_ABI_MIN = "12.8"
 
 PG13_EARLIEST = "13.2"
-PG13_LATEST = "13.8"
+PG13_LATEST = "13.9"
 PG13_ABI_MIN = "13.5"
 
 PG14_EARLIEST = "14.0"
-PG14_LATEST = "14.5"
+PG14_LATEST = "14.6"
 PG14_ABI_MIN = "14.0"
 
 PG_LATEST = [PG12_LATEST, PG13_LATEST, PG14_LATEST]


### PR DESCRIPTION
Use PG 12.13, 13.9 and 14.6 in our CI