### PR TITLE
Update compress chunk interval on compressed data

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -3934,7 +3934,10 @@ process_altertable_set_options(AlterTableCmd *cmd, Hypertable *ht)
 	if (compress_options)
 	{
 		parse_results = ts_compress_hypertable_set_clause_parse(compress_options);
-		if (parse_results[CompressEnabled].is_default)
+		/* We allow updating compress chunk time interval independently of other compression
+		 * options. */
+		if (parse_results[CompressEnabled].is_default &&
+			parse_results[CompressChunkTimeInterval].is_default)
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("the option timescaledb.compress must be set to true to enable "

--- a/tsl/src/compression/create.c
+++ b/tsl/src/compression/create.c
@@ -1041,6 +1041,25 @@ drop_column_from_compression_table(Hypertable *compress_ht, char *name)
 	ts_alter_table_with_event_trigger(compress_relid, NULL, list_make1(cmd), true);
 }
 
+static bool
+update_compress_chunk_time_interval(Hypertable *ht, WithClauseResult *with_clause_options)
+{
+	const Dimension *time_dim = hyperspace_get_open_dimension(ht->space, 0);
+	Interval *compress_interval =
+		ts_compress_hypertable_parse_chunk_time_interval(with_clause_options, ht);
+	if (!compress_interval)
+	{
+		return false;
+	}
+	int64 compress_interval_usec =
+		ts_interval_value_to_internal(IntervalPGetDatum(compress_interval), INTERVALOID);
+	if (compress_interval_usec % time_dim->fd.interval_length > 0)
+		elog(WARNING,
+			 "compress chunk interval is not a multiple of chunk interval, you should use a "
+			 "factor of chunk interval to merge as much as possible");
+	return ts_hypertable_set_compress_interval(ht, compress_interval_usec);
+}
+
 /*
  * enables compression for the passed in table by
  * creating a compression hypertable with special properties
@@ -1065,8 +1084,6 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 	List *segmentby_cols;
 	List *orderby_cols;
 	List *constraint_list = NIL;
-	Interval *compress_interval;
-	const Dimension *time_dim;
 
 	if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
 	{
@@ -1085,6 +1102,11 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 
 	/* reload info after lock */
 	ht = ts_hypertable_get_by_id(ht->fd.id);
+	/* If we are not enabling compression, we must be just altering compressed chunk interval. */
+	if (with_clause_options[CompressEnabled].is_default)
+	{
+		return update_compress_chunk_time_interval(ht, with_clause_options);
+	}
 	if (!compress_enable)
 	{
 		return disable_compression(ht, with_clause_options);
@@ -1093,7 +1115,6 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 	segmentby_cols = ts_compress_hypertable_parse_segment_by(with_clause_options, ht);
 	orderby_cols = ts_compress_hypertable_parse_order_by(with_clause_options, ht);
 	orderby_cols = add_time_to_order_by_if_not_included(orderby_cols, segmentby_cols, ht);
-	compress_interval = ts_compress_hypertable_parse_chunk_time_interval(with_clause_options, ht);
 
 	if (TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht))
 		check_modify_compression_options(ht, with_clause_options, orderby_cols);
@@ -1133,16 +1154,9 @@ tsl_process_compress_table(AlterTableCmd *cmd, Hypertable *ht,
 	ht = ts_hypertable_get_by_id(ht->fd.id); /*reload updated info*/
 	ts_hypertable_clone_constraints_to_compressed(ht, constraint_list);
 
-	if (compress_interval != NULL)
+	if (!with_clause_options[CompressChunkTimeInterval].is_default)
 	{
-		time_dim = hyperspace_get_open_dimension(ht->space, 0);
-		int64 compress_interval_usec =
-			ts_interval_value_to_internal(IntervalPGetDatum(compress_interval), INTERVALOID);
-		if (compress_interval_usec % time_dim->fd.interval_length > 0)
-			elog(WARNING,
-				 "compress chunk interval is not a multiple of chunk interval, you should use a "
-				 "factor of chunk interval to merge as much as possible");
-		ts_hypertable_set_compress_interval(ht, compress_interval_usec);
+		update_compress_chunk_time_interval(ht, with_clause_options);
 	}
 
 	/* do not release any locks, will get released by xact end */

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -343,14 +343,33 @@ SELECT compress_chunk(i) FROM show_chunks('test6') i;
  _timescaledb_internal._hyper_11_210_chunk
 (24 rows)
 
-SELECT 12 as expected_number_of_chunks, count(*) as number_of_chunks FROM show_chunks('test6');
- expected_number_of_chunks | number_of_chunks 
----------------------------+------------------
-                        12 |               12
+SELECT count(*) as number_of_chunks FROM show_chunks('test6');
+ number_of_chunks 
+------------------
+               12
 (1 row)
 
-SELECT decompress_chunk(i) FROM show_chunks('test6') i;
-             decompress_chunk              
+-- This will generate another 24 chunks
+INSERT INTO test6 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-03 1:00'::TIMESTAMPTZ, '2018-03-04 0:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+-- Altering compress chunk time interval will cause us to create 6 chunks from the additional 24 chunks.
+ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='4 hours');
+SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
+NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
+              compress_chunk               
 -------------------------------------------
  _timescaledb_internal._hyper_11_188_chunk
  _timescaledb_internal._hyper_11_190_chunk
@@ -364,33 +383,166 @@ SELECT decompress_chunk(i) FROM show_chunks('test6') i;
  _timescaledb_internal._hyper_11_206_chunk
  _timescaledb_internal._hyper_11_208_chunk
  _timescaledb_internal._hyper_11_210_chunk
-(12 rows)
+ _timescaledb_internal._hyper_11_210_chunk
+ _timescaledb_internal._hyper_11_210_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_238_chunk
+ _timescaledb_internal._hyper_11_238_chunk
+ _timescaledb_internal._hyper_11_238_chunk
+ _timescaledb_internal._hyper_11_238_chunk
+ _timescaledb_internal._hyper_11_242_chunk
+ _timescaledb_internal._hyper_11_242_chunk
+ _timescaledb_internal._hyper_11_242_chunk
+ _timescaledb_internal._hyper_11_242_chunk
+ _timescaledb_internal._hyper_11_246_chunk
+ _timescaledb_internal._hyper_11_246_chunk
+(36 rows)
 
--- Altering compress chunk time interval will cause us to create 6 chunks instead of 12.
-ALTER TABLE test6 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='4 hours');
+SELECT count(*) as number_of_chunks FROM show_chunks('test6');
+ number_of_chunks 
+------------------
+               18
+(1 row)
+
+-- This will generate another 3 chunks
+INSERT INTO test6 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-04 1:00'::TIMESTAMPTZ, '2018-03-04 3:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+-- Altering compress chunk time interval will cause us to create 3 chunks from the additional 3 chunks.
+-- Setting compressed chunk to anything less than chunk interval should disable merging chunks.
+ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval='30 minutes');
+WARNING:  compress chunk interval is not a multiple of chunk interval, you should use a factor of chunk interval to merge as much as possible
 SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
+NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_238_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_242_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_246_chunk" is already compressed
               compress_chunk               
 -------------------------------------------
  _timescaledb_internal._hyper_11_188_chunk
- _timescaledb_internal._hyper_11_188_chunk
+ _timescaledb_internal._hyper_11_190_chunk
  _timescaledb_internal._hyper_11_192_chunk
- _timescaledb_internal._hyper_11_192_chunk
+ _timescaledb_internal._hyper_11_194_chunk
  _timescaledb_internal._hyper_11_196_chunk
- _timescaledb_internal._hyper_11_196_chunk
+ _timescaledb_internal._hyper_11_198_chunk
  _timescaledb_internal._hyper_11_200_chunk
- _timescaledb_internal._hyper_11_200_chunk
+ _timescaledb_internal._hyper_11_202_chunk
  _timescaledb_internal._hyper_11_204_chunk
- _timescaledb_internal._hyper_11_204_chunk
+ _timescaledb_internal._hyper_11_206_chunk
  _timescaledb_internal._hyper_11_208_chunk
- _timescaledb_internal._hyper_11_208_chunk
-(12 rows)
+ _timescaledb_internal._hyper_11_210_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_238_chunk
+ _timescaledb_internal._hyper_11_242_chunk
+ _timescaledb_internal._hyper_11_246_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_255_chunk
+ _timescaledb_internal._hyper_11_256_chunk
+(21 rows)
 
-SELECT 6 as expected_number_of_chunks, count(*) as number_of_chunks FROM show_chunks('test6');
- expected_number_of_chunks | number_of_chunks 
----------------------------+------------------
-                         6 |                6
+SELECT count(*) as number_of_chunks FROM show_chunks('test6');
+ number_of_chunks 
+------------------
+               21
 (1 row)
 
+-- This will generate another 3 chunks
+INSERT INTO test6 
+SELECT t, i, gen_rand_minstd() 
+FROM generate_series('2018-03-04 4:00'::TIMESTAMPTZ, '2018-03-04 6:59', '1 minute') t
+CROSS JOIN generate_series(1, 5, 1) i;
+-- Altering compress chunk time interval will cause us to create 3 chunks from the additional 3 chunks.
+-- Setting compressed chunk to anything less than chunk interval should disable merging chunks.
+ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval=0);
+SELECT compress_chunk(i, true) FROM show_chunks('test6') i;
+NOTICE:  chunk "_hyper_11_188_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_190_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_192_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_194_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_196_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_198_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_200_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_202_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_204_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_206_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_208_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_210_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_226_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_230_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_234_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_238_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_242_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_246_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_254_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_255_chunk" is already compressed
+NOTICE:  chunk "_hyper_11_256_chunk" is already compressed
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_11_188_chunk
+ _timescaledb_internal._hyper_11_190_chunk
+ _timescaledb_internal._hyper_11_192_chunk
+ _timescaledb_internal._hyper_11_194_chunk
+ _timescaledb_internal._hyper_11_196_chunk
+ _timescaledb_internal._hyper_11_198_chunk
+ _timescaledb_internal._hyper_11_200_chunk
+ _timescaledb_internal._hyper_11_202_chunk
+ _timescaledb_internal._hyper_11_204_chunk
+ _timescaledb_internal._hyper_11_206_chunk
+ _timescaledb_internal._hyper_11_208_chunk
+ _timescaledb_internal._hyper_11_210_chunk
+ _timescaledb_internal._hyper_11_226_chunk
+ _timescaledb_internal._hyper_11_230_chunk
+ _timescaledb_internal._hyper_11_234_chunk
+ _timescaledb_internal._hyper_11_238_chunk
+ _timescaledb_internal._hyper_11_242_chunk
+ _timescaledb_internal._hyper_11_246_chunk
+ _timescaledb_internal._hyper_11_254_chunk
+ _timescaledb_internal._hyper_11_255_chunk
+ _timescaledb_internal._hyper_11_256_chunk
+ _timescaledb_internal._hyper_11_260_chunk
+ _timescaledb_internal._hyper_11_261_chunk
+ _timescaledb_internal._hyper_11_262_chunk
+(24 rows)
+
+SELECT count(*) as number_of_chunks FROM show_chunks('test6');
+ number_of_chunks 
+------------------
+               24
+(1 row)
+
+-- Setting compress chunk time to NULL will error out.
+\set ON_ERROR_STOP 0
+ALTER TABLE test6 set (timescaledb.compress_chunk_time_interval=NULL);
+ERROR:  invalid value for timescaledb.compress_chunk_time_interval 'null'
+\set ON_ERROR_STOP 1
 DROP TABLE test6;
 CREATE TABLE test7 ("Time" timestamptz, i integer, j integer, k integer, value integer);
 SELECT table_name from create_hypertable('test7', 'Time', chunk_time_interval=> INTERVAL '1 hour');


### PR DESCRIPTION
Compress chunk interval is set using an ALTER TABLE statement.
This change makes it so you can update the compress chunk interval
while keeping the rest of the compression settings intact.
Updating it will only affect chunks that are compressed and rolled
up after the change.