### PR TITLE
Fix race in bgw_db_scheduler_fixed

### DIFF
--- a/tsl/test/expected/bgw_db_scheduler_fixed.out
+++ b/tsl/test/expected/bgw_db_scheduler_fixed.out
@@ -251,6 +251,12 @@ SELECT delete_job(:job_id);
 (1 row)
 
 RESET client_min_messages;
+SELECT count(*) FROM wait_for_logentry(:job_id);
+ count 
+-------
+     1
+(1 row)
+
 SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
  application_name 
 ------------------

--- a/tsl/test/sql/bgw_db_scheduler_fixed.sql
+++ b/tsl/test/sql/bgw_db_scheduler_fixed.sql
@@ -173,6 +173,7 @@ SELECT datname, usename, application_name, state, query, wait_event_type, wait_e
 SET client_min_messages TO WARNING;
 SELECT delete_job(:job_id);
 RESET client_min_messages;
+SELECT count(*) FROM wait_for_logentry(:job_id);
 SELECT application_name FROM pg_stat_activity WHERE application_name LIKE 'User-Defined Action%';
 
 --


### PR DESCRIPTION
When deleting a job in the test, the job does not necessarily terminate immediately, so wait for a log entries from the job before checking the jobs table.

Fixed #4859