### PR TITLE
Read until EOF in COPY fetcher

### DIFF
--- a/tsl/test/shared/expected/dist_fetcher_type-12.out
+++ b/tsl/test/shared/expected/dist_fetcher_type-12.out
@@ -267,3 +267,21 @@ WHERE
     AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
 ORDER BY 1 DESC LIMIT 1;
 ERROR:  cannot use COPY fetcher because the plan is parameterized
+-- Test copy fetcher when query is aborted before EOF due to LIMIT
+SET timescaledb.remote_data_fetcher = 'copy';
+SELECT * FROM metrics_dist ORDER BY time, device_id LIMIT 11;
+             time             | device_id | v0 | v1 | v2  | v3 
+------------------------------+-----------+----+----+-----+----
+ Fri Dec 31 16:00:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:04:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+(11 rows)
+

--- a/tsl/test/shared/expected/dist_fetcher_type-13.out
+++ b/tsl/test/shared/expected/dist_fetcher_type-13.out
@@ -267,3 +267,21 @@ WHERE
     AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
 ORDER BY 1 DESC LIMIT 1;
 ERROR:  cannot use COPY fetcher because the plan is parameterized
+-- Test copy fetcher when query is aborted before EOF due to LIMIT
+SET timescaledb.remote_data_fetcher = 'copy';
+SELECT * FROM metrics_dist ORDER BY time, device_id LIMIT 11;
+             time             | device_id | v0 | v1 | v2  | v3 
+------------------------------+-----------+----+----+-----+----
+ Fri Dec 31 16:00:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:04:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+(11 rows)
+

--- a/tsl/test/shared/expected/dist_fetcher_type-14.out
+++ b/tsl/test/shared/expected/dist_fetcher_type-14.out
@@ -267,3 +267,21 @@ WHERE
     AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
 ORDER BY 1 DESC LIMIT 1;
 ERROR:  cannot use COPY fetcher because the plan is parameterized
+-- Test copy fetcher when query is aborted before EOF due to LIMIT
+SET timescaledb.remote_data_fetcher = 'copy';
+SELECT * FROM metrics_dist ORDER BY time, device_id LIMIT 11;
+             time             | device_id | v0 | v1 | v2  | v3 
+------------------------------+-----------+----+----+-----+----
+ Fri Dec 31 16:00:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:04:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+(11 rows)
+

--- a/tsl/test/shared/expected/dist_fetcher_type-15.out
+++ b/tsl/test/shared/expected/dist_fetcher_type-15.out
@@ -268,3 +268,21 @@ WHERE
     AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
 ORDER BY 1 DESC LIMIT 1;
 ERROR:  cannot use COPY fetcher because the plan is parameterized
+-- Test copy fetcher when query is aborted before EOF due to LIMIT
+SET timescaledb.remote_data_fetcher = 'copy';
+SELECT * FROM metrics_dist ORDER BY time, device_id LIMIT 11;
+             time             | device_id | v0 | v1 | v2  | v3 
+------------------------------+-----------+----+----+-----+----
+ Fri Dec 31 16:00:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:00:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         2 |  3 |  4 | 2.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         3 |  4 |  5 | 3.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         4 |  5 |  6 | 4.5 |   
+ Fri Dec 31 16:02:00 1999 PST |         5 |  6 |  7 | 5.5 |   
+ Fri Dec 31 16:04:00 1999 PST |         1 |  2 |  3 | 1.5 |   
+(11 rows)
+

--- a/tsl/test/shared/sql/dist_fetcher_type.sql.in
+++ b/tsl/test/shared/sql/dist_fetcher_type.sql.in
@@ -173,3 +173,7 @@ WHERE
     m.lookup_id = ANY((SELECT array_agg(l.id) FROM lookup l WHERE l.key = 'host' AND l.val = 'localhost')::int[])
     AND m.ts BETWEEN '2021-08-17 00:00:00' AND '2021-08-17 01:00:00'
 ORDER BY 1 DESC LIMIT 1;
+
+-- Test copy fetcher when query is aborted before EOF due to LIMIT
+SET timescaledb.remote_data_fetcher = 'copy';
+SELECT * FROM metrics_dist ORDER BY time, device_id LIMIT 11;

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -89,6 +89,8 @@ SELECT * FROM add_data_node('data_node_2', host => 'localhost', database => 'dat
 SELECT * FROM add_data_node('data_node_3', host => 'localhost', database => 'data_node_3');
 GRANT USAGE ON FOREIGN SERVER data_node_1, data_node_2, data_node_3 TO PUBLIC;
 GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
+-- set artificially low fetch_size to test fetcher behavior
+ALTER FOREIGN DATA WRAPPER timescaledb_fdw OPTIONS (ADD fetch_size '10');
 -- Import testsupport.sql file to data nodes
 \unset ECHO
 \o /dev/null


### PR DESCRIPTION
Ensure the COPY fetcher implementation reads data until EOF with `PQgetCopyData()`. Also ensure the malloc'ed copy data is freed with `PQfreemem()` if an error is thrown in the processing loop.

Previously, the COPY fetcher didn't read until EOF, and instead assumed EOF when the COPY file trailer is received. Since EOF wasn't reached, it required terminating the COPY with an extra call to the (deprecated) `PQendcopy()` function.

Still, there are cases when a COPY needs to be prematurely terminated, for example, when querying with a LIMIT clause. Therefore, distinguish between "normal" end (when receiving EOF) and forceful end (cancel the ongoing query).
