### PR TITLE
Swap message and detail in Ensure

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -66,6 +66,7 @@
 #include "ts_catalog/continuous_agg.h"
 #include "ts_catalog/hypertable_data_node.h"
 #include "utils.h"
+#include "debug_assert.h"
 
 TS_FUNCTION_INFO_V1(ts_chunk_show_chunks);
 TS_FUNCTION_INFO_V1(ts_chunk_drop_chunks);

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -66,7 +66,6 @@
 #include "ts_catalog/continuous_agg.h"
 #include "ts_catalog/hypertable_data_node.h"
 #include "utils.h"
-#include "debug_assert.h"
 
 TS_FUNCTION_INFO_V1(ts_chunk_show_chunks);
 TS_FUNCTION_INFO_V1(ts_chunk_drop_chunks);

--- a/src/debug_assert.h
+++ b/src/debug_assert.h
@@ -10,6 +10,15 @@
 #include <postgres.h>
 
 /*
+ * Try to use file name without path that is available on the newer compilers.
+ */
+#ifdef __FILE_NAME__
+#define ENSURE_FILE_NO_PATH __FILE_NAME__
+#else
+#define ENSURE_FILE_NO_PATH __FILE__
+#endif
+
+/*
  * Macro that expands to an assert in debug builds and to an ereport in
  * release builds.
  *
@@ -34,8 +43,8 @@
 		if (!(COND))                                                                               \
 			ereport(ERROR,                                                                         \
 					(errcode(ERRCODE_INTERNAL_ERROR),                                              \
-					 errdetail("Assertion '" #COND "' failed."),                                   \
-					 errmsg(FMT, ##__VA_ARGS__)));                                                 \
+					 errmsg("assertion '%s' at %s:%d failed", #COND, ENSURE_FILE_NO_PATH, __LINE__),                                   \
+					 errdetail(FMT, ##__VA_ARGS__)));                                                 \
 	} while (0)
 #endif
 


### PR DESCRIPTION
  
    
    The message will be "assertion 'true == false' failed", and the detail
    will contain the description of the error. There are two reasons for
    that:
    
    1) Errdetail is not shown with the default psql settings. The
       description of the internal error might confuse the user, making them
    think it's a system or a user error and try to troubleshoot it. The
    primary message should make it clear that it is an internal program
    error.
    2) When debugging, the developer wants to see the failed condition and
       its location. Again, the default settings don't show the detail or
    location of the error, so this information should be in the main message.
    
    This is how the error report looks after the changes:
    ```
    ERROR:  XX000: assertion 'false' at chunk.c:2174 failed
    DETAIL:  the invariant 'false = true' is violated
    ```
