### PR TITLE
Run all the tests on every commit in main

### DIFF
--- a/.github/workflows/coccinelle.yaml
+++ b/.github/workflows/coccinelle.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - prerelease_test
 jobs:
   coccinelle:

--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -1,10 +1,8 @@
 name: Code style
 on:
-  schedule:
-    # run daily 20:00 on main branch
-    - cron: '0 20 * * *'
   push:
     branches:
+      - main
       - prerelease_test
   pull_request:
 jobs:

--- a/.github/workflows/cron-tests.yaml
+++ b/.github/workflows/cron-tests.yaml
@@ -1,10 +1,8 @@
 name: Additional tests
 on:
-  schedule:
-    # run daily 20:00 on main branch
-    - cron: '0 20 * * *'
   push:
     branches:
+      - main
       - prerelease_test
 jobs:
   config:

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -1,10 +1,8 @@
 name: Regression Linux i386
 on:
-  schedule:
-    # run daily 20:00 on main branch
-    - cron: '0 20 * * *'
   push:
     branches:
+      - main
       - prerelease_test
   pull_request:
 jobs:

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -9,6 +9,7 @@ on:
     - cron: '0 0 * * *'
   push:
     branches:
+      - main
       - prerelease_test
   pull_request:
 jobs:

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -1,10 +1,8 @@
 name: Memory tests
 on:
-  schedule:
-    # run daily 20:00 on main branch
-    - cron: '0 20 * * *'
   push:
     branches:
+      - main
       - prerelease_test
       - memory_test
 jobs:

--- a/.github/workflows/pgspot.yaml
+++ b/.github/workflows/pgspot.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - prerelease_test
 
 jobs:

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -1,11 +1,9 @@
 # Run regression tests under memory sanitizer
 name: Sanitizer test
 on:
-  schedule:
-    # run daily 21:00 on main branch
-    - cron: '0 21 * * *'
   push:
     branches:
+      - main
       - prerelease_test
   pull_request:
 

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - prerelease_test
 jobs:
   shellcheck:

--- a/.github/workflows/update-test.yaml
+++ b/.github/workflows/update-test.yaml
@@ -1,10 +1,8 @@
 name: Test Update and Downgrade
 on:
-  schedule:
-    # run daily 20:00 on main branch
-    - cron: '0 20 * * *'
   push:
     branches:
+      - main
       - prerelease_test
   pull_request:
 jobs:

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -1,11 +1,9 @@
 # Test building the extension on Windows
 name: Regression Windows
 on:
-  schedule:
-    # run daily 20:00 on main branch
-    - cron: '0 20 * * *'
   push:
     branches:
+      - main
       - prerelease_test
   pull_request:
 jobs:


### PR DESCRIPTION
If we test every commit in main, we can allow GitHub to merge the PRs automatically without requiring a manual rebase on the current master. These rebases are a real time sink.

Also it will help to get more statistics for our test result database, and get more coverage for probabilistic tests like sqlsmith.