### PR TITLE
Add telemetry for caggs on top of caggs

### DIFF
--- a/src/telemetry/stats.c
+++ b/src/telemetry/stats.c
@@ -273,6 +273,9 @@ process_continuous_agg(CaggStats *cs, Form_pg_class class, const ContinuousAgg *
 
 	if (ContinuousAggIsFinalized(cagg))
 		cs->finalized++;
+
+	if (cagg->data.parent_mat_hypertable_id != INVALID_HYPERTABLE_ID)
+		cs->nested++;
 }
 
 static void

--- a/src/telemetry/stats.h
+++ b/src/telemetry/stats.h
@@ -76,6 +76,7 @@ typedef struct CaggStats
 	int64 on_distributed_hypertable_count;
 	int64 uses_real_time_aggregation_count;
 	int64 finalized;
+	int64 nested;
 } CaggStats;
 
 typedef struct TelemetryStats

--- a/src/telemetry/telemetry.c
+++ b/src/telemetry/telemetry.c
@@ -609,6 +609,7 @@ format_iso8601(Datum value)
 #define REQ_RELKIND_CAGG_ON_DISTRIBUTED_HYPERTABLE_COUNT "num_caggs_on_distributed_hypertables"
 #define REQ_RELKIND_CAGG_USES_REAL_TIME_AGGREGATION_COUNT "num_caggs_using_real_time_aggregation"
 #define REQ_RELKIND_CAGG_FINALIZED "num_caggs_finalized"
+#define REQ_RELKIND_CAGG_NESTED "num_caggs_nested"
 
 static JsonbValue *
 add_compression_stats_object(JsonbParseState *parse_state, StatsRelType reltype,
@@ -702,6 +703,7 @@ add_relkind_stats_object(JsonbParseState *parse_state, const char *relkindname,
 						   REQ_RELKIND_CAGG_USES_REAL_TIME_AGGREGATION_COUNT,
 						   cs->uses_real_time_aggregation_count);
 		ts_jsonb_add_int64(parse_state, REQ_RELKIND_CAGG_FINALIZED, cs->finalized);
+		ts_jsonb_add_int64(parse_state, REQ_RELKIND_CAGG_NESTED, cs->nested);
 	}
 
 	return pushJsonbValue(&parse_state, WJB_END_OBJECT, NULL);

--- a/tsl/test/expected/telemetry_stats.out
+++ b/tsl/test/expected/telemetry_stats.out
@@ -153,6 +153,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "num_children": 0,                         +
          "num_relations": 2,                        +
          "num_reltuples": 0,                        +
+         "num_caggs_nested": 0,                     +
          "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
          "num_caggs_using_real_time_aggregation": 2 +
@@ -301,6 +302,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "num_children": 4,                         +
          "num_relations": 2,                        +
          "num_reltuples": 0,                        +
+         "num_caggs_nested": 0,                     +
          "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
          "num_caggs_using_real_time_aggregation": 2 +
@@ -451,6 +453,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "num_children": 4,                         +
          "num_relations": 2,                        +
          "num_reltuples": 452,                      +
+         "num_caggs_nested": 0,                     +
          "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
          "num_caggs_using_real_time_aggregation": 1 +
@@ -950,6 +953,7 @@ FROM relations;
      "num_children": 8,                        +
      "num_relations": 4,                       +
      "num_reltuples": 452,                     +
+     "num_caggs_nested": 0,                    +
      "num_caggs_finalized": 2,                 +
      "num_caggs_on_distributed_hypertables": 2,+
      "num_caggs_using_real_time_aggregation": 3+
@@ -1140,6 +1144,47 @@ SELECT jsonb_pretty(get_telemetry_report() -> 'stats_by_job_type');
          "max_consecutive_failures": 1         +
      }                                         +
  }
+(1 row)
+
+-- create nested continuous aggregates - copied from cagg_on_cagg_common
+CREATE TABLE conditions (
+  time timestamptz NOT NULL,
+  temperature int
+);
+SELECT create_hypertable('conditions', 'time');
+    create_hypertable     
+--------------------------
+ (10,public,conditions,t)
+(1 row)
+
+CREATE MATERIALIZED VIEW conditions_summary_hourly_1
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket('1 hour', "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+CREATE MATERIALIZED VIEW conditions_summary_daily_2
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket('1 day', "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions_summary_hourly_1
+GROUP BY 1
+WITH NO DATA;
+CREATE MATERIALIZED VIEW conditions_summary_weekly_3
+WITH (timescaledb.continuous, timescaledb.materialized_only=true) AS
+SELECT
+  time_bucket('1 week', "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions_summary_daily_2
+GROUP BY 1
+WITH NO DATA;
+SELECT jsonb_pretty(get_telemetry_report() -> 'relations' -> 'continuous_aggregates' -> 'num_caggs_nested');
+ jsonb_pretty 
+--------------
+ 2
 (1 row)
 
 DROP VIEW relations;


### PR DESCRIPTION
Commit #4668 introduced hierarchical caggs. This patch adds a field `num_caggs_nested` to the telemetry report to include the number of caggs defined on top of other caggs.