### PR TITLE
Add Hierarchical Continuous Aggregates validations

### DIFF
--- a/src/ts_catalog/continuous_agg.c
+++ b/src/ts_catalog/continuous_agg.c
@@ -38,6 +38,7 @@
 #include "time_bucket.h"
 #include "time_utils.h"
 #include "ts_catalog/catalog.h"
+#include "errors.h"
 
 #define BUCKET_FUNCTION_SERIALIZE_VERSION 1
 #define CHECK_NAME_MATCH(name1, name2) (namestrcmp(name1, name2) == 0)
@@ -1897,4 +1898,40 @@ ts_cagg_permissions_check(Oid cagg_oid, Oid userid)
 				 errmsg("must be owner of continuous aggregate \"%s\"", get_rel_name(cagg_oid))));
 
 	return ownerid;
+}
+
+Query *
+ts_continuous_agg_get_query(ContinuousAgg *cagg)
+{
+	Oid cagg_view_oid;
+	Relation cagg_view_rel;
+	RuleLock *cagg_view_rules;
+	RewriteRule *rule;
+	Query *cagg_view_query;
+
+	/*
+	 * Get the direct_view definition for the finalized version because
+	 * the user view doesn't have the "GROUP BY" clause anymore.
+	 */
+	if (ContinuousAggIsFinalized(cagg))
+		cagg_view_oid =
+			get_relname_relid(NameStr(cagg->data.direct_view_name),
+							  get_namespace_oid(NameStr(cagg->data.direct_view_schema), false));
+	else
+		cagg_view_oid =
+			get_relname_relid(NameStr(cagg->data.user_view_name),
+							  get_namespace_oid(NameStr(cagg->data.user_view_schema), false));
+
+	cagg_view_rel = table_open(cagg_view_oid, AccessShareLock);
+	cagg_view_rules = cagg_view_rel->rd_rules;
+	Assert(cagg_view_rules && cagg_view_rules->numLocks == 1);
+
+	rule = cagg_view_rules->rules[0];
+	if (rule->event != CMD_SELECT)
+		ereport(ERROR, (errcode(ERRCODE_TS_UNEXPECTED), errmsg("unexpected rule event for view")));
+
+	cagg_view_query = (Query *) copyObject(linitial(rule->actions));
+	table_close(cagg_view_rel, NoLock);
+
+	return cagg_view_query;
 }

--- a/src/ts_catalog/continuous_agg.h
+++ b/src/ts_catalog/continuous_agg.h
@@ -8,6 +8,7 @@
 #define TIMESCALEDB_CONTINUOUS_AGG_H
 #include <postgres.h>
 #include <catalog/pg_type.h>
+#include <nodes/parsenodes.h>
 
 #include "ts_catalog/catalog.h"
 #include "chunk.h"
@@ -213,5 +214,7 @@ ts_compute_circumscribed_bucketed_refresh_window_variable(int64 *start, int64 *e
 														  const ContinuousAggsBucketFunction *bf);
 extern TSDLLEXPORT int64 ts_compute_beginning_of_the_next_bucket_variable(
 	int64 timeval, const ContinuousAggsBucketFunction *bf);
+
+extern TSDLLEXPORT Query *ts_continuous_agg_get_query(ContinuousAgg *cagg);
 
 #endif /* TIMESCALEDB_CONTINUOUS_AGG_H */

--- a/tsl/test/expected/cagg_on_cagg_integer.out
+++ b/tsl/test/expected/cagg_on_cagg_integer.out
@@ -11,7 +11,9 @@
 \set BUCKET_WIDTH_1ST 'INTEGER \'1\''
 \set BUCKET_WIDTH_2TH 'INTEGER \'5\''
 \set BUCKET_WIDTH_3TH 'INTEGER \'10\''
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -367,3 +369,147 @@ psql:include/cagg_on_cagg_common.sql:209: NOTICE:  drop cascades to table _times
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 psql:include/cagg_on_cagg_common.sql:212: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
 \set ON_ERROR_STOP 1
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'5\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because non-multiple bucket sizes
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should not be equal to previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater than the time bucket width of "public.conditions_summary_1" [2].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'4\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should be greater than previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be multiple of the time bucket width of "public.conditions_summary_1" [4].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;

--- a/tsl/test/expected/cagg_on_cagg_integer_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_integer_dist_ht.out
@@ -45,7 +45,9 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 \set BUCKET_WIDTH_1ST 'INTEGER \'1\''
 \set BUCKET_WIDTH_2TH 'INTEGER \'5\''
 \set BUCKET_WIDTH_3TH 'INTEGER \'10\''
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -401,7 +403,151 @@ psql:include/cagg_on_cagg_common.sql:209: NOTICE:  drop cascades to table _times
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 psql:include/cagg_on_cagg_common.sql:212: ERROR:  relation "conditions_summary_1_1" does not exist at character 15
 \set ON_ERROR_STOP 1
--- cleanup
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'5\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because non-multiple bucket sizes
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should not be equal to previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater than the time bucket width of "public.conditions_summary_1" [2].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'4\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should be greater than previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be multiple of the time bucket width of "public.conditions_summary_1" [4].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+-- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/expected/cagg_on_cagg_timestamp.out
+++ b/tsl/test/expected/cagg_on_cagg_timestamp.out
@@ -12,7 +12,9 @@
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
 \set BUCKET_WIDTH_3TH 'INTERVAL \'1 week\''
 SET timezone TO 'UTC';
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -364,3 +366,196 @@ psql:include/cagg_on_cagg_common.sql:209: NOTICE:  drop cascades to table _times
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 psql:include/cagg_on_cagg_common.sql:212: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
+The variance can lead to the fixed width one not being a multiple of the variable width one.
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because non-multiple bucket sizes
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should not be equal to previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater than the time bucket width of "public.conditions_summary_1" [@ 1 hour].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should be greater than previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;

--- a/tsl/test/expected/cagg_on_cagg_timestamp_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_timestamp_dist_ht.out
@@ -46,7 +46,9 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
 \set BUCKET_WIDTH_3TH 'INTERVAL \'1 week\''
 SET timezone TO 'UTC';
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -398,7 +400,200 @@ psql:include/cagg_on_cagg_common.sql:209: NOTICE:  drop cascades to table _times
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 psql:include/cagg_on_cagg_common.sql:212: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
--- cleanup
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
+The variance can lead to the fixed width one not being a multiple of the variable width one.
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because non-multiple bucket sizes
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should not be equal to previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater than the time bucket width of "public.conditions_summary_1" [@ 1 hour].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should be greater than previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+-- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/expected/cagg_on_cagg_timestamptz.out
+++ b/tsl/test/expected/cagg_on_cagg_timestamptz.out
@@ -12,7 +12,9 @@
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
 \set BUCKET_WIDTH_3TH 'INTERVAL \'1 week\''
 SET timezone TO 'UTC';
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -363,3 +365,196 @@ psql:include/cagg_on_cagg_common.sql:209: NOTICE:  drop cascades to table _times
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 psql:include/cagg_on_cagg_common.sql:212: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
+The variance can lead to the fixed width one not being a multiple of the variable width one.
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because non-multiple bucket sizes
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should not be equal to previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater than the time bucket width of "public.conditions_summary_1" [@ 1 hour].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should be greater than previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;

--- a/tsl/test/expected/cagg_on_cagg_timestamptz_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_timestamptz_dist_ht.out
@@ -46,7 +46,9 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 day\''
 \set BUCKET_WIDTH_3TH 'INTERVAL \'1 week\''
 SET timezone TO 'UTC';
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
@@ -397,7 +399,200 @@ psql:include/cagg_on_cagg_common.sql:209: NOTICE:  drop cascades to table _times
 SELECT * FROM :CAGG_NAME_1ST_LEVEL ORDER BY bucket;
 psql:include/cagg_on_cagg_common.sql:212: ERROR:  relation "conditions_summary_1_hourly" does not exist at character 15
 \set ON_ERROR_STOP 1
--- cleanup
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
+The variance can lead to the fixed width one not being a multiple of the variable width one.
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because non-multiple bucket sizes
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should not be equal to previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater than the time bucket width of "public.conditions_summary_1" [@ 1 hour].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD ERROR because new bucket should be greater than previous
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+psql:include/cagg_on_cagg_validations.sql:33: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+psql:include/cagg_on_cagg_validations.sql:40: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+-- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/cagg_on_cagg_integer.sql
+++ b/tsl/test/sql/cagg_on_cagg_integer.sql
@@ -13,5 +13,31 @@
 \set BUCKET_WIDTH_2TH 'INTEGER \'5\''
 \set BUCKET_WIDTH_3TH 'INTEGER \'10\''
 
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
+
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'5\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'4\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql

--- a/tsl/test/sql/cagg_on_cagg_integer_dist_ht.sql
+++ b/tsl/test/sql/cagg_on_cagg_integer_dist_ht.sql
@@ -31,10 +31,36 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 \set BUCKET_WIDTH_2TH 'INTEGER \'5\''
 \set BUCKET_WIDTH_3TH 'INTEGER \'10\''
 
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 
--- cleanup
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'5\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'2\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTEGER \'4\''
+\set BUCKET_WIDTH_2TH 'INTEGER \'2\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+
+-- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/cagg_on_cagg_timestamp.sql
+++ b/tsl/test/sql/cagg_on_cagg_timestamp.sql
@@ -15,5 +15,39 @@
 
 SET timezone TO 'UTC';
 
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
+
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql

--- a/tsl/test/sql/cagg_on_cagg_timestamp_dist_ht.sql
+++ b/tsl/test/sql/cagg_on_cagg_timestamp_dist_ht.sql
@@ -33,10 +33,44 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 
 SET timezone TO 'UTC';
 
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 
--- cleanup
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+
+-- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/cagg_on_cagg_timestamptz.sql
+++ b/tsl/test/sql/cagg_on_cagg_timestamptz.sql
@@ -15,5 +15,39 @@
 
 SET timezone TO 'UTC';
 
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
+
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql

--- a/tsl/test/sql/cagg_on_cagg_timestamptz_dist_ht.sql
+++ b/tsl/test/sql/cagg_on_cagg_timestamptz_dist_ht.sql
@@ -33,10 +33,44 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 
 SET timezone TO 'UTC';
 
--- Run tests
+--
+-- Run common tests
+--
 \ir include/cagg_on_cagg_common.sql
 
--- cleanup
+--
+-- Validation test for variable bucket on top of fixed bucket
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'60 days\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because is not allowed variable-size bucket on top of fixed-size bucket'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for non-multiple bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'3 hours\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for equal bucket sizes
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should not be equal to previous'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Validation test for bucket size less than source
+--
+\set BUCKET_WIDTH_1ST 'INTERVAL \'2 hours\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
+\set WARNING_MESSAGE '-- SHOULD ERROR because new bucket should be greater than previous'
+\ir include/cagg_on_cagg_validations.sql
+
+-- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;
 DROP DATABASE :DATA_NODE_1;
 DROP DATABASE :DATA_NODE_2;

--- a/tsl/test/sql/include/cagg_on_cagg_validations.sql
+++ b/tsl/test/sql/include/cagg_on_cagg_validations.sql
@@ -1,0 +1,41 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\set ON_ERROR_STOP 0
+\set VERBOSITY terse
+
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;


### PR DESCRIPTION
Commit https://github.com/timescale/timescaledb/commit/3749953e9704e45df8f621607989ada0714ce28d introduce Hierarchical Continuous Aggregates (aka
Continuous Aggregate on top of another Continuous Aggregate) but it
lacks of some basic validations.

Validations added during the creation of a Hierarchical Continuous
Aggregate:

* Forbid create a continuous aggregate with fixed-width bucket on top of
  a continuous aggregate with variable-width bucket.

* Forbid incompatible bucket widths:
  - should not be equal;
  - bucket width of the new continuous aggregate should be greater than
    the source continuous aggregate;
  - bucket width of the new continuous aggregate should be multiple of
    the source continuous aggregate.