### PR TITLE
Use packaged postgres for sqlsmith and coverity CI

### DIFF
--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -7,53 +7,23 @@ on:
     branches:
       - coverity_scan
 jobs:
-  config:
-    runs-on: ubuntu-latest
-    outputs:
-      pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
-    steps:
-    - name: Checkout source code
-      uses: actions/checkout@v3
-    - name: Read configuration
-      id: setter
-      run: python .github/gh_config_reader.py
 
   coverity:
     name: Coverity ${{ matrix.pg }}
     runs-on: ${{ matrix.os }}
-    needs: config
     strategy:
       fail-fast: false
       matrix:
-        pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
+        pg: [12,13,14]
         os: [ubuntu-20.04]
-    env:
-      PG_SRC_DIR: pgbuild
-      PG_INSTALL_DIR: postgresql
-      MAKE_JOBS: 4
     steps:
     - name: Install Dependencies
-      run: sudo apt install flex bison clang-9 llvm-9 llvm-9-dev llvm-9-tools
-
-    # this workflow depends on the cached postgres build from the main regression
-    # workflow since that workflow runs daily there should always be a cache hit
-    - name: Cache PostgreSQL ${{ matrix.pg }}
-      id: cache-postgresql
-      uses: actions/cache@v3
-      with:
-        path: ~/${{ env.PG_SRC_DIR }}
-        key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-gcc-Release
-
-    # we abort on cache miss otherwise we would have to reproduce most variables
-    # of the main regression build matrix in this workflow
-    - name: Abort on cache miss
-      if: steps.cache-postgresql.outputs.cache-hit != 'true'
-      run: false
-
-    - name: Install PostgreSQL ${{ matrix.pg }}
       run: |
-        make -C ~/$PG_SRC_DIR install
-        make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
+        sudo apt-get update
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev
+        yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        sudo apt-get update
+        sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3
@@ -67,7 +37,7 @@ jobs:
     - name: Build TimescaleDB
       run: |
         PATH="$GITHUB_WORKSPACE/coverity/bin:$PATH"
-        ./bootstrap -DCMAKE_BUILD_TYPE=Release -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR
+        ./bootstrap -DCMAKE_BUILD_TYPE=Release
         cov-build --dir cov-int make -C build
 
     - name: Upload report

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -94,9 +94,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/${{ env.PG_SRC_DIR }}
-        key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ matrix.build_type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}${{ env.CACHE_SUFFIX }}
+        key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('.github/**') }}${{ env.CACHE_SUFFIX }}
 
-    - name: Build PostgreSQL ${{ matrix.pg }}${{ matrix.snapshot }} ${{ matrix.build_type }}
+    - name: Build PostgreSQL ${{ matrix.pg }}${{ matrix.snapshot }}
       if: steps.cache-postgresql.outputs.cache-hit != 'true'
       run: |
         if [ "${{ matrix.snapshot }}" = "snapshot" ]; then
@@ -112,7 +112,7 @@ jobs:
         make -j $MAKE_JOBS -C src/test/isolation
         make -j $MAKE_JOBS -C contrib/postgres_fdw
 
-    - name: Install PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }}
+    - name: Install PostgreSQL ${{ matrix.pg }}
       run: |
         make -C ~/$PG_SRC_DIR install
         make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -1,33 +1,20 @@
 name: SQLsmith
 on:
   schedule:
-    # run daily 20:00 on main branch
+    # run daily 2:00 on main branch
     - cron: '0 2 * * *'
   workflow_dispatch:
   push:
     branches:
       - sqlsmith
 jobs:
-  config:
-    runs-on: ubuntu-latest
-    outputs:
-      pg14_latest: ${{ steps.setter.outputs.PG14_LATEST }}
-    steps:
-    - name: Checkout source code
-      uses: actions/checkout@v3
-    - name: Read configuration
-      id: setter
-      run: python .github/gh_config_reader.py
-
-  regress:
+  sqlsmith:
     name: SQLsmith PG${{ matrix.pg }}
     runs-on: ${{ matrix.os }}
-    needs: config
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
-        pg: [ "${{ fromJson(needs.config.outputs.pg14_latest) }}" ]
-        cc: ["gcc"]
+        pg: [ "14" ]
         build_type: ["Debug"]
       fail-fast: false
     env:
@@ -38,36 +25,23 @@ jobs:
     - name: Install Linux Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install flex bison systemd-coredump gdb clang-9 llvm-9 llvm-9-dev llvm-9-tools build-essential autoconf autoconf-archive libpqxx-dev libboost-regex-dev libsqlite3-dev
 
-    # this workflow depends on the cached postgres build from the main regression
-    # workflow since that workflow runs daily there should always be a cache hit
-    - name: Cache PostgreSQL ${{ matrix.pg }}
-      id: cache-postgresql
-      uses: actions/cache@v3
-      with:
-        path: ~/${{ env.PG_SRC_DIR }}
-        key: ${{ matrix.os }}-postgresql-${{ matrix.pg }}-${{ matrix.cc }}-${{ matrix.build_type }}
-
-    # we abort on cache miss otherwise we would have to reproduce most variables
-    # of the main regression build matrix in this workflow
-    - name: Abort on cache miss
-      if: steps.cache-postgresql.outputs.cache-hit != 'true'
-      run: false
-
-    - name: Install PostgreSQL ${{ matrix.pg }} ${{ matrix.build_type }}
+    - name: Install Dependencies
       run: |
-        make -C ~/$PG_SRC_DIR install
-        make -C ~/$PG_SRC_DIR/contrib/postgres_fdw install
+        sudo apt-get update
+        sudo apt-get install gnupg systemd-coredump gdb postgresql-common libkrb5-dev build-essential autoconf autoconf-archive libpqxx-dev libboost-regex-dev libsqlite3-dev
+        yes | sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+        sudo apt-get update
+        sudo apt-get install postgresql-${{ matrix.pg }} postgresql-server-dev-${{ matrix.pg }}
 
     - name: Checkout TimescaleDB
       uses: actions/checkout@v3
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR ${{ matrix.tsdb_build_args }}
+        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.tsdb_build_args }}
         make -C build
-        make -C build install
+        sudo make -C build install
 
     - name: Checkout sqlsmith
       uses: actions/checkout@v3
@@ -86,8 +60,8 @@ jobs:
     - name: Setup test environment
       run: |
         mkdir ~/pgdata
-        ~/$PG_INSTALL_DIR/bin/initdb ~/pgdata
-        ~/$PG_INSTALL_DIR/bin/pg_ctl -D ~/pgdata start -o "-cshared_preload_libraries=timescaledb" -o "-cmax_connections=200" -o "-cmax_prepared_transactions=100"
+        /usr/lib/postgresql/${{ matrix.pg }}/bin/pg_ctl initdb -D ~/pgdata
+        /usr/lib/postgresql/${{ matrix.pg }}/bin/pg_ctl -D ~/pgdata start -o "-cshared_preload_libraries=timescaledb" -o "-cmax_connections=200" -o "-cmax_prepared_transactions=100" -o "-cunix_socket_directories=/tmp"
         psql -h /tmp postgres -c 'CREATE DATABASE smith;'
         psql -h /tmp smith -c 'CREATE EXTENSION timescaledb;'
         psql -h /tmp smith -c '\i ${{ github.workspace }}/tsl/test/shared/sql/include/shared_setup.sql'


### PR DESCRIPTION
The sqlsmith and coverity workflows used the cache postgres build but could not produce a build by themselves and therefore relied on other workflows to produce the cached binaries. This patch changes those workflows to use normal postgres packages instead of custom built postgres to remove that dependency.