### PR TITLE
Fix segfault in cagg creation

### DIFF
--- a/tsl/test/expected/cagg_errors.out
+++ b/tsl/test/expected/cagg_errors.out
@@ -640,3 +640,11 @@ ERROR:  hypertable is an internal compressed hypertable
 --Check error handling for this case
 SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
 ERROR:  compression not enabled on "i2980"
+-- cagg on normal view should error out
+CREATE VIEW v1 AS SELECT now() AS time;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
+ERROR:  invalid continuous aggregate query
+-- cagg on normal view should error out
+CREATE MATERIALIZED VIEW matv1 AS SELECT now() AS time;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM matv1 GROUP BY 1;
+ERROR:  invalid continuous aggregate view

--- a/tsl/test/sql/cagg_errors.sql
+++ b/tsl/test/sql/cagg_errors.sql
@@ -535,3 +535,12 @@ CREATE MATERIALIZED VIEW cagg1 WITH(timescaledb.continuous) AS SELECT time_bucke
 --TEST ht + cagg, do not enable compression on ht and try to compress chunk on ht.
 --Check error handling for this case
 SELECT compress_chunk(ch) FROM show_chunks('i2980') ch;
+
+-- cagg on normal view should error out
+CREATE VIEW v1 AS SELECT now() AS time;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM v1 GROUP BY 1;
+
+-- cagg on normal view should error out
+CREATE MATERIALIZED VIEW matv1 AS SELECT now() AS time;
+CREATE MATERIALIZED VIEW cagg1 WITH (timescaledb.continuous) AS SELECT time_bucket('1h',time) FROM matv1 GROUP BY 1;
+


### PR DESCRIPTION
When trying to create cagg on top of any relation that is a neither a hypertable nor a continuous aggregate the command would segfault. This patch changes the code to handle this case gracefully and error out when trying to create a cagg on top of a relation that is not supported. Found by coverity.