### PR TITLE
Check for presence of RelationGetSmgr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,18 @@ if(NOT EXISTS ${PG_INCLUDEDIR}/pg_config.h)
   )
 endif()
 
+# This is currently only available in snapshot branches so we cannot use the
+# normal pg version check to determine availability.
+if(EXISTS ${PG_INCLUDEDIR_SERVER}/utils/rel.h)
+  file(READ ${PG_INCLUDEDIR_SERVER}/utils/rel.h PG_UTILS_REL_H)
+  string(REGEX MATCH "RelationGetSmgr" PG_HAVE_RELATION_GET_SMGR
+               ${PG_UTILS_REL_H})
+endif()
+
+if(PG_HAVE_RELATION_GET_SMGR)
+  add_compile_definitions(PG_HAVE_RELATION_GET_SMGR=1)
+endif()
+
 file(READ ${PG_INCLUDEDIR}/pg_config.h PG_CONFIG_H)
 string(REGEX MATCH "#define USE_ASSERT_CHECKING 1" PG_USE_ASSERT_CHECKING
              ${PG_CONFIG_H})

--- a/src/copy.c
+++ b/src/copy.c
@@ -703,31 +703,6 @@ has_other_before_insert_row_trigger_than_ts(ResultRelInfo *resultRelInfo)
 	return false;
 }
 
-#if PG13_GE
-/*
- * RelationGetSmgr
- *		Returns smgr file handle for a relation, opening it if needed.
- *
- * Very little code is authorized to touch rel->rd_smgr directly.  Instead
- * use this function to fetch its value.
- *
- * Note: since a relcache flush can cause the file handle to be closed again,
- * it's unwise to hold onto the pointer returned by this function for any
- * long period.  Recommended practice is to just re-execute RelationGetSmgr
- * each time you need to access the SMgrRelation.  It's quite cheap in
- * comparison to whatever an smgr function is going to do.
- *
- * copied verbatim from postgres because it is a static function
- */
-static inline SMgrRelation
-RelationGetSmgr(Relation rel)
-{
-	if (unlikely(rel->rd_smgr == NULL))
-		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_node, rel->rd_backend));
-	return rel->rd_smgr;
-}
-#endif
-
 /*
  * Use COPY FROM to copy data from file to relation.
  */


### PR DESCRIPTION
RelationGetSmgr was backported by upstream to the STABLE branches but is not yet available in any released version so we cannot use pg version to determine presence of RelationGetSmgr.