### PR TITLE
Enable various PG15 CI Checks

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -26,6 +26,8 @@ from ci_settings import (
     PG13_LATEST,
     PG14_EARLIEST,
     PG14_LATEST,
+    PG15_EARLIEST,
+    PG15_LATEST,
 )
 
 # github event type which is either push, pull_request or schedule
@@ -134,6 +136,11 @@ def macos_config(overrides):
     base_config.update(overrides)
     return base_config
 
+# common installcheck_args for all pg15 tests
+# dist_move_chunk is skipped due to #4972
+# telemetry_stats is ignored due to #5037
+# partialize_finalize is ignored due to #4937
+pg15_installcheck_args = "SKIPS='dist_move_chunk' IGNORES='telemetry_stats partialize_finalize'"
 
 # always test debug build on latest of all supported pg versions
 m["include"].append(build_debug_config({"pg": PG12_LATEST}))
@@ -141,24 +148,12 @@ m["include"].append(
     build_debug_config({"pg": PG13_LATEST, "cc": "clang-14", "cxx": "clang++-14"})
 )
 m["include"].append(build_debug_config({"pg": PG14_LATEST}))
+m["include"].append(build_debug_config({"pg": PG15_LATEST, "installcheck_args": pg15_installcheck_args}))
 
-m["include"].append(build_release_config(macos_config({})))
-
-m["include"].append(build_without_telemetry({"pg": PG14_LATEST}))
-
-m["include"].append(
-    build_debug_config(
-        {
-            "pg": 15,
-            "snapshot": "snapshot",
-            "tsdb_build_args": "-DASSERTIONS=ON -DREQUIRE_ALL_TESTS=ON -DEXPERIMENTAL=ON",
-            # below tests are tracked as part of #4972
-            "installcheck_args": "SKIPS='dist_move_chunk' "
-            # below tests are tracked as part of #4835
-            "IGNORES='telemetry_stats partialize_finalize'",
-        }
-    )
-)
+# test latest postgres release in MacOS
+m["include"].append(build_release_config(macos_config({"pg": PG15_LATEST, "installcheck_args": pg15_installcheck_args})))
+# test latest postgres release without telemetry
+m["include"].append(build_without_telemetry({"pg": PG15_LATEST, "installcheck_args": pg15_installcheck_args}))
 
 # if this is not a pull request e.g. a scheduled run or a push
 # to a specific branch like prerelease_test we add additional
@@ -198,18 +193,23 @@ if event_type != "pull_request":
         )
     )
 
+    # add debug test for first supported PG15 version
+    m["include"].append(build_debug_config({"pg": PG15_EARLIEST, "installcheck_args": pg15_installcheck_args}))
+
     # add debug test for MacOS
     m["include"].append(build_debug_config(macos_config({})))
 
-    # add release test for latest pg 12 and 13
+    # add release test for latest pg releases
     m["include"].append(build_release_config({"pg": PG12_LATEST}))
     m["include"].append(build_release_config({"pg": PG13_LATEST}))
     m["include"].append(build_release_config({"pg": PG14_LATEST}))
+    m["include"].append(build_release_config({"pg": PG15_LATEST, "installcheck_args": pg15_installcheck_args}))
 
     # add apache only test for latest pg
     m["include"].append(build_apache_config({"pg": PG12_LATEST}))
     m["include"].append(build_apache_config({"pg": PG13_LATEST}))
     m["include"].append(build_apache_config({"pg": PG14_LATEST}))
+    m["include"].append(build_apache_config({"pg": PG15_LATEST}))
 
     # to discover issues with upcoming releases we run CI against
     # the stable branches of supported PG releases
@@ -224,6 +224,7 @@ if event_type != "pull_request":
             }
         )
     )
+    m["include"].append(build_debug_config({"pg": 15, "snapshot": "snapshot", "installcheck_args": pg15_installcheck_args}))
 else:
     # Check if we need to check for the flaky tests. Determine which test files
     # have been changed in the PR. The sql files might include other files that

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -21,9 +21,11 @@ jobs:
       pg12_abi_min: ${{ steps.config.outputs.pg12_abi_min }}
       pg13_abi_min: ${{ steps.config.outputs.pg13_abi_min }}
       pg14_abi_min: ${{ steps.config.outputs.pg14_abi_min }}
+      pg15_abi_min: ${{ steps.config.outputs.pg15_abi_min }}
       pg12_latest: ${{ steps.config.outputs.pg12_latest }}
       pg13_latest: ${{ steps.config.outputs.pg13_latest }}
       pg14_latest: ${{ steps.config.outputs.pg14_latest }}
+      pg15_latest: ${{ steps.config.outputs.pg15_latest }}
 
     steps:
     - name: Checkout source code
@@ -33,13 +35,13 @@ jobs:
       run: python .github/gh_config_reader.py
 
   abi_test:
-    name: ABI Test ${{ matrix.type}} PG${{ matrix.test }}
+    name: ABI Test PG${{ matrix.test }}
     runs-on: ubuntu-latest
     needs: config
     strategy:
       fail-fast: false
       matrix:
-        test: [ "12backward", "12forward", "13backward", "13forward", "14backward", "14forward" ]
+        test: [ "12backward", "12forward", "13backward", "13forward", "14backward", "14forward", "15backward", "15forward" ]
         os: [ windows-2019 ]
         include:
           - test: 12backward
@@ -62,10 +64,21 @@ jobs:
             pg: 14
             builder: ${{ fromJson(needs.config.outputs.pg14_latest) }}
             tester: ${{ fromJson(needs.config.outputs.pg14_abi_min) }}
+            ignores: memoize
           - test: 14forward
             pg: 14
             builder: ${{ fromJson(needs.config.outputs.pg14_abi_min) }}
             tester: ${{ fromJson(needs.config.outputs.pg14_latest) }}
+          - test: 15backward
+            pg: 15
+            builder: ${{ fromJson(needs.config.outputs.pg15_latest) }}
+            tester: ${{ fromJson(needs.config.outputs.pg15_abi_min) }}
+            ignores: partialize_finalize
+          - test: 15forward
+            pg: 15
+            builder: ${{ fromJson(needs.config.outputs.pg15_abi_min) }}
+            tester: ${{ fromJson(needs.config.outputs.pg15_latest) }}
+            ignores: partialize_finalize
 
     steps:
 
@@ -110,7 +123,7 @@ jobs:
           cp build_abi/install_lib/* `pg_config --pkglibdir`
           chown -R postgres /mnt
           set -o pipefail
-          sudo -u postgres make -C build_abi -k regresscheck regresscheck-t regresscheck-shared IGNORES="memoize" | tee installcheck.log
+          sudo -u postgres make -C build_abi -k regresscheck regresscheck-t regresscheck-shared IGNORES="${{matrix.ignores}}" | tee installcheck.log
         EOF
 
     - name: Show regression diffs

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg: [12,13,14]
+        # run only on the 3 latest PG versions as we have rate limit on coverity
+        pg: [13, 14, 15]
         os: [ubuntu-20.04]
     steps:
     - name: Install Dependencies

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+      pg15_latest: ${{ steps.setter.outputs.PG15_LATEST }}
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
@@ -29,11 +30,16 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
         IGNORES: append-* debug_notice transparent_decompression-* transparent_decompress_chunk-* plan_skip_scan-12 pg_dump
+        SKIPS: chunk_adaptive
     strategy:
       fail-fast: false
       matrix:
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
         build_type: [ Debug ]
+        include:
+          - pg: ${{ fromJson(needs.config.outputs.pg15_latest) }}
+            skips_version: dist_move_chunk
+            ignores_version: telemetry_stats partialize_finalize
 
     steps:
 
@@ -77,7 +83,7 @@ jobs:
       run: |
         set -o pipefail
         export LANG=C.UTF-8
-        sudo -u postgres make -k -C build installcheck IGNORES="${IGNORES}" SKIPS="chunk_adaptive" | tee installcheck.log
+        sudo -u postgres make -k -C build installcheck IGNORES="${IGNORES} ${{ matrix.ignores_version }}" SKIPS="${SKIPS} ${{ matrix.skips_version }}" | tee installcheck.log
 
     - name: Show regression diffs
       if: always()

--- a/.github/workflows/memory-tests.yaml
+++ b/.github/workflows/memory-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        pg: [12, 13, 14]
+        pg: [12, 13, 14, 15]
       fail-fast: false
 
     steps:

--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -37,11 +37,14 @@ env:
   ASAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_asan.txt detect_odr_violation=0 log_path=${{ github.workspace }}/sanitizer/sanitizer log_exe_name=true print_suppressions=false exitcode=27 external_symbolizer_path=/usr/lib/llvm-10/bin/llvm-symbolizer
   LSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_leak.txt print_suppressions=0 log_path=${{ github.workspace }}/sanitizer/sanitizer log_exe_name=true print_suppressions=false exitcode=27 external_symbolizer_path=/usr/lib/llvm-10/bin/llvm-symbolizer
   UBSAN_OPTIONS: suppressions=${{ github.workspace }}/scripts/suppressions/suppr_ub.txt print_stacktrace=1 halt_on_error=1 log_path=${{ github.workspace }}/sanitizer/sanitizer log_exe_name=true print_suppressions=false exitcode=27 external_symbolizer_path=/usr/lib/llvm-10/bin/llvm-symbolizer
+  IGNORES: "bgw_db_scheduler bgw_db_scheduler_fixed"
+  SKIPS: "remote_txn"
 jobs:
   config:
     runs-on: ubuntu-latest
     outputs:
       pg_latest: ${{ steps.setter.outputs.PG_LATEST }}
+      pg15_latest: ${{ steps.setter.outputs.PG15_LATEST }}
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
@@ -61,6 +64,12 @@ jobs:
         # "os" has to be in the matrix due to a bug in "env": https://github.community/t/how-to-use-env-context/16975
         os: ["ubuntu-20.04"]
         pg: ${{ fromJson(needs.config.outputs.pg_latest) }}
+        include:
+          - pg: ${{ fromJson(needs.config.outputs.pg15_latest) }}
+            # telemetry_stats is ignored in PG15 due to #5037
+            # partialize_finalize is ignored in PG15 due to #4937
+            ignores_version: telemetry_stats partialize_finalize
+            skips_version: 002_replication_telemetry 003_connections_privs 004_multinode_rdwr_1pc
     steps:
     - name: Install Linux Dependencies
       run: |
@@ -130,7 +139,7 @@ jobs:
         # test seems to fail due to a PostgreSQL bug where AbortStartTime in
         # postmaster.c is not atomic but read/written across signal handlers
         # and ServerLoop.
-        make -k -C build installcheck SKIPS='remote_txn' IGNORES='bgw_db_scheduler bgw_db_scheduler_fixed debug_notice' | tee installcheck.log
+        make -k -C build installcheck SKIPS="${SKIPS} ${{matrix.skips_version}}" IGNORES="${IGNORES} ${{matrix.ignores_version}}" | tee installcheck.log
 
     - name: Show regression diffs
       if: always()

--- a/.github/workflows/sqlsmith.yaml
+++ b/.github/workflows/sqlsmith.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
-        pg: [ "14" ]
+        pg: [ "15" ]
         build_type: ["Debug"]
       fail-fast: false
     env:
@@ -39,7 +39,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.tsdb_build_args }}
+        ./bootstrap -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         make -C build
         sudo make -C build install
 

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -61,6 +61,7 @@ jobs:
           - pg: 15
             pkg_version: 15.0.1 # hardcoded due to issues with PG15.1 on chocolatey
             tsl_skips_version: dist_partial_agg-15 dist_grant-15
+            tsl_ignores_version: telemetry_stats partialize_finalize
     env:
       # PostgreSQL configuration
       PGPORT: 55432
@@ -172,7 +173,7 @@ jobs:
 
         # isolationtester is only packaged with pg14+ so we would have to build our own postgres
         # to get it for earlier versions so we skip it for < 14.
-        if [[ "${{ matrix.pg }}" == "14" ]]; then
+        if [[ "${{ matrix.pg }}" -ge "14" ]]; then
           make -C build_wsl isolationchecklocal | tee -a installcheck.log
         fi
 
@@ -200,11 +201,11 @@ jobs:
 
         # isolationtester is only packaged with pg14+ so we would have to build our own postgres
         # to get it for earlier versions so we skip it for < 14.
-        if [[ "${{ matrix.pg }}" == "14" ]]; then
+        if [[ "${{ matrix.pg }}" -ge "14" ]]; then
           make -C build_wsl isolationchecklocal-t | tee -a installcheck.log
         fi
 
-        make -C build_wsl -k regresschecklocal-t IGNORES="${{ matrix.tsl_ignores }}" SKIPS="${{ matrix.tsl_skips }} ${{ matrix.tsl_skips_version }}" | tee -a installcheck.log
+        make -C build_wsl -k regresschecklocal-t IGNORES="${{ matrix.tsl_ignores }} ${{ matrix.tsl_ignores_version }}" SKIPS="${{ matrix.tsl_skips }} ${{ matrix.tsl_skips_version }}" | tee -a installcheck.log
 
     - name: Show regression diffs
       id: collectlogs


### PR DESCRIPTION
This PR enables PG15 in the following workflows:
 - Regression Linux
 - ABI test
 - Memory tests
 - Coverity
 - SQLSmith
 - Additional cron tests