### PR TITLE
Fix ABI openssl issue

### DIFF
--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -45,27 +45,33 @@ jobs:
           - test: 12backward
             pg: 12
             builder: ${{ fromJson(needs.config.outputs.pg12_latest) }}
+            builder_openssl: openssl1.1-compat-dev
             tester: ${{ fromJson(needs.config.outputs.pg12_abi_min ) }}
           - test: 12forward
             pg: 12
             builder: ${{ fromJson(needs.config.outputs.pg12_abi_min ) }}
             tester: ${{ fromJson(needs.config.outputs.pg12_latest) }}
+            tester_openssl: openssl1.1-compat-dev
           - test: 13backward
             pg: 13
             builder: ${{ fromJson(needs.config.outputs.pg13_latest) }}
             tester: ${{ fromJson(needs.config.outputs.pg13_abi_min ) }}
+            tester_openssl: openssl3-dev
           - test: 13forward
             pg: 13
             builder: ${{ fromJson(needs.config.outputs.pg13_abi_min ) }}
+            builder_openssl: openssl3-dev
             tester: ${{ fromJson(needs.config.outputs.pg13_latest) }}
           - test: 14backward
             pg: 14
             builder: ${{ fromJson(needs.config.outputs.pg14_latest) }}
+            builder_openssl: openssl1.1-compat-dev
             tester: ${{ fromJson(needs.config.outputs.pg14_abi_min) }}
           - test: 14forward
             pg: 14
             builder: ${{ fromJson(needs.config.outputs.pg14_abi_min) }}
             tester: ${{ fromJson(needs.config.outputs.pg14_latest) }}
+            tester_openssl: openssl1.1-compat-dev
 
     steps:
 
@@ -77,7 +83,8 @@ jobs:
         BUILDER_IMAGE="postgres:${{matrix.builder}}-alpine"
 
         docker run -i --rm -v $(pwd):/mnt ${BUILDER_IMAGE} bash <<"EOF"
-          apk add cmake gcc make build-base krb5-dev openssl-dev git > /dev/null
+          OPENSSL=${{matrix.builder_openssl}}
+          apk add cmake gcc make build-base krb5-dev "${OPENSSL:-openssl-dev}" git > /dev/null
           git config --global --add safe.directory /mnt
           cd /mnt
           BUILD_DIR=build_abi BUILD_FORCE_REMOVE=true ./bootstrap
@@ -92,7 +99,8 @@ jobs:
         TEST_IMAGE="postgres:${{ matrix.tester }}-alpine"
 
         docker run -i --rm -v $(pwd):/mnt ${TEST_IMAGE} bash <<"EOF"
-          apk add cmake gcc make build-base krb5-dev openssl-dev sudo > /dev/null
+          OPENSSL=${{matrix.tester_openssl}}
+          apk add cmake gcc make build-base krb5-dev "${OPENSSL:-openssl-dev}" sudo > /dev/null
           cd /mnt
           cp build_abi/install_ext/* `pg_config --sharedir`/extension/
           cp build_abi/install_lib/* `pg_config --pkglibdir`

--- a/.github/workflows/abi.yaml
+++ b/.github/workflows/abi.yaml
@@ -11,6 +11,7 @@ on:
   schedule:
     # run daily 20:00 on main branch
     - cron: '0 20 * * *'
+  pull_request:
   push:
     branches:
       - prerelease_test


### PR DESCRIPTION
The latest Alpine Linux versions on which the recent PostgreSQL docker
images are based, updated their OpenSSL default to version 3. Due to
this there is a difference in the version of the OpenSSL libs available
between the builder and test images of the ABI tests causing them to
fail. Fixed that by updating the workflow to use the same version of the
OpenSSL lib available in both builder and test images.