### PR TITLE
Fix segfault after second ANALYZE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 `psql` with the `-X` flag to prevent any `.psqlrc` commands from
 accidentally triggering the load of a previous DB version.**
 
+**Bugfixes**
+* #5054 Fix segfault after second ANALYZE
+
+**Thanks**
+* @kyrias for reporting a crash when ANALYZE is executed on extended query protocol mode with extension loaded.
+
 ## 2.9.0
 This release adds major new features since the 2.8.1 release.
 We deem it moderate priority for upgrading.

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -906,6 +906,8 @@ process_vacuum(ProcessUtilityArgs *args)
 	Hypertable *ht;
 	List *vacuum_rels = NIL;
 	bool is_vacuumcmd;
+	/* save original VacuumRelation list */
+	List *saved_stmt_rels = stmt->rels;
 
 	is_vacuumcmd = stmt->is_vacuumcmd;
 
@@ -975,6 +977,12 @@ process_vacuum(ProcessUtilityArgs *args)
 															  cp->compressed_relid);
 		}
 	}
+	/*
+	Restore original list. stmt->rels which has references to
+	VacuumRelation list is freed up, however VacuumStmt is not
+	cleaned up because of which there is a crash.
+	*/
+	stmt->rels = saved_stmt_rels;
 	return DDL_DONE;
 }
 

--- a/test/expected/size_utils.out
+++ b/test/expected/size_utils.out
@@ -744,3 +744,17 @@ SELECT * FROM hypertable_index_size('hypersize_time_idx');
                  24576
 (1 row)
 
+-- github issue #4857
+-- below procedure should not crash
+SET client_min_messages = ERROR;
+do
+$$
+DECLARE
+  o INT;
+BEGIN
+  FOR c IN 1..20 LOOP
+    ANALYZE;
+  END LOOP;
+END;
+$$;
+RESET client_min_messages;

--- a/test/sql/size_utils.sql
+++ b/test/sql/size_utils.sql
@@ -273,3 +273,18 @@ SELECT * FROM chunks_detailed_size('hypersize') ORDER BY node_name;
 SELECT * FROM hypertable_compression_stats('hypersize') ORDER BY node_name;
 SELECT * FROM chunk_compression_stats('hypersize') ORDER BY node_name;
 SELECT * FROM hypertable_index_size('hypersize_time_idx');
+
+-- github issue #4857
+-- below procedure should not crash
+SET client_min_messages = ERROR;
+do
+$$
+DECLARE
+  o INT;
+BEGIN
+  FOR c IN 1..20 LOOP
+    ANALYZE;
+  END LOOP;
+END;
+$$;
+RESET client_min_messages;


### PR DESCRIPTION
Issue occurs in extended query protocol mode only where every query goes through PREPARE and EXECUTE phase. First time ANALYZE is executed, a list of relations to be vaccumed is extracted and saved in a list. This list is referenced in parsetree node. Once execution of ANALYZE is complete, this list is cleaned up, however reference to the same is not cleaned up in parsetree node. When second time ANALYZE is executed, segfault happens as we access an invalid memory location.

Fixed the issue by restoring the actual value in parsetree node once ANALYZE completes its execution.

Fixes #4857