### PR TITLE
Ensure dist_hypertable is executed as solo test

### DIFF
--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -114,6 +114,8 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
 endif()
 
 set(SOLO_TESTS
+    # dist_hypertable needs a lot of memory when the Sanitizer is active
+    dist_hypertable-${PG_VERSION_MAJOR}
     bgw_db_scheduler
     troubleshooting_job_errors
     bgw_db_scheduler_fixed


### PR DESCRIPTION
The `dist_hypertable` test needs a lot of memory, especially when the sanitizer is enabled. This patch runs this test as a `SOLO_TEST`. This ensures that PostgreSQL does not run into an out-of-memory situation.

Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/3642792492
Link to successful CI run (containing this change): https://github.com/timescale/timescaledb/actions/runs/3643058327/jobs/6150867765