### PR TITLE
Reduce parallel test group size in sanitizer runs

### DIFF
--- a/.github/workflows/sanitizer-build-and-test.yaml
+++ b/.github/workflows/sanitizer-build-and-test.yaml
@@ -119,7 +119,7 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
-        ./bootstrap -DCMAKE_BUILD_TYPE=Debug -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR -DCODECOVERAGE=OFF -DREQUIRE_ALL_TESTS=ON
+        ./bootstrap -DCMAKE_BUILD_TYPE=Debug -DPG_SOURCE_DIR=~/$PG_SRC_DIR -DPG_PATH=~/$PG_INSTALL_DIR -DCODECOVERAGE=OFF -DREQUIRE_ALL_TESTS=ON -DTEST_GROUP_SIZE=5
         make -j $MAKE_JOBS -C build
         make -C build install
 


### PR DESCRIPTION
When the sanitizer is active, the tests require a lot of memory. If they are run in large parallel groups, out-of-memory situations can occur. This patch reduces the size of parallel groups to 5 when the sanitizer is active.

Link to failed CI run: https://github.com/timescale/timescaledb/actions/runs/3648618648/jobs/6162253916

The 'show regression logs' step shows:

```
Dec 08 13:50:13 fv-az344-99 kernel: Out of memory: Killed process 24065 (postgres) total-vm:21475224588kB, anon-rss:108576kB, file-rss:2172kB, shmem-rss:62416kB, UID:1001 pgtables:3360kB oom_score_adj:500
```