### PR TITLE
Allow analyze to work on dist hypertable list

### DIFF
--- a/tsl/src/deparse.h
+++ b/tsl/src/deparse.h
@@ -52,5 +52,6 @@ const char *deparse_func_call(FunctionCallInfo fcinfo);
 const char *deparse_oid_function_call_coll(Oid funcid, Oid collation, unsigned int num_args, ...);
 const char *deparse_grant_revoke_on_database(const GrantStmt *stmt, const char *dbname);
 const char *deparse_create_trigger(CreateTrigStmt *stmt);
+const char *deparse_vacuum(const VacuumStmt *stmt);
 
 #endif


### PR DESCRIPTION
Analyze currently does not work on a list of distributed hypertables because this would require deparsing of vacuum statements and sending a separate vacuum statement per data node.

To execute an unqualified vacuum (all tables), we need to decide if the sql of a command includes specific tables. We can not do this from a VacuumStmt node but would need to add an extra field to ProcessUtilityArgs.

I decided to go the extra mile and implement a vacuum statement deparser, solving the entire problem space.

A compromise was made on unqualified VERBOSE statements, as these would require parsing the DistResponseSet. If VERBOSE is specified in such a way, we simply emit a notice about skipping these tables. This remains an error when a list of tables is specified.

Fixes #4046