### PR TITLE
Fix git permission issue in CI build

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -63,6 +63,10 @@ jobs:
 
     - name: Build TimescaleDB
       run: |
+        # The owner of the checkout directory and the files do not match. Add the directory to
+        # Git's "safe.directory" setting. Otherwise git would complain about
+        # 'detected dubious ownership in repository'
+        git config --global --add safe.directory $(pwd)
         ./bootstrap -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" -DPG_SOURCE_DIR=~/postgresql -DREQUIRE_ALL_TESTS=ON
         make -C build install
         chown -R postgres:postgres .


### PR DESCRIPTION
The new permissions checks to fix CVE-2022-29187 in Git caused some issues in our CI pipeline. This patch adds the checkout directory to Git's "safe.directory" setting.

Failed CI run: https://github.com/timescale/timescaledb/actions/runs/3690974658/jobs/6248545042