### PR TITLE
Fix broken postgres install on Windows CI

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -55,7 +55,7 @@ jobs:
             pkg_version: ${{ fromJson(needs.config.outputs.pg13_latest) }}.1
             tsl_skips_version: dist_grant-13 dist_partial_agg-13
           - pg: 14
-            pkg_version: ${{ fromJson(needs.config.outputs.pg14_latest) }}.1
+            pkg_version: 14.5.1 # hardcoded due to issues with PG14.6 on chocolatey
             tsl_skips_version: dist_partial_agg-14 dist_grant-14
     env:
       # PostgreSQL configuration


### PR DESCRIPTION
The last minor versions for PG14 (14.6) and PG15 (15.1) were unlisted by
chocolatey maintainers due to some issues.

Fixed it by hardcoding the 14.5 until the packages become available
again.

This is intended to be a temporary fix until the chocolatey maintainers
fix their issues and make the packages listed and we can revert this change.
