### PR TITLE
Fix enabling compression on caggs with renamed columns

### DIFF
--- a/tsl/src/continuous_aggs/options.c
+++ b/tsl/src/continuous_aggs/options.c
@@ -133,7 +133,7 @@ cagg_find_groupingcols(ContinuousAgg *agg, Hypertable *mat_ht)
 		{
 			/* "resname" is the same as "mat column names" in the finalized version */
 			if (!cagg_tle->resjunk && cagg_tle->resname)
-				retlist = lappend(retlist, cagg_tle->resname);
+				retlist = lappend(retlist, get_attname(mat_relid, cagg_tle->resno, false));
 		}
 		else
 		{

--- a/tsl/test/shared/expected/cagg_compression.out
+++ b/tsl/test/shared/expected/cagg_compression.out
@@ -334,3 +334,18 @@ DROP MATERIALIZED VIEW metrics_summary;
 NOTICE:  drop cascades to 2 other objects
 DROP VIEW all_devices;
 DROP TABLE extra_devices;
+-- test enabling compression on cagg after column rename
+CREATE TABLE comp_rename(time timestamptz);
+SELECT table_name FROM create_hypertable('comp_rename', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ table_name  
+ comp_rename
+(1 row)
+
+CREATE MATERIALIZED VIEW comp_rename_cagg WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', time) AS bucket FROM comp_rename GROUP BY 1;
+NOTICE:  continuous aggregate "comp_rename_cagg" is already up-to-date
+ALTER MATERIALIZED VIEW comp_rename_cagg RENAME COLUMN bucket to "time";
+ALTER MATERIALIZED VIEW comp_rename_cagg SET ( timescaledb.compress='true');
+DROP TABLE comp_rename CASCADE;
+NOTICE:  drop cascades to 3 other objects

--- a/tsl/test/shared/sql/cagg_compression.sql
+++ b/tsl/test/shared/sql/cagg_compression.sql
@@ -95,3 +95,16 @@ DROP MATERIALIZED VIEW metrics_compressed_summary;
 DROP MATERIALIZED VIEW metrics_summary;
 DROP VIEW all_devices;
 DROP TABLE extra_devices;
+
+-- test enabling compression on cagg after column rename
+CREATE TABLE comp_rename(time timestamptz);
+SELECT table_name FROM create_hypertable('comp_rename', 'time');
+
+CREATE MATERIALIZED VIEW comp_rename_cagg WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 week', time) AS bucket FROM comp_rename GROUP BY 1;
+
+ALTER MATERIALIZED VIEW comp_rename_cagg RENAME COLUMN bucket to "time";
+ALTER MATERIALIZED VIEW comp_rename_cagg SET ( timescaledb.compress='true');
+
+DROP TABLE comp_rename CASCADE;
+


### PR DESCRIPTION
On caggs with realtime aggregation changing the column name does not update all the column aliases inside the view metadata. This patch changes the code that creates the compression configuration for caggs to get the column name from the materialization hypertable instead of the view internals.

Fixes #5100