### PR TITLE
Fix column ordering in compressed table index.

### DIFF
--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1228,3 +1228,45 @@ SELECT timescaledb_post_restore();
 (1 row)
 
 DROP TABLE issue4140;
+-- github issue 5104
+CREATE TABLE metric(
+	time TIMESTAMPTZ NOT NULL,
+	value DOUBLE PRECISION NOT NULL,
+	series_id BIGINT NOT NULL);
+SELECT create_hypertable('metric', 'time',
+	chunk_time_interval => interval '1 h',
+	create_default_indexes => false);
+  create_hypertable   
+----------------------
+ (22,public,metric,t)
+(1 row)
+
+-- enable compression
+ALTER TABLE metric set(timescaledb.compress,
+    timescaledb.compress_segmentby = 'series_id, value',
+    timescaledb.compress_orderby = 'time'
+);
+SELECT
+      comp_hypertable.schema_name AS "COMP_SCHEMA_NAME",
+      comp_hypertable.table_name AS "COMP_TABLE_NAME"
+FROM _timescaledb_catalog.hypertable uc_hypertable
+INNER JOIN _timescaledb_catalog.hypertable comp_hypertable ON (comp_hypertable.id = uc_hypertable.compressed_hypertable_id)
+WHERE uc_hypertable.table_name like 'metric' \gset
+-- get definition of compressed hypertable and notice the index
+\d :COMP_SCHEMA_NAME.:COMP_TABLE_NAME
+                    Table "_timescaledb_internal._compressed_hypertable_23"
+        Column         |                 Type                  | Collation | Nullable | Default 
+-----------------------+---------------------------------------+-----------+----------+---------
+ time                  | _timescaledb_internal.compressed_data |           |          | 
+ value                 | double precision                      |           |          | 
+ series_id             | bigint                                |           |          | 
+ _ts_meta_count        | integer                               |           |          | 
+ _ts_meta_sequence_num | integer                               |           |          | 
+ _ts_meta_min_1        | timestamp with time zone              |           |          | 
+ _ts_meta_max_1        | timestamp with time zone              |           |          | 
+Indexes:
+    "_compressed_hypertable_23_series_id_value__ts_meta_sequence_idx" btree (series_id, value, _ts_meta_sequence_num)
+Triggers:
+    ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._compressed_hypertable_23 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
+
+DROP TABLE metric CASCADE;

--- a/tsl/test/expected/transparent_decompression_queries.out
+++ b/tsl/test/expected/transparent_decompression_queries.out
@@ -87,8 +87,8 @@ EXPLAIN (analyze,costs off,timing off,summary off) SELECT
 FROM merge_sort
 WHERE time < now()
 GROUP BY 2, 3;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: merge_sort.device_id, merge_sort.measure_id
    ->  Custom Scan (ConstraintAwareAppend) (actual rows=745 loops=1)
@@ -98,10 +98,7 @@ GROUP BY 2, 3;
                Sort Key: _hyper_3_5_chunk.device_id, _hyper_3_5_chunk.measure_id
                ->  Custom Scan (DecompressChunk) on _hyper_3_5_chunk (actual rows=120 loops=1)
                      Filter: ("time" < now())
-                     ->  Sort (actual rows=1 loops=1)
-                           Sort Key: compress_hyper_4_10_chunk.device_id, compress_hyper_4_10_chunk.measure_id
-                           Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_4_10_chunk (actual rows=1 loops=1)
+                     ->  Index Scan using compress_hyper_4_10_chunk__compressed_hypertable_4_device_id_me on compress_hyper_4_10_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=168 loops=1)
                      Sort Key: _hyper_3_6_chunk.device_id, _hyper_3_6_chunk.measure_id
                      Sort Method: quicksort 
@@ -122,7 +119,7 @@ GROUP BY 2, 3;
                      Sort Method: quicksort 
                      ->  Seq Scan on _hyper_3_9_chunk (actual rows=121 loops=1)
                            Filter: ("time" < now())
-(33 rows)
+(30 rows)
 
 -- this should exclude the decompressed chunk
 EXPLAIN (analyze,costs off,timing off,summary off) SELECT


### PR DESCRIPTION
When defining compression segment by parameter using multiple columns, the parameter ordering is not respected for index creation.

This patch fixes the issue by maintaining the same order in which user has defined columns in segment by clause.

Fixes #5104