### PR TITLE
Skip package downgrade test for PG15

### DIFF
--- a/.github/workflows/apt-packages.yaml
+++ b/.github/workflows/apt-packages.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         # Debian images:  10 (buster), 11 (bullseye)
         # Ubuntu images:  18.04 LTS (bionic), 20.04 LTS (focal), 21.10 (impish), 22.04 (jammy)
-        image: [ "debian:10-slim", "debian:11-slim", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy"]
+        image: [ "debian:10-slim", "debian:11-slim", "ubuntu:focal", "ubuntu:jammy"]
         pg: [ 12, 13, 14, 15 ]
         license: [ "TSL", "Apache"]
         include:
@@ -79,7 +79,7 @@ jobs:
 
     - name: Test Downgrade
       # ubuntu:jammy only has 1 released version at the moment so downgrade will not be possible
-      if: matrix.image != 'ubuntu:jammy'
+      if: matrix.pg != '15'
       run: |
         # since this runs nightly on main we have to get the previous version from the last released version and not current branch
         prev_version=$(wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')

--- a/.github/workflows/rpm-packages.yaml
+++ b/.github/workflows/rpm-packages.yaml
@@ -84,6 +84,7 @@ jobs:
         fi
 
     - name: Test Downgrade
+      if: matrix.pg != '15'
       run: |
         # since this runs nightly on main we have to get the previous version from the last released version and not current branch
         prev_version=$(wget --quiet -O - https://raw.githubusercontent.com/timescale/timescaledb/${{ steps.versions.outputs.version }}/version.config | grep update_from_version | sed -e 's!update_from_version = !!')


### PR DESCRIPTION
Since we currently only have 1 released version that supports PG15 we cannot test downgrade with PG15.