### PR TITLE
Stats improvement for Uncompressed Chunks

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -139,14 +139,35 @@ def macos_config(overrides):
 
 # common installcheck_args for all pg15 tests
 # partialize_finalize is ignored due to #4937
-pg15_installcheck_args = "IGNORES='partialize_finalize'"
+pg15_installcheck_args = "IGNORES='partialize_finalize transparent_decompress_chunk-15'"
+
+# transparent_decompress_chunk-[12,13,14] is ignored due to #5118
+pg14_installcheck_args = "IGNORES='bgw_db_scheduler bgw_db_scheduler_fixed partialize_finalize transparent_decompress_chunk-14'"
+
+pg13_installcheck_args = "IGNORES='bgw_db_scheduler bgw_db_scheduler_fixed partialize_finalize transparent_decompress_chunk-13'"
+
+pg12_installcheck_args = "IGNORES='bgw_db_scheduler bgw_db_scheduler_fixed partialize_finalize transparent_decompress_chunk-12'"
 
 # always test debug build on latest of all supported pg versions
-m["include"].append(build_debug_config({"pg": PG12_LATEST}))
 m["include"].append(
-    build_debug_config({"pg": PG13_LATEST, "cc": "clang-14", "cxx": "clang++-14"})
+    build_debug_config({"pg": PG12_LATEST, "installcheck_args": pg12_installcheck_args})
 )
-m["include"].append(build_debug_config({"pg": PG14_LATEST}))
+
+m["include"].append(
+    build_debug_config(
+        {
+            "pg": PG13_LATEST,
+            "cc": "clang-14",
+            "cxx": "clang++-14",
+            "installcheck_args": pg13_installcheck_args,
+        }
+    )
+)
+
+m["include"].append(
+    build_debug_config({"pg": PG14_LATEST, "installcheck_args": pg14_installcheck_args})
+)
+
 m["include"].append(
     build_debug_config({"pg": PG15_LATEST, "installcheck_args": pg15_installcheck_args})
 )
@@ -185,7 +206,7 @@ if event_type != "pull_request":
         "pg": PG13_EARLIEST,
         # The early releases don't build with llvm 14.
         "pg_extra_args": "--enable-debug --enable-cassert --without-llvm",
-        "installcheck_args": "SKIPS='001_extension' IGNORES='dist_gapfill_pushdown-13'",
+        "installcheck_args": "SKIPS='001_extension' IGNORES='dist_gapfill_pushdown-13 transparent_decompress_chunk-13'",
         "tsdb_build_args": "-DWARNINGS_AS_ERRORS=ON -DASSERTIONS=ON -DPG_ISOLATION_REGRESS=OFF",
     }
     m["include"].append(build_debug_config(pg13_debug_earliest))

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -53,7 +53,7 @@ jobs:
         os: [ windows-2022 ]
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         ignores: ["chunk_adaptive metadata"]
-        tsl_ignores: ["compression_algos remote_connection"]
+        tsl_ignores: ["compression_algos remote_connection telemetry_stats-13 telemetry_stats-14"]
         tsl_skips: ["bgw_db_scheduler bgw_db_scheduler_fixed cagg_ddl_dist_ht
           data_fetcher dist_compression dist_remote_error remote_txn"]
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ Sooner to that time, we will announce the specific version of TimescaleDB in whi
 * #5262 Extend enabling compression on a continuous aggregrate with 'compress_segmentby' and 'compress_orderby' parameters
 
 **Bugfixes**
+* #4926 Fix corruption when inserting into compressed chunks
+* #5118 Enable auto vacuum for uncompressed chunks
+* #5218 Add role-level security to job error log
 * #5214 Fix use of prepared statement in async module
 * #5218 Add role-level security to job error log
 * #5239 Fix next_start calculation for fixed schedules

--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -394,6 +394,86 @@ $BODY$ SET search_path TO pg_catalog, pg_temp;
 -- Estimated number of rows according to catalog tables
 CREATE OR REPLACE FUNCTION @extschema@.approximate_row_count(relation REGCLASS)
 RETURNS BIGINT
+LANGUAGE PLPGSQL VOLATILE STRICT AS
+$BODY$
+DECLARE
+    local_table_name       NAME = NULL;
+    local_schema_name      NAME = NULL;
+    is_distributed   BOOL = FALSE;
+    is_compressed    BOOL = FALSE;
+    uncompressed_row_count BIGINT = 0;
+    compressed_row_count BIGINT = 0;
+    local_compressed_hypertable_id INTEGER = 0;
+    local_compressed_chunk_id INTEGER = 0;
+    compressed_hypertable_oid  OID;
+    local_compressed_chunk_oid  OID;
+    max_compressed_row_count BIGINT = 1000;
+    is_compressed_chunk INTEGER;
+BEGIN
+    SELECT relname, nspname FROM pg_class c
+    INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
+    INTO local_table_name, local_schema_name
+    WHERE c.OID = relation;
+
+    -- Check for input relation is Hypertable
+    IF EXISTS (SELECT 1
+               FROM _timescaledb_catalog.hypertable WHERE table_name = local_table_name AND schema_name = local_schema_name) THEN
+        SELECT compressed_hypertable_id FROM _timescaledb_catalog.hypertable INTO local_compressed_hypertable_id
+        WHERE table_name = local_table_name AND schema_name = local_schema_name;
+        IF local_compressed_hypertable_id IS NOT NULL THEN
+           uncompressed_row_count = _timescaledb_internal.get_approx_row_count(relation);
+
+           WITH compressed_hypertable AS (SELECT table_name, schema_name FROM _timescaledb_catalog.hypertable ht
+           WHERE ht.id = local_compressed_hypertable_id)
+           SELECT c.oid INTO compressed_hypertable_oid FROM pg_class c
+           INNER JOIN compressed_hypertable h ON (c.relname = h.table_name)
+           INNER JOIN pg_namespace n ON (n.nspname = h.schema_name);
+
+           compressed_row_count = _timescaledb_internal.get_approx_row_count(compressed_hypertable_oid);
+           RETURN (uncompressed_row_count + (compressed_row_count * max_compressed_row_count));
+        ELSE
+           uncompressed_row_count = _timescaledb_internal.get_approx_row_count(relation);
+           RETURN uncompressed_row_count;
+        END IF;
+    END IF;
+    -- Check for input relation is CHUNK
+    IF EXISTS (SELECT 1 FROM _timescaledb_catalog.chunk WHERE table_name = local_table_name AND schema_name = local_schema_name) THEN
+        with compressed_chunk as (select 1 as is_compressed_chunk from _timescaledb_catalog.chunk c
+        inner join _timescaledb_catalog.hypertable h on (c.hypertable_id = h.compressed_hypertable_id)
+        where c.table_name = local_table_name and c.schema_name = local_schema_name ),
+        chunk_temp as (select compressed_chunk_id from _timescaledb_catalog.chunk c where c.table_name = local_table_name and c.schema_name = local_schema_name)
+        select ct.compressed_chunk_id, cc.is_compressed_chunk from chunk_temp ct LEFT OUTER JOIN compressed_chunk cc ON 1 = 1
+        INTO local_compressed_chunk_id, is_compressed_chunk;
+        -- 'input is chunk #1';
+        IF is_compressed_chunk IS NULL AND local_compressed_chunk_id IS NOT NULL THEN
+        -- 'Include both uncompressed  and compressed chunk #2';
+            WITH compressed_ns_oid AS ( SELECT table_name, oid FROM _timescaledb_catalog.chunk ch INNER JOIN pg_namespace ns ON
+            (ch.id = local_compressed_chunk_id and ch.schema_name = ns.nspname))
+            SELECT c.oid FROM pg_class c INNER JOIN compressed_ns_oid
+            ON ( c.relnamespace = compressed_ns_oid.oid AND c.relname = compressed_ns_oid.table_name)
+            INTO local_compressed_chunk_oid;
+
+            uncompressed_row_count = _timescaledb_internal.get_approx_row_count(relation);
+            compressed_row_count = _timescaledb_internal.get_approx_row_count(local_compressed_chunk_oid);
+            RETURN uncompressed_row_count + (compressed_row_count * max_compressed_row_count);
+        ELSIF is_compressed_chunk IS NULL AND local_compressed_chunk_id IS NULL THEN
+        -- 'input relation is uncompressed chunk #3';
+            uncompressed_row_count = _timescaledb_internal.get_approx_row_count(relation);
+            RETURN uncompressed_row_count;
+        ELSE
+        -- 'compressed chunk only #4';
+            compressed_row_count = _timescaledb_internal.get_approx_row_count(relation) * max_compressed_row_count;
+            RETURN compressed_row_count;
+        END IF;
+    END IF;
+    -- Check for input relation is Plain RELATION
+    uncompressed_row_count = _timescaledb_internal.get_approx_row_count(relation);
+    RETURN uncompressed_row_count;
+END;
+$BODY$ SET search_path TO pg_catalog, pg_temp;
+
+CREATE OR REPLACE FUNCTION _timescaledb_internal.get_approx_row_count(relation REGCLASS)
+RETURNS BIGINT
 LANGUAGE SQL VOLATILE STRICT AS
 $BODY$
   WITH RECURSIVE inherited_id(oid) AS

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -2,3 +2,5 @@ DROP FUNCTION _timescaledb_internal.ping_data_node(NAME, INTERVAL);
 
 CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME) RETURNS BOOLEAN
 AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;
+
+DROP FUNCTION IF EXISTS _timescaledb_internal.get_approx_row_count(REGCLASS);

--- a/src/cross_module_fn.c
+++ b/src/cross_module_fn.c
@@ -382,12 +382,6 @@ func_call_on_data_nodes_default(FunctionCallInfo finfo, List *data_node_oids)
 }
 
 static void
-update_compressed_chunk_relstats_default(Oid uncompressed_relid, Oid compressed_relid)
-{
-	error_no_default_fn_community();
-}
-
-static void
 dist_update_stale_chunk_metadata_default(Chunk *new_chunk, List *chunk_data_nodes)
 {
 	error_no_default_fn_community();
@@ -560,7 +554,6 @@ TSDLLEXPORT CrossModuleFunctions ts_cm_functions_default = {
 	.chunk_create_empty_table = error_no_default_fn_pg_community,
 	.chunk_create_replica_table = error_no_default_fn_pg_community,
 	.hypertable_distributed_set_replication_factor = error_no_default_fn_pg_community,
-	.update_compressed_chunk_relstats = update_compressed_chunk_relstats_default,
 	.health_check = error_no_default_fn_pg_community,
 	.mn_get_foreign_join_paths = mn_get_foreign_join_path_default_fn_pg_community,
 };

--- a/src/cross_module_fn.h
+++ b/src/cross_module_fn.h
@@ -204,7 +204,6 @@ typedef struct CrossModuleFunctions
 	PGFunction chunk_freeze_chunk;
 	PGFunction chunk_unfreeze_chunk;
 	PGFunction chunks_drop_stale;
-	void (*update_compressed_chunk_relstats)(Oid uncompressed_relid, Oid compressed_relid);
 	PGFunction health_check;
 	void (*mn_get_foreign_join_paths)(PlannerInfo *root, RelOptInfo *joinrel, RelOptInfo *outerrel,
 									  RelOptInfo *innerrel, JoinType jointype,

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1332,20 +1332,6 @@ timescaledb_get_relation_info_hook(PlannerInfo *root, Oid relation_objectid, boo
 					 * IndexPaths at all
 					 */
 					rel->indexlist = NIL;
-
-					/* Relation size estimates are messed up on compressed chunks due to there
-					 * being no actual pages for the table in the storage manager.
-					 */
-					rel->pages = (BlockNumber) uncompressed_chunk->rd_rel->relpages;
-					rel->tuples = (double) uncompressed_chunk->rd_rel->reltuples;
-					if (rel->pages == 0)
-						rel->allvisfrac = 0.0;
-					else if (uncompressed_chunk->rd_rel->relallvisible >= (int32) rel->pages)
-						rel->allvisfrac = 1.0;
-					else
-						rel->allvisfrac =
-							(double) uncompressed_chunk->rd_rel->relallvisible / rel->pages;
-
 					table_close(uncompressed_chunk, NoLock);
 				}
 			}

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -768,30 +768,6 @@ typedef struct ChunkPair
 	Oid compressed_relid;
 } ChunkPair;
 
-static void
-add_compressed_chunk_to_vacuum(Hypertable *ht, Oid comp_chunk_relid, void *arg)
-{
-	VacuumCtx *ctx = (VacuumCtx *) arg;
-	Chunk *compressed_chunk = ts_chunk_get_by_relid(comp_chunk_relid, true);
-	VacuumRelation *chunk_vacuum_rel;
-
-	Chunk *chunk_parent;
-	/* chunk is from a compressed hypertable */
-	Assert(TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht));
-
-	/*chunks for internal compression table have a parent */
-	chunk_parent = ts_chunk_get_compressed_chunk_parent(compressed_chunk);
-	Assert(chunk_parent != NULL);
-
-	ChunkPair *cp = palloc(sizeof(ChunkPair));
-	cp->uncompressed_relid = chunk_parent->table_id;
-	cp->compressed_relid = comp_chunk_relid;
-	ctx->chunk_pairs = lappend(ctx->chunk_pairs, cp);
-	/* analyze/vacuum the compressed rel instead */
-	chunk_vacuum_rel = makeVacuumRelation(NULL, comp_chunk_relid, NIL);
-	ctx->chunk_rels = lappend(ctx->chunk_rels, chunk_vacuum_rel);
-}
-
 /* Adds a chunk to the list of tables to be vacuumed */
 static void
 add_chunk_to_vacuum(Hypertable *ht, Oid chunk_relid, void *arg)
@@ -801,30 +777,11 @@ add_chunk_to_vacuum(Hypertable *ht, Oid chunk_relid, void *arg)
 	VacuumRelation *chunk_vacuum_rel;
 	RangeVar *chunk_range_var;
 
-	/* If the chunk has an associated compressed chunk, analyze that instead
-	 * When we compress a chunk, we save stats for the raw chunk, do
-	 * not modify that. Data now lives in the compressed chunk, so
-	 * analyze it.
-	 */
-	if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
-	{
-		Chunk *comp_chunk = ts_chunk_get_by_id(chunk->fd.compressed_chunk_id, true);
-		ChunkPair *cp = palloc(sizeof(ChunkPair));
-		cp->uncompressed_relid = chunk_relid;
-		cp->compressed_relid = comp_chunk->table_id;
-		ctx->chunk_pairs = lappend(ctx->chunk_pairs, cp);
-		/* analyze/vacuum the compressed rel instead */
-		chunk_vacuum_rel = makeVacuumRelation(NULL, comp_chunk->table_id, NIL);
-		ctx->chunk_rels = lappend(ctx->chunk_rels, chunk_vacuum_rel);
-	}
-	else
-	{
-		chunk_range_var = copyObject(ctx->ht_vacuum_rel->relation);
-		chunk_range_var->relname = NameStr(chunk->fd.table_name);
-		chunk_range_var->schemaname = NameStr(chunk->fd.schema_name);
-		chunk_vacuum_rel =
-			makeVacuumRelation(chunk_range_var, chunk_relid, ctx->ht_vacuum_rel->va_cols);
-	}
+	chunk_range_var = copyObject(ctx->ht_vacuum_rel->relation);
+	chunk_range_var->relname = NameStr(chunk->fd.table_name);
+	chunk_range_var->schemaname = NameStr(chunk->fd.schema_name);
+	chunk_vacuum_rel =
+		makeVacuumRelation(chunk_range_var, chunk_relid, ctx->ht_vacuum_rel->va_cols);
 	ctx->chunk_rels = lappend(ctx->chunk_rels, chunk_vacuum_rel);
 }
 
@@ -851,7 +808,6 @@ ts_get_all_vacuum_rels(bool is_vacuumcmd)
 	{
 		Form_pg_class classform = (Form_pg_class) GETSTRUCT(tuple);
 		Hypertable *ht;
-		Chunk *chunk;
 		Oid relid;
 
 		relid = classform->oid;
@@ -873,16 +829,8 @@ ts_get_all_vacuum_rels(bool is_vacuumcmd)
 
 		ht = ts_hypertable_cache_get_entry(hcache, relid, CACHE_FLAG_MISSING_OK);
 		if (ht)
-		{
 			if (hypertable_is_distributed(ht))
 				continue;
-		}
-		else
-		{
-			chunk = ts_chunk_get_by_relid(relid, false);
-			if (chunk && chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
-				continue;
-		}
 
 		/*
 		 * Build VacuumRelation(s) specifying the table OIDs to be processed.
@@ -950,17 +898,8 @@ process_vacuum(ProcessUtilityArgs *args)
 					 */
 					if (hypertable_is_distributed(ht))
 						continue;
-
-					if (TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht))
-					{
-						ctx.ht_vacuum_rel = vacuum_rel;
-						foreach_chunk(ht, add_compressed_chunk_to_vacuum, &ctx);
-					}
-					else
-					{
-						ctx.ht_vacuum_rel = vacuum_rel;
-						foreach_chunk(ht, add_chunk_to_vacuum, &ctx);
-					}
+					ctx.ht_vacuum_rel = vacuum_rel;
+					foreach_chunk(ht, add_chunk_to_vacuum, &ctx);
 				}
 			}
 			vacuum_rels = lappend(vacuum_rels, vacuum_rel);
@@ -978,12 +917,6 @@ process_vacuum(ProcessUtilityArgs *args)
 
 		/* ACL permission checks inside vacuum_rel and analyze_rel called by this ExecVacuum */
 		ExecVacuum(args->parse_state, stmt, is_toplevel);
-		foreach (lc, ctx.chunk_pairs)
-		{
-			ChunkPair *cp = (ChunkPair *) lfirst(lc);
-			ts_cm_functions->update_compressed_chunk_relstats(cp->uncompressed_relid,
-															  cp->compressed_relid);
-		}
 	}
 	/*
 	Restore original list. stmt->rels which has references to

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -150,8 +150,6 @@ extern void decompress_chunk(Oid in_table, Oid out_table);
 
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(
 	CompressionAlgorithms algorithm, bool reverse))(Datum, Oid element_type);
-extern void update_compressed_chunk_relstats(Oid uncompressed_relid, Oid compressed_relid);
-extern void merge_chunk_relstats(Oid merged_relid, Oid compressed_relid);
 
 typedef struct Chunk Chunk;
 typedef struct ChunkInsertState ChunkInsertState;

--- a/tsl/src/init.c
+++ b/tsl/src/init.c
@@ -235,7 +235,6 @@ CrossModuleFunctions tsl_cm_functions = {
 	.chunk_create_replica_table = chunk_create_replica_table,
 	.hypertable_distributed_set_replication_factor = hypertable_set_replication_factor,
 	.cache_syscache_invalidate = cache_syscache_invalidate,
-	.update_compressed_chunk_relstats = update_compressed_chunk_relstats,
 	.health_check = ts_dist_health_check,
 	.mn_get_foreign_join_paths = tsl_mn_get_foreign_join_paths,
 };

--- a/tsl/test/expected/chunk_merge.out
+++ b/tsl/test/expected/chunk_merge.out
@@ -106,7 +106,22 @@ FROM test1
 GROUP BY i, bucket;
 NOTICE:  refreshing continuous aggregate "test_cagg"
 -- Merging cagg chunks should also work.
-SELECT _timescaledb_internal.test_merge_chunks_on_dimension('_timescaledb_internal._hyper_4_37_chunk','_timescaledb_internal._hyper_4_39_chunk', 4);
+WITH adjacent_slices AS
+  (SELECT S1.id AS PRIMARY,
+          s2.id AS secondary
+   FROM _timescaledb_catalog.dimension_slice s2
+   INNER JOIN _timescaledb_catalog.dimension_slice s1 ON s1.range_end = s2.range_start
+   WHERE s1.dimension_id = 4
+     AND s2.dimension_id = 4
+   LIMIT 1),
+     chunks AS
+  (SELECT c1.chunk_id AS primary_chunk,
+          c2.chunk_id AS secondary_chunk
+   FROM adjacent_slices
+   INNER JOIN _timescaledb_catalog.chunk_constraint c1 ON c1.dimension_slice_id = adjacent_slices.primary
+   INNER JOIN _timescaledb_catalog.chunk_constraint c2 ON c2.dimension_slice_id = adjacent_slices.secondary)
+SELECT _timescaledb_internal.test_merge_chunks_on_dimension(format('_timescaledb_internal._hyper_4_%s_chunk', chunks.primary_chunk), format('_timescaledb_internal._hyper_4_%s_chunk', chunks.secondary_chunk), 4)
+FROM chunks;
  test_merge_chunks_on_dimension 
 --------------------------------
  

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -243,16 +243,16 @@ select decompress_chunk( '_timescaledb_internal._hyper_1_2_chunk');
 insert into foo values( 11 , 10 , 20, 120);
 update foo set b =20 where a = 10;
 ERROR:  duplicate key value violates unique constraint "_hyper_1_2_chunk_foo_uniq"
-select * from _timescaledb_internal._hyper_1_2_chunk order by a;
+select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
  a  | b  | c  |  d  
 ----+----+----+-----
- 10 | 24 | 12 |  12
  10 | 10 | 20 |    
+ 10 | 24 | 12 |  12
  11 | 10 | 20 | 120
 (3 rows)
 
 delete from foo where a = 10;
-select * from _timescaledb_internal._hyper_1_2_chunk order by a;
+select * from _timescaledb_internal._hyper_1_2_chunk order by a,b;
  a  | b  | c  |  d  
 ----+----+----+-----
  11 | 10 | 20 | 120
@@ -1286,13 +1286,14 @@ SELECT compress_chunk(c) FROM show_chunks('stattest') c;
 SELECT approximate_row_count('stattest');
  approximate_row_count 
 -----------------------
-                    26
+                     0
 (1 row)
 
-SELECT relpages, reltuples FROM pg_class WHERE relname = :statchunk;
+-- reltuples is initially -1 on PG14 before VACUUM/ANALYZE was run
+SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples FROM pg_class WHERE relname = :statchunk;
  relpages | reltuples 
 ----------+-----------
-        1 |        26
+        0 |         0
 (1 row)
 
 SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname = 'c1';
@@ -1327,17 +1328,19 @@ SELECT histogram_bounds FROM pg_stats WHERE tablename = 'stattest' AND attname =
 ------------------
 (0 rows)
 
-SELECT relpages, reltuples FROM pg_class WHERE relname = :statchunk;
+-- reltuples is initially -1 on PG14 before VACUUM/ANALYZE was run
+SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples FROM pg_class WHERE relname = :statchunk;
  relpages | reltuples 
 ----------+-----------
-        1 |        26
+        0 |         0
 (1 row)
 
 -- verify that corresponding compressed chunk's stats is updated as well.
-SELECT relpages, reltuples FROM pg_class WHERE relname = :'STAT_COMP_CHUNK_NAME';
+-- reltuples is initially -1 on PG14 before VACUUM/ANALYZE was run
+SELECT relpages, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END as reltuples FROM pg_class WHERE relname = :'STAT_COMP_CHUNK_NAME';
  relpages | reltuples 
 ----------+-----------
-        1 |         1
+        0 |         0
 (1 row)
 
 -- Verify that even a global analyze doesn't affect the chunk stats, changing message scope here
@@ -1354,14 +1357,14 @@ SELECT histogram_bounds FROM pg_stats WHERE tablename = :statchunk AND attname =
 SELECT relpages, reltuples FROM pg_class WHERE relname = :statchunk;
  relpages | reltuples 
 ----------+-----------
-        1 |        26
+        0 |         0
 (1 row)
 
 -- Verify that decompressing the chunk restores autoanalyze to the hypertable's setting
 SELECT reloptions FROM pg_class WHERE relname = :statchunk;
-         reloptions         
-----------------------------
- {autovacuum_enabled=false}
+ reloptions 
+------------
+ 
 (1 row)
 
 SELECT decompress_chunk(c) FROM show_chunks('stattest') c;
@@ -1371,9 +1374,9 @@ SELECT decompress_chunk(c) FROM show_chunks('stattest') c;
 (1 row)
 
 SELECT reloptions FROM pg_class WHERE relname = :statchunk;
-        reloptions         
----------------------------
- {autovacuum_enabled=true}
+ reloptions 
+------------
+ 
 (1 row)
 
 SELECT compress_chunk(c) FROM show_chunks('stattest') c;
@@ -1383,9 +1386,9 @@ SELECT compress_chunk(c) FROM show_chunks('stattest') c;
 (1 row)
 
 SELECT reloptions FROM pg_class WHERE relname = :statchunk;
-         reloptions         
-----------------------------
- {autovacuum_enabled=false}
+ reloptions 
+------------
+ 
 (1 row)
 
 ALTER TABLE stattest SET (autovacuum_enabled = false);
@@ -1430,7 +1433,7 @@ SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, 
 order by relname;
       relname       | reltuples | relpages | relallvisible 
 --------------------+-----------+----------+---------------
- _hyper_29_58_chunk |       200 |        2 |             0
+ _hyper_29_58_chunk |         0 |        0 |             0
  _hyper_29_59_chunk |         0 |        0 |             0
 (2 rows)
 
@@ -1470,7 +1473,7 @@ SELECT relname, CASE WHEN reltuples > 0 THEN reltuples ELSE 0 END AS reltuples, 
 ORDER BY relname;
       relname       | reltuples | relpages | relallvisible 
 --------------------+-----------+----------+---------------
- _hyper_29_58_chunk |       200 |        1 |             0
+ _hyper_29_58_chunk |         0 |        0 |             0
  _hyper_29_59_chunk |         0 |        0 |             0
 (2 rows)
 
@@ -1493,7 +1496,7 @@ SELECT relname, reltuples, relpages, relallvisible FROM pg_class
 ORDER BY relname;
       relname       | reltuples | relpages | relallvisible 
 --------------------+-----------+----------+---------------
- _hyper_29_58_chunk |       200 |        1 |             0
+ _hyper_29_58_chunk |         0 |        0 |             0
  _hyper_29_59_chunk |       200 |        2 |             0
 (2 rows)
 

--- a/tsl/test/expected/telemetry_stats-12.out
+++ b/tsl/test/expected/telemetry_stats-12.out
@@ -420,7 +420,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 122880,                    +
          "num_children": 9,                         +
          "num_relations": 1,                        +
-         "num_reltuples": 697                       +
+         "num_reltuples": 413                       +
      },                                             +
      "materialized_views": {                        +
          "toast_size": 8192,                        +
@@ -454,7 +454,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 180224,                    +
          "num_children": 4,                         +
          "num_relations": 2,                        +
-         "num_reltuples": 452,                      +
+         "num_reltuples": 0,                        +
          "num_caggs_nested": 0,                     +
          "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
@@ -792,7 +792,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 18,                        +
      "num_relations": 1,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 0,                   +
      "num_replicated_distributed_hypertables": 0+
  }
@@ -829,7 +829,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 357
+    "num_reltuples": 285
 }
 (1 row)
 
@@ -859,7 +859,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 340
+    "num_reltuples": 296
 }
 (1 row)
 
@@ -903,7 +903,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 36,                        +
      "num_relations": 2,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 18,                  +
      "num_replicated_distributed_hypertables": 1+
  }
@@ -951,10 +951,10 @@ FROM relations;
          "uncompressed_toast_size": 0,         +
          "uncompressed_indexes_size": 81920    +
      },                                        +
-     "indexes_size": 409600,                   +
+     "indexes_size": 393216,                   +
      "num_children": 8,                        +
      "num_relations": 4,                       +
-     "num_reltuples": 452,                     +
+     "num_reltuples": 0,                       +
      "num_caggs_nested": 0,                    +
      "num_caggs_finalized": 2,                 +
      "num_caggs_on_distributed_hypertables": 2,+

--- a/tsl/test/expected/telemetry_stats-13.out
+++ b/tsl/test/expected/telemetry_stats-13.out
@@ -420,7 +420,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 122880,                    +
          "num_children": 9,                         +
          "num_relations": 1,                        +
-         "num_reltuples": 697                       +
+         "num_reltuples": 413                       +
      },                                             +
      "materialized_views": {                        +
          "toast_size": 8192,                        +
@@ -454,7 +454,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 180224,                    +
          "num_children": 4,                         +
          "num_relations": 2,                        +
-         "num_reltuples": 452,                      +
+         "num_reltuples": 0,                        +
          "num_caggs_nested": 0,                     +
          "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
@@ -792,7 +792,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 18,                        +
      "num_relations": 1,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 0,                   +
      "num_replicated_distributed_hypertables": 0+
  }
@@ -829,7 +829,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 357
+    "num_reltuples": 285
 }
 (1 row)
 
@@ -859,7 +859,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 340
+    "num_reltuples": 296
 }
 (1 row)
 
@@ -903,7 +903,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 36,                        +
      "num_relations": 2,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 18,                  +
      "num_replicated_distributed_hypertables": 1+
  }
@@ -951,10 +951,10 @@ FROM relations;
          "uncompressed_toast_size": 0,         +
          "uncompressed_indexes_size": 81920    +
      },                                        +
-     "indexes_size": 409600,                   +
+     "indexes_size": 393216,                   +
      "num_children": 8,                        +
      "num_relations": 4,                       +
-     "num_reltuples": 452,                     +
+     "num_reltuples": 0,                       +
      "num_caggs_nested": 0,                    +
      "num_caggs_finalized": 2,                 +
      "num_caggs_on_distributed_hypertables": 2,+

--- a/tsl/test/expected/telemetry_stats-14.out
+++ b/tsl/test/expected/telemetry_stats-14.out
@@ -420,7 +420,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 122880,                    +
          "num_children": 9,                         +
          "num_relations": 1,                        +
-         "num_reltuples": 697                       +
+         "num_reltuples": 413                       +
      },                                             +
      "materialized_views": {                        +
          "toast_size": 8192,                        +
@@ -454,7 +454,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 180224,                    +
          "num_children": 4,                         +
          "num_relations": 2,                        +
-         "num_reltuples": 452,                      +
+         "num_reltuples": 0,                        +
          "num_caggs_nested": 0,                     +
          "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
@@ -792,7 +792,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 18,                        +
      "num_relations": 1,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 0,                   +
      "num_replicated_distributed_hypertables": 0+
  }
@@ -829,7 +829,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 357
+    "num_reltuples": 285
 }
 (1 row)
 
@@ -859,7 +859,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 340
+    "num_reltuples": 296
 }
 (1 row)
 
@@ -903,7 +903,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 36,                        +
      "num_relations": 2,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 18,                  +
      "num_replicated_distributed_hypertables": 1+
  }
@@ -951,10 +951,10 @@ FROM relations;
          "uncompressed_toast_size": 0,         +
          "uncompressed_indexes_size": 81920    +
      },                                        +
-     "indexes_size": 409600,                   +
+     "indexes_size": 393216,                   +
      "num_children": 8,                        +
      "num_relations": 4,                       +
-     "num_reltuples": 452,                     +
+     "num_reltuples": 0,                       +
      "num_caggs_nested": 0,                    +
      "num_caggs_finalized": 2,                 +
      "num_caggs_on_distributed_hypertables": 2,+

--- a/tsl/test/expected/telemetry_stats-15.out
+++ b/tsl/test/expected/telemetry_stats-15.out
@@ -420,7 +420,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 122880,                    +
          "num_children": 9,                         +
          "num_relations": 1,                        +
-         "num_reltuples": 697                       +
+         "num_reltuples": 413                       +
      },                                             +
      "materialized_views": {                        +
          "toast_size": 8192,                        +
@@ -454,7 +454,7 @@ SELECT jsonb_pretty(rels) AS relations FROM relations;
          "indexes_size": 180224,                    +
          "num_children": 4,                         +
          "num_relations": 2,                        +
-         "num_reltuples": 452,                      +
+         "num_reltuples": 0,                        +
          "num_caggs_nested": 0,                     +
          "num_caggs_finalized": 1,                  +
          "num_caggs_on_distributed_hypertables": 0, +
@@ -792,7 +792,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 18,                        +
      "num_relations": 1,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 0,                   +
      "num_replicated_distributed_hypertables": 0+
  }
@@ -829,7 +829,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 368
+    "num_reltuples": 312
 }
 (1 row)
 
@@ -859,7 +859,7 @@ distributed_hypertables_dn
     "indexes_size": 278528,
     "num_children": 9,
     "num_relations": 1,
-    "num_reltuples": 329
+    "num_reltuples": 269
 }
 (1 row)
 
@@ -903,7 +903,7 @@ FROM relations;
      "indexes_size": 0,                         +
      "num_children": 36,                        +
      "num_relations": 2,                        +
-     "num_reltuples": 697,                      +
+     "num_reltuples": 581,                      +
      "num_replica_chunks": 18,                  +
      "num_replicated_distributed_hypertables": 1+
  }
@@ -951,10 +951,10 @@ FROM relations;
          "uncompressed_toast_size": 0,         +
          "uncompressed_indexes_size": 81920    +
      },                                        +
-     "indexes_size": 409600,                   +
+     "indexes_size": 393216,                   +
      "num_children": 8,                        +
      "num_relations": 4,                       +
-     "num_reltuples": 452,                     +
+     "num_reltuples": 0,                       +
      "num_caggs_nested": 0,                    +
      "num_caggs_finalized": 2,                 +
      "num_caggs_on_distributed_hypertables": 2,+

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -1916,31 +1916,26 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=0 loops=1)
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-         Sort Key: _hyper_1_1_chunk."time"
-         Sort Method: quicksort 
+   Sort Method: quicksort 
+   ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
-         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-         Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 2520
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-         Sort Key: _hyper_1_3_chunk."time"
-         Sort Method: quicksort 
+         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
+               Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+               Filter: (_hyper_1_2_chunk.device_id_peer = 1)
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
-(24 rows)
+(19 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -2236,14 +2231,14 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Join (actual rows=10 loops=1)
-         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: m1."time", m1.device_id
-               Sort Method: quicksort 
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=6840 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
                      ->  Sort (actual rows=1800 loops=1)
@@ -2257,23 +2252,22 @@ FROM :TEST_TABLE m1
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: m2."time", m2.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
-                     Order: m2."time"
-                     ->  Sort (actual rows=1800 loops=1)
-                           Sort Key: m2_1."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
-                     ->  Sort (actual rows=2520 loops=1)
-                           Sort Key: m2_3."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
-(35 rows)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
+                           Order: m2."time"
+                           ->  Sort (actual rows=1800 loops=1)
+                                 Sort Key: m2_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
+                                 Sort Key: m2_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
+(34 rows)
 
 :PREFIX
 SELECT *
@@ -2457,14 +2451,14 @@ FROM :TEST_TABLE m1
 ORDER BY m1.time,
     m1.device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Left Join (actual rows=10 loops=1)
-         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: m1."time", m1.device_id
-               Sort Method: quicksort 
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Left Join (actual rows=6840 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
                ->  Custom Scan (ChunkAppend) on metrics m1 (actual rows=6840 loops=1)
                      Order: m1."time"
                      ->  Sort (actual rows=1800 loops=1)
@@ -2478,23 +2472,22 @@ LIMIT 10;
                            Sort Method: quicksort 
                            ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m1_3 (actual rows=2520 loops=1)
                                  ->  Seq Scan on compress_hyper_5_16_chunk (actual rows=5 loops=1)
-         ->  Sort (actual rows=10 loops=1)
-               Sort Key: m2."time", m2.device_id
-               Sort Method: quicksort 
-               ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
-                     Order: m2."time"
-                     ->  Sort (actual rows=1800 loops=1)
-                           Sort Key: m2_1."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
-                     ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
-                     ->  Sort (actual rows=2520 loops=1)
-                           Sort Key: m2_3."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
-                                 ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
-(35 rows)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
+                     ->  Custom Scan (ChunkAppend) on metrics m2 (actual rows=6840 loops=1)
+                           Order: m2."time"
+                           ->  Sort (actual rows=1800 loops=1)
+                                 Sort Key: m2_1."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m2_1 (actual rows=1800 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_15_chunk compress_hyper_5_15_chunk_1 (actual rows=5 loops=1)
+                           ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _hyper_1_2_chunk m2_2 (actual rows=2520 loops=1)
+                           ->  Sort (actual rows=2520 loops=1)
+                                 Sort Key: m2_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m2_3 (actual rows=2520 loops=1)
+                                       ->  Seq Scan on compress_hyper_5_16_chunk compress_hyper_5_16_chunk_1 (actual rows=5 loops=1)
+(34 rows)
 
 :PREFIX
 SELECT *
@@ -5444,70 +5437,49 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=0 loops=1)
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
    Sort Key: _hyper_2_4_chunk."time"
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-         Sort Key: _hyper_2_4_chunk."time"
-         Sort Method: quicksort 
+   Sort Method: quicksort 
+   ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-         Sort Key: _hyper_2_5_chunk."time"
-         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-         Sort Key: _hyper_2_6_chunk."time"
-         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-         Filter: (_hyper_2_7_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 504
-   ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-         Filter: (_hyper_2_8_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 1512
-   ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-         Filter: (_hyper_2_9_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 504
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-         Sort Key: _hyper_2_10_chunk."time"
-         Sort Method: quicksort 
+         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+               Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
+         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
+               Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
+         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
+               Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-         Sort Key: _hyper_2_11_chunk."time"
-         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-         Filter: (_hyper_2_12_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 504
-(63 rows)
+         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
+               Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
+(42 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -5969,16 +5941,16 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                  QUERY PLAN                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
-   ->  Merge Join (actual rows=10 loops=1)
-         Merge Cond: (m1."time" = m3."time")
-         ->  Merge Join (actual rows=10 loops=1)
-               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Sort (actual rows=10 loops=1)
-                     Sort Key: m1."time", m1.device_id
-                     Sort Method: quicksort 
+   ->  Sort (actual rows=10 loops=1)
+         Sort Key: m1."time", m1.device_id
+         Sort Method: top-N heapsort 
+         ->  Hash Join (actual rows=6840 loops=1)
+               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Hash Join (actual rows=6840 loops=1)
+                     Hash Cond: (m1."time" = m3."time")
                      ->  Append (actual rows=6840 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1 (actual rows=360 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
@@ -5994,9 +5966,18 @@ FROM :TEST_TABLE m1
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_7 (actual rows=1512 loops=1)
                                  ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
                            ->  Seq Scan on _hyper_2_12_chunk m1_8 (actual rows=504 loops=1)
-               ->  Sort (actual rows=10 loops=1)
-                     Sort Key: m2."time", m2.device_id
-                     Sort Method: quicksort 
+                     ->  Hash (actual rows=1368 loops=1)
+                           Buckets: 2048  Batches: 1 
+                           ->  Append (actual rows=1368 loops=1)
+                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3 (actual rows=360 loops=1)
+                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                             Filter: (device_id = 3)
+                                 ->  Seq Scan on _hyper_2_9_chunk m3_1 (actual rows=504 loops=1)
+                                       Filter: (device_id = 3)
+                                 ->  Seq Scan on _hyper_2_12_chunk m3_2 (actual rows=504 loops=1)
+                                       Filter: (device_id = 3)
+               ->  Hash (actual rows=6840 loops=1)
+                     Buckets: 16384  Batches: 1 
                      ->  Append (actual rows=6840 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2 (actual rows=360 loops=1)
                                  ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
@@ -6012,20 +5993,7 @@ FROM :TEST_TABLE m1
                            ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_7 (actual rows=1512 loops=1)
                                  ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (actual rows=3 loops=1)
                            ->  Seq Scan on _hyper_2_12_chunk m2_8 (actual rows=504 loops=1)
-         ->  Materialize (actual rows=10 loops=1)
-               ->  Merge Append (actual rows=3 loops=1)
-                     Sort Key: m3."time"
-                     ->  Sort (actual rows=3 loops=1)
-                           Sort Key: m3."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3 (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
-                                       Filter: (device_id = 3)
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_1 (actual rows=1 loops=1)
-                           Filter: (device_id = 3)
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3_2 (actual rows=1 loops=1)
-                           Filter: (device_id = 3)
-(54 rows)
+(50 rows)
 
 :PREFIX
 SELECT *

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -2056,31 +2056,26 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=0 loops=1)
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-         Sort Key: _hyper_1_1_chunk."time"
-         Sort Method: quicksort 
+   Sort Method: quicksort 
+   ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
-         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-         Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 2520
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-         Sort Key: _hyper_1_3_chunk."time"
-         Sort Method: quicksort 
+         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
+               Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+               Filter: (_hyper_1_2_chunk.device_id_peer = 1)
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
-(24 rows)
+(19 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -3245,64 +3240,32 @@ FROM :TEST_TABLE
 WHERE device_id IN (1, 2)
 ORDER BY time,
     device_id;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=2736 loops=1)
-   Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 86  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=2736 loops=1)
-         Order: metrics_space."time"
-         ->  Merge Append (actual rows=720 loops=1)
-               Sort Key: _hyper_2_4_chunk."time"
-               ->  Sort (actual rows=360 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=360 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                       Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=360 loops=1)
-                     Sort Key: _hyper_2_5_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=360 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
-                                       Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                       Rows Removed by Filter: 2
-         ->  Merge Append (actual rows=1008 loops=1)
-               Sort Key: _hyper_2_7_chunk."time"
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=504 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=2736 loops=1)
+   Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+   Sort Method: quicksort 
+   ->  Result (actual rows=2736 loops=1)
+         ->  Append (actual rows=2736 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=360 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 2
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=504 loops=1)
                      Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=504 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 1008
-         ->  Merge Append (actual rows=1008 loops=1)
-               Sort Key: _hyper_2_10_chunk."time"
-               ->  Sort (actual rows=504 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Filter: (device_id = ANY ('{1,2}'::integer[]))
-               ->  Sort (actual rows=504 loops=1)
-                     Sort Key: _hyper_2_11_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
-                                       Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                       Rows Removed by Filter: 2
-(55 rows)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=504 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=504 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=1 loops=1)
+                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           Rows Removed by Filter: 2
+(23 rows)
 
 -- test empty targetlist
 :PREFIX
@@ -3625,84 +3588,42 @@ WHERE device_id IS NULL
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 3
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 1
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+         Sort Method: quicksort 
+         ->  Append (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
+                           Rows Removed by Filter: 3
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                                             Filter: (device_id IS NULL)
-                                             Rows Removed by Filter: 3
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
+                           Rows Removed by Filter: 1
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id IS NULL)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id IS NULL)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id IS NULL)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
                            Filter: (device_id IS NULL)
-                           Rows Removed by Filter: 504
-(75 rows)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                           Filter: (device_id IS NULL)
+                           Rows Removed by Filter: 3
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id IS NULL)
+(33 rows)
 
 -- test IN (Const,Const)
 :PREFIX
@@ -4407,89 +4328,47 @@ WHERE v0 < 1
 ORDER BY time,
     device_id
 LIMIT 10;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
-   ->  Incremental Sort (actual rows=0 loops=1)
-         Sort Key: metrics_space."time", metrics_space.device_id
-         Presorted Key: metrics_space."time"
-         Full-sort Groups: 1  Sort Method: quicksort 
-         ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=0 loops=1)
-               Order: metrics_space."time"
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_4_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_5_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 3
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_6_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 1
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_7_chunk."time"
-                     ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 504
-                     ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 1512
-                     ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 504
-               ->  Merge Append (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_10_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 1
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Sort (actual rows=0 loops=1)
-                                 Sort Key: _hyper_2_11_chunk."time"
-                                 Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
-                                       Filter: (v0 < 1)
-                                       ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
-                                             Filter: (_ts_meta_min_1 < 1)
-                                             Rows Removed by Filter: 3
-                     ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=0 loops=1)
-                           Filter: (v0 < 1)
-                           Rows Removed by Filter: 504
-(80 rows)
+   ->  Sort (actual rows=0 loops=1)
+         Sort Key: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id
+         Sort Method: quicksort 
+         ->  Append (actual rows=0 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                     Filter: (v0 < 1)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_min_1 < 1)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                     Filter: (v0 < 1)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_min_1 < 1)
+                           Rows Removed by Filter: 3
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                     Filter: (v0 < 1)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_min_1 < 1)
+                           Rows Removed by Filter: 1
+               ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_7_chunk (actual rows=0 loops=1)
+                     Index Cond: (v0 < 1)
+               ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_8_chunk (actual rows=0 loops=1)
+                     Index Cond: (v0 < 1)
+               ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _hyper_2_9_chunk (actual rows=0 loops=1)
+                     Index Cond: (v0 < 1)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=0 loops=1)
+                     Filter: (v0 < 1)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_min_1 < 1)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=0 loops=1)
+                     Filter: (v0 < 1)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_min_1 < 1)
+                           Rows Removed by Filter: 3
+               ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _hyper_2_12_chunk (actual rows=0 loops=1)
+                     Index Cond: (v0 < 1)
+(38 rows)
 
 :PREFIX
 SELECT *
@@ -5208,63 +5087,41 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
-                                                                                                                                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                                                                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
-   Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-   Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on public.metrics_space (actual rows=4195 loops=1)
-         Output: metrics_space."time", metrics_space.device_id, metrics_space.device_id_peer, metrics_space.v0, metrics_space.v1, metrics_space.v2, metrics_space.v3
-         Order: metrics_space."time"
-         Startup Exclusion: false
-         Runtime Exclusion: false
-         ->  Merge Append (actual rows=1675 loops=1)
-               Sort Key: _hyper_2_7_chunk."time"
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
-                     Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-                     Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
-                     Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-                     Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
-                     Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-                     Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Merge Append (actual rows=2520 loops=1)
-               Sort Key: _hyper_2_10_chunk."time"
-               ->  Sort (actual rows=504 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Sort Key: _hyper_2_10_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
-                                 Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                                 Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Sort (actual rows=1512 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Sort Key: _hyper_2_11_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=1512 loops=1)
-                           Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                                 Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                                       Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
-                     Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-                     Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(54 rows)
+                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
+   Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+   Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
+               Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+               Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
+               Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
+               Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
+               Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
+               Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
+               Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
+               Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
+               Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
+               Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+(32 rows)
 
 -- should produce ordered path
 :PREFIX_VERBOSE
@@ -5519,48 +5376,41 @@ ORDER BY device_id,
     v1 DESC,
     time,
     v3;
-                                                                                                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
+                                                                                                                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
    Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
    Sort Key: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1 DESC, _hyper_2_7_chunk."time", _hyper_2_7_chunk.v3
-   Presorted Key: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk."time"
-   Full-sort Groups: 132  Sort Method: quicksort 
-   ->  Merge Append (actual rows=4195 loops=1)
-         Sort Key: _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1 DESC, _hyper_2_7_chunk."time"
-         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
+   Sort Method: quicksort 
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_7_chunk (actual rows=335 loops=1)
                Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-               Index Cond: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
+               Filter: (_hyper_2_7_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _timescaledb_internal._hyper_2_8_chunk (actual rows=1005 loops=1)
                Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-               Index Cond: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_t on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
+               Filter: (_hyper_2_8_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _timescaledb_internal._hyper_2_9_chunk (actual rows=335 loops=1)
                Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-               Index Cond: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=504 loops=1)
+               Filter: (_hyper_2_9_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-               Sort Key: _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1 DESC, _hyper_2_10_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=504 loops=1)
-                     Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-                     Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                           Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Sort (actual rows=1512 loops=1)
+               Filter: (_hyper_2_10_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_20_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-               Sort Key: _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1 DESC, _hyper_2_11_chunk."time"
-               Sort Method: quicksort 
-               ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=1512 loops=1)
-                     Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-                     Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                     ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                           Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
-                           Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v1_ on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
+               Filter: (_hyper_2_11_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
+                     Filter: (compress_hyper_6_21_chunk._ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _timescaledb_internal._hyper_2_12_chunk (actual rows=504 loops=1)
                Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-               Index Cond: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(39 rows)
+               Filter: (_hyper_2_12_chunk."time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+(32 rows)
 
 -- should produce ordered path
 -- ASC/DESC for segmentby columns can be pushed down
@@ -5668,47 +5518,32 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'
 ORDER BY time,
     device_id;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
-   Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
-   ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=4195 loops=1)
-         Order: metrics_space."time"
-         ->  Merge Append (actual rows=1675 loops=1)
-               Sort Key: _hyper_2_7_chunk."time"
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1005 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-         ->  Merge Append (actual rows=2520 loops=1)
-               Sort Key: _hyper_2_10_chunk."time"
-               ->  Sort (actual rows=504 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Sort (actual rows=1512 loops=1)
-                     Sort Key: _hyper_2_11_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=1512 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
-                     Index Cond: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
-(38 rows)
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
+   Sort Key: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id
+   Sort Method: quicksort 
+   ->  Append (actual rows=4195 loops=1)
+         ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Seq Scan on _hyper_2_8_chunk (actual rows=1005 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 507
+         ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               Rows Removed by Filter: 169
+         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+               ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                     Filter: (_ts_meta_max_3 > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+         ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+               Filter: ("time" > 'Sat Jan 08 00:00:00 2000 PST'::timestamp with time zone)
+(23 rows)
 
 -- test runtime exclusion
 -- first chunk should be excluded
@@ -5718,82 +5553,49 @@ FROM :TEST_TABLE
 WHERE time > '2000-01-08'::text::timestamptz
 ORDER BY time,
     device_id;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Incremental Sort (actual rows=4195 loops=1)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Sort (actual rows=4195 loops=1)
    Sort Key: metrics_space."time", metrics_space.device_id
-   Presorted Key: metrics_space."time"
-   Full-sort Groups: 120  Sort Method: quicksort 
+   Sort Method: quicksort 
    ->  Custom Scan (ChunkAppend) on metrics_space (actual rows=4195 loops=1)
-         Order: metrics_space."time"
          ->  Merge Append (actual rows=0 loops=1)
-               Sort Key: _hyper_2_4_chunk."time"
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_4_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_4_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-                                       Rows Removed by Filter: 1
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_5_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_5_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-                                       Rows Removed by Filter: 3
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: _hyper_2_6_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=0 loops=1)
-                           Sort Key: _hyper_2_6_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-                                       Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk (actual rows=0 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 1
+               ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk (actual rows=0 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 3
+               ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk (actual rows=0 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=0 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+                           Rows Removed by Filter: 1
          ->  Merge Append (actual rows=1675 loops=1)
-               Sort Key: _hyper_2_7_chunk."time"
-               ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_7_chunk (actual rows=335 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Rows Removed by Filter: 169
                ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk (actual rows=1005 loops=1)
                      Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk (actual rows=335 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_9_chunk (actual rows=335 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     Rows Removed by Filter: 169
          ->  Merge Append (actual rows=2520 loops=1)
-               Sort Key: _hyper_2_10_chunk."time"
-               ->  Sort (actual rows=504 loops=1)
-                     Sort Key: _hyper_2_10_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=504 loops=1)
-                           Sort Key: _hyper_2_10_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1512 loops=1)
-                     Sort Key: _hyper_2_11_chunk."time"
-                     Sort Method: quicksort 
-                     ->  Sort (actual rows=1512 loops=1)
-                           Sort Key: _hyper_2_11_chunk."time"
-                           Sort Method: quicksort 
-                           ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
-                                 Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-                                 ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
-                                       Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
-               ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk (actual rows=504 loops=1)
-                     Index Cond: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
-(73 rows)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk (actual rows=504 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_20_chunk (actual rows=1 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+               ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk (actual rows=1512 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+                     ->  Seq Scan on compress_hyper_6_21_chunk (actual rows=3 loops=1)
+                           Filter: (_ts_meta_max_3 > ('2000-01-08'::cstring)::timestamp with time zone)
+               ->  Seq Scan on _hyper_2_12_chunk (actual rows=504 loops=1)
+                     Filter: ("time" > ('2000-01-08'::cstring)::timestamp with time zone)
+(40 rows)
 
 -- test aggregate
 :PREFIX
@@ -6285,70 +6087,49 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=0 loops=1)
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
    Sort Key: _hyper_2_4_chunk."time"
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
-         Sort Key: _hyper_2_4_chunk."time"
-         Sort Method: quicksort 
+   Sort Method: quicksort 
+   ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_4_chunk (actual rows=0 loops=1)
                Output: _hyper_2_4_chunk."time", _hyper_2_4_chunk.device_id, _hyper_2_4_chunk.device_id_peer, _hyper_2_4_chunk.v0, _hyper_2_4_chunk.v1, _hyper_2_4_chunk.v2, _hyper_2_4_chunk.v3
                ->  Index Scan using compress_hyper_6_17_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_17_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_17_chunk."time", compress_hyper_6_17_chunk.device_id, compress_hyper_6_17_chunk.device_id_peer, compress_hyper_6_17_chunk.v0, compress_hyper_6_17_chunk.v1, compress_hyper_6_17_chunk.v2, compress_hyper_6_17_chunk.v3, compress_hyper_6_17_chunk._ts_meta_count, compress_hyper_6_17_chunk._ts_meta_sequence_num, compress_hyper_6_17_chunk._ts_meta_min_3, compress_hyper_6_17_chunk._ts_meta_max_3, compress_hyper_6_17_chunk._ts_meta_min_1, compress_hyper_6_17_chunk._ts_meta_max_1, compress_hyper_6_17_chunk._ts_meta_min_2, compress_hyper_6_17_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_17_chunk.device_id_peer = 1)
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
-         Sort Key: _hyper_2_5_chunk."time"
-         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_5_chunk (actual rows=0 loops=1)
                Output: _hyper_2_5_chunk."time", _hyper_2_5_chunk.device_id, _hyper_2_5_chunk.device_id_peer, _hyper_2_5_chunk.v0, _hyper_2_5_chunk.v1, _hyper_2_5_chunk.v2, _hyper_2_5_chunk.v3
                ->  Index Scan using compress_hyper_6_18_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_18_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_18_chunk."time", compress_hyper_6_18_chunk.device_id, compress_hyper_6_18_chunk.device_id_peer, compress_hyper_6_18_chunk.v0, compress_hyper_6_18_chunk.v1, compress_hyper_6_18_chunk.v2, compress_hyper_6_18_chunk.v3, compress_hyper_6_18_chunk._ts_meta_count, compress_hyper_6_18_chunk._ts_meta_sequence_num, compress_hyper_6_18_chunk._ts_meta_min_3, compress_hyper_6_18_chunk._ts_meta_max_3, compress_hyper_6_18_chunk._ts_meta_min_1, compress_hyper_6_18_chunk._ts_meta_max_1, compress_hyper_6_18_chunk._ts_meta_min_2, compress_hyper_6_18_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_18_chunk.device_id_peer = 1)
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
-         Sort Key: _hyper_2_6_chunk."time"
-         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_6_chunk (actual rows=0 loops=1)
                Output: _hyper_2_6_chunk."time", _hyper_2_6_chunk.device_id, _hyper_2_6_chunk.device_id_peer, _hyper_2_6_chunk.v0, _hyper_2_6_chunk.v1, _hyper_2_6_chunk.v2, _hyper_2_6_chunk.v3
                ->  Index Scan using compress_hyper_6_19_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_19_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_19_chunk."time", compress_hyper_6_19_chunk.device_id, compress_hyper_6_19_chunk.device_id_peer, compress_hyper_6_19_chunk.v0, compress_hyper_6_19_chunk.v1, compress_hyper_6_19_chunk.v2, compress_hyper_6_19_chunk.v3, compress_hyper_6_19_chunk._ts_meta_count, compress_hyper_6_19_chunk._ts_meta_sequence_num, compress_hyper_6_19_chunk._ts_meta_min_3, compress_hyper_6_19_chunk._ts_meta_max_3, compress_hyper_6_19_chunk._ts_meta_min_1, compress_hyper_6_19_chunk._ts_meta_max_1, compress_hyper_6_19_chunk._ts_meta_min_2, compress_hyper_6_19_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_19_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
-         Filter: (_hyper_2_7_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 504
-   ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
-         Filter: (_hyper_2_8_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 1512
-   ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
-         Filter: (_hyper_2_9_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 504
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
-         Sort Key: _hyper_2_10_chunk."time"
-         Sort Method: quicksort 
+         ->  Index Scan using _hyper_2_7_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_7_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_7_chunk."time", _hyper_2_7_chunk.device_id, _hyper_2_7_chunk.device_id_peer, _hyper_2_7_chunk.v0, _hyper_2_7_chunk.v1, _hyper_2_7_chunk.v2, _hyper_2_7_chunk.v3
+               Index Cond: (_hyper_2_7_chunk.device_id_peer = 1)
+         ->  Index Scan using _hyper_2_8_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_8_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_8_chunk."time", _hyper_2_8_chunk.device_id, _hyper_2_8_chunk.device_id_peer, _hyper_2_8_chunk.v0, _hyper_2_8_chunk.v1, _hyper_2_8_chunk.v2, _hyper_2_8_chunk.v3
+               Index Cond: (_hyper_2_8_chunk.device_id_peer = 1)
+         ->  Index Scan using _hyper_2_9_chunk_metrics_space_device_id_device_id_peer_v0_v1_2 on _timescaledb_internal._hyper_2_9_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_9_chunk."time", _hyper_2_9_chunk.device_id, _hyper_2_9_chunk.device_id_peer, _hyper_2_9_chunk.v0, _hyper_2_9_chunk.v1, _hyper_2_9_chunk.v2, _hyper_2_9_chunk.v3
+               Index Cond: (_hyper_2_9_chunk.device_id_peer = 1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_10_chunk (actual rows=0 loops=1)
                Output: _hyper_2_10_chunk."time", _hyper_2_10_chunk.device_id, _hyper_2_10_chunk.device_id_peer, _hyper_2_10_chunk.v0, _hyper_2_10_chunk.v1, _hyper_2_10_chunk.v2, _hyper_2_10_chunk.v3
                ->  Index Scan using compress_hyper_6_20_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_20_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_20_chunk."time", compress_hyper_6_20_chunk.device_id, compress_hyper_6_20_chunk.device_id_peer, compress_hyper_6_20_chunk.v0, compress_hyper_6_20_chunk.v1, compress_hyper_6_20_chunk.v2, compress_hyper_6_20_chunk.v3, compress_hyper_6_20_chunk._ts_meta_count, compress_hyper_6_20_chunk._ts_meta_sequence_num, compress_hyper_6_20_chunk._ts_meta_min_3, compress_hyper_6_20_chunk._ts_meta_max_3, compress_hyper_6_20_chunk._ts_meta_min_1, compress_hyper_6_20_chunk._ts_meta_max_1, compress_hyper_6_20_chunk._ts_meta_min_2, compress_hyper_6_20_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_20_chunk.device_id_peer = 1)
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
-         Sort Key: _hyper_2_11_chunk."time"
-         Sort Method: quicksort 
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_2_11_chunk (actual rows=0 loops=1)
                Output: _hyper_2_11_chunk."time", _hyper_2_11_chunk.device_id, _hyper_2_11_chunk.device_id_peer, _hyper_2_11_chunk.v0, _hyper_2_11_chunk.v1, _hyper_2_11_chunk.v2, _hyper_2_11_chunk.v3
                ->  Index Scan using compress_hyper_6_21_chunk__compressed_hypertable_6_device_id_pe on _timescaledb_internal.compress_hyper_6_21_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_6_21_chunk."time", compress_hyper_6_21_chunk.device_id, compress_hyper_6_21_chunk.device_id_peer, compress_hyper_6_21_chunk.v0, compress_hyper_6_21_chunk.v1, compress_hyper_6_21_chunk.v2, compress_hyper_6_21_chunk.v3, compress_hyper_6_21_chunk._ts_meta_count, compress_hyper_6_21_chunk._ts_meta_sequence_num, compress_hyper_6_21_chunk._ts_meta_min_3, compress_hyper_6_21_chunk._ts_meta_max_3, compress_hyper_6_21_chunk._ts_meta_min_1, compress_hyper_6_21_chunk._ts_meta_max_1, compress_hyper_6_21_chunk._ts_meta_min_2, compress_hyper_6_21_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_6_21_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
-         Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
-         Filter: (_hyper_2_12_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 504
-(63 rows)
+         ->  Index Scan using _hyper_2_12_chunk_metrics_space_device_id_device_id_peer_v0_v_2 on _timescaledb_internal._hyper_2_12_chunk (actual rows=0 loops=1)
+               Output: _hyper_2_12_chunk."time", _hyper_2_12_chunk.device_id, _hyper_2_12_chunk.device_id_peer, _hyper_2_12_chunk.v0, _hyper_2_12_chunk.v1, _hyper_2_12_chunk.v2, _hyper_2_12_chunk.v3
+               Index Cond: (_hyper_2_12_chunk.device_id_peer = 1)
+(42 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer
@@ -6878,129 +6659,129 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
-                                                                       QUERY PLAN                                                                        
----------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10 loops=1)
    ->  Incremental Sort (actual rows=10 loops=1)
          Sort Key: m1."time", m1.device_id
          Presorted Key: m1."time"
          Full-sort Groups: 1  Sort Method: quicksort 
          ->  Merge Join (actual rows=11 loops=1)
-               Merge Cond: (m1."time" = m3_1."time")
-               ->  Merge Join (actual rows=11 loops=1)
-                     Merge Cond: (m1."time" = m2."time")
-                     Join Filter: (m1.device_id = m2.device_id)
-                     Rows Removed by Join Filter: 40
-                     ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=11 loops=1)
-                           Order: m1."time"
-                           ->  Merge Append (actual rows=11 loops=1)
-                                 Sort Key: m1_1."time"
-                                 ->  Sort (actual rows=3 loops=1)
-                                       Sort Key: m1_1."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m1_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
-                                 ->  Sort (actual rows=7 loops=1)
-                                       Sort Key: m1_2."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=1080 loops=1)
-                                             Sort Key: m1_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
-                                 ->  Sort (actual rows=3 loops=1)
-                                       Sort Key: m1_3."time"
-                                       Sort Method: quicksort 
-                                       ->  Sort (actual rows=360 loops=1)
-                                             Sort Key: m1_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
-                                                   ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
-                           ->  Merge Append (never executed)
-                                 Sort Key: m1_4."time"
-                                 ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
-                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
-                           ->  Merge Append (never executed)
-                                 Sort Key: m1_7."time"
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m1_7."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
-                                 ->  Sort (never executed)
-                                       Sort Key: m1_8."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m1_8."time"
-                                             ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
-                                                   ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
-                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
-                     ->  Materialize (actual rows=51 loops=1)
-                           ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
-                                 Order: m2."time"
-                                 ->  Merge Append (actual rows=11 loops=1)
-                                       Sort Key: m2_1."time"
-                                       ->  Sort (actual rows=3 loops=1)
-                                             Sort Key: m2_1."time"
-                                             Sort Method: quicksort 
-                                             ->  Sort (actual rows=360 loops=1)
-                                                   Sort Key: m2_1."time"
-                                                   Sort Method: quicksort 
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
-                                       ->  Sort (actual rows=7 loops=1)
-                                             Sort Key: m2_2."time"
-                                             Sort Method: quicksort 
-                                             ->  Sort (actual rows=1080 loops=1)
-                                                   Sort Key: m2_2."time"
-                                                   Sort Method: quicksort 
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
-                                       ->  Sort (actual rows=3 loops=1)
-                                             Sort Key: m2_3."time"
-                                             Sort Method: quicksort 
-                                             ->  Sort (actual rows=360 loops=1)
-                                                   Sort Key: m2_3."time"
-                                                   Sort Method: quicksort 
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
-                                                         ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
-                                 ->  Merge Append (never executed)
-                                       Sort Key: m2_4."time"
-                                       ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
-                                       ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
-                                       ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
-                                 ->  Merge Append (never executed)
-                                       Sort Key: m2_7."time"
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_7."time"
-                                             ->  Sort (never executed)
-                                                   Sort Key: m2_7."time"
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
-                                       ->  Sort (never executed)
-                                             Sort Key: m2_8."time"
-                                             ->  Sort (never executed)
-                                                   Sort Key: m2_8."time"
-                                                   ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
-                                                         ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
-                                       ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
-               ->  Materialize (actual rows=11 loops=1)
-                     ->  Merge Append (actual rows=3 loops=1)
-                           Sort Key: m3_1."time"
+               Merge Cond: (m2."time" = m1."time")
+               Join Filter: (m1.device_id = m2.device_id)
+               Rows Removed by Join Filter: 40
+               ->  Custom Scan (ChunkAppend) on metrics_space m2 (actual rows=11 loops=1)
+                     Order: m2."time"
+                     ->  Merge Append (actual rows=11 loops=1)
+                           Sort Key: m2_1."time"
                            ->  Sort (actual rows=3 loops=1)
-                                 Sort Key: m3_1."time"
+                                 Sort Key: m2_1."time"
                                  Sort Method: quicksort 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
-                                       ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
-                                             Filter: (device_id = 3)
-                           ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
-                                 Filter: (device_id = 3)
-                           ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3_3 (actual rows=1 loops=1)
-                                 Filter: (device_id = 3)
+                                 ->  Sort (actual rows=360 loops=1)
+                                       Sort Key: m2_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m2_1 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_17_chunk compress_hyper_6_17_chunk_1 (actual rows=1 loops=1)
+                           ->  Sort (actual rows=7 loops=1)
+                                 Sort Key: m2_2."time"
+                                 Sort Method: quicksort 
+                                 ->  Sort (actual rows=1080 loops=1)
+                                       Sort Key: m2_2."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m2_2 (actual rows=1080 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_18_chunk compress_hyper_6_18_chunk_1 (actual rows=3 loops=1)
+                           ->  Sort (actual rows=3 loops=1)
+                                 Sort Key: m2_3."time"
+                                 Sort Method: quicksort 
+                                 ->  Sort (actual rows=360 loops=1)
+                                       Sort Key: m2_3."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m2_3 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_1 (actual rows=1 loops=1)
+                     ->  Merge Append (never executed)
+                           Sort Key: m2_4."time"
+                           ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m2_4 (never executed)
+                           ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m2_5 (never executed)
+                           ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m2_6 (never executed)
+                     ->  Merge Append (never executed)
+                           Sort Key: m2_7."time"
+                           ->  Sort (never executed)
+                                 Sort Key: m2_7."time"
+                                 ->  Sort (never executed)
+                                       Sort Key: m2_7."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m2_7 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_20_chunk compress_hyper_6_20_chunk_1 (never executed)
+                           ->  Sort (never executed)
+                                 Sort Key: m2_8."time"
+                                 ->  Sort (never executed)
+                                       Sort Key: m2_8."time"
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m2_8 (never executed)
+                                             ->  Seq Scan on compress_hyper_6_21_chunk compress_hyper_6_21_chunk_1 (never executed)
+                           ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m2_9 (never executed)
+               ->  Materialize (actual rows=51 loops=1)
+                     ->  Merge Join (actual rows=11 loops=1)
+                           Merge Cond: (m3_1."time" = m1."time")
+                           ->  Merge Append (actual rows=3 loops=1)
+                                 Sort Key: m3_1."time"
+                                 ->  Sort (actual rows=3 loops=1)
+                                       Sort Key: m3_1."time"
+                                       Sort Method: quicksort 
+                                       ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m3_1 (actual rows=360 loops=1)
+                                             ->  Seq Scan on compress_hyper_6_19_chunk compress_hyper_6_19_chunk_2 (actual rows=1 loops=1)
+                                                   Filter: (device_id = 3)
+                                 ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m3_2 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+                                 ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m3_3 (actual rows=1 loops=1)
+                                       Filter: (device_id = 3)
+                           ->  Materialize (actual rows=11 loops=1)
+                                 ->  Custom Scan (ChunkAppend) on metrics_space m1 (actual rows=11 loops=1)
+                                       Order: m1."time"
+                                       ->  Merge Append (actual rows=11 loops=1)
+                                             Sort Key: m1_1."time"
+                                             ->  Sort (actual rows=3 loops=1)
+                                                   Sort Key: m1_1."time"
+                                                   Sort Method: quicksort 
+                                                   ->  Sort (actual rows=360 loops=1)
+                                                         Sort Key: m1_1."time"
+                                                         Sort Method: quicksort 
+                                                         ->  Custom Scan (DecompressChunk) on _hyper_2_4_chunk m1_1 (actual rows=360 loops=1)
+                                                               ->  Seq Scan on compress_hyper_6_17_chunk (actual rows=1 loops=1)
+                                             ->  Sort (actual rows=7 loops=1)
+                                                   Sort Key: m1_2."time"
+                                                   Sort Method: quicksort 
+                                                   ->  Sort (actual rows=1080 loops=1)
+                                                         Sort Key: m1_2."time"
+                                                         Sort Method: quicksort 
+                                                         ->  Custom Scan (DecompressChunk) on _hyper_2_5_chunk m1_2 (actual rows=1080 loops=1)
+                                                               ->  Seq Scan on compress_hyper_6_18_chunk (actual rows=3 loops=1)
+                                             ->  Sort (actual rows=3 loops=1)
+                                                   Sort Key: m1_3."time"
+                                                   Sort Method: quicksort 
+                                                   ->  Sort (actual rows=360 loops=1)
+                                                         Sort Key: m1_3."time"
+                                                         Sort Method: quicksort 
+                                                         ->  Custom Scan (DecompressChunk) on _hyper_2_6_chunk m1_3 (actual rows=360 loops=1)
+                                                               ->  Seq Scan on compress_hyper_6_19_chunk (actual rows=1 loops=1)
+                                       ->  Merge Append (never executed)
+                                             Sort Key: m1_4."time"
+                                             ->  Index Scan Backward using _hyper_2_7_chunk_metrics_space_time_idx on _hyper_2_7_chunk m1_4 (never executed)
+                                             ->  Index Scan Backward using _hyper_2_8_chunk_metrics_space_time_idx on _hyper_2_8_chunk m1_5 (never executed)
+                                             ->  Index Scan Backward using _hyper_2_9_chunk_metrics_space_time_idx on _hyper_2_9_chunk m1_6 (never executed)
+                                       ->  Merge Append (never executed)
+                                             Sort Key: m1_7."time"
+                                             ->  Sort (never executed)
+                                                   Sort Key: m1_7."time"
+                                                   ->  Sort (never executed)
+                                                         Sort Key: m1_7."time"
+                                                         ->  Custom Scan (DecompressChunk) on _hyper_2_10_chunk m1_7 (never executed)
+                                                               ->  Seq Scan on compress_hyper_6_20_chunk (never executed)
+                                             ->  Sort (never executed)
+                                                   Sort Key: m1_8."time"
+                                                   ->  Sort (never executed)
+                                                         Sort Key: m1_8."time"
+                                                         ->  Custom Scan (DecompressChunk) on _hyper_2_11_chunk m1_8 (never executed)
+                                                               ->  Seq Scan on compress_hyper_6_21_chunk (never executed)
+                                             ->  Index Scan Backward using _hyper_2_12_chunk_metrics_space_time_idx on _hyper_2_12_chunk m1_9 (never executed)
 (121 rows)
 
 :PREFIX

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -2056,31 +2056,26 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=0 loops=1)
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-         Sort Key: _hyper_1_1_chunk."time"
-         Sort Method: quicksort 
+   Sort Method: quicksort 
+   ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
-         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-         Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 2520
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-         Sort Key: _hyper_1_3_chunk."time"
-         Sort Method: quicksort 
+         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
+               Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+               Filter: (_hyper_1_2_chunk.device_id_peer = 1)
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
-(24 rows)
+(19 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -2057,31 +2057,26 @@ ORDER BY device_id_peer,
     time;
                                                                                                                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                                                                                                                         
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Merge Append (actual rows=0 loops=1)
+ Sort (actual rows=0 loops=1)
+   Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
-         Sort Key: _hyper_1_1_chunk."time"
-         Sort Method: quicksort 
+   Sort Method: quicksort 
+   ->  Append (actual rows=0 loops=1)
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_1_chunk (actual rows=0 loops=1)
                Output: _hyper_1_1_chunk."time", _hyper_1_1_chunk.device_id, _hyper_1_1_chunk.device_id_peer, _hyper_1_1_chunk.v0, _hyper_1_1_chunk.v1, _hyper_1_1_chunk.v2, _hyper_1_1_chunk.v3
                ->  Index Scan using compress_hyper_5_15_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_15_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_15_chunk."time", compress_hyper_5_15_chunk.device_id, compress_hyper_5_15_chunk.device_id_peer, compress_hyper_5_15_chunk.v0, compress_hyper_5_15_chunk.v1, compress_hyper_5_15_chunk.v2, compress_hyper_5_15_chunk.v3, compress_hyper_5_15_chunk._ts_meta_count, compress_hyper_5_15_chunk._ts_meta_sequence_num, compress_hyper_5_15_chunk._ts_meta_min_3, compress_hyper_5_15_chunk._ts_meta_max_3, compress_hyper_5_15_chunk._ts_meta_min_1, compress_hyper_5_15_chunk._ts_meta_max_1, compress_hyper_5_15_chunk._ts_meta_min_2, compress_hyper_5_15_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_15_chunk.device_id_peer = 1)
-   ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
-         Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
-         Filter: (_hyper_1_2_chunk.device_id_peer = 1)
-         Rows Removed by Filter: 2520
-   ->  Sort (actual rows=0 loops=1)
-         Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
-         Sort Key: _hyper_1_3_chunk."time"
-         Sort Method: quicksort 
+         ->  Index Scan Backward using _hyper_1_2_chunk_metrics_time_idx on _timescaledb_internal._hyper_1_2_chunk (actual rows=0 loops=1)
+               Output: _hyper_1_2_chunk."time", _hyper_1_2_chunk.device_id, _hyper_1_2_chunk.device_id_peer, _hyper_1_2_chunk.v0, _hyper_1_2_chunk.v1, _hyper_1_2_chunk.v2, _hyper_1_2_chunk.v3
+               Filter: (_hyper_1_2_chunk.device_id_peer = 1)
+               Rows Removed by Filter: 2520
          ->  Custom Scan (DecompressChunk) on _timescaledb_internal._hyper_1_3_chunk (actual rows=0 loops=1)
                Output: _hyper_1_3_chunk."time", _hyper_1_3_chunk.device_id, _hyper_1_3_chunk.device_id_peer, _hyper_1_3_chunk.v0, _hyper_1_3_chunk.v1, _hyper_1_3_chunk.v2, _hyper_1_3_chunk.v3
                ->  Index Scan using compress_hyper_5_16_chunk__compressed_hypertable_5_device_id_pe on _timescaledb_internal.compress_hyper_5_16_chunk (actual rows=0 loops=1)
                      Output: compress_hyper_5_16_chunk."time", compress_hyper_5_16_chunk.device_id, compress_hyper_5_16_chunk.device_id_peer, compress_hyper_5_16_chunk.v0, compress_hyper_5_16_chunk.v1, compress_hyper_5_16_chunk.v2, compress_hyper_5_16_chunk.v3, compress_hyper_5_16_chunk._ts_meta_count, compress_hyper_5_16_chunk._ts_meta_sequence_num, compress_hyper_5_16_chunk._ts_meta_min_3, compress_hyper_5_16_chunk._ts_meta_max_3, compress_hyper_5_16_chunk._ts_meta_min_1, compress_hyper_5_16_chunk._ts_meta_max_1, compress_hyper_5_16_chunk._ts_meta_min_2, compress_hyper_5_16_chunk._ts_meta_max_2
                      Index Cond: (compress_hyper_5_16_chunk.device_id_peer = 1)
-(24 rows)
+(19 rows)
 
 :PREFIX_VERBOSE
 SELECT device_id_peer

--- a/tsl/test/isolation/expected/compression_chunk_race.out
+++ b/tsl/test/isolation/expected/compression_chunk_race.out
@@ -38,10 +38,10 @@ step s3_unlock_compression:
     SELECT locktype, mode, granted, objid FROM pg_locks WHERE not granted AND (locktype = 'advisory' or relation::regclass::text LIKE '%chunk') ORDER BY relation, locktype, mode, granted;
     SELECT debug_waitpoint_release('compress_chunk_impl_start');
 
-locktype|mode     |granted|     objid
---------+---------+-------+----------
-relation|ShareLock|f      |          
-advisory|ShareLock|f      |3379597659
+locktype|mode         |granted|     objid
+--------+-------------+-------+----------
+relation|ExclusiveLock|f      |          
+advisory|ShareLock    |f      |3379597659
 (2 rows)
 
 debug_waitpoint_release

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -74,6 +74,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_internal.first_sfunc(internal,anyelement,"any")
  _timescaledb_internal.freeze_chunk(regclass)
  _timescaledb_internal.generate_uuid()
+ _timescaledb_internal.get_approx_row_count(regclass)
  _timescaledb_internal.get_chunk_colstats(regclass)
  _timescaledb_internal.get_chunk_relstats(regclass)
  _timescaledb_internal.get_create_command(name)

--- a/tsl/test/shared/expected/ordered_append_join-12.out
+++ b/tsl/test/shared/expected/ordered_append_join-12.out
@@ -2495,11 +2495,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1."time" = o2."time") AND (o1.device_id = o2.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1."time", o1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2507,16 +2507,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2."time", o2.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -3585,11 +3586,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1."time" = o2."time") AND (o1.device_id = o2.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1."time", o1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3609,28 +3610,29 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_8 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=10794 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2."time", o2.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=10794 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(47 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-13.out
+++ b/tsl/test/shared/expected/ordered_append_join-13.out
@@ -2495,11 +2495,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2507,16 +2507,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -3585,11 +3586,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3609,28 +3610,29 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(47 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -2495,11 +2495,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2507,16 +2507,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -3585,11 +3586,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3609,28 +3610,29 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(47 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -2511,11 +2511,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2523,16 +2523,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -3605,11 +3606,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3629,28 +3630,29 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(47 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/transparent_decompress_chunk-12.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-12.out
@@ -666,18 +666,19 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m2."time", m2.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(13 rows)
 
 :PREFIX
 SELECT *
@@ -691,24 +692,24 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
+   ->  Nested Loop (actual rows=10 loops=1)
+         Join Filter: (m1."time" = m3."time")
+         Rows Removed by Join Filter: 35969
+         ->  Merge Join (actual rows=10 loops=1)
+               Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=10)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=10)
+                     Index Cond: (device_id = 3)
 (19 rows)
 
 :PREFIX
@@ -780,18 +781,19 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m2."time", m2.device_id
+               Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(13 rows)
 
 :PREFIX
 SELECT *
@@ -806,21 +808,26 @@ ORDER BY m1.time,
 LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: (m1."time" = m2."time")
-               Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 14392
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                                 Index Cond: (device_id = 2)
-(15 rows)
+   ->  Gather Merge (actual rows=100 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=90 loops=2)
+               Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: top-N heapsort 
+               ->  Parallel Hash Left Join (actual rows=8995 loops=2)
+                     Hash Cond: (m1."time" = m2."time")
+                     Join Filter: (m1.device_id = 1)
+                     Rows Removed by Join Filter: 7196
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+                     ->  Parallel Hash (actual rows=1799 loops=2)
+                           Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                                       Filter: (device_id = 2)
+                                       Rows Removed by Filter: 16
+(20 rows)
 
 SET parallel_leader_participation TO false;
 -- test implicit self-join

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -668,18 +668,21 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+   ->  Nested Loop (actual rows=10 loops=1)
+         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         Rows Removed by Join Filter: 179889
+         ->  Gather Merge (actual rows=10 loops=1)
+               Workers Planned: 1
+               Workers Launched: 1
+               ->  Sort (actual rows=304 loops=2)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
+                     Worker 0:  Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+(15 rows)
 
 :PREFIX
 SELECT *
@@ -693,25 +696,27 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
-(19 rows)
+   ->  Nested Loop (actual rows=10 loops=1)
+         Join Filter: (m1."time" = m3."time")
+         Rows Removed by Join Filter: 35969
+         ->  Nested Loop (actual rows=10 loops=1)
+               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               Rows Removed by Join Filter: 179889
+               ->  Gather Merge (actual rows=10 loops=1)
+                     Workers Planned: 1
+                     Workers Launched: 1
+                     ->  Sort (actual rows=304 loops=2)
+                           Sort Key: m1."time", m1.device_id
+                           Sort Method: quicksort 
+                           Worker 0:  Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=10)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=10)
+                     Index Cond: (device_id = 3)
+(21 rows)
 
 :PREFIX
 SELECT *
@@ -782,18 +787,21 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+   ->  Nested Loop Left Join (actual rows=10 loops=1)
+         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         Rows Removed by Join Filter: 179889
+         ->  Gather Merge (actual rows=10 loops=1)
+               Workers Planned: 1
+               Workers Launched: 1
+               ->  Sort (actual rows=5 loops=2)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
+                     Worker 0:  Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+(15 rows)
 
 :PREFIX
 SELECT *
@@ -808,21 +816,26 @@ ORDER BY m1.time,
 LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
+   ->  Incremental Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: (m1."time" = m2."time")
+         Presorted Key: m1."time"
+         Full-sort Groups: 3  Sort Method: quicksort 
+         ->  Merge Left Join (actual rows=101 loops=1)
+               Merge Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 14392
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+               Rows Removed by Join Filter: 81
+               ->  Sort (actual rows=101 loops=1)
+                     Sort Key: m1."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=102 loops=1)
+                     Sort Key: m2."time"
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
                                  Index Cond: (device_id = 2)
-(15 rows)
+(20 rows)
 
 SET parallel_leader_participation TO false;
 -- test implicit self-join

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -668,18 +668,21 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+   ->  Nested Loop (actual rows=10 loops=1)
+         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         Rows Removed by Join Filter: 179889
+         ->  Gather Merge (actual rows=10 loops=1)
+               Workers Planned: 1
+               Workers Launched: 1
+               ->  Sort (actual rows=5 loops=2)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
+                     Worker 0:  Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+(15 rows)
 
 :PREFIX
 SELECT *
@@ -693,25 +696,27 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
-(19 rows)
+   ->  Nested Loop (actual rows=10 loops=1)
+         Join Filter: (m1."time" = m3."time")
+         Rows Removed by Join Filter: 35969
+         ->  Nested Loop (actual rows=10 loops=1)
+               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               Rows Removed by Join Filter: 179889
+               ->  Gather Merge (actual rows=10 loops=1)
+                     Workers Planned: 1
+                     Workers Launched: 1
+                     ->  Sort (actual rows=5 loops=2)
+                           Sort Key: m1."time", m1.device_id
+                           Sort Method: quicksort 
+                           Worker 0:  Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=10)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=10)
+                     Index Cond: (device_id = 3)
+(21 rows)
 
 :PREFIX
 SELECT *
@@ -782,18 +787,21 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+   ->  Nested Loop Left Join (actual rows=10 loops=1)
+         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         Rows Removed by Join Filter: 179889
+         ->  Gather Merge (actual rows=10 loops=1)
+               Workers Planned: 1
+               Workers Launched: 1
+               ->  Sort (actual rows=5 loops=2)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
+                     Worker 0:  Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+(15 rows)
 
 :PREFIX
 SELECT *
@@ -808,21 +816,26 @@ ORDER BY m1.time,
 LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
+   ->  Incremental Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: (m1."time" = m2."time")
+         Presorted Key: m1."time"
+         Full-sort Groups: 3  Sort Method: quicksort 
+         ->  Merge Left Join (actual rows=101 loops=1)
+               Merge Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 14392
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+               Rows Removed by Join Filter: 81
+               ->  Sort (actual rows=101 loops=1)
+                     Sort Key: m1."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=102 loops=1)
+                     Sort Key: m2."time"
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
                                  Index Cond: (device_id = 2)
-(15 rows)
+(20 rows)
 
 SET parallel_leader_participation TO false;
 -- test implicit self-join

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -670,18 +670,21 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+   ->  Nested Loop (actual rows=10 loops=1)
+         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         Rows Removed by Join Filter: 179889
+         ->  Gather Merge (actual rows=10 loops=1)
+               Workers Planned: 1
+               Workers Launched: 1
+               ->  Sort (actual rows=5 loops=2)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
+                     Worker 0:  Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+(15 rows)
 
 :PREFIX
 SELECT *
@@ -695,25 +698,27 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
-(19 rows)
+   ->  Nested Loop (actual rows=10 loops=1)
+         Join Filter: (m1."time" = m3."time")
+         Rows Removed by Join Filter: 35969
+         ->  Nested Loop (actual rows=10 loops=1)
+               Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+               Rows Removed by Join Filter: 179889
+               ->  Gather Merge (actual rows=10 loops=1)
+                     Workers Planned: 1
+                     Workers Launched: 1
+                     ->  Sort (actual rows=5 loops=2)
+                           Sort Key: m1."time", m1.device_id
+                           Sort Method: quicksort 
+                           Worker 0:  Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                                 ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=10)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=10)
+                     Index Cond: (device_id = 3)
+(21 rows)
 
 :PREFIX
 SELECT *
@@ -784,18 +789,21 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+   ->  Nested Loop Left Join (actual rows=10 loops=1)
+         Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         Rows Removed by Join Filter: 179889
+         ->  Gather Merge (actual rows=10 loops=1)
+               Workers Planned: 1
+               Workers Launched: 1
+               ->  Sort (actual rows=5 loops=2)
+                     Sort Key: m1."time", m1.device_id
+                     Sort Method: quicksort 
+                     Worker 0:  Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=8995 loops=2)
+                           ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=10)
+               ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=10)
+(15 rows)
 
 :PREFIX
 SELECT *
@@ -810,21 +818,26 @@ ORDER BY m1.time,
 LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
+   ->  Incremental Sort (actual rows=100 loops=1)
          Sort Key: m1."time", m1.device_id, m2."time", m2.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: (m1."time" = m2."time")
+         Presorted Key: m1."time"
+         Full-sort Groups: 3  Sort Method: quicksort 
+         ->  Merge Left Join (actual rows=101 loops=1)
+               Merge Cond: (m1."time" = m2."time")
                Join Filter: (m1.device_id = 1)
-               Rows Removed by Join Filter: 14392
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+               Rows Removed by Join Filter: 81
+               ->  Sort (actual rows=101 loops=1)
+                     Sort Key: m1."time"
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Sort (actual rows=102 loops=1)
+                     Sort Key: m2."time"
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
                                  Index Cond: (device_id = 2)
-(15 rows)
+(20 rows)
 
 SET parallel_leader_participation TO false;
 -- test implicit self-join


### PR DESCRIPTION
During the compression autovacuum use to be disabled for uncompressed chunk and enable after decompression. This leads to postgres maintainence issue. Let's not disable autovacuum for uncompressed chunk anymore. Let postgres take care of the stats in its natural way.

Fixes #3376 #4578 #4156