### PR TITLE
Release 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #4926 Fix corruption when inserting into compressed chunks
+
+## 2.9.1 (2022-12-23)
+
+This release contains bug fixes since the 2.9.0 release.
+This release is high priority for upgrade. We strongly recommend that you
+upgrade as soon as possible.
+
+**Bugfixes**
+* #5072 Fix CAgg on CAgg bucket size validation
 * #5101 Fix enabling compression on caggs with renamed columns
+* #5106 Fix building against PG15 on Windows
+* #5117 Fix postgres server restart on background worker exit
+* #5121 Fix privileges for job_errors in update script
 
 ## 2.9.0 (2022-12-15)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -40,7 +40,8 @@ set(MOD_FILES
     updates/2.7.1--2.7.2.sql
     updates/2.7.2--2.8.0.sql
     updates/2.8.0--2.8.1.sql
-    updates/2.8.1--2.9.0.sql)
+    updates/2.8.1--2.9.0.sql
+    updates/2.9.0--2.9.1.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/sql/updates/2.9.0--2.9.1.sql
+++ b/sql/updates/2.9.0--2.9.1.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON _timescaledb_internal.job_errors to PUBLIC;

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -1,1 +1,0 @@
-GRANT SELECT ON _timescaledb_internal.job_errors to PUBLIC;

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.10.0-dev
-update_from_version = 2.9.0
+update_from_version = 2.9.1
 downgrade_to_version = 2.9.0


### PR DESCRIPTION
This release contains bug fixes since the 2.9.0 release.
This release is high priority for upgrade. We strongly recommend that you
upgrade as soon as possible.

**Bugfixes**
* https://github.com/timescale/timescaledb/pull/5072 Fix CAgg on CAgg bucket size validation
* https://github.com/timescale/timescaledb/pull/5101 Fix enabling compression on caggs with renamed columns
* https://github.com/timescale/timescaledb/pull/5106 Fix building against PG15 on Windows
* https://github.com/timescale/timescaledb/pull/5117 Fix postgres server restart on background worker exit
* https://github.com/timescale/timescaledb/pull/5121 Fix privileges for job_errors in update script