### PR TITLE
SELECT from partial compressed chunks crashes

### DIFF
--- a/tsl/src/nodes/decompress_chunk/decompress_chunk.c
+++ b/tsl/src/nodes/decompress_chunk/decompress_chunk.c
@@ -589,7 +589,7 @@ ts_decompress_chunk_generate_paths(PlannerInfo *root, RelOptInfo *chunk_rel, Hyp
 			 * from compressed and uncompressed chunk.
 			 */
 			path = (Path *) decompress_chunk_path_create(root, info, parallel_workers, child_path);
-			if (ts_chunk_is_partial(chunk))
+			if (ts_chunk_is_partial(chunk) && uncompressed_partial_path)
 				path =
 					(Path *) create_append_path_compat(root,
 													   chunk_rel,

--- a/tsl/test/shared/expected/compression_dml.out
+++ b/tsl/test/shared/expected/compression_dml.out
@@ -63,3 +63,44 @@ INSERT INTO metric_5m (time, series_id, value)
 -- clean up
 RESET work_mem;
 DROP TABLE metric_5m;
+-- github issue 5134
+CREATE TABLE mytab (time TIMESTAMPTZ NOT NULL, a INT, b INT, c INT);
+SELECT table_name FROM create_hypertable('mytab', 'time', chunk_time_interval => interval '1 day');
+ table_name 
+ mytab
+(1 row)
+
+INSERT INTO mytab
+    SELECT time,
+        CASE WHEN (:'start_date'::timestamptz - time < interval '1 days') THEN 1
+             WHEN (:'start_date'::timestamptz - time < interval '2 days') THEN 2
+             WHEN (:'start_date'::timestamptz - time < interval '3 days') THEN 3 ELSE 4 END as a
+    from generate_series(:'start_date'::timestamptz - interval '3 days', :'start_date'::timestamptz, interval '5 sec') as g1(time);
+-- enable compression
+ALTER TABLE mytab SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'a, c'
+);
+-- get first chunk name
+SELECT chunk_schema || '.' || chunk_name as "chunk_table"
+       FROM timescaledb_information.chunks
+       WHERE hypertable_name = 'mytab' ORDER BY range_start limit 1 \gset
+-- compress only the first chunk
+SELECT compress_chunk(:'chunk_table');
+              compress_chunk               
+ _timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+-- insert a row into first compressed chunk
+INSERT INTO mytab SELECT '2022-10-07 05:30:10+05:30'::timestamp with time zone, 3, 3;
+-- should not crash
+EXPLAIN (costs off) SELECT * FROM :chunk_table;
+QUERY PLAN
+ Append
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
+         ->  Seq Scan on compress_hyper_X_X_chunk
+   ->  Seq Scan on _hyper_X_X_chunk
+(4 rows)
+
+DROP TABLE mytab CASCADE;
+NOTICE:  drop cascades to table _timescaledb_internal.compress_hyper_X_X_chunk


### PR DESCRIPTION
SELECT from partially compressed chunk crashes due to reference to NULL pointer. When generating paths for DecompressChunk, uncompressed_partial_path is null which is not checked, thus causing a crash. This patch checks for NULL before calling create_append_path().

Fixes #5134