### PR TITLE
Insert into index during chunk compression

### DIFF
--- a/.unreleased/feature_5137
+++ b/.unreleased/feature_5137
@@ -1,0 +1,1 @@
+Implements: #5137 Insert into index during chunk compression

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1065,7 +1065,7 @@ tsl_get_compressed_chunk_index_for_recompression(PG_FUNCTION_ARGS)
 						in_column_offsets,
 						compressed_rel_tupdesc->natts,
 						true /*need_bistate*/,
-						true /*segmentwise_recompress*/);
+						true /*reset_sequence*/);
 
 	/*
 	 * Keep the ExclusiveLock on the compressed chunk. This lock will be requested
@@ -1363,7 +1363,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 						in_column_offsets,
 						compressed_rel_tupdesc->natts,
 						true /*need_bistate*/,
-						true /*segmentwise_recompress*/);
+						true /*reset_sequence*/);
 
 	/* create an array of the segmentby column offsets in the compressed chunk */
 	int16 *segmentby_column_offsets_compressed =

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -225,6 +225,10 @@ typedef struct RowCompressor
 	BulkInsertState bistate;
 	/* segment by index Oid if any */
 	Oid index_oid;
+	/* relation info necessary to update indexes on compressed table */
+	ResultRelInfo *resultRelInfo;
+	/* segment by index index in the RelInfo if any */
+	int8 segmentby_index_index;
 
 	/* in theory we could have more input columns than outputted ones, so we
 	   store the number of inputs/compressors separately */
@@ -251,8 +255,8 @@ typedef struct RowCompressor
 	bool *compressed_is_null;
 	int64 rowcnt_pre_compression;
 	int64 num_compressed_rows;
-	/* if recompressing segmentwise, we must know this so we can reset the sequence number */
-	bool segmentwise_recompress;
+	/* if recompressing segmentwise, we use this info to reset the sequence number */
+	bool reset_sequence;
 	/* flag for checking if we are working on the first tuple */
 	bool first_iteration;
 } RowCompressor;
@@ -345,7 +349,7 @@ extern void row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompr
 								Relation compressed_table, int num_compression_infos,
 								const ColumnCompressionInfo **column_compression_info,
 								int16 *column_offsets, int16 num_columns_in_compressed_table,
-								bool need_bistate, bool segmentwise_recompress);
+								bool need_bistate, bool reset_sequence);
 extern void row_compressor_finish(RowCompressor *row_compressor);
 extern void populate_per_compressed_columns_from_data(PerCompressedColumn *per_compressed_cols,
 													  int16 num_cols, Datum *compressed_datums,

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -616,6 +616,20 @@ and ht.table_name like 'test_collation' ORDER BY ch1.id LIMIT 2;
  _timescaledb_internal._hyper_9_20_chunk
 (2 rows)
 
+CREATE OR REPLACE PROCEDURE reindex_compressed_hypertable(hypertable REGCLASS)
+AS $$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = hypertable::name;
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END $$ LANGUAGE plpgsql;
+-- reindexing compressed hypertable to update statistics
+CALL reindex_compressed_hypertable('test_collation');
 --segment bys are pushed down correctly
 EXPLAIN (costs off) SELECT * FROM test_collation WHERE device_id < 'a';
                         QUERY PLAN                        
@@ -1755,6 +1769,7 @@ SELECT compress_chunk(i) FROM show_chunks('f_sensor_data') i;
  _timescaledb_internal._hyper_37_71_chunk
 (1 row)
 
+CALL reindex_compressed_hypertable('f_sensor_data');
 -- Encourage use of parallel plans
 SET parallel_setup_cost = 0;
 SET parallel_tuple_cost = 0;

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -593,6 +593,7 @@ SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
  _timescaledb_internal._hyper_31_19_chunk
 (1 row)
 
+ANALYZE test;
 --below query should pass after chunks are compressed
 SELECT 1 FROM test GROUP BY enum_col;
  ?column? 

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -195,6 +195,7 @@ SELECT compress_chunk(i) from show_chunks('pushdown_relabel') i;
  _timescaledb_internal._hyper_5_6_chunk
 (1 row)
 
+ANALYZE pushdown_relabel;
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar';
                      QUERY PLAN                     
 ----------------------------------------------------

--- a/tsl/test/expected/compression_sorted_merge-12.out
+++ b/tsl/test/expected/compression_sorted_merge-12.out
@@ -24,6 +24,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -46,6 +47,7 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
  _timescaledb_internal._hyper_3_3_chunk
 (1 row)
 
+ANALYZE test2;
 CREATE TABLE test_with_defined_null (
     time timestamptz NOT NULL,
     x1 integer,
@@ -66,6 +68,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_with_defined_null') i;
  _timescaledb_internal._hyper_5_5_chunk
 (1 row)
 
+ANALYZE test_with_defined_null;
 -- test1 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time DESC, x3 ASC, x4 ASC'
 -- test2 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time ASC, x3 DESC, x4 DESC'
 -- test_with_defined_null uses compress_segmentby='x1' and compress_orderby = 'x2 ASC NULLS FIRST'
@@ -888,6 +891,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 -- Test with a changed physical layout
 -- build_physical_tlist() can not be used for the scan on the compressed chunk anymore
 SELECT * FROM test1 ORDER BY time DESC;
@@ -1328,6 +1332,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 
@@ -1375,6 +1380,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 

--- a/tsl/test/expected/compression_sorted_merge-13.out
+++ b/tsl/test/expected/compression_sorted_merge-13.out
@@ -24,6 +24,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -46,6 +47,7 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
  _timescaledb_internal._hyper_3_3_chunk
 (1 row)
 
+ANALYZE test2;
 CREATE TABLE test_with_defined_null (
     time timestamptz NOT NULL,
     x1 integer,
@@ -66,6 +68,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_with_defined_null') i;
  _timescaledb_internal._hyper_5_5_chunk
 (1 row)
 
+ANALYZE test_with_defined_null;
 -- test1 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time DESC, x3 ASC, x4 ASC'
 -- test2 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time ASC, x3 DESC, x4 DESC'
 -- test_with_defined_null uses compress_segmentby='x1' and compress_orderby = 'x2 ASC NULLS FIRST'
@@ -888,6 +891,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 -- Test with a changed physical layout
 -- build_physical_tlist() can not be used for the scan on the compressed chunk anymore
 SELECT * FROM test1 ORDER BY time DESC;
@@ -1328,6 +1332,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 
@@ -1375,6 +1380,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 

--- a/tsl/test/expected/compression_sorted_merge-14.out
+++ b/tsl/test/expected/compression_sorted_merge-14.out
@@ -24,6 +24,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -46,6 +47,7 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
  _timescaledb_internal._hyper_3_3_chunk
 (1 row)
 
+ANALYZE test2;
 CREATE TABLE test_with_defined_null (
     time timestamptz NOT NULL,
     x1 integer,
@@ -66,6 +68,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_with_defined_null') i;
  _timescaledb_internal._hyper_5_5_chunk
 (1 row)
 
+ANALYZE test_with_defined_null;
 -- test1 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time DESC, x3 ASC, x4 ASC'
 -- test2 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time ASC, x3 DESC, x4 DESC'
 -- test_with_defined_null uses compress_segmentby='x1' and compress_orderby = 'x2 ASC NULLS FIRST'
@@ -888,6 +891,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 -- Test with a changed physical layout
 -- build_physical_tlist() can not be used for the scan on the compressed chunk anymore
 SELECT * FROM test1 ORDER BY time DESC;
@@ -1328,6 +1332,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 
@@ -1375,6 +1380,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 

--- a/tsl/test/expected/compression_sorted_merge-15.out
+++ b/tsl/test/expected/compression_sorted_merge-15.out
@@ -24,6 +24,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 CREATE TABLE test2 (
 time timestamptz NOT NULL,
     x1 integer,
@@ -46,6 +47,7 @@ SELECT compress_chunk(i) FROM show_chunks('test2') i;
  _timescaledb_internal._hyper_3_3_chunk
 (1 row)
 
+ANALYZE test2;
 CREATE TABLE test_with_defined_null (
     time timestamptz NOT NULL,
     x1 integer,
@@ -66,6 +68,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_with_defined_null') i;
  _timescaledb_internal._hyper_5_5_chunk
 (1 row)
 
+ANALYZE test_with_defined_null;
 -- test1 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time DESC, x3 ASC, x4 ASC'
 -- test2 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time ASC, x3 DESC, x4 DESC'
 -- test_with_defined_null uses compress_segmentby='x1' and compress_orderby = 'x2 ASC NULLS FIRST'
@@ -888,6 +891,7 @@ SELECT compress_chunk(i) FROM show_chunks('test1') i;
  _timescaledb_internal._hyper_1_1_chunk
 (1 row)
 
+ANALYZE test1;
 -- Test with a changed physical layout
 -- build_physical_tlist() can not be used for the scan on the compressed chunk anymore
 SELECT * FROM test1 ORDER BY time DESC;
@@ -1328,6 +1332,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 
@@ -1375,6 +1380,7 @@ SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
  _timescaledb_internal._hyper_9_20_chunk
 (1 row)
 
+ANALYZE test_costs;
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
  count 

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -6845,6 +6845,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_11_28_chunk
 (3 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
 :PREFIX SELECT * FROM metrics_ordered ORDER BY time DESC LIMIT 10;
                                         QUERY PLAN                                        

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -7928,6 +7928,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_11_28_chunk
 (3 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
 :PREFIX SELECT * FROM metrics_ordered ORDER BY time DESC LIMIT 10;
                                         QUERY PLAN                                        

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -8142,6 +8142,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_11_28_chunk
 (3 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
 :PREFIX SELECT * FROM metrics_ordered ORDER BY time DESC LIMIT 10;
                                         QUERY PLAN                                        

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -8144,6 +8144,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_11_28_chunk
 (3 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
 :PREFIX SELECT * FROM metrics_ordered ORDER BY time DESC LIMIT 10;
                                         QUERY PLAN                                        

--- a/tsl/test/expected/transparent_decompression_join_index.out
+++ b/tsl/test/expected/transparent_decompression_join_index.out
@@ -35,7 +35,7 @@ select compress_chunk(show_chunks('test'));
 set enable_seqscan = 'off';
 -- disable jit to avoid test flakiness
 set jit = off;
-explain with query_params as (
+explain (costs off) with query_params as (
 	select distinct a, b
 	from test_copy
 	where test_copy.a IN ('lat', 'lon')
@@ -55,17 +55,17 @@ where test.time between '2020-01-01 00:00' and '2020-01-01 00:02'
 order by test.time;
                                                                                                         QUERY PLAN                                                                                                         
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort  (cost=10000000024.30..10000000024.30 rows=1 width=541)
+ Sort
    Sort Key: _hyper_1_1_chunk."time"
-   ->  Nested Loop  (cost=10000000014.27..10000000024.29 rows=1 width=541)
-         ->  Unique  (cost=10000000012.11..10000000012.12 rows=1 width=520)
-               ->  Sort  (cost=10000000012.11..10000000012.11 rows=1 width=520)
+   ->  Nested Loop
+         ->  Unique
+               ->  Sort
                      Sort Key: test_copy.a
-                     ->  Seq Scan on test_copy  (cost=10000000000.00..10000000012.10 rows=1 width=520)
+                     ->  Seq Scan on test_copy
                            Filter: (((a)::text = ANY ('{lat,lon}'::text[])) AND (b = 1))
-         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk  (cost=2.15..2.15 rows=1000 width=20)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk
                Filter: (("time" >= 'Wed Jan 01 00:00:00 2020 PST'::timestamp with time zone) AND ("time" <= 'Wed Jan 01 00:02:00 2020 PST'::timestamp with time zone) AND ((test_copy.a)::text = a) AND (test_copy.b = b))
-               ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_a_b__ts_meta_ on compress_hyper_2_2_chunk  (cost=0.13..2.15 rows=1 width=604)
+               ->  Index Scan using compress_hyper_2_2_chunk__compressed_hypertable_2_a_b__ts_meta_ on compress_hyper_2_2_chunk
                      Index Cond: ((a = (test_copy.a)::text) AND (b = test_copy.b))
                      Filter: ((_ts_meta_max_1 >= 'Wed Jan 01 00:00:00 2020 PST'::timestamp with time zone) AND (_ts_meta_min_1 <= 'Wed Jan 01 00:02:00 2020 PST'::timestamp with time zone))
 (13 rows)

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -89,6 +89,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_1_5_chunk
 (5 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered_idx';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -89,6 +89,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_1_5_chunk
 (5 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered_idx';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -89,6 +89,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_1_5_chunk
 (5 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered_idx';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -89,6 +89,20 @@ ORDER BY c.id;
  _timescaledb_internal._hyper_1_5_chunk
 (5 rows)
 
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered_idx';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 -- run queries on compressed hypertable and store result
 \set PREFIX ''
 \set PREFIX_VERBOSE ''

--- a/tsl/test/isolation/expected/compression_merge_race.out
+++ b/tsl/test/isolation/expected/compression_merge_race.out
@@ -103,3 +103,50 @@ count|expected
    24|      24
 (1 row)
 
+
+starting permutation: s1_compress_single_chunk s1_compress_all_chunks_single_transaction s3_select_on_compressed_chunk s3_wait_for_finish s1_compress_finish
+step s1_compress_single_chunk: 
+    select compress_chunk(c, true) from show_chunks('sensor_data') c limit 1;
+
+compress_chunk                            
+------------------------------------------
+_timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+step s1_compress_all_chunks_single_transaction: 
+    BEGIN;
+    select count(compress_chunk(c, true)) from show_chunks('sensor_data') c;
+
+s1: NOTICE:  chunk "_hyper_X_X_chunk" is already compressed
+count
+-----
+   48
+(1 row)
+
+step s3_select_on_compressed_chunk: 
+    DO $$
+    DECLARE
+      hyper_id int;
+      chunk_id int;
+    BEGIN
+      SELECT h.compressed_hypertable_id, c.compressed_chunk_id 
+      INTO hyper_id, chunk_id
+      FROM _timescaledb_catalog.hypertable h 
+      INNER JOIN _timescaledb_catalog.chunk c  
+      ON h.id = c.hypertable_id 
+      WHERE h.table_name = 'sensor_data' 
+      AND c.compressed_chunk_id IS NOT NULL;
+      EXECUTE format('SELECT * 
+        FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
+        WHERE sensor_id = 40 
+        AND temperature IS NOT NULL;', 
+        hyper_id, 
+        chunk_id);
+    END;
+    $$;
+
+step s3_wait_for_finish: 
+
+step s1_compress_finish: 
+    COMMIT;
+

--- a/tsl/test/isolation/specs/compression_merge_race.spec.in
+++ b/tsl/test/isolation/specs/compression_merge_race.spec.in
@@ -54,6 +54,7 @@ setup {
    ALTER TABLE sensor_data SET (
    timescaledb.compress, 
    timescaledb.compress_segmentby = 'sensor_id',
+   timescaledb.compress_orderby = 'time',
    timescaledb.compress_chunk_time_interval = '2 hours');
 }
 
@@ -69,6 +70,20 @@ step "s1_compress_first_half_of_chunks" {
      $$
    ); 
 }
+
+step "s1_compress_all_chunks_single_transaction" {
+    BEGIN;
+    select count(compress_chunk(c, true)) from show_chunks('sensor_data') c;
+}
+
+step "s1_compress_finish" {
+    COMMIT;
+}
+
+step "s1_compress_single_chunk" {
+    select compress_chunk(c, true) from show_chunks('sensor_data') c limit 1;
+}
+
 
 # Compress first two chunks, skip two and compress next two etc.
 step "s1_compress_first_two_by_two" {
@@ -116,9 +131,40 @@ step "s3_count_chunks_post_compression" {
     select count(*), 24 as expected from show_chunks('sensor_data');
 }
 
+step "s3_select_on_compressed_chunk" {
+    DO $$
+    DECLARE
+      hyper_id int;
+      chunk_id int;
+    BEGIN
+      SELECT h.compressed_hypertable_id, c.compressed_chunk_id 
+      INTO hyper_id, chunk_id
+      FROM _timescaledb_catalog.hypertable h 
+      INNER JOIN _timescaledb_catalog.chunk c  
+      ON h.id = c.hypertable_id 
+      WHERE h.table_name = 'sensor_data' 
+      AND c.compressed_chunk_id IS NOT NULL;
+      EXECUTE format('SELECT * 
+        FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
+        WHERE sensor_id = 40 
+        AND temperature IS NOT NULL;', 
+        hyper_id, 
+        chunk_id);
+    END;
+    $$;
+}
+
+step "s3_wait_for_finish" {
+}
+
+
 
 # Check that we produce 24 chunks out of 48 chunks by merging two 1hour chunks
 # into 2 hour chunks from two different sessions. First session will run until
 # it hits an already compressed chunk.
 permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_half_of_chunks" "s2_compress_second_half_of_chunks" (s1_compress_first_half_of_chunks) "s3_unlock_compression" (s2_compress_second_half_of_chunks, s1_compress_first_half_of_chunks) "s3_count_chunks_post_compression"
 permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_two_by_two" "s2_compress_second_two_by_two" (s1_compress_first_two_by_two) "s3_unlock_compression" (s2_compress_second_two_by_two, s1_compress_first_two_by_two) "s3_count_chunks_post_compression"
+
+# Check that we can read existing compressed data during chunk compression when merging.
+# The query uses an index scan to verify we are not blocked on using it during compression.
+permutation "s1_compress_single_chunk" "s1_compress_all_chunks_single_transaction" "s3_select_on_compressed_chunk"  "s3_wait_for_finish" "s1_compress_finish"

--- a/tsl/test/shared/sql/include/shared_setup.sql
+++ b/tsl/test/shared/sql/include/shared_setup.sql
@@ -60,6 +60,10 @@ ALTER TABLE metrics_compressed SET (timescaledb.compress, timescaledb.compress_o
 SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_compressed' and c.compressed_chunk_id IS NULL
 ORDER BY c.table_name DESC;
+-- Reindexing compressed hypertable to update statistics
+-- this is for planner tests which depend on them
+-- necessary because this operation was previously done by compress_chunk
+REINDEX TABLE _timescaledb_internal._compressed_hypertable_4;
 
 -- create hypertable with space partitioning and compression
 CREATE TABLE metrics_space_compressed(filler_1 int, filler_2 int, filler_3 int, time timestamptz NOT NULL, device_id int, v0 int, v1 int, v2 float, v3 float);
@@ -80,6 +84,10 @@ ALTER TABLE metrics_space_compressed SET (timescaledb.compress, timescaledb.comp
 SELECT compress_chunk(c.schema_name|| '.' || c.table_name)
 FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where c.hypertable_id = ht.id and ht.table_name = 'metrics_space_compressed' and c.compressed_chunk_id IS NULL
 ORDER BY c.table_name DESC;
+-- Reindexing compressed hypertable to update statistics
+-- this is for planner tests which depend on them
+-- necessary because this operation was previously done by compress_chunk
+REINDEX TABLE _timescaledb_internal._compressed_hypertable_6;
 
 RESET ROLE;
 

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -353,6 +353,7 @@ EXPLAIN SELECT DISTINCT 1 FROM test;
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
+ANALYZE test;
 
 --below query should pass after chunks are compressed
 SELECT 1 FROM test GROUP BY enum_col;

--- a/tsl/test/sql/compression_qualpushdown.sql
+++ b/tsl/test/sql/compression_qualpushdown.sql
@@ -106,6 +106,7 @@ ALTER TABLE pushdown_relabel SET (timescaledb.compress, timescaledb.compress_seg
 
 INSERT INTO pushdown_relabel SELECT '2000-01-01','varchar','char';
 SELECT compress_chunk(i) from show_chunks('pushdown_relabel') i;
+ANALYZE pushdown_relabel;
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar';
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_c = 'char';

--- a/tsl/test/sql/compression_sorted_merge.sql.in
+++ b/tsl/test/sql/compression_sorted_merge.sql.in
@@ -22,6 +22,7 @@ INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2,
 INSERT INTO test1 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 
 SELECT compress_chunk(i) FROM show_chunks('test1') i;
+ANALYZE test1;
 
 CREATE TABLE test2 (
 time timestamptz NOT NULL,
@@ -41,6 +42,7 @@ INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 02:00:00-00', 2,
 INSERT INTO test2 (time, x1, x2, x3, x4, x5) values('2000-01-01 03:00:00-00', 1, 2, 4, 4, 0);
 
 SELECT compress_chunk(i) FROM show_chunks('test2') i;
+ANALYZE test2;
 
 CREATE TABLE test_with_defined_null (
     time timestamptz NOT NULL,
@@ -58,6 +60,7 @@ INSERT INTO test_with_defined_null (time, x1, x2) values('2000-01-01','1',1);
 INSERT INTO test_with_defined_null (time, x1, x2) values('2000-01-01','1',2);
 
 SELECT compress_chunk(i) FROM show_chunks('test_with_defined_null') i;
+ANALYZE test_with_defined_null;
 
 -- test1 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time DESC, x3 ASC, x4 ASC'
 -- test2 uses compress_segmentby='x1, x2, x5' and compress_orderby = 'time ASC, x3 DESC, x4 DESC'
@@ -275,6 +278,7 @@ SELECT * FROM test1 ORDER BY time DESC;
 -- Recompress
 SELECT decompress_chunk(i) FROM show_chunks('test1') i;
 SELECT compress_chunk(i) FROM show_chunks('test1') i;
+ANALYZE test1;
 
 -- Test with a changed physical layout
 -- build_physical_tlist() can not be used for the scan on the compressed chunk anymore
@@ -448,6 +452,7 @@ ORDER BY time;
 SELECT add_compression_policy('test_costs','1 minute'::INTERVAL);
 
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
+ANALYZE test_costs;
 
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;
@@ -471,6 +476,7 @@ ORDER BY time;
 
 -- Recompress chunk
 SELECT compress_chunk(i) FROM show_chunks('test_costs') i;
+ANALYZE test_costs;
 
 -- Number of segments
 SELECT count(*) FROM (SELECT segment_by from test_costs group by segment_by) AS s;

--- a/tsl/test/sql/include/transparent_decompression_ordered.sql
+++ b/tsl/test/sql/include/transparent_decompression_ordered.sql
@@ -21,6 +21,20 @@ FROM _timescaledb_catalog.chunk c
   INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id=ht.id
 WHERE ht.table_name = 'metrics_ordered'
 ORDER BY c.id;
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 
 -- should not have ordered DecompressChunk path because segmentby columns are not part of pathkeys
 :PREFIX SELECT * FROM metrics_ordered ORDER BY time DESC LIMIT 10;

--- a/tsl/test/sql/transparent_decompression_join_index.sql
+++ b/tsl/test/sql/transparent_decompression_join_index.sql
@@ -31,7 +31,7 @@ set enable_seqscan = 'off';
 -- disable jit to avoid test flakiness
 set jit = off;
 
-explain with query_params as (
+explain (costs off) with query_params as (
 	select distinct a, b
 	from test_copy
 	where test_copy.a IN ('lat', 'lon')

--- a/tsl/test/sql/transparent_decompression_ordered_index.sql.in
+++ b/tsl/test/sql/transparent_decompression_ordered_index.sql.in
@@ -97,6 +97,20 @@ FROM _timescaledb_catalog.chunk c
     INNER JOIN _timescaledb_catalog.hypertable ht ON c.hypertable_id = ht.id
 WHERE ht.table_name = 'metrics_ordered_idx'
 ORDER BY c.id;
+-- reindexing compressed hypertable to update statistics
+DO
+$$
+DECLARE
+  hyper_id int;
+BEGIN
+  SELECT h.compressed_hypertable_id
+  INTO hyper_id
+  FROM _timescaledb_catalog.hypertable h
+  WHERE h.table_name = 'metrics_ordered_idx';
+  EXECUTE format('REINDEX TABLE _timescaledb_internal._compressed_hypertable_%s',
+    hyper_id);
+END;
+$$;
 
 -- run queries on compressed hypertable and store result
 \set PREFIX ''


### PR DESCRIPTION
If there is an index on the compressed chunk, insert into it while inserting the heap data rather than reindexing the relation at the end. This reduces the amount of locking on the compressed chunk index which created issues when merging chunks and should help with the future updates of compressed data.