### PR TITLE
MERGE support on hypertables

### DIFF
--- a/.unreleased/PR_5150
+++ b/.unreleased/PR_5150
@@ -1,0 +1,1 @@
+Implements: #5150 MERGE support on hypertables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This release includes these noteworthy features:
 * #5584 Reduce decompression during constraint checking
 * #5530 Optimize compressed chunk resorting
 * #5639 Support sending telemetry event reports
+* #5150 MERGE support on hypertables
 
 **Bugfixes**
 * #5396 Fix SEGMENTBY columns predicates to be pushed down

--- a/src/nodes/chunk_dispatch/chunk_dispatch.c
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.c
@@ -11,6 +11,7 @@
 #include <nodes/nodeFuncs.h>
 #include <parser/parsetree.h>
 #include <utils/rel.h>
+#include <utils/syscache.h>
 #include <catalog/pg_type.h>
 
 #include "compat/compat.h"
@@ -20,6 +21,7 @@
 #include "subspace_store.h"
 #include "dimension.h"
 #include "guc.h"
+#include "nodes/hypertable_modify.h"
 #include "ts_catalog/chunk_data_node.h"
 
 static Node *chunk_dispatch_state_create(CustomScan *cscan);
@@ -244,6 +246,15 @@ chunk_dispatch_plan_create(PlannerInfo *root, RelOptInfo *relopt, CustomPath *be
 	cscan->custom_scan_tlist = tlist;
 	cscan->scan.plan.targetlist = tlist;
 
+#if PG15_GE
+	if (root->parse->mergeUseOuterJoin)
+	{
+		/* replace expressions of ROWID_VAR */
+		tlist = ts_replace_rowid_vars(root, tlist, relopt->relid);
+		cscan->scan.plan.targetlist = tlist;
+		cscan->custom_scan_tlist = tlist;
+	}
+#endif
 	return &cscan->scan.plan;
 }
 
@@ -339,8 +350,61 @@ chunk_dispatch_exec(CustomScanState *node)
 	/* Switch to the executor's per-tuple memory context */
 	old = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
 
+#if PG15_GE
+	TupleTableSlot *newslot = NULL;
+	if (dispatch->dispatch_state->mtstate->operation == CMD_MERGE)
+	{
+		HeapTuple tp;
+		AttrNumber natts;
+		AttrNumber attno;
+
+		tp = SearchSysCache1(RELOID, ObjectIdGetDatum(ht->main_table_relid));
+		if (!HeapTupleIsValid(tp))
+			elog(ERROR, "cache lookup failed for relation %u", ht->main_table_relid);
+		natts = ((Form_pg_class) GETSTRUCT(tp))->relnatts;
+		ReleaseSysCache(tp);
+		for (attno = 1; attno <= natts; attno++)
+		{
+			tp = SearchSysCache2(ATTNUM,
+								 ObjectIdGetDatum(ht->main_table_relid),
+								 Int16GetDatum(attno));
+			if (!HeapTupleIsValid(tp))
+				continue;
+			Form_pg_attribute att_tup = (Form_pg_attribute) GETSTRUCT(tp);
+			ReleaseSysCache(tp);
+			if (att_tup->attisdropped || att_tup->atthasmissing)
+			{
+				state->is_dropped_attr_exists = true;
+				continue;
+			}
+		}
+		for (int i = 0; i < ht->space->num_dimensions; i++)
+		{
+			List *actionStates =
+				dispatch->dispatch_state->mtstate->resultRelInfo->ri_notMatchedMergeAction;
+			ListCell *l;
+			foreach (l, actionStates)
+			{
+				MergeActionState *action = (MergeActionState *) lfirst(l);
+				CmdType commandType = action->mas_action->commandType;
+				if (commandType == CMD_INSERT)
+				{
+					/* fetch full projection list */
+					action->mas_proj->pi_exprContext->ecxt_innertuple = slot;
+					newslot = ExecProject(action->mas_proj);
+					break;
+				}
+			}
+			if (newslot)
+				break;
+		}
+	}
 	/* Calculate the tuple's point in the N-dimensional hyperspace */
+	point = ts_hyperspace_calculate_point(ht->space, (newslot ? newslot : slot));
+
+#else
 	point = ts_hyperspace_calculate_point(ht->space, slot);
+#endif
 
 	/* Save the main table's (hypertable's) ResultRelInfo */
 	if (!dispatch->hypertable_result_rel_info)
@@ -375,7 +439,7 @@ chunk_dispatch_exec(CustomScanState *node)
 	MemoryContextSwitchTo(old);
 
 	/* Convert the tuple to the chunk's rowtype, if necessary */
-	if (cis->hyper_to_chunk_map != NULL)
+	if (cis->hyper_to_chunk_map != NULL && state->is_dropped_attr_exists == false)
 		slot = execute_attr_map_slot(cis->hyper_to_chunk_map->attrMap, slot, cis->slot);
 
 	return slot;

--- a/src/nodes/chunk_dispatch/chunk_dispatch.h
+++ b/src/nodes/chunk_dispatch/chunk_dispatch.h
@@ -72,6 +72,8 @@ typedef struct ChunkDispatchState
 	 */
 	ChunkDispatch *dispatch;
 	ResultRelInfo *rri;
+	/* flag to represent dropped attributes */
+	bool is_dropped_attr_exists;
 } ChunkDispatchState;
 
 extern TSDLLEXPORT bool ts_is_chunk_dispatch_state(PlanState *state);

--- a/src/partitioning.c
+++ b/src/partitioning.c
@@ -260,6 +260,13 @@ ts_partitioning_func_apply(PartitioningInfo *pinfo, Oid collation, Datum value)
 	return result;
 }
 
+/*
+ * Helper function to find the right partition value from a tuple,
+ * for space partitioned hypertables. Since attributes in tuple can
+ * be of different order when compared to physical table columns order,
+ * we pass partition_col_idx which points to correct space parititioned
+ * column in the given tuple.
+ */
 TSDLLEXPORT Datum
 ts_partitioning_func_apply_slot(PartitioningInfo *pinfo, TupleTableSlot *slot, bool *isnull)
 {

--- a/src/planner/planner.c
+++ b/src/planner/planner.c
@@ -1267,13 +1267,33 @@ timescaledb_set_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, Index rti, Rang
 			break;
 		case TS_REL_CHUNK_STANDALONE:
 		case TS_REL_CHUNK_CHILD:
-			/* Check for UPDATE/DELETE (DML) on compressed chunks */
+			/* Check for UPDATE/DELETE/MERGE (DML) on compressed chunks */
 			if (IS_UPDL_CMD(root->parse) && dml_involves_hypertable(root, ht, rti))
 			{
 				if (ts_cm_functions->set_rel_pathlist_dml != NULL)
 					ts_cm_functions->set_rel_pathlist_dml(root, rel, rti, rte, ht);
 				break;
 			}
+#if PG15_GE
+			/*
+			 * For MERGE command if there is an UPDATE or DELETE action, then
+			 * do not allow this to succeed on compressed chunks
+			 */
+			if (root->parse->commandType == CMD_MERGE && dml_involves_hypertable(root, ht, rti))
+			{
+				ListCell *ml;
+				foreach (ml, root->parse->mergeActionList)
+				{
+					MergeAction *action = (MergeAction *) lfirst(ml);
+					if (action->commandType == CMD_UPDATE || action->commandType == CMD_DELETE)
+					{
+						if (ts_cm_functions->set_rel_pathlist_dml != NULL)
+							ts_cm_functions->set_rel_pathlist_dml(root, rel, rti, rte, ht);
+					}
+				}
+				break;
+			}
+#endif
 			TS_FALLTHROUGH;
 		default:
 			apply_optimizations(root, reltype, rel, rte, ht);
@@ -1475,35 +1495,41 @@ replace_hypertable_modify_paths(PlannerInfo *root, List *pathlist, RelOptInfo *i
 		if (IsA(path, ModifyTablePath))
 		{
 			ModifyTablePath *mt = castNode(ModifyTablePath, path);
-
+			RangeTblEntry *rte = planner_rt_fetch(mt->nominalRelation, root);
+			Hypertable *ht = ts_planner_get_hypertable(rte->relid, CACHE_FLAG_CHECK);
 			if (
 #if PG14_GE
 				/* We only route UPDATE/DELETE through our CustomNode for PG 14+ because
 				 * the codepath for earlier versions is different. */
 				mt->operation == CMD_UPDATE || mt->operation == CMD_DELETE ||
 #endif
-#if PG15_GE
-				mt->operation == CMD_MERGE ||
-#endif
 				mt->operation == CMD_INSERT)
 			{
-				RangeTblEntry *rte = planner_rt_fetch(mt->nominalRelation, root);
-				Hypertable *ht = ts_planner_get_hypertable(rte->relid, CACHE_FLAG_CHECK);
-
-#if PG15_GE
-				if (ht && mt->operation == CMD_MERGE)
-					ereport(ERROR,
-							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-							 errmsg("The MERGE command does not support hypertables in this "
-									"version"),
-							 errhint("Check https://github.com/timescale/timescaledb/issues/4929 "
-									 "for more information and current status")));
-#endif
 				if (ht && (mt->operation == CMD_INSERT || !hypertable_is_distributed(ht)))
 				{
 					path = ts_hypertable_modify_path_create(root, mt, ht, input_rel);
 				}
 			}
+#if PG15_GE
+			if (ht && mt->operation == CMD_MERGE)
+			{
+				List *firstMergeActionList = linitial(mt->mergeActionLists);
+				ListCell *l;
+				/*
+				 * Iterate over merge action to check if there is an INSERT sql.
+				 * If so, then add ChunkDispatch node.
+				 */
+				foreach (l, firstMergeActionList)
+				{
+					MergeAction *action = (MergeAction *) lfirst(l);
+					if (action->commandType == CMD_INSERT)
+					{
+						path = ts_hypertable_modify_path_create(root, mt, ht, input_rel);
+						break;
+					}
+				}
+			}
+#endif
 		}
 
 		new_pathlist = lappend(new_pathlist, path);

--- a/test/expected/merge.out
+++ b/test/expected/merge.out
@@ -1,22 +1,24 @@
 -- This file and its contents are licensed under the Apache License 2.0.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
--- Create conditions table with location and temperature
-CREATE TABLE conditions (
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- Create target table with location and temperature
+CREATE TABLE target (
    time        TIMESTAMPTZ       NOT NULL,
    location    SMALLINT          NOT NULL,
-   temperature DOUBLE PRECISION  NULL
+   temperature DOUBLE PRECISION  NULL,
+   val text default 'string -'
 );
 SELECT create_hypertable(
-  'conditions',
+  'target',
   'time',
   chunk_time_interval => INTERVAL '5 seconds');
-    create_hypertable    
--------------------------
- (1,public,conditions,t)
+  create_hypertable  
+---------------------
+ (1,public,target,t)
 (1 row)
 
-INSERT INTO conditions
+INSERT INTO target
 SELECT time, location, 14 as temperature
 FROM generate_series(
 	'2021-01-01 00:00:00',
@@ -24,23 +26,23 @@ FROM generate_series(
     INTERVAL '5 seconds'
   ) as time,
 generate_series(1,4) as location;
--- Create conditions_updated table with location and temperature
-CREATE TABLE conditions_updated (
+-- Create source table with location and temperature
+CREATE TABLE source (
    time        TIMESTAMPTZ       NOT NULL,
    location    SMALLINT          NOT NULL,
    temperature DOUBLE PRECISION  NULL
 );
 SELECT create_hypertable(
-  'conditions_updated',
+  'source',
   'time',
   chunk_time_interval => INTERVAL '5 seconds');
-        create_hypertable        
----------------------------------
- (2,public,conditions_updated,t)
+  create_hypertable  
+---------------------
+ (2,public,source,t)
 (1 row)
 
--- Generate data that overlaps with conditions table
-INSERT INTO conditions_updated
+-- Generate data that overlaps with target table
+INSERT INTO source
 SELECT time, location, 80 as temperature
 FROM generate_series(
 	'2021-01-01 00:00:05',
@@ -49,20 +51,20 @@ FROM generate_series(
   ) as time,
 generate_series(1,4) as location;
 -- Print table/rows/num of chunks
-select * from conditions order by time, location asc;
-             time             | location | temperature 
-------------------------------+----------+-------------
- Fri Jan 01 00:00:00 2021 PST |        1 |          14
- Fri Jan 01 00:00:00 2021 PST |        2 |          14
- Fri Jan 01 00:00:00 2021 PST |        3 |          14
- Fri Jan 01 00:00:00 2021 PST |        4 |          14
- Fri Jan 01 00:00:05 2021 PST |        1 |          14
- Fri Jan 01 00:00:05 2021 PST |        2 |          14
- Fri Jan 01 00:00:05 2021 PST |        3 |          14
- Fri Jan 01 00:00:05 2021 PST |        4 |          14
+select * from target order by time, location asc;
+             time             | location | temperature |   val    
+------------------------------+----------+-------------+----------
+ Fri Jan 01 00:00:00 2021 PST |        1 |          14 | string -
+ Fri Jan 01 00:00:00 2021 PST |        2 |          14 | string -
+ Fri Jan 01 00:00:00 2021 PST |        3 |          14 | string -
+ Fri Jan 01 00:00:00 2021 PST |        4 |          14 | string -
+ Fri Jan 01 00:00:05 2021 PST |        1 |          14 | string -
+ Fri Jan 01 00:00:05 2021 PST |        2 |          14 | string -
+ Fri Jan 01 00:00:05 2021 PST |        3 |          14 | string -
+ Fri Jan 01 00:00:05 2021 PST |        4 |          14 | string -
 (8 rows)
 
-select * from conditions_updated order by time, location asc;
+select * from source order by time, location asc;
              time             | location | temperature 
 ------------------------------+----------+-------------
  Fri Jan 01 00:00:05 2021 PST |        1 |          80
@@ -75,85 +77,875 @@ select * from conditions_updated order by time, location asc;
  Fri Jan 01 00:00:10 2021 PST |        4 |          80
 (8 rows)
 
-select hypertable_name, count(*) as num_of_chunks from timescaledb_information.chunks group by hypertable_name;
-  hypertable_name   | num_of_chunks 
---------------------+---------------
- conditions         |             2
- conditions_updated |             2
-(2 rows)
-
--- Print expected values in the conditions table once conditions_updated is merged into it
--- If a key exists in both tables, we take average of the temperature measured
--- average logic here is a mess but it works
-SELECT COALESCE(c.time, cu.time) as time,
-       COALESCE(c.location, cu.location) as location,
-       (COALESCE(c.temperature, cu.temperature) + COALESCE(cu.temperature, c.temperature))/2 as temperature
-FROM conditions AS c FULL JOIN conditions_updated AS cu
-ON c.time = cu.time AND c.location = cu.location;
-             time             | location | temperature 
-------------------------------+----------+-------------
- Fri Jan 01 00:00:00 2021 PST |        1 |          14
- Fri Jan 01 00:00:00 2021 PST |        2 |          14
- Fri Jan 01 00:00:00 2021 PST |        3 |          14
- Fri Jan 01 00:00:00 2021 PST |        4 |          14
- Fri Jan 01 00:00:05 2021 PST |        1 |          47
- Fri Jan 01 00:00:05 2021 PST |        2 |          47
- Fri Jan 01 00:00:05 2021 PST |        3 |          47
- Fri Jan 01 00:00:05 2021 PST |        4 |          47
- Fri Jan 01 00:00:10 2021 PST |        1 |          80
- Fri Jan 01 00:00:10 2021 PST |        2 |          80
- Fri Jan 01 00:00:10 2021 PST |        3 |          80
- Fri Jan 01 00:00:10 2021 PST |        4 |          80
-(12 rows)
-
--- Test that normal PostgreSQL tables can merge without exceptions
-CREATE TABLE conditions_pg AS SELECT * FROM conditions;
-CREATE TABLE conditions_updated_pg AS SELECT * FROM conditions_updated;
-MERGE INTO conditions_pg c
-USING conditions_updated_pg cu
-ON c.time = cu.time AND c.location = cu.location
+-- CREATE normal PostgreSQL tables
+CREATE TABLE target_pg AS SELECT * FROM target;
+CREATE TABLE source_pg AS SELECT * FROM source;
+-- Merge UPDATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
 WHEN MATCHED THEN
-UPDATE SET temperature = (c.temperature + cu.temperature)/2
-WHEN NOT MATCHED THEN
-INSERT (time, location, temperature) VALUES (cu.time, cu.location, cu.temperature);
-SELECT * FROM conditions_pg ORDER BY time, location ASC;
-             time             | location | temperature 
-------------------------------+----------+-------------
- Fri Jan 01 00:00:00 2021 PST |        1 |          14
- Fri Jan 01 00:00:00 2021 PST |        2 |          14
- Fri Jan 01 00:00:00 2021 PST |        3 |          14
- Fri Jan 01 00:00:00 2021 PST |        4 |          14
- Fri Jan 01 00:00:05 2021 PST |        1 |          47
- Fri Jan 01 00:00:05 2021 PST |        2 |          47
- Fri Jan 01 00:00:05 2021 PST |        3 |          47
- Fri Jan 01 00:00:05 2021 PST |        4 |          47
- Fri Jan 01 00:00:10 2021 PST |        1 |          80
- Fri Jan 01 00:00:10 2021 PST |        2 |          80
- Fri Jan 01 00:00:10 2021 PST |        3 |          80
- Fri Jan 01 00:00:10 2021 PST |        4 |          80
-(12 rows)
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
+-- Merge UPDATE matched rows for hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
 
--- Merge conditions_updated into conditions
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+-- Merge DELETE matched rows for hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- clean up tables
+DELETE FROM target_pg;
+DELETE FROM target;
+DELETE FROM source_pg;
+DELETE FROM source;
+INSERT INTO target
+SELECT time, location, 14 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:00',
+    '2021-01-01 00:00:09',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+INSERT INTO source
+SELECT time, location, 80 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:05',
+    '2021-01-01 00:00:14',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+INSERT INTO target_pg SELECT * FROM target;
+INSERT INTO source_pg SELECT * FROM source;
+-- Merge UPDATE matched rows and INSERT new row for unmatched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE'
+WHEN NOT MATCHED THEN
+INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+-- Merge UPDATE matched rows and INSERT new row for unmatched rows for hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE'
+WHEN NOT MATCHED THEN
+INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge INSERT with constant literals for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+-- Merge INSERT with constant literals for hypertables
+MERGE INTO target t
+USING source s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge with INSERT/DELETE/UPDATE on PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED AND t.location = 560076 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.location = 560083 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+-- Merge with INSERT/DELETE/UPDATE on hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED AND t.location = 560076 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.location = 560083 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge with Subqueries on PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location > (SELECT count(*) FROM source_pg)
+WHEN MATCHED AND t.temperature = 23 THEN
+ UPDATE SET temperature = (SELECT count(*) FROM target_pg) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'SUBQUERY string - INSERTED BY MERGE');
+-- Merge with Subqueries on hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location > (SELECT count(*) FROM source)
+WHEN MATCHED AND t.temperature = 23 THEN
+ UPDATE SET temperature = (SELECT count(*) FROM target) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'SUBQUERY string - INSERTED BY MERGE');
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- clean up tables
+DELETE FROM target_pg;
+DELETE FROM target;
+DELETE FROM source_pg;
+DELETE FROM source;
+-- TEST with target as hypertable and source as normal PG table
+INSERT INTO target
+SELECT time, location, 14 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:00',
+    '2021-01-01 00:00:09',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+INSERT INTO source
+SELECT time, location, 80 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:05',
+    '2021-01-01 00:00:14',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+INSERT INTO target_pg SELECT * FROM target;
+INSERT INTO source_pg SELECT * FROM source;
+-- Merge UPDATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
+-- Merge UPDATE with target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+-- Merge DELETE with target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge INSERT with constant literals for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+-- Merge INSERT with constant literals for target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge with INSERT/DELETE/UPDATE on PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED AND t.temperature = 23 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+-- Merge with INSERT/DELETE/UPDATE on target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED  AND t.temperature = 23 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED  AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+DROP TABLE target_pg CASCADE;
+DROP TABLE target CASCADE;
+DROP TABLE source_pg CASCADE;
+DROP TABLE source CASCADE;
+-- test MERGE with source being a PARTITION table
+CREATE TABLE source_pg(
+   id INT NOT NULL,
+   dev INT NOT NULL,
+   value INT,
+   CONSTRAINT cstr_source_pky PRIMARY KEY (id)
+) PARTITION BY LIST (id);
+CREATE TABLE source_1_2_3_4 PARTITION OF source_pg FOR VALUES IN (1,2,3,4);
+CREATE TABLE source_5_6_7_8 PARTITION OF source_pg FOR VALUES IN (5,6,7,8);
+INSERT INTO source_pg SELECT generate_series(1,8), 44,55;
+CREATE TABLE target (
+   ts TIMESTAMP WITH TIME ZONE NOT NULL,
+   id INT NOT NULL,
+   dev INT NOT NULL,
+   FOREIGN KEY (id)  REFERENCES source_pg(id) ON DELETE CASCADE
+);
+SELECT create_hypertable(
+   relation => 'target',
+   time_column_name => 'ts'
+);
+  create_hypertable  
+---------------------
+ (3,public,target,t)
+(1 row)
+
+insert into target values ('2023-01-12 00:00:05'::timestamp with time zone, 1,2);
+insert into target values ('2023-01-12 00:00:10'::timestamp with time zone, 2,2);
+insert into target values ('2023-01-12 00:00:15'::timestamp with time zone, 3,2);
+insert into target values ('2023-01-12 00:00:20'::timestamp with time zone, 4,2);
+insert into target values ('2023-01-14 00:00:25'::timestamp with time zone, 5,2);
+insert into target values ('2023-01-14 00:00:30'::timestamp with time zone, 6,2);
+insert into target values ('2023-01-14 00:00:35'::timestamp with time zone, 7,2);
+insert into target values ('2023-01-14 00:00:40'::timestamp with time zone, 8,2);
+CREATE TABLE target_pg AS SELECT * FROM target;
+-- Merge UPDATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+UPDATE SET dev = (t.dev + s.dev)/2;
+-- Merge UPDATE matched rows for hypertables
+MERGE INTO target t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+UPDATE SET dev = (t.dev + s.dev)/2;
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+DELETE;
+-- Merge DELETE matched rows for hypertables
+MERGE INTO target t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+DELETE;
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- clean up tables
+DROP TABLE target_pg CASCADE;
+DROP TABLE target CASCADE;
+DROP TABLE source_pg CASCADE;
+-- test MERGE with hypertables with time and space partitions
+CREATE TABLE target (
+     filler_1 int,
+     filler_2 int,
+     filler_3 int,
+     time timestamptz NOT NULL,
+     device_id int,
+     device_id_peer int,
+     v0 int,
+     v1 float,
+     v2 float,
+     v3 float
+ );
+SELECT create_hypertable ('target', 'time', 'device_id', 5);
+  create_hypertable  
+---------------------
+ (4,public,target,t)
+(1 row)
+
+SELECT add_dimension('target', 'device_id_peer', 5);
+           add_dimension            
+------------------------------------
+ (6,public,target,device_id_peer,t)
+(1 row)
+
+SELECT add_dimension('target', 'v2', 5);
+     add_dimension      
+------------------------
+ (7,public,target,v2,t)
+(1 row)
+
+INSERT INTO target (time, device_id, device_id_peer, v0, v1, v2, v3)
+  SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 2, 1) gdevice (device_id);
+CREATE TABLE source (
+         filler_1 int,
+         filler_2 int,
+         filler_3 int,
+         time timestamptz NOT NULL,
+         device_id int
+  );
+SELECT create_hypertable ('source', 'time', 'device_id', 3);
+  create_hypertable  
+---------------------
+ (5,public,source,t)
+(1 row)
+
+INSERT INTO source (time, device_id, filler_2, filler_3, filler_1)
+  SELECT time,
+    device_id,
+    device_id + 134,
+    device_id + 209,
+    device_id + 0.50127
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+-- create PG tables to compare PG target and hypertable target tables
+CREATE table target_pg as SELECT * FROM target;
+CREATE table source_pg as SELECT * FROM source;
+-- Merge UDPATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET filler_2 = s.filler_1 + 100;
+-- Merge UDPATE matched rows for space partitioned hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET filler_2 = s.filler_1 + 100;
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+       USING source_pg s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+-- Merge DELETE matched rows for space partitioned hypertables
+MERGE INTO target t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge INSERT matched rows for normal PG tables
+MERGE INTO target_pg t
+              USING source_pg s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+-- Merge INSERT matched rows for space partitioned hypertables
+MERGE INTO target t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- Merge with INSERT/DELETE/UPDATE on PG tables
+MERGE INTO target_pg t
+    USING source_pg s
+        ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED AND t.device_id_peer = 2 THEN
+                  UPDATE SET filler_2 = s.filler_1 + s.filler_2 + s.filler_3 + 100
+              WHEN MATCHED AND t.device_id_peer = 7 THEN
+                  DELETE
+              WHEN NOT MATCHED THEN
+                  INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                         (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+-- Merge with INSERT/DELETE/UPDATE on space partitioned hypertables
+MERGE INTO target t
+    USING source s
+        ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED AND t.device_id_peer = 2 THEN
+                  UPDATE SET filler_2 = s.filler_1 + s.filler_2 + s.filler_3 + 100
+              WHEN MATCHED AND t.device_id_peer = 7 THEN
+                  DELETE
+              WHEN NOT MATCHED THEN
+                  INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                         (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+-- clean up tables
+DROP TABLE target_pg CASCADE;
+DROP TABLE target CASCADE;
+DROP TABLE source_pg CASCADE;
+DROP TABLE source CASCADE;
+-- TEST with parition column place after similar data type column
+CREATE TABLE target (
+     filler_1 int,
+     filler_2 int,
+     filler_3 int,
+     time timestamptz NOT NULL,
+     device_id int,
+     device_id_peer int,
+     v0 int,
+     v1 float,
+     v2 float,
+     v3 float,
+     partition_column TIMESTAMPTZ NOT NULL
+ );
+SELECT create_hypertable ('target', 'partition_column');
+  create_hypertable  
+---------------------
+ (6,public,target,t)
+(1 row)
+
+INSERT INTO target (time, device_id, device_id_peer, v0, v1, v2, v3, partition_column)
+  SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL,
+    time + interval '10m'
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 2, 1) gdevice (device_id);
+CREATE TABLE source (
+         filler_1 int,
+         filler_2 int,
+         filler_3 int,
+         time timestamptz NOT NULL,
+         device_id int
+  );
+SELECT create_hypertable ('source', 'time', 'device_id', 3);
+  create_hypertable  
+---------------------
+ (7,public,source,t)
+(1 row)
+
+INSERT INTO source (time, device_id, filler_2, filler_3, filler_1)
+  SELECT time,
+    device_id,
+    device_id + 134,
+    device_id + 209,
+    device_id + 0.50127
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+-- create PG tables to compare PG target and hypertable target tables
+CREATE table target_pg as SELECT * FROM target;
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, device_id_peer, v0, v1, v2, v3, partition_column) VALUES
+('2010-01-06 05:30:00+05:30', 23, 2, 11, 22, 33, 44, '2023-01-06 05:33:00+05:30');
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, device_id_peer, v0, v1, v2, v3, partition_column) VALUES
+('2010-01-06 05:30:00+05:30', 23, 2, 11, 22, 33, 44, '2023-01-06 05:33:00+05:30');
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN  MATCHED THEN
+DELETE;
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN  MATCHED THEN
+DELETE;
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+--------
+ same
+(1 row)
+
+MERGE INTO target_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+-- time dimension column is NULL, this will report an null constraint violation error
 \set ON_ERROR_STOP 0
-MERGE INTO conditions c
-USING conditions_updated cu
-ON c.time = cu.time AND c.location = cu.location
-WHEN MATCHED THEN
-UPDATE SET temperature = (c.temperature + cu.temperature)/2
-WHEN NOT MATCHED THEN
-INSERT (time, location, temperature) VALUES (cu.time, cu.location, cu.temperature);
-ERROR:  The MERGE command does not support hypertables in this version
-SELECT * FROM conditions ORDER BY time, location ASC;
-             time             | location | temperature 
-------------------------------+----------+-------------
- Fri Jan 01 00:00:00 2021 PST |        1 |          14
- Fri Jan 01 00:00:00 2021 PST |        2 |          14
- Fri Jan 01 00:00:00 2021 PST |        3 |          14
- Fri Jan 01 00:00:00 2021 PST |        4 |          14
- Fri Jan 01 00:00:05 2021 PST |        1 |          14
- Fri Jan 01 00:00:05 2021 PST |        2 |          14
- Fri Jan 01 00:00:05 2021 PST |        3 |          14
- Fri Jan 01 00:00:05 2021 PST |        4 |          14
-(8 rows)
-
+MERGE INTO target t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+ERROR:  NULL value in column "partition_column" violates not-null constraint
 \set ON_ERROR_STOP 1
+DROP TABLE target CASCADE;
+DROP TABLE target_pg CASCADE;
+DROP TABLE source CASCADE;
+-- TEST with target table have CHECK constraints
+CREATE TABLE target (
+   time        TIMESTAMPTZ       NOT NULL,
+   location    SMALLINT          NOT NULL,
+   temperature DOUBLE PRECISION  NULL CHECK (temperature > 10),
+   val text default 'string -'
+);
+SELECT create_hypertable(
+  'target',
+  'time',
+  chunk_time_interval => INTERVAL '5 seconds');
+  create_hypertable  
+---------------------
+ (8,public,target,t)
+(1 row)
+
+INSERT INTO target
+SELECT time, location, 14 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:00',
+    '2021-01-01 00:00:09',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+-- Create source table with location and temperature
+CREATE TABLE source (
+   time        TIMESTAMPTZ       NOT NULL,
+   location    SMALLINT          NOT NULL,
+   temperature DOUBLE PRECISION  NULL
+);
+-- Generate data that overlaps with target table
+INSERT INTO source
+SELECT time, location, 80 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:05',
+    '2021-01-01 00:00:14',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+-- CREATE normal PostgreSQL tables
+CREATE TABLE target_pg AS SELECT * FROM target;
+-- Merge UPDATE/DELETE with DO NOTHING on pg tables
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DO NOTHING
+WHEN NOT MATCHED THEN
+DO NOTHING;
+-- Merge UPDATE/DELETE with DO NOTHING on hypertable
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DO NOTHING
+WHEN NOT MATCHED THEN
+DO NOTHING;
+-- Error cases for Merge
+\set ON_ERROR_STOP 0
+-- Merge UPDATE should fail with check constraint violation
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE';
+-- Merge UPDATE should fail with check constraint violation
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE';
+ERROR:  new row for relation "_hyper_8_24_chunk" violates check constraint "target_temperature_check"
+-- Merge error with unreachable WHEN clause on pg tables
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.time < now() THEN
+DELETE
+WHEN NOT MATCHED THEN
+DO NOTHING;
+ERROR:  unreachable WHEN clause specified after unconditional WHEN clause
+-- Merge error with unreachable WHEN clause on hypertable
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.time < now() THEN
+DELETE
+WHEN NOT MATCHED THEN
+DO NOTHING;
+ERROR:  unreachable WHEN clause specified after unconditional WHEN clause
+-- Merge error with unknown action in MERGE WHEN MATCHED clause on pg tables
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+SELECT 1;
+ERROR:  syntax error at or near "SELECT" at character 105
+-- Merge error with unknown action in MERGE WHEN MATCHED clause on hypertable
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+SELECT 1;
+ERROR:  syntax error at or near "SELECT" at character 102
+-- Merge error cannot affect row a second time on pg tables
+MERGE INTO target_pg t
+USING source s
+ON  t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 28, val = val || ' UPDATED BY MERGE';
+ERROR:  MERGE command cannot affect row a second time
+-- Merge error cannot affect row a second time on hypertable
+MERGE INTO target t
+USING source s
+ON  t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 28, val = val || ' UPDATED BY MERGE';
+ERROR:  MERGE command cannot affect row a second time
+\set ON_ERROR_STOP 1
+DROP TABLE target CASCADE;
+DROP TABLE target_pg CASCADE;
+DROP TABLE source CASCADE;
+-- TEST for PERMISSIONS
+CREATE USER priv_user;
+CREATE USER non_priv_user;
+CREATE TABLE target (
+    value DOUBLE PRECISION NOT NULL,
+    time TIMESTAMPTZ NOT NULL
+);
+SELECT table_name FROM create_hypertable(
+                            'target'::regclass,
+                            'time'::name, chunk_time_interval=>interval '8 hours',
+                            create_default_indexes=> false);
+ table_name 
+------------
+ target
+(1 row)
+
+SELECT '2022-10-10 14:33:44.1234+05:30' as start_date \gset
+INSERT INTO target (value, time)
+  SELECT 1,t from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
+    generate_series(1,3) s;
+CREATE TABLE source (
+        time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        value DOUBLE PRECISION NOT NULL
+    );
+SELECT table_name FROM create_hypertable(
+                                'source'::regclass,
+                                'time'::name, chunk_time_interval=>interval '6 hours',
+                                create_default_indexes=> false);
+ table_name 
+------------
+ source
+(1 row)
+
+ALTER TABLE target OWNER TO priv_user;
+ALTER TABLE source OWNER TO priv_user;
+GRANT SELECT ON source TO non_priv_user;
+SET SESSION AUTHORIZATION non_priv_user;
+\set ON_ERROR_STOP 0
+-- non_priv_user does not have UPDATE privilege on target table
+MERGE INTO target
+USING source
+ON target.time = source.time
+WHEN MATCHED THEN
+	UPDATE SET value = 0;
+ERROR:  permission denied for table target
+-- non_priv_user does not have DELETE privilege on target table
+MERGE INTO target
+USING source
+ON target.time = source.time
+WHEN MATCHED THEN
+	DELETE;
+ERROR:  permission denied for table target
+-- non_priv_user does not have INSERT privilege on target table
+MERGE INTO target
+USING source
+ON target.time = source.time
+WHEN NOT MATCHED THEN
+	INSERT VALUES (10, '2023-01-15 00:00:10'::timestamp with time zone);
+ERROR:  permission denied for table target
+\set ON_ERROR_STOP 1
+RESET SESSION AUTHORIZATION;
+DROP TABLE target;
+DROP TABLE source;
+DROP USER priv_user;
+DROP USER non_priv_user;

--- a/test/expected/ts_merge.out
+++ b/test/expected/ts_merge.out
@@ -1,0 +1,2551 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SET client_min_messages TO error;
+\set TEST_BASE_NAME ts_merge
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_load_ht.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_HT_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_WITH_HYPERTABLE",
+    format('%s/results/%s_ht_results.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_WITH_NO_HYPERTABLE" \gset
+SELECT format('\! diff -u --label "Base pg table results" --label "Hyperatable results" %s %s', :'TEST_RESULTS_WITH_HYPERTABLE', :'TEST_RESULTS_WITH_NO_HYPERTABLE') AS "DIFF_CMD" \gset
+\ir :TEST_LOAD_NAME
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+CREATE USER regress_merge_privs;
+CREATE USER regress_merge_no_privs;
+DROP TABLE IF EXISTS target;
+DROP TABLE IF EXISTS source;
+CREATE TABLE target (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE source (sid integer, delta integer) -- no index
+  WITH (autovacuum_enabled=off);
+INSERT INTO target VALUES (1, 10);
+INSERT INTO target VALUES (2, 20);
+INSERT INTO target VALUES (3, 30);
+SELECT t.ctid is not null as matched, t.*, s.* FROM source s FULL OUTER JOIN target t ON s.sid = t.tid ORDER BY t.tid, s.sid;
+ matched | tid | balance | sid | delta 
+---------+-----+---------+-----+-------
+ t       |   1 |      10 |     |      
+ t       |   2 |      20 |     |      
+ t       |   3 |      30 |     |      
+(3 rows)
+
+ALTER TABLE target OWNER TO regress_merge_privs;
+ALTER TABLE source OWNER TO regress_merge_privs;
+CREATE TABLE target2 (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE source2 (sid integer, delta integer)
+  WITH (autovacuum_enabled=off);
+ALTER TABLE target2 OWNER TO regress_merge_no_privs;
+ALTER TABLE source2 OWNER TO regress_merge_no_privs;
+GRANT INSERT ON target TO regress_merge_no_privs;
+GRANT CREATE ON SCHEMA public TO regress_merge_privs;
+SET SESSION AUTHORIZATION regress_merge_privs;
+CREATE TABLE sq_target (tid integer NOT NULL, balance integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE sq_source (delta integer, sid integer, balance integer DEFAULT 0)
+  WITH (autovacuum_enabled=off);
+INSERT INTO sq_target(tid, balance) VALUES (1,100), (2,200), (3,300);
+INSERT INTO sq_source(sid, delta) VALUES (1,10), (2,20), (4,40);
+-- conditional WHEN clause
+CREATE TABLE wq_target (tid integer not null, balance integer DEFAULT -1)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE wq_source (balance integer, sid integer)
+  WITH (autovacuum_enabled=off);
+INSERT INTO wq_source (sid, balance) VALUES (1, 100);
+CREATE TABLE cj_target (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE cj_source1 (sid1 integer, scat integer, delta integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE cj_source2 (sid2 integer, sval text)
+  WITH (autovacuum_enabled=off);
+INSERT INTO cj_source1 VALUES (1, 10, 100);
+INSERT INTO cj_source1 VALUES (1, 20, 200);
+INSERT INTO cj_source1 VALUES (2, 20, 300);
+INSERT INTO cj_source1 VALUES (3, 10, 400);
+INSERT INTO cj_source2 VALUES (1, 'initial source2');
+INSERT INTO cj_source2 VALUES (2, 'initial source2');
+INSERT INTO cj_source2 VALUES (3, 'initial source2');
+CREATE TABLE fs_target (a int, b int, c text)
+  WITH (autovacuum_enabled=off);
+-- run tests on normal table
+\o :TEST_RESULTS_WITH_NO_HYPERTABLE
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+--
+-- Errors
+--
+MERGE INTO target t RANDOMWORD
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:12: ERROR:  syntax error at or near "RANDOMWORD"
+LINE 1: MERGE INTO target t RANDOMWORD
+                            ^
+-- MATCHED/INSERT error
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:18: ERROR:  syntax error at or near "INSERT"
+LINE 5:  INSERT DEFAULT VALUES;
+         ^
+-- incorrectly specifying INTO target
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT INTO target DEFAULT VALUES;
+psql:include/ts_merge_query.sql:24: ERROR:  syntax error at or near "INTO"
+LINE 5:  INSERT INTO target DEFAULT VALUES;
+                ^
+-- Multiple VALUES clause
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (1,1), (2,2);
+psql:include/ts_merge_query.sql:30: ERROR:  syntax error at or near ","
+LINE 5:  INSERT VALUES (1,1), (2,2);
+                            ^
+-- SELECT query for INSERT
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT SELECT (1, 1);
+psql:include/ts_merge_query.sql:36: ERROR:  syntax error at or near "SELECT"
+LINE 5:  INSERT SELECT (1, 1);
+                ^
+-- NOT MATCHED/UPDATE
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:42: ERROR:  syntax error at or near "UPDATE"
+LINE 5:  UPDATE SET balance = 0;
+         ^
+-- UPDATE tablename
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE target SET balance = 0;
+psql:include/ts_merge_query.sql:48: ERROR:  syntax error at or near "target"
+LINE 5:  UPDATE target SET balance = 0;
+                ^
+-- source and target names the same
+MERGE INTO target
+USING target
+ON tid = tid
+WHEN MATCHED THEN DO NOTHING;
+psql:include/ts_merge_query.sql:53: ERROR:  name "target" specified more than once
+DETAIL:  The name is used both as MERGE target table and data source.
+-- used in a CTE
+WITH foo AS (
+  MERGE INTO target USING source ON (true)
+  WHEN MATCHED THEN DELETE
+) SELECT * FROM foo;
+psql:include/ts_merge_query.sql:58: ERROR:  MERGE not supported in WITH query
+LINE 1: WITH foo AS (
+             ^
+-- used in COPY
+COPY (
+  MERGE INTO target USING source ON (true)
+  WHEN MATCHED THEN DELETE
+) TO stdout;
+psql:include/ts_merge_query.sql:63: ERROR:  MERGE not supported in COPY
+-- unsupported relation types
+-- view
+CREATE VIEW tv AS SELECT * FROM target;
+MERGE INTO tv t
+USING source s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:72: ERROR:  cannot execute MERGE on relation "tv"
+DETAIL:  This operation is not supported for views.
+DROP VIEW tv;
+-- materialized view
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM target;
+MERGE INTO mv t
+USING source s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:81: ERROR:  cannot execute MERGE on relation "mv"
+DETAIL:  This operation is not supported for materialized views.
+DROP MATERIALIZED VIEW mv;
+-- permissions
+MERGE INTO target
+USING source2
+ON target.tid = source2.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:90: ERROR:  permission denied for table source2
+GRANT INSERT ON target TO regress_merge_no_privs;
+SET SESSION AUTHORIZATION regress_merge_no_privs;
+MERGE INTO target
+USING source2
+ON target.tid = source2.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:99: ERROR:  permission denied for table target
+GRANT UPDATE ON target2 TO regress_merge_privs;
+SET SESSION AUTHORIZATION regress_merge_privs;
+MERGE INTO target2
+USING source
+ON target2.tid = source.sid
+WHEN MATCHED THEN
+	DELETE;
+psql:include/ts_merge_query.sql:108: ERROR:  permission denied for table target2
+MERGE INTO target2
+USING source
+ON target2.tid = source.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:114: ERROR:  permission denied for table target2
+-- check if the target can be accessed from source relation subquery; we should
+-- not be able to do so
+MERGE INTO target t
+USING (SELECT * FROM source WHERE t.tid > sid) s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:122: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 2: USING (SELECT * FROM source WHERE t.tid > sid) s
+                                          ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+--
+-- initial tests
+--
+-- zero rows in source has no effect
+MERGE INTO target
+USING source
+ON target.tid = source.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+ROLLBACK;
+-- insert some non-matching source rows to work from
+INSERT INTO source VALUES (4, 40);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	DO NOTHING;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (5, 50);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- index plans
+INSERT INTO target SELECT generate_series(1000,2500), 0;
+ALTER TABLE target ADD PRIMARY KEY (tid);
+ANALYZE target;
+DELETE FROM target WHERE tid > 100;
+ANALYZE target;
+-- insert some matching source rows to work from
+INSERT INTO source VALUES (2, 5);
+INSERT INTO source VALUES (3, 20);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+-- equivalent of an UPDATE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- equivalent of a DELETE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DO NOTHING;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, NULL);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- duplicate source row causes multiple target row update ERROR
+INSERT INTO source VALUES (2, 5);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:241: ERROR:  MERGE command cannot affect row a second time
+HINT:  Ensure that not more than one source row matches any one target row.
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+psql:include/ts_merge_query.sql:249: ERROR:  MERGE command cannot affect row a second time
+HINT:  Ensure that not more than one source row matches any one target row.
+ROLLBACK;
+-- remove duplicate MATCHED data from source data
+DELETE FROM source WHERE sid = 2;
+INSERT INTO source VALUES (2, 5);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+-- duplicate source row on INSERT should fail because of target_pkey
+INSERT INTO source VALUES (4, 40);
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+  INSERT VALUES (4, NULL);
+psql:include/ts_merge_query.sql:265: ERROR:  duplicate key value violates unique constraint "target_pkey"
+DETAIL:  Key (tid)=(4) already exists.
+SELECT * FROM target ORDER BY tid;
+psql:include/ts_merge_query.sql:266: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+-- remove duplicate NOT MATCHED data from source data
+DELETE FROM source WHERE sid = 4;
+INSERT INTO source VALUES (4, 40);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+-- remove constraints
+alter table target drop CONSTRAINT target_pkey;
+alter table target alter column tid drop not null;
+-- multiple actions
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, 4)
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- should be equivalent
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, 4);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- column references
+-- do a simple equivalent of an UPDATE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.delta;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- do a simple equivalent of an INSERT SELECT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- and again with duplicate source rows
+INSERT INTO source VALUES (5, 50);
+INSERT INTO source VALUES (5, 50);
+-- do a simple equivalent of an INSERT SELECT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+  INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- removing duplicate source rows
+DELETE FROM source WHERE sid = 5;
+-- and again with explicitly identified column list
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- and again with a subtle error: referring to non-existent target row for NOT MATCHED
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (t.tid, s.delta);
+psql:include/ts_merge_query.sql:356: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 5:  INSERT (tid, balance) VALUES (t.tid, s.delta);
+                                       ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+-- and again with a constant ON clause
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON (SELECT true)
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (t.tid, s.delta);
+psql:include/ts_merge_query.sql:364: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 5:  INSERT (tid, balance) VALUES (t.tid, s.delta);
+                                       ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+SELECT * FROM target ORDER BY tid;
+psql:include/ts_merge_query.sql:365: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+-- now the classic UPSERT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.delta
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- this time with a FALSE condition
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND FALSE THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+-- this time with an actual condition which returns false
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance <> 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+BEGIN;
+-- and now with a condition which returns true
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+ROLLBACK;
+-- conditions in the NOT MATCHED clause can only refer to source columns
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND t.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+psql:include/ts_merge_query.sql:408: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 3: WHEN NOT MATCHED AND t.balance = 100 THEN
+                             ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+SELECT * FROM wq_target;
+psql:include/ts_merge_query.sql:409: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+-- conditions in MATCHED clause can refer to both source and target
+SELECT * FROM wq_source;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND s.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+-- check if AND works
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 AND s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 AND s.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+-- check if OR works
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 OR s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 199 OR s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+-- check source-side whole-row references
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON (t.tid = s.sid)
+WHEN matched and t = s or t.tid = s.sid THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+ROLLBACK;
+-- check if subqueries work in the conditions?
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance > (SELECT max(balance) FROM target) THEN
+	UPDATE SET balance = t.balance + s.balance;
+-- check if we can access system columns in the conditions
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.xmin = t.xmax THEN
+	UPDATE SET balance = t.balance + s.balance;
+psql:include/ts_merge_query.sql:477: ERROR:  cannot use system column "xmin" in MERGE WHEN condition
+LINE 3: WHEN MATCHED AND t.xmin = t.xmax THEN
+                         ^
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.tableoid >= 0 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+DROP TABLE wq_target CASCADE;
+DROP TABLE wq_source;
+-- test triggers
+create or replace function merge_trigfunc () returns trigger
+language plpgsql as
+$$
+DECLARE
+	line text;
+BEGIN
+	SELECT INTO line format('%s %s %s trigger%s',
+		TG_WHEN, TG_OP, TG_LEVEL, CASE
+		WHEN TG_OP = 'INSERT' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s', NEW)
+		WHEN TG_OP = 'UPDATE' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s -> %s', OLD, NEW)
+		WHEN TG_OP = 'DELETE' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s', OLD)
+		END);
+
+	RAISE NOTICE '%', line;
+	IF (TG_WHEN = 'BEFORE' AND TG_LEVEL = 'ROW') THEN
+		IF (TG_OP = 'DELETE') THEN
+			RETURN OLD;
+		ELSE
+			RETURN NEW;
+		END IF;
+	ELSE
+		RETURN NULL;
+	END IF;
+END;
+$$;
+CREATE TRIGGER merge_bsi BEFORE INSERT ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bsu BEFORE UPDATE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bsd BEFORE DELETE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asi AFTER INSERT ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asu AFTER UPDATE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asd AFTER DELETE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bri BEFORE INSERT ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bru BEFORE UPDATE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_brd BEFORE DELETE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_ari AFTER INSERT ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_aru AFTER UPDATE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_ard AFTER DELETE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+-- now the classic UPSERT, with a DELETE
+BEGIN;
+UPDATE target SET balance = 0 WHERE tid = 3;
+--EXPLAIN (ANALYZE ON, COSTS OFF, SUMMARY OFF, TIMING OFF)
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND t.balance > s.delta THEN
+	UPDATE SET balance = t.balance - s.delta
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- Test behavior of triggers that turn UPDATE/DELETE into no-ops
+create or replace function skip_merge_op() returns trigger
+language plpgsql as
+$$
+BEGIN
+	RETURN NULL;
+END;
+$$;
+SELECT * FROM target full outer join source on (sid = tid);
+create trigger merge_skip BEFORE INSERT OR UPDATE or DELETE
+  ON target FOR EACH ROW EXECUTE FUNCTION skip_merge_op();
+DO $$
+DECLARE
+  result integer;
+BEGIN
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND s.sid = 3 THEN UPDATE SET balance = t.balance + s.delta
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT VALUES (sid, delta);
+IF FOUND THEN
+  RAISE NOTICE 'Found';
+ELSE
+  RAISE NOTICE 'Not found';
+END IF;
+GET DIAGNOSTICS result := ROW_COUNT;
+RAISE NOTICE 'ROW_COUNT = %', result;
+END;
+$$;
+SELECT * FROM target FULL OUTER JOIN source ON (sid = tid);
+DROP TRIGGER merge_skip ON target;
+DROP FUNCTION skip_merge_op();
+-- test from PL/pgSQL
+-- make sure MERGE INTO isn't interpreted to mean returning variables like SELECT INTO
+BEGIN;
+DO LANGUAGE plpgsql $$
+BEGIN
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND t.balance > s.delta THEN
+	UPDATE SET balance = t.balance - s.delta;
+END;
+$$;
+ROLLBACK;
+--source constants
+BEGIN;
+MERGE INTO target t
+USING (SELECT 9 AS sid, 57 AS delta) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+--source query
+BEGIN;
+MERGE INTO target t
+USING (SELECT sid, delta FROM source WHERE delta > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING (SELECT sid, delta as newname FROM source WHERE delta > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.newname);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+--self-merge
+BEGIN;
+MERGE INTO target t1
+USING target t2
+ON t1.tid = t2.tid
+WHEN MATCHED THEN
+	UPDATE SET balance = t1.balance + t2.balance
+WHEN NOT MATCHED THEN
+	INSERT VALUES (t2.tid, t2.balance);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING (SELECT tid as sid, balance as delta FROM target WHERE balance > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING
+(SELECT sid, max(delta) AS delta
+ FROM source
+ GROUP BY sid
+ HAVING count(*) = 1
+ ORDER BY sid ASC) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- plpgsql parameters and results
+BEGIN;
+CREATE FUNCTION merge_func (p_id integer, p_bal integer)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+ result integer;
+BEGIN
+MERGE INTO target t
+USING (SELECT p_id AS sid) AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance - p_bal;
+IF FOUND THEN
+	GET DIAGNOSTICS result := ROW_COUNT;
+END IF;
+RETURN result;
+END;
+$$;
+SELECT merge_func(3, 4);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- PREPARE
+BEGIN;
+prepare foom as merge into target t using (select 1 as sid) s on (t.tid = s.sid) when matched then update set balance = 1;
+execute foom;
+ROLLBACK;
+BEGIN;
+PREPARE foom2 (integer, integer) AS
+MERGE INTO target t
+USING (SELECT 1) s
+ON t.tid = $1
+WHEN MATCHED THEN
+UPDATE SET balance = $2;
+--EXPLAIN (ANALYZE ON, COSTS OFF, SUMMARY OFF, TIMING OFF)
+execute foom2 (1, 1);
+ROLLBACK;
+-- subqueries in source relation
+BEGIN;
+MERGE INTO sq_target t
+USING (SELECT * FROM sq_source) s
+ON tid = sid
+WHEN MATCHED AND t.balance > delta THEN
+	UPDATE SET balance = t.balance + delta;
+SELECT * FROM sq_target ORDER BY tid;
+ROLLBACK;
+-- try a view
+CREATE VIEW v AS SELECT * FROM sq_source WHERE sid < 2;
+BEGIN;
+MERGE INTO sq_target
+USING v
+ON tid = sid
+WHEN MATCHED THEN
+    UPDATE SET balance = v.balance + delta;
+SELECT * FROM sq_target ORDER BY tid;
+ROLLBACK;
+-- ambiguous reference to a column
+BEGIN;
+MERGE INTO sq_target
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+psql:include/ts_merge_query.sql:732: ERROR:  column reference "balance" is ambiguous
+LINE 5:     UPDATE SET balance = balance + delta
+                                 ^
+ROLLBACK;
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+SELECT * FROM sq_target;
+ROLLBACK;
+-- CTEs
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+WITH targq AS (
+	SELECT * FROM v
+)
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+ROLLBACK;
+-- RETURNING
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE
+RETURNING *;
+psql:include/ts_merge_query.sql:778: ERROR:  syntax error at or near "RETURNING"
+LINE 10: RETURNING *;
+         ^
+ROLLBACK;
+-- EXPLAIN
+CREATE TABLE ex_mtarget (a int, b int)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE ex_msource (a int, b int)
+  WITH (autovacuum_enabled=off);
+INSERT INTO ex_mtarget SELECT i, i*10 FROM generate_series(1,100,2) i;
+INSERT INTO ex_msource SELECT i, i*10 FROM generate_series(1,100,1) i;
+CREATE FUNCTION explain_merge(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE ln text;
+BEGIN
+    FOR ln IN
+        EXECUTE 'explain (analyze, timing off, summary off, costs off) ' ||
+		  query
+    LOOP
+        ln := regexp_replace(ln, '(Memory( Usage)?|Buckets|Batches): \S*',  '\1: xxx', 'g');
+        RETURN NEXT ln;
+    END LOOP;
+END;
+$$;
+-- only updates
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED THEN
+	UPDATE SET b = t.b + 1');
+-- only updates to selected tuples
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1');
+-- updates + deletes
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1
+WHEN MATCHED AND t.a >= 10 AND t.a <= 20 THEN
+	DELETE');
+-- only inserts
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN NOT MATCHED AND s.a < 10 THEN
+	INSERT VALUES (a, b)');
+-- all three
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1
+WHEN MATCHED AND t.a >= 30 AND t.a <= 40 THEN
+	DELETE
+WHEN NOT MATCHED AND s.a < 20 THEN
+	INSERT VALUES (a, b)');
+-- nothing
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a AND t.a < -1000
+WHEN MATCHED AND t.a < 10 THEN
+	DO NOTHING');
+DROP TABLE ex_msource, ex_mtarget;
+DROP FUNCTION explain_merge(text);
+-- Subqueries
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED THEN
+    UPDATE SET balance = (SELECT count(*) FROM sq_target);
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND (SELECT count(*) > 0 FROM sq_target) THEN
+    UPDATE SET balance = 42;
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid AND (SELECT count(*) > 0 FROM sq_target)
+WHEN MATCHED THEN
+    UPDATE SET balance = 42;
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+DROP TABLE sq_target CASCADE;
+DROP TABLE sq_source CASCADE;
+CREATE TABLE pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+CREATE TABLE part1 PARTITION OF pa_target FOR VALUES IN (1,4)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 PARTITION OF pa_target FOR VALUES IN (2,5,6)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 PARTITION OF pa_target FOR VALUES IN (3,8,9)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 PARTITION OF pa_target DEFAULT
+  WITH (autovacuum_enabled=off);
+CREATE TABLE pa_source (sid integer, delta float);
+-- insert many rows to the source table
+INSERT INTO pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- same with a constant qual
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid AND tid = 1
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- try updating the partition key column
+BEGIN;
+CREATE FUNCTION merge_func() RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE
+  result integer;
+BEGIN
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+IF FOUND THEN
+  GET DIAGNOSTICS result := ROW_COUNT;
+END IF;
+RETURN result;
+END;
+$$;
+SELECT merge_func();
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+DROP TABLE pa_target CASCADE;
+-- The target table is partitioned in the same way, but this time by attaching
+-- partitions which have columns in different order, dropped columns etc.
+CREATE TABLE pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+CREATE TABLE part1 (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 (balance float, tid integer, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 (extraid text, tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+ALTER TABLE part4 DROP COLUMN extraid;
+ALTER TABLE pa_target ATTACH PARTITION part1 FOR VALUES IN (1,4);
+ALTER TABLE pa_target ATTACH PARTITION part2 FOR VALUES IN (2,5,6);
+ALTER TABLE pa_target ATTACH PARTITION part3 FOR VALUES IN (3,8,9);
+ALTER TABLE pa_target ATTACH PARTITION part4 DEFAULT;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- same with a constant qual
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid AND tid IN (1, 5)
+  WHEN MATCHED AND tid % 5 = 0 THEN DELETE
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- try updating the partition key column
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+DROP TABLE pa_source;
+DROP TABLE pa_target CASCADE;
+-- Sub-partitioning
+CREATE TABLE pa_target (logts timestamp, tid integer, balance float, val text)
+	PARTITION BY RANGE (logts);
+CREATE TABLE part_m01 PARTITION OF pa_target
+	FOR VALUES FROM ('2017-01-01') TO ('2017-02-01')
+	PARTITION BY LIST (tid);
+CREATE TABLE part_m01_odd PARTITION OF part_m01
+	FOR VALUES IN (1,3,5,7,9) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m01_even PARTITION OF part_m01
+	FOR VALUES IN (2,4,6,8) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m02 PARTITION OF pa_target
+	FOR VALUES FROM ('2017-02-01') TO ('2017-03-01')
+	PARTITION BY LIST (tid);
+CREATE TABLE part_m02_odd PARTITION OF part_m02
+	FOR VALUES IN (1,3,5,7,9) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m02_even PARTITION OF part_m02
+	FOR VALUES IN (2,4,6,8) WITH (autovacuum_enabled=off);
+CREATE TABLE pa_source (sid integer, delta float)
+  WITH (autovacuum_enabled=off);
+-- insert many rows to the source table
+INSERT INTO pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT '2017-01-31', id, id * 100, 'initial' FROM generate_series(1,9,3) AS id;
+INSERT INTO pa_target SELECT '2017-02-28', id, id * 100, 'initial' FROM generate_series(2,9,3) AS id;
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING (SELECT '2017-01-15' AS slogts, * FROM pa_source WHERE sid < 10) s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+DROP TABLE pa_source;
+DROP TABLE pa_target CASCADE;
+-- some complex joins on the source side
+-- source relation is an unaliased join
+MERGE INTO cj_target t
+USING cj_source1 s1
+	INNER JOIN cj_source2 s2 ON sid1 = sid2
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid1, delta, sval);
+-- try accessing columns from either side of the source join
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2 AND scat = 20
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid2, delta, sval)
+WHEN MATCHED THEN
+	DELETE;
+-- some simple expressions in INSERT targetlist
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid2, delta + scat, sval)
+WHEN MATCHED THEN
+	UPDATE SET val = val || ' updated by merge';
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2 AND scat = 20
+ON t.tid = sid1
+WHEN MATCHED THEN
+	UPDATE SET val = val || ' ' || delta::text;
+SELECT * FROM cj_target ORDER BY tid;
+ALTER TABLE cj_source1 RENAME COLUMN sid1 TO sid;
+ALTER TABLE cj_source2 RENAME COLUMN sid2 TO sid;
+TRUNCATE cj_target;
+MERGE INTO cj_target t
+USING cj_source1 s1
+	INNER JOIN cj_source2 s2 ON s1.sid = s2.sid
+ON t.tid = s1.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s2.sid, delta, sval);
+DROP TABLE cj_source2, cj_source1;
+DROP TABLE cj_target CASCADE;
+-- Function scans
+MERGE INTO fs_target t
+USING generate_series(1,100,1) AS id
+ON t.a = id
+WHEN MATCHED THEN
+	UPDATE SET b = b + id
+WHEN NOT MATCHED THEN
+	INSERT VALUES (id, -1);
+MERGE INTO fs_target t
+USING generate_series(1,100,2) AS id
+ON t.a = id
+WHEN MATCHED THEN
+	UPDATE SET b = b + id, c = 'updated '|| id.*::text
+WHEN NOT MATCHED THEN
+	INSERT VALUES (id, -1, 'inserted ' || id.*::text);
+SELECT count(*) FROM fs_target;
+DROP TABLE fs_target CASCADE;
+-- SERIALIZABLE test
+-- handled in isolation tests
+-- Inheritance-based partitioning
+CREATE TABLE measurement (
+    city_id         int not null,
+    logdate         date not null,
+    peaktemp        int,
+    unitsales       int
+) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2006m02 (
+    CHECK ( logdate >= DATE '2006-02-01' AND logdate < DATE '2006-03-01' )
+) INHERITS (measurement) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2006m03 (
+    CHECK ( logdate >= DATE '2006-03-01' AND logdate < DATE '2006-04-01' )
+) INHERITS (measurement) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2007m01 (
+    filler          text,
+    peaktemp        int,
+    logdate         date not null,
+    city_id         int not null,
+    unitsales       int
+    CHECK ( logdate >= DATE '2007-01-01' AND logdate < DATE '2007-02-01')
+) WITH (autovacuum_enabled=off);
+ALTER TABLE measurement_y2007m01 DROP COLUMN filler;
+ALTER TABLE measurement_y2007m01 INHERIT measurement;
+INSERT INTO measurement VALUES (0, '2005-07-21', 5, 15);
+CREATE OR REPLACE FUNCTION measurement_insert_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF ( NEW.logdate >= DATE '2006-02-01' AND
+         NEW.logdate < DATE '2006-03-01' ) THEN
+        INSERT INTO measurement_y2006m02 VALUES (NEW.*);
+    ELSIF ( NEW.logdate >= DATE '2006-03-01' AND
+            NEW.logdate < DATE '2006-04-01' ) THEN
+        INSERT INTO measurement_y2006m03 VALUES (NEW.*);
+    ELSIF ( NEW.logdate >= DATE '2007-01-01' AND
+            NEW.logdate < DATE '2007-02-01' ) THEN
+        INSERT INTO measurement_y2007m01 (city_id, logdate, peaktemp, unitsales)
+            VALUES (NEW.*);
+    ELSE
+        RAISE EXCEPTION 'Date out of range.  Fix the measurement_insert_trigger() function!';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql ;
+CREATE TRIGGER insert_measurement_trigger
+    BEFORE INSERT ON measurement
+    FOR EACH ROW EXECUTE PROCEDURE measurement_insert_trigger();
+INSERT INTO measurement VALUES (1, '2006-02-10', 35, 10);
+INSERT INTO measurement VALUES (1, '2006-02-16', 45, 20);
+INSERT INTO measurement VALUES (1, '2006-03-17', 25, 10);
+INSERT INTO measurement VALUES (1, '2006-03-27', 15, 40);
+INSERT INTO measurement VALUES (1, '2007-01-15', 10, 10);
+INSERT INTO measurement VALUES (1, '2007-01-17', 10, 10);
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
+CREATE TABLE new_measurement (LIKE measurement) WITH (autovacuum_enabled=off);
+INSERT INTO new_measurement VALUES (0, '2005-07-21', 25, 20);
+INSERT INTO new_measurement VALUES (1, '2006-03-01', 20, 10);
+INSERT INTO new_measurement VALUES (1, '2006-02-16', 50, 10);
+INSERT INTO new_measurement VALUES (2, '2006-02-10', 20, 20);
+INSERT INTO new_measurement VALUES (1, '2006-03-27', NULL, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-17', NULL, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-15', 5, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-16', 10, 10);
+BEGIN;
+MERGE INTO ONLY measurement m
+ USING new_measurement nm ON
+      (m.city_id = nm.city_id and m.logdate=nm.logdate)
+WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE
+WHEN MATCHED THEN UPDATE
+     SET peaktemp = greatest(m.peaktemp, nm.peaktemp),
+        unitsales = m.unitsales + coalesce(nm.unitsales, 0)
+WHEN NOT MATCHED THEN INSERT
+     (city_id, logdate, peaktemp, unitsales)
+   VALUES (city_id, logdate, peaktemp, unitsales);
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate, peaktemp;
+ROLLBACK;
+MERGE into measurement m
+ USING new_measurement nm ON
+      (m.city_id = nm.city_id and m.logdate=nm.logdate)
+WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE
+WHEN MATCHED THEN UPDATE
+     SET peaktemp = greatest(m.peaktemp, nm.peaktemp),
+        unitsales = m.unitsales + coalesce(nm.unitsales, 0)
+WHEN NOT MATCHED THEN INSERT
+     (city_id, logdate, peaktemp, unitsales)
+   VALUES (city_id, logdate, peaktemp, unitsales);
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
+BEGIN;
+MERGE INTO new_measurement nm
+ USING ONLY measurement m ON
+      (nm.city_id = m.city_id and nm.logdate=m.logdate)
+WHEN MATCHED THEN DELETE;
+SELECT * FROM new_measurement ORDER BY city_id, logdate;
+ROLLBACK;
+MERGE INTO new_measurement nm
+ USING measurement m ON
+      (nm.city_id = m.city_id and nm.logdate=m.logdate)
+WHEN MATCHED THEN DELETE;
+SELECT * FROM new_measurement ORDER BY city_id, logdate;
+DROP TABLE measurement, new_measurement CASCADE;
+DROP FUNCTION measurement_insert_trigger();
+RESET SESSION AUTHORIZATION;
+DROP TABLE target CASCADE;
+DROP TABLE target2 CASCADE;
+DROP TABLE source, source2;
+DROP FUNCTION merge_trigfunc();
+REVOKE CREATE ON SCHEMA public FROM regress_merge_privs;
+DROP USER regress_merge_privs;
+DROP USER regress_merge_no_privs;
+\o
+\ir :TEST_LOAD_HT_NAME
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+CREATE USER regress_merge_privs;
+CREATE USER regress_merge_no_privs;
+DROP TABLE IF EXISTS target;
+DROP TABLE IF EXISTS source;
+CREATE TABLE target (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('target', 'tid', chunk_time_interval => 3);
+  create_hypertable  
+---------------------
+ (1,public,target,t)
+(1 row)
+
+CREATE TABLE source (sid integer, delta integer) -- no index
+  WITH (autovacuum_enabled=off);
+INSERT INTO target VALUES (1, 10);
+INSERT INTO target VALUES (2, 20);
+INSERT INTO target VALUES (3, 30);
+SELECT t.ctid is not null as matched, t.*, s.* FROM source s FULL OUTER JOIN target t ON s.sid = t.tid ORDER BY t.tid, s.sid;
+ matched | tid | balance | sid | delta 
+---------+-----+---------+-----+-------
+ t       |   1 |      10 |     |      
+ t       |   2 |      20 |     |      
+ t       |   3 |      30 |     |      
+(3 rows)
+
+ALTER TABLE target OWNER TO regress_merge_privs;
+ALTER TABLE source OWNER TO regress_merge_privs;
+CREATE TABLE target2 (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('target2', 'tid', chunk_time_interval => 3);
+  create_hypertable   
+----------------------
+ (2,public,target2,t)
+(1 row)
+
+CREATE TABLE source2 (sid integer, delta integer)
+  WITH (autovacuum_enabled=off);
+ALTER TABLE target2 OWNER TO regress_merge_no_privs;
+ALTER TABLE source2 OWNER TO regress_merge_no_privs;
+GRANT INSERT ON target TO regress_merge_no_privs;
+GRANT CREATE ON SCHEMA public TO regress_merge_privs;
+SET SESSION AUTHORIZATION regress_merge_privs;
+CREATE TABLE sq_target (tid integer NOT NULL, balance integer)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('sq_target', 'tid', chunk_time_interval => 3);
+   create_hypertable    
+------------------------
+ (3,public,sq_target,t)
+(1 row)
+
+CREATE TABLE sq_source (delta integer, sid integer, balance integer DEFAULT 0)
+  WITH (autovacuum_enabled=off);
+INSERT INTO sq_target(tid, balance) VALUES (1,100), (2,200), (3,300);
+INSERT INTO sq_source(sid, delta) VALUES (1,10), (2,20), (4,40);
+-- conditional WHEN clause
+CREATE TABLE wq_target (tid integer not null, balance integer DEFAULT -1)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('wq_target', 'tid', chunk_time_interval => 3);
+   create_hypertable    
+------------------------
+ (4,public,wq_target,t)
+(1 row)
+
+CREATE TABLE wq_source (balance integer, sid integer)
+  WITH (autovacuum_enabled=off);
+INSERT INTO wq_source (sid, balance) VALUES (1, 100);
+-- some complex joins on the source side
+CREATE TABLE cj_target (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('cj_target', 'tid', chunk_time_interval => 3);
+   create_hypertable    
+------------------------
+ (5,public,cj_target,t)
+(1 row)
+
+CREATE TABLE cj_source1 (sid1 integer, scat integer, delta integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE cj_source2 (sid2 integer, sval text)
+  WITH (autovacuum_enabled=off);
+INSERT INTO cj_source1 VALUES (1, 10, 100);
+INSERT INTO cj_source1 VALUES (1, 20, 200);
+INSERT INTO cj_source1 VALUES (2, 20, 300);
+INSERT INTO cj_source1 VALUES (3, 10, 400);
+INSERT INTO cj_source2 VALUES (1, 'initial source2');
+INSERT INTO cj_source2 VALUES (2, 'initial source2');
+INSERT INTO cj_source2 VALUES (3, 'initial source2');
+CREATE TABLE fs_target (a int, b int, c text)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('fs_target', 'a', chunk_time_interval => 3);
+   create_hypertable    
+------------------------
+ (6,public,fs_target,t)
+(1 row)
+
+-- run tests on hypertable
+\o :TEST_RESULTS_WITH_HYPERTABLE
+\ir :TEST_QUERY_NAME
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+--
+-- Errors
+--
+MERGE INTO target t RANDOMWORD
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:12: ERROR:  syntax error at or near "RANDOMWORD"
+LINE 1: MERGE INTO target t RANDOMWORD
+                            ^
+-- MATCHED/INSERT error
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:18: ERROR:  syntax error at or near "INSERT"
+LINE 5:  INSERT DEFAULT VALUES;
+         ^
+-- incorrectly specifying INTO target
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT INTO target DEFAULT VALUES;
+psql:include/ts_merge_query.sql:24: ERROR:  syntax error at or near "INTO"
+LINE 5:  INSERT INTO target DEFAULT VALUES;
+                ^
+-- Multiple VALUES clause
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (1,1), (2,2);
+psql:include/ts_merge_query.sql:30: ERROR:  syntax error at or near ","
+LINE 5:  INSERT VALUES (1,1), (2,2);
+                            ^
+-- SELECT query for INSERT
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT SELECT (1, 1);
+psql:include/ts_merge_query.sql:36: ERROR:  syntax error at or near "SELECT"
+LINE 5:  INSERT SELECT (1, 1);
+                ^
+-- NOT MATCHED/UPDATE
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:42: ERROR:  syntax error at or near "UPDATE"
+LINE 5:  UPDATE SET balance = 0;
+         ^
+-- UPDATE tablename
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE target SET balance = 0;
+psql:include/ts_merge_query.sql:48: ERROR:  syntax error at or near "target"
+LINE 5:  UPDATE target SET balance = 0;
+                ^
+-- source and target names the same
+MERGE INTO target
+USING target
+ON tid = tid
+WHEN MATCHED THEN DO NOTHING;
+psql:include/ts_merge_query.sql:53: ERROR:  name "target" specified more than once
+DETAIL:  The name is used both as MERGE target table and data source.
+-- used in a CTE
+WITH foo AS (
+  MERGE INTO target USING source ON (true)
+  WHEN MATCHED THEN DELETE
+) SELECT * FROM foo;
+psql:include/ts_merge_query.sql:58: ERROR:  MERGE not supported in WITH query
+LINE 1: WITH foo AS (
+             ^
+-- used in COPY
+COPY (
+  MERGE INTO target USING source ON (true)
+  WHEN MATCHED THEN DELETE
+) TO stdout;
+psql:include/ts_merge_query.sql:63: ERROR:  MERGE not supported in COPY
+-- unsupported relation types
+-- view
+CREATE VIEW tv AS SELECT * FROM target;
+MERGE INTO tv t
+USING source s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:72: ERROR:  cannot execute MERGE on relation "tv"
+DETAIL:  This operation is not supported for views.
+DROP VIEW tv;
+-- materialized view
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM target;
+MERGE INTO mv t
+USING source s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:81: ERROR:  cannot execute MERGE on relation "mv"
+DETAIL:  This operation is not supported for materialized views.
+DROP MATERIALIZED VIEW mv;
+-- permissions
+MERGE INTO target
+USING source2
+ON target.tid = source2.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:90: ERROR:  permission denied for table source2
+GRANT INSERT ON target TO regress_merge_no_privs;
+SET SESSION AUTHORIZATION regress_merge_no_privs;
+MERGE INTO target
+USING source2
+ON target.tid = source2.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:99: ERROR:  permission denied for table target
+GRANT UPDATE ON target2 TO regress_merge_privs;
+SET SESSION AUTHORIZATION regress_merge_privs;
+MERGE INTO target2
+USING source
+ON target2.tid = source.sid
+WHEN MATCHED THEN
+	DELETE;
+psql:include/ts_merge_query.sql:108: ERROR:  permission denied for table target2
+MERGE INTO target2
+USING source
+ON target2.tid = source.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:114: ERROR:  permission denied for table target2
+-- check if the target can be accessed from source relation subquery; we should
+-- not be able to do so
+MERGE INTO target t
+USING (SELECT * FROM source WHERE t.tid > sid) s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+psql:include/ts_merge_query.sql:122: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 2: USING (SELECT * FROM source WHERE t.tid > sid) s
+                                          ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+--
+-- initial tests
+--
+-- zero rows in source has no effect
+MERGE INTO target
+USING source
+ON target.tid = source.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+ROLLBACK;
+-- insert some non-matching source rows to work from
+INSERT INTO source VALUES (4, 40);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	DO NOTHING;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (5, 50);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- index plans
+INSERT INTO target SELECT generate_series(1000,2500), 0;
+ALTER TABLE target ADD PRIMARY KEY (tid);
+ANALYZE target;
+DELETE FROM target WHERE tid > 100;
+ANALYZE target;
+-- insert some matching source rows to work from
+INSERT INTO source VALUES (2, 5);
+INSERT INTO source VALUES (3, 20);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+-- equivalent of an UPDATE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- equivalent of a DELETE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DO NOTHING;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, NULL);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- duplicate source row causes multiple target row update ERROR
+INSERT INTO source VALUES (2, 5);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+psql:include/ts_merge_query.sql:241: ERROR:  MERGE command cannot affect row a second time
+HINT:  Ensure that not more than one source row matches any one target row.
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+psql:include/ts_merge_query.sql:249: ERROR:  MERGE command cannot affect row a second time
+HINT:  Ensure that not more than one source row matches any one target row.
+ROLLBACK;
+-- remove duplicate MATCHED data from source data
+DELETE FROM source WHERE sid = 2;
+INSERT INTO source VALUES (2, 5);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+-- duplicate source row on INSERT should fail because of target_pkey
+INSERT INTO source VALUES (4, 40);
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+  INSERT VALUES (4, NULL);
+psql:include/ts_merge_query.sql:265: ERROR:  duplicate key value violates unique constraint "2_2_target_pkey"
+DETAIL:  Key (tid)=(4) already exists.
+SELECT * FROM target ORDER BY tid;
+psql:include/ts_merge_query.sql:266: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+-- remove duplicate NOT MATCHED data from source data
+DELETE FROM source WHERE sid = 4;
+INSERT INTO source VALUES (4, 40);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+-- remove constraints
+alter table target drop CONSTRAINT target_pkey;
+alter table target alter column tid drop not null;
+psql:include/ts_merge_query.sql:277: ERROR:  cannot drop not-null constraint from a time-partitioned column
+-- multiple actions
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, 4)
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- should be equivalent
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, 4);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- column references
+-- do a simple equivalent of an UPDATE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.delta;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- do a simple equivalent of an INSERT SELECT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- and again with duplicate source rows
+INSERT INTO source VALUES (5, 50);
+INSERT INTO source VALUES (5, 50);
+-- do a simple equivalent of an INSERT SELECT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+  INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- removing duplicate source rows
+DELETE FROM source WHERE sid = 5;
+-- and again with explicitly identified column list
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- and again with a subtle error: referring to non-existent target row for NOT MATCHED
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (t.tid, s.delta);
+psql:include/ts_merge_query.sql:356: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 5:  INSERT (tid, balance) VALUES (t.tid, s.delta);
+                                       ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+-- and again with a constant ON clause
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON (SELECT true)
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (t.tid, s.delta);
+psql:include/ts_merge_query.sql:364: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 5:  INSERT (tid, balance) VALUES (t.tid, s.delta);
+                                       ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+SELECT * FROM target ORDER BY tid;
+psql:include/ts_merge_query.sql:365: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+-- now the classic UPSERT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.delta
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- this time with a FALSE condition
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND FALSE THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+-- this time with an actual condition which returns false
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance <> 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+BEGIN;
+-- and now with a condition which returns true
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+ROLLBACK;
+-- conditions in the NOT MATCHED clause can only refer to source columns
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND t.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+psql:include/ts_merge_query.sql:408: ERROR:  invalid reference to FROM-clause entry for table "t"
+LINE 3: WHEN NOT MATCHED AND t.balance = 100 THEN
+                             ^
+HINT:  There is an entry for table "t", but it cannot be referenced from this part of the query.
+SELECT * FROM wq_target;
+psql:include/ts_merge_query.sql:409: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+-- conditions in MATCHED clause can refer to both source and target
+SELECT * FROM wq_source;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND s.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+-- check if AND works
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 AND s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 AND s.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+-- check if OR works
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 OR s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 199 OR s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+-- check source-side whole-row references
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON (t.tid = s.sid)
+WHEN matched and t = s or t.tid = s.sid THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+ROLLBACK;
+-- check if subqueries work in the conditions?
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance > (SELECT max(balance) FROM target) THEN
+	UPDATE SET balance = t.balance + s.balance;
+-- check if we can access system columns in the conditions
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.xmin = t.xmax THEN
+	UPDATE SET balance = t.balance + s.balance;
+psql:include/ts_merge_query.sql:477: ERROR:  cannot use system column "xmin" in MERGE WHEN condition
+LINE 3: WHEN MATCHED AND t.xmin = t.xmax THEN
+                         ^
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.tableoid >= 0 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+DROP TABLE wq_target CASCADE;
+DROP TABLE wq_source;
+-- test triggers
+create or replace function merge_trigfunc () returns trigger
+language plpgsql as
+$$
+DECLARE
+	line text;
+BEGIN
+	SELECT INTO line format('%s %s %s trigger%s',
+		TG_WHEN, TG_OP, TG_LEVEL, CASE
+		WHEN TG_OP = 'INSERT' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s', NEW)
+		WHEN TG_OP = 'UPDATE' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s -> %s', OLD, NEW)
+		WHEN TG_OP = 'DELETE' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s', OLD)
+		END);
+
+	RAISE NOTICE '%', line;
+	IF (TG_WHEN = 'BEFORE' AND TG_LEVEL = 'ROW') THEN
+		IF (TG_OP = 'DELETE') THEN
+			RETURN OLD;
+		ELSE
+			RETURN NEW;
+		END IF;
+	ELSE
+		RETURN NULL;
+	END IF;
+END;
+$$;
+CREATE TRIGGER merge_bsi BEFORE INSERT ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bsu BEFORE UPDATE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bsd BEFORE DELETE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asi AFTER INSERT ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asu AFTER UPDATE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asd AFTER DELETE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bri BEFORE INSERT ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bru BEFORE UPDATE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_brd BEFORE DELETE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_ari AFTER INSERT ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_aru AFTER UPDATE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_ard AFTER DELETE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+-- now the classic UPSERT, with a DELETE
+BEGIN;
+UPDATE target SET balance = 0 WHERE tid = 3;
+--EXPLAIN (ANALYZE ON, COSTS OFF, SUMMARY OFF, TIMING OFF)
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND t.balance > s.delta THEN
+	UPDATE SET balance = t.balance - s.delta
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- Test behavior of triggers that turn UPDATE/DELETE into no-ops
+create or replace function skip_merge_op() returns trigger
+language plpgsql as
+$$
+BEGIN
+	RETURN NULL;
+END;
+$$;
+SELECT * FROM target full outer join source on (sid = tid);
+create trigger merge_skip BEFORE INSERT OR UPDATE or DELETE
+  ON target FOR EACH ROW EXECUTE FUNCTION skip_merge_op();
+DO $$
+DECLARE
+  result integer;
+BEGIN
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND s.sid = 3 THEN UPDATE SET balance = t.balance + s.delta
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT VALUES (sid, delta);
+IF FOUND THEN
+  RAISE NOTICE 'Found';
+ELSE
+  RAISE NOTICE 'Not found';
+END IF;
+GET DIAGNOSTICS result := ROW_COUNT;
+RAISE NOTICE 'ROW_COUNT = %', result;
+END;
+$$;
+SELECT * FROM target FULL OUTER JOIN source ON (sid = tid);
+DROP TRIGGER merge_skip ON target;
+DROP FUNCTION skip_merge_op();
+-- test from PL/pgSQL
+-- make sure MERGE INTO isn't interpreted to mean returning variables like SELECT INTO
+BEGIN;
+DO LANGUAGE plpgsql $$
+BEGIN
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND t.balance > s.delta THEN
+	UPDATE SET balance = t.balance - s.delta;
+END;
+$$;
+ROLLBACK;
+--source constants
+BEGIN;
+MERGE INTO target t
+USING (SELECT 9 AS sid, 57 AS delta) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+--source query
+BEGIN;
+MERGE INTO target t
+USING (SELECT sid, delta FROM source WHERE delta > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING (SELECT sid, delta as newname FROM source WHERE delta > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.newname);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+--self-merge
+BEGIN;
+MERGE INTO target t1
+USING target t2
+ON t1.tid = t2.tid
+WHEN MATCHED THEN
+	UPDATE SET balance = t1.balance + t2.balance
+WHEN NOT MATCHED THEN
+	INSERT VALUES (t2.tid, t2.balance);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING (SELECT tid as sid, balance as delta FROM target WHERE balance > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+BEGIN;
+MERGE INTO target t
+USING
+(SELECT sid, max(delta) AS delta
+ FROM source
+ GROUP BY sid
+ HAVING count(*) = 1
+ ORDER BY sid ASC) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- plpgsql parameters and results
+BEGIN;
+CREATE FUNCTION merge_func (p_id integer, p_bal integer)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+ result integer;
+BEGIN
+MERGE INTO target t
+USING (SELECT p_id AS sid) AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance - p_bal;
+IF FOUND THEN
+	GET DIAGNOSTICS result := ROW_COUNT;
+END IF;
+RETURN result;
+END;
+$$;
+SELECT merge_func(3, 4);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+-- PREPARE
+BEGIN;
+prepare foom as merge into target t using (select 1 as sid) s on (t.tid = s.sid) when matched then update set balance = 1;
+psql:include/ts_merge_query.sql:685: ERROR:  prepared statement "foom" already exists
+execute foom;
+psql:include/ts_merge_query.sql:686: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+BEGIN;
+PREPARE foom2 (integer, integer) AS
+MERGE INTO target t
+USING (SELECT 1) s
+ON t.tid = $1
+WHEN MATCHED THEN
+UPDATE SET balance = $2;
+psql:include/ts_merge_query.sql:695: ERROR:  prepared statement "foom2" already exists
+--EXPLAIN (ANALYZE ON, COSTS OFF, SUMMARY OFF, TIMING OFF)
+execute foom2 (1, 1);
+psql:include/ts_merge_query.sql:697: ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK;
+-- subqueries in source relation
+BEGIN;
+MERGE INTO sq_target t
+USING (SELECT * FROM sq_source) s
+ON tid = sid
+WHEN MATCHED AND t.balance > delta THEN
+	UPDATE SET balance = t.balance + delta;
+SELECT * FROM sq_target ORDER BY tid;
+ROLLBACK;
+-- try a view
+CREATE VIEW v AS SELECT * FROM sq_source WHERE sid < 2;
+BEGIN;
+MERGE INTO sq_target
+USING v
+ON tid = sid
+WHEN MATCHED THEN
+    UPDATE SET balance = v.balance + delta;
+SELECT * FROM sq_target ORDER BY tid;
+ROLLBACK;
+-- ambiguous reference to a column
+BEGIN;
+MERGE INTO sq_target
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+psql:include/ts_merge_query.sql:732: ERROR:  column reference "balance" is ambiguous
+LINE 5:     UPDATE SET balance = balance + delta
+                                 ^
+ROLLBACK;
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+SELECT * FROM sq_target;
+ROLLBACK;
+-- CTEs
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+WITH targq AS (
+	SELECT * FROM v
+)
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+ROLLBACK;
+-- RETURNING
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE
+RETURNING *;
+psql:include/ts_merge_query.sql:778: ERROR:  syntax error at or near "RETURNING"
+LINE 10: RETURNING *;
+         ^
+ROLLBACK;
+-- EXPLAIN
+CREATE TABLE ex_mtarget (a int, b int)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE ex_msource (a int, b int)
+  WITH (autovacuum_enabled=off);
+INSERT INTO ex_mtarget SELECT i, i*10 FROM generate_series(1,100,2) i;
+INSERT INTO ex_msource SELECT i, i*10 FROM generate_series(1,100,1) i;
+CREATE FUNCTION explain_merge(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE ln text;
+BEGIN
+    FOR ln IN
+        EXECUTE 'explain (analyze, timing off, summary off, costs off) ' ||
+		  query
+    LOOP
+        ln := regexp_replace(ln, '(Memory( Usage)?|Buckets|Batches): \S*',  '\1: xxx', 'g');
+        RETURN NEXT ln;
+    END LOOP;
+END;
+$$;
+-- only updates
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED THEN
+	UPDATE SET b = t.b + 1');
+-- only updates to selected tuples
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1');
+-- updates + deletes
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1
+WHEN MATCHED AND t.a >= 10 AND t.a <= 20 THEN
+	DELETE');
+-- only inserts
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN NOT MATCHED AND s.a < 10 THEN
+	INSERT VALUES (a, b)');
+-- all three
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1
+WHEN MATCHED AND t.a >= 30 AND t.a <= 40 THEN
+	DELETE
+WHEN NOT MATCHED AND s.a < 20 THEN
+	INSERT VALUES (a, b)');
+-- nothing
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a AND t.a < -1000
+WHEN MATCHED AND t.a < 10 THEN
+	DO NOTHING');
+DROP TABLE ex_msource, ex_mtarget;
+DROP FUNCTION explain_merge(text);
+-- Subqueries
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED THEN
+    UPDATE SET balance = (SELECT count(*) FROM sq_target);
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND (SELECT count(*) > 0 FROM sq_target) THEN
+    UPDATE SET balance = 42;
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid AND (SELECT count(*) > 0 FROM sq_target)
+WHEN MATCHED THEN
+    UPDATE SET balance = 42;
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+DROP TABLE sq_target CASCADE;
+DROP TABLE sq_source CASCADE;
+CREATE TABLE pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+CREATE TABLE part1 PARTITION OF pa_target FOR VALUES IN (1,4)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 PARTITION OF pa_target FOR VALUES IN (2,5,6)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 PARTITION OF pa_target FOR VALUES IN (3,8,9)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 PARTITION OF pa_target DEFAULT
+  WITH (autovacuum_enabled=off);
+CREATE TABLE pa_source (sid integer, delta float);
+-- insert many rows to the source table
+INSERT INTO pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- same with a constant qual
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid AND tid = 1
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- try updating the partition key column
+BEGIN;
+CREATE FUNCTION merge_func() RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE
+  result integer;
+BEGIN
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+IF FOUND THEN
+  GET DIAGNOSTICS result := ROW_COUNT;
+END IF;
+RETURN result;
+END;
+$$;
+SELECT merge_func();
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+DROP TABLE pa_target CASCADE;
+-- The target table is partitioned in the same way, but this time by attaching
+-- partitions which have columns in different order, dropped columns etc.
+CREATE TABLE pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+CREATE TABLE part1 (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 (balance float, tid integer, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 (extraid text, tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+ALTER TABLE part4 DROP COLUMN extraid;
+ALTER TABLE pa_target ATTACH PARTITION part1 FOR VALUES IN (1,4);
+ALTER TABLE pa_target ATTACH PARTITION part2 FOR VALUES IN (2,5,6);
+ALTER TABLE pa_target ATTACH PARTITION part3 FOR VALUES IN (3,8,9);
+ALTER TABLE pa_target ATTACH PARTITION part4 DEFAULT;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- same with a constant qual
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid AND tid IN (1, 5)
+  WHEN MATCHED AND tid % 5 = 0 THEN DELETE
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+-- try updating the partition key column
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+DROP TABLE pa_source;
+DROP TABLE pa_target CASCADE;
+-- Sub-partitioning
+CREATE TABLE pa_target (logts timestamp, tid integer, balance float, val text)
+	PARTITION BY RANGE (logts);
+CREATE TABLE part_m01 PARTITION OF pa_target
+	FOR VALUES FROM ('2017-01-01') TO ('2017-02-01')
+	PARTITION BY LIST (tid);
+CREATE TABLE part_m01_odd PARTITION OF part_m01
+	FOR VALUES IN (1,3,5,7,9) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m01_even PARTITION OF part_m01
+	FOR VALUES IN (2,4,6,8) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m02 PARTITION OF pa_target
+	FOR VALUES FROM ('2017-02-01') TO ('2017-03-01')
+	PARTITION BY LIST (tid);
+CREATE TABLE part_m02_odd PARTITION OF part_m02
+	FOR VALUES IN (1,3,5,7,9) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m02_even PARTITION OF part_m02
+	FOR VALUES IN (2,4,6,8) WITH (autovacuum_enabled=off);
+CREATE TABLE pa_source (sid integer, delta float)
+  WITH (autovacuum_enabled=off);
+-- insert many rows to the source table
+INSERT INTO pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT '2017-01-31', id, id * 100, 'initial' FROM generate_series(1,9,3) AS id;
+INSERT INTO pa_target SELECT '2017-02-28', id, id * 100, 'initial' FROM generate_series(2,9,3) AS id;
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING (SELECT '2017-01-15' AS slogts, * FROM pa_source WHERE sid < 10) s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+DROP TABLE pa_source;
+DROP TABLE pa_target CASCADE;
+-- some complex joins on the source side
+-- source relation is an unaliased join
+MERGE INTO cj_target t
+USING cj_source1 s1
+	INNER JOIN cj_source2 s2 ON sid1 = sid2
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid1, delta, sval);
+-- try accessing columns from either side of the source join
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2 AND scat = 20
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid2, delta, sval)
+WHEN MATCHED THEN
+	DELETE;
+-- some simple expressions in INSERT targetlist
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid2, delta + scat, sval)
+WHEN MATCHED THEN
+	UPDATE SET val = val || ' updated by merge';
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2 AND scat = 20
+ON t.tid = sid1
+WHEN MATCHED THEN
+	UPDATE SET val = val || ' ' || delta::text;
+SELECT * FROM cj_target ORDER BY tid;
+ALTER TABLE cj_source1 RENAME COLUMN sid1 TO sid;
+ALTER TABLE cj_source2 RENAME COLUMN sid2 TO sid;
+TRUNCATE cj_target;
+MERGE INTO cj_target t
+USING cj_source1 s1
+	INNER JOIN cj_source2 s2 ON s1.sid = s2.sid
+ON t.tid = s1.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s2.sid, delta, sval);
+DROP TABLE cj_source2, cj_source1;
+DROP TABLE cj_target CASCADE;
+-- Function scans
+MERGE INTO fs_target t
+USING generate_series(1,100,1) AS id
+ON t.a = id
+WHEN MATCHED THEN
+	UPDATE SET b = b + id
+WHEN NOT MATCHED THEN
+	INSERT VALUES (id, -1);
+MERGE INTO fs_target t
+USING generate_series(1,100,2) AS id
+ON t.a = id
+WHEN MATCHED THEN
+	UPDATE SET b = b + id, c = 'updated '|| id.*::text
+WHEN NOT MATCHED THEN
+	INSERT VALUES (id, -1, 'inserted ' || id.*::text);
+SELECT count(*) FROM fs_target;
+DROP TABLE fs_target CASCADE;
+-- SERIALIZABLE test
+-- handled in isolation tests
+-- Inheritance-based partitioning
+CREATE TABLE measurement (
+    city_id         int not null,
+    logdate         date not null,
+    peaktemp        int,
+    unitsales       int
+) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2006m02 (
+    CHECK ( logdate >= DATE '2006-02-01' AND logdate < DATE '2006-03-01' )
+) INHERITS (measurement) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2006m03 (
+    CHECK ( logdate >= DATE '2006-03-01' AND logdate < DATE '2006-04-01' )
+) INHERITS (measurement) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2007m01 (
+    filler          text,
+    peaktemp        int,
+    logdate         date not null,
+    city_id         int not null,
+    unitsales       int
+    CHECK ( logdate >= DATE '2007-01-01' AND logdate < DATE '2007-02-01')
+) WITH (autovacuum_enabled=off);
+ALTER TABLE measurement_y2007m01 DROP COLUMN filler;
+ALTER TABLE measurement_y2007m01 INHERIT measurement;
+INSERT INTO measurement VALUES (0, '2005-07-21', 5, 15);
+CREATE OR REPLACE FUNCTION measurement_insert_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF ( NEW.logdate >= DATE '2006-02-01' AND
+         NEW.logdate < DATE '2006-03-01' ) THEN
+        INSERT INTO measurement_y2006m02 VALUES (NEW.*);
+    ELSIF ( NEW.logdate >= DATE '2006-03-01' AND
+            NEW.logdate < DATE '2006-04-01' ) THEN
+        INSERT INTO measurement_y2006m03 VALUES (NEW.*);
+    ELSIF ( NEW.logdate >= DATE '2007-01-01' AND
+            NEW.logdate < DATE '2007-02-01' ) THEN
+        INSERT INTO measurement_y2007m01 (city_id, logdate, peaktemp, unitsales)
+            VALUES (NEW.*);
+    ELSE
+        RAISE EXCEPTION 'Date out of range.  Fix the measurement_insert_trigger() function!';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql ;
+CREATE TRIGGER insert_measurement_trigger
+    BEFORE INSERT ON measurement
+    FOR EACH ROW EXECUTE PROCEDURE measurement_insert_trigger();
+INSERT INTO measurement VALUES (1, '2006-02-10', 35, 10);
+INSERT INTO measurement VALUES (1, '2006-02-16', 45, 20);
+INSERT INTO measurement VALUES (1, '2006-03-17', 25, 10);
+INSERT INTO measurement VALUES (1, '2006-03-27', 15, 40);
+INSERT INTO measurement VALUES (1, '2007-01-15', 10, 10);
+INSERT INTO measurement VALUES (1, '2007-01-17', 10, 10);
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
+CREATE TABLE new_measurement (LIKE measurement) WITH (autovacuum_enabled=off);
+INSERT INTO new_measurement VALUES (0, '2005-07-21', 25, 20);
+INSERT INTO new_measurement VALUES (1, '2006-03-01', 20, 10);
+INSERT INTO new_measurement VALUES (1, '2006-02-16', 50, 10);
+INSERT INTO new_measurement VALUES (2, '2006-02-10', 20, 20);
+INSERT INTO new_measurement VALUES (1, '2006-03-27', NULL, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-17', NULL, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-15', 5, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-16', 10, 10);
+BEGIN;
+MERGE INTO ONLY measurement m
+ USING new_measurement nm ON
+      (m.city_id = nm.city_id and m.logdate=nm.logdate)
+WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE
+WHEN MATCHED THEN UPDATE
+     SET peaktemp = greatest(m.peaktemp, nm.peaktemp),
+        unitsales = m.unitsales + coalesce(nm.unitsales, 0)
+WHEN NOT MATCHED THEN INSERT
+     (city_id, logdate, peaktemp, unitsales)
+   VALUES (city_id, logdate, peaktemp, unitsales);
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate, peaktemp;
+ROLLBACK;
+MERGE into measurement m
+ USING new_measurement nm ON
+      (m.city_id = nm.city_id and m.logdate=nm.logdate)
+WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE
+WHEN MATCHED THEN UPDATE
+     SET peaktemp = greatest(m.peaktemp, nm.peaktemp),
+        unitsales = m.unitsales + coalesce(nm.unitsales, 0)
+WHEN NOT MATCHED THEN INSERT
+     (city_id, logdate, peaktemp, unitsales)
+   VALUES (city_id, logdate, peaktemp, unitsales);
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
+BEGIN;
+MERGE INTO new_measurement nm
+ USING ONLY measurement m ON
+      (nm.city_id = m.city_id and nm.logdate=m.logdate)
+WHEN MATCHED THEN DELETE;
+SELECT * FROM new_measurement ORDER BY city_id, logdate;
+ROLLBACK;
+MERGE INTO new_measurement nm
+ USING measurement m ON
+      (nm.city_id = m.city_id and nm.logdate=m.logdate)
+WHEN MATCHED THEN DELETE;
+SELECT * FROM new_measurement ORDER BY city_id, logdate;
+DROP TABLE measurement, new_measurement CASCADE;
+DROP FUNCTION measurement_insert_trigger();
+RESET SESSION AUTHORIZATION;
+DROP TABLE target CASCADE;
+DROP TABLE target2 CASCADE;
+DROP TABLE source, source2;
+DROP FUNCTION merge_trigfunc();
+REVOKE CREATE ON SCHEMA public FROM regress_merge_privs;
+DROP USER regress_merge_privs;
+DROP USER regress_merge_no_privs;
+\o
+:DIFF_CMD

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -122,7 +122,7 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
 endif()
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
-  list(APPEND TEST_FILES merge.sql)
+  list(APPEND TEST_FILES merge.sql ts_merge.sql)
 endif()
 
 # only test custom type if we are in 64-bit architecture

--- a/test/sql/include/ts_merge_load.sql
+++ b/test/sql/include/ts_merge_load.sql
@@ -1,0 +1,64 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE USER regress_merge_privs;
+CREATE USER regress_merge_no_privs;
+DROP TABLE IF EXISTS target;
+DROP TABLE IF EXISTS source;
+CREATE TABLE target (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE source (sid integer, delta integer) -- no index
+  WITH (autovacuum_enabled=off);
+INSERT INTO target VALUES (1, 10);
+INSERT INTO target VALUES (2, 20);
+INSERT INTO target VALUES (3, 30);
+SELECT t.ctid is not null as matched, t.*, s.* FROM source s FULL OUTER JOIN target t ON s.sid = t.tid ORDER BY t.tid, s.sid;
+
+ALTER TABLE target OWNER TO regress_merge_privs;
+ALTER TABLE source OWNER TO regress_merge_privs;
+
+CREATE TABLE target2 (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE source2 (sid integer, delta integer)
+  WITH (autovacuum_enabled=off);
+
+ALTER TABLE target2 OWNER TO regress_merge_no_privs;
+ALTER TABLE source2 OWNER TO regress_merge_no_privs;
+
+GRANT INSERT ON target TO regress_merge_no_privs;
+GRANT CREATE ON SCHEMA public TO regress_merge_privs;
+SET SESSION AUTHORIZATION regress_merge_privs;
+
+CREATE TABLE sq_target (tid integer NOT NULL, balance integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE sq_source (delta integer, sid integer, balance integer DEFAULT 0)
+  WITH (autovacuum_enabled=off);
+
+INSERT INTO sq_target(tid, balance) VALUES (1,100), (2,200), (3,300);
+INSERT INTO sq_source(sid, delta) VALUES (1,10), (2,20), (4,40);
+
+-- conditional WHEN clause
+CREATE TABLE wq_target (tid integer not null, balance integer DEFAULT -1)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE wq_source (balance integer, sid integer)
+  WITH (autovacuum_enabled=off);
+
+INSERT INTO wq_source (sid, balance) VALUES (1, 100);
+
+CREATE TABLE cj_target (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE cj_source1 (sid1 integer, scat integer, delta integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE cj_source2 (sid2 integer, sval text)
+  WITH (autovacuum_enabled=off);
+INSERT INTO cj_source1 VALUES (1, 10, 100);
+INSERT INTO cj_source1 VALUES (1, 20, 200);
+INSERT INTO cj_source1 VALUES (2, 20, 300);
+INSERT INTO cj_source1 VALUES (3, 10, 400);
+INSERT INTO cj_source2 VALUES (1, 'initial source2');
+INSERT INTO cj_source2 VALUES (2, 'initial source2');
+INSERT INTO cj_source2 VALUES (3, 'initial source2');
+
+CREATE TABLE fs_target (a int, b int, c text)
+  WITH (autovacuum_enabled=off);

--- a/test/sql/include/ts_merge_load_ht.sql
+++ b/test/sql/include/ts_merge_load_ht.sql
@@ -1,0 +1,73 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+CREATE USER regress_merge_privs;
+CREATE USER regress_merge_no_privs;
+DROP TABLE IF EXISTS target;
+DROP TABLE IF EXISTS source;
+CREATE TABLE target (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('target', 'tid', chunk_time_interval => 3);
+CREATE TABLE source (sid integer, delta integer) -- no index
+  WITH (autovacuum_enabled=off);
+INSERT INTO target VALUES (1, 10);
+INSERT INTO target VALUES (2, 20);
+INSERT INTO target VALUES (3, 30);
+SELECT t.ctid is not null as matched, t.*, s.* FROM source s FULL OUTER JOIN target t ON s.sid = t.tid ORDER BY t.tid, s.sid;
+
+ALTER TABLE target OWNER TO regress_merge_privs;
+ALTER TABLE source OWNER TO regress_merge_privs;
+
+CREATE TABLE target2 (tid integer, balance integer)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('target2', 'tid', chunk_time_interval => 3);
+CREATE TABLE source2 (sid integer, delta integer)
+  WITH (autovacuum_enabled=off);
+
+ALTER TABLE target2 OWNER TO regress_merge_no_privs;
+ALTER TABLE source2 OWNER TO regress_merge_no_privs;
+
+GRANT INSERT ON target TO regress_merge_no_privs;
+GRANT CREATE ON SCHEMA public TO regress_merge_privs;
+SET SESSION AUTHORIZATION regress_merge_privs;
+
+CREATE TABLE sq_target (tid integer NOT NULL, balance integer)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('sq_target', 'tid', chunk_time_interval => 3);
+
+CREATE TABLE sq_source (delta integer, sid integer, balance integer DEFAULT 0)
+  WITH (autovacuum_enabled=off);
+
+INSERT INTO sq_target(tid, balance) VALUES (1,100), (2,200), (3,300);
+INSERT INTO sq_source(sid, delta) VALUES (1,10), (2,20), (4,40);
+
+-- conditional WHEN clause
+CREATE TABLE wq_target (tid integer not null, balance integer DEFAULT -1)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('wq_target', 'tid', chunk_time_interval => 3);
+CREATE TABLE wq_source (balance integer, sid integer)
+  WITH (autovacuum_enabled=off);
+
+INSERT INTO wq_source (sid, balance) VALUES (1, 100);
+
+-- some complex joins on the source side
+
+CREATE TABLE cj_target (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('cj_target', 'tid', chunk_time_interval => 3);
+CREATE TABLE cj_source1 (sid1 integer, scat integer, delta integer)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE cj_source2 (sid2 integer, sval text)
+  WITH (autovacuum_enabled=off);
+INSERT INTO cj_source1 VALUES (1, 10, 100);
+INSERT INTO cj_source1 VALUES (1, 20, 200);
+INSERT INTO cj_source1 VALUES (2, 20, 300);
+INSERT INTO cj_source1 VALUES (3, 10, 400);
+INSERT INTO cj_source2 VALUES (1, 'initial source2');
+INSERT INTO cj_source2 VALUES (2, 'initial source2');
+INSERT INTO cj_source2 VALUES (3, 'initial source2');
+
+CREATE TABLE fs_target (a int, b int, c text)
+  WITH (autovacuum_enabled=off);
+SELECT create_hypertable('fs_target', 'a', chunk_time_interval => 3);

--- a/test/sql/include/ts_merge_query.sql
+++ b/test/sql/include/ts_merge_query.sql
@@ -1,0 +1,1248 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+--
+-- Errors
+--
+MERGE INTO target t RANDOMWORD
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+-- MATCHED/INSERT error
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	INSERT DEFAULT VALUES;
+-- incorrectly specifying INTO target
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT INTO target DEFAULT VALUES;
+-- Multiple VALUES clause
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (1,1), (2,2);
+-- SELECT query for INSERT
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT SELECT (1, 1);
+-- NOT MATCHED/UPDATE
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	UPDATE SET balance = 0;
+-- UPDATE tablename
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE target SET balance = 0;
+-- source and target names the same
+MERGE INTO target
+USING target
+ON tid = tid
+WHEN MATCHED THEN DO NOTHING;
+-- used in a CTE
+WITH foo AS (
+  MERGE INTO target USING source ON (true)
+  WHEN MATCHED THEN DELETE
+) SELECT * FROM foo;
+-- used in COPY
+COPY (
+  MERGE INTO target USING source ON (true)
+  WHEN MATCHED THEN DELETE
+) TO stdout;
+
+-- unsupported relation types
+-- view
+CREATE VIEW tv AS SELECT * FROM target;
+MERGE INTO tv t
+USING source s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+DROP VIEW tv;
+
+-- materialized view
+CREATE MATERIALIZED VIEW mv AS SELECT * FROM target;
+MERGE INTO mv t
+USING source s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+DROP MATERIALIZED VIEW mv;
+
+-- permissions
+
+MERGE INTO target
+USING source2
+ON target.tid = source2.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+
+GRANT INSERT ON target TO regress_merge_no_privs;
+SET SESSION AUTHORIZATION regress_merge_no_privs;
+
+MERGE INTO target
+USING source2
+ON target.tid = source2.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+
+GRANT UPDATE ON target2 TO regress_merge_privs;
+SET SESSION AUTHORIZATION regress_merge_privs;
+
+MERGE INTO target2
+USING source
+ON target2.tid = source.sid
+WHEN MATCHED THEN
+	DELETE;
+
+MERGE INTO target2
+USING source
+ON target2.tid = source.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+
+-- check if the target can be accessed from source relation subquery; we should
+-- not be able to do so
+MERGE INTO target t
+USING (SELECT * FROM source WHERE t.tid > sid) s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+
+--
+-- initial tests
+--
+-- zero rows in source has no effect
+MERGE INTO target
+USING source
+ON target.tid = source.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT DEFAULT VALUES;
+ROLLBACK;
+
+-- insert some non-matching source rows to work from
+INSERT INTO source VALUES (4, 40);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	DO NOTHING;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (5, 50);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- index plans
+INSERT INTO target SELECT generate_series(1000,2500), 0;
+ALTER TABLE target ADD PRIMARY KEY (tid);
+ANALYZE target;
+DELETE FROM target WHERE tid > 100;
+ANALYZE target;
+
+-- insert some matching source rows to work from
+INSERT INTO source VALUES (2, 5);
+INSERT INTO source VALUES (3, 20);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+
+-- equivalent of an UPDATE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- equivalent of a DELETE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DO NOTHING;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, NULL);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- duplicate source row causes multiple target row update ERROR
+INSERT INTO source VALUES (2, 5);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	DELETE;
+ROLLBACK;
+
+-- remove duplicate MATCHED data from source data
+DELETE FROM source WHERE sid = 2;
+INSERT INTO source VALUES (2, 5);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+
+-- duplicate source row on INSERT should fail because of target_pkey
+INSERT INTO source VALUES (4, 40);
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+  INSERT VALUES (4, NULL);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- remove duplicate NOT MATCHED data from source data
+DELETE FROM source WHERE sid = 4;
+INSERT INTO source VALUES (4, 40);
+SELECT * FROM source ORDER BY sid;
+SELECT * FROM target ORDER BY tid;
+
+-- remove constraints
+alter table target drop CONSTRAINT target_pkey;
+alter table target alter column tid drop not null;
+
+-- multiple actions
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, 4)
+WHEN MATCHED THEN
+	UPDATE SET balance = 0;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- should be equivalent
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = 0
+WHEN NOT MATCHED THEN
+	INSERT VALUES (4, 4);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- column references
+-- do a simple equivalent of an UPDATE join
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.delta;
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- do a simple equivalent of an INSERT SELECT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- and again with duplicate source rows
+INSERT INTO source VALUES (5, 50);
+INSERT INTO source VALUES (5, 50);
+
+-- do a simple equivalent of an INSERT SELECT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+  INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- removing duplicate source rows
+DELETE FROM source WHERE sid = 5;
+
+-- and again with explicitly identified column list
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- and again with a subtle error: referring to non-existent target row for NOT MATCHED
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (t.tid, s.delta);
+
+-- and again with a constant ON clause
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON (SELECT true)
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (t.tid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- now the classic UPSERT
+BEGIN;
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance + s.delta
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- this time with a FALSE condition
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND FALSE THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+
+-- this time with an actual condition which returns false
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance <> 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+
+BEGIN;
+-- and now with a condition which returns true
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+ROLLBACK;
+
+-- conditions in the NOT MATCHED clause can only refer to source columns
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND t.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+ROLLBACK;
+
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN NOT MATCHED AND s.balance = 100 THEN
+	INSERT (tid) VALUES (s.sid);
+SELECT * FROM wq_target;
+
+-- conditions in MATCHED clause can refer to both source and target
+SELECT * FROM wq_source;
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND s.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+
+-- check if AND works
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 AND s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 AND s.balance = 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+
+-- check if OR works
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 99 OR s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance = 199 OR s.balance > 100 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+
+-- check source-side whole-row references
+BEGIN;
+MERGE INTO wq_target t
+USING wq_source s ON (t.tid = s.sid)
+WHEN matched and t = s or t.tid = s.sid THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+ROLLBACK;
+
+-- check if subqueries work in the conditions?
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.balance > (SELECT max(balance) FROM target) THEN
+	UPDATE SET balance = t.balance + s.balance;
+
+-- check if we can access system columns in the conditions
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.xmin = t.xmax THEN
+	UPDATE SET balance = t.balance + s.balance;
+
+MERGE INTO wq_target t
+USING wq_source s ON t.tid = s.sid
+WHEN MATCHED AND t.tableoid >= 0 THEN
+	UPDATE SET balance = t.balance + s.balance;
+SELECT * FROM wq_target;
+
+DROP TABLE wq_target CASCADE;
+DROP TABLE wq_source;
+
+-- test triggers
+create or replace function merge_trigfunc () returns trigger
+language plpgsql as
+$$
+DECLARE
+	line text;
+BEGIN
+	SELECT INTO line format('%s %s %s trigger%s',
+		TG_WHEN, TG_OP, TG_LEVEL, CASE
+		WHEN TG_OP = 'INSERT' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s', NEW)
+		WHEN TG_OP = 'UPDATE' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s -> %s', OLD, NEW)
+		WHEN TG_OP = 'DELETE' AND TG_LEVEL = 'ROW'
+			THEN format(' row: %s', OLD)
+		END);
+
+	RAISE NOTICE '%', line;
+	IF (TG_WHEN = 'BEFORE' AND TG_LEVEL = 'ROW') THEN
+		IF (TG_OP = 'DELETE') THEN
+			RETURN OLD;
+		ELSE
+			RETURN NEW;
+		END IF;
+	ELSE
+		RETURN NULL;
+	END IF;
+END;
+$$;
+CREATE TRIGGER merge_bsi BEFORE INSERT ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bsu BEFORE UPDATE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bsd BEFORE DELETE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asi AFTER INSERT ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asu AFTER UPDATE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_asd AFTER DELETE ON target FOR EACH STATEMENT EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bri BEFORE INSERT ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_bru BEFORE UPDATE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_brd BEFORE DELETE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_ari AFTER INSERT ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_aru AFTER UPDATE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+CREATE TRIGGER merge_ard AFTER DELETE ON target FOR EACH ROW EXECUTE PROCEDURE merge_trigfunc ();
+
+-- now the classic UPSERT, with a DELETE
+BEGIN;
+UPDATE target SET balance = 0 WHERE tid = 3;
+--EXPLAIN (ANALYZE ON, COSTS OFF, SUMMARY OFF, TIMING OFF)
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND t.balance > s.delta THEN
+	UPDATE SET balance = t.balance - s.delta
+WHEN MATCHED THEN
+	DELETE
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- Test behavior of triggers that turn UPDATE/DELETE into no-ops
+create or replace function skip_merge_op() returns trigger
+language plpgsql as
+$$
+BEGIN
+	RETURN NULL;
+END;
+$$;
+
+SELECT * FROM target full outer join source on (sid = tid);
+create trigger merge_skip BEFORE INSERT OR UPDATE or DELETE
+  ON target FOR EACH ROW EXECUTE FUNCTION skip_merge_op();
+DO $$
+DECLARE
+  result integer;
+BEGIN
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND s.sid = 3 THEN UPDATE SET balance = t.balance + s.delta
+WHEN MATCHED THEN DELETE
+WHEN NOT MATCHED THEN INSERT VALUES (sid, delta);
+IF FOUND THEN
+  RAISE NOTICE 'Found';
+ELSE
+  RAISE NOTICE 'Not found';
+END IF;
+GET DIAGNOSTICS result := ROW_COUNT;
+RAISE NOTICE 'ROW_COUNT = %', result;
+END;
+$$;
+SELECT * FROM target FULL OUTER JOIN source ON (sid = tid);
+DROP TRIGGER merge_skip ON target;
+DROP FUNCTION skip_merge_op();
+
+-- test from PL/pgSQL
+-- make sure MERGE INTO isn't interpreted to mean returning variables like SELECT INTO
+BEGIN;
+DO LANGUAGE plpgsql $$
+BEGIN
+MERGE INTO target t
+USING source AS s
+ON t.tid = s.sid
+WHEN MATCHED AND t.balance > s.delta THEN
+	UPDATE SET balance = t.balance - s.delta;
+END;
+$$;
+ROLLBACK;
+
+--source constants
+BEGIN;
+MERGE INTO target t
+USING (SELECT 9 AS sid, 57 AS delta) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+--source query
+BEGIN;
+MERGE INTO target t
+USING (SELECT sid, delta FROM source WHERE delta > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO target t
+USING (SELECT sid, delta as newname FROM source WHERE delta > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.newname);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+--self-merge
+BEGIN;
+MERGE INTO target t1
+USING target t2
+ON t1.tid = t2.tid
+WHEN MATCHED THEN
+	UPDATE SET balance = t1.balance + t2.balance
+WHEN NOT MATCHED THEN
+	INSERT VALUES (t2.tid, t2.balance);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO target t
+USING (SELECT tid as sid, balance as delta FROM target WHERE balance > 0) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO target t
+USING
+(SELECT sid, max(delta) AS delta
+ FROM source
+ GROUP BY sid
+ HAVING count(*) = 1
+ ORDER BY sid ASC) AS s
+ON t.tid = s.sid
+WHEN NOT MATCHED THEN
+	INSERT (tid, balance) VALUES (s.sid, s.delta);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- plpgsql parameters and results
+BEGIN;
+CREATE FUNCTION merge_func (p_id integer, p_bal integer)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+ result integer;
+BEGIN
+MERGE INTO target t
+USING (SELECT p_id AS sid) AS s
+ON t.tid = s.sid
+WHEN MATCHED THEN
+	UPDATE SET balance = t.balance - p_bal;
+IF FOUND THEN
+	GET DIAGNOSTICS result := ROW_COUNT;
+END IF;
+RETURN result;
+END;
+$$;
+SELECT merge_func(3, 4);
+SELECT * FROM target ORDER BY tid;
+ROLLBACK;
+
+-- PREPARE
+BEGIN;
+prepare foom as merge into target t using (select 1 as sid) s on (t.tid = s.sid) when matched then update set balance = 1;
+execute foom;
+ROLLBACK;
+
+BEGIN;
+PREPARE foom2 (integer, integer) AS
+MERGE INTO target t
+USING (SELECT 1) s
+ON t.tid = $1
+WHEN MATCHED THEN
+UPDATE SET balance = $2;
+--EXPLAIN (ANALYZE ON, COSTS OFF, SUMMARY OFF, TIMING OFF)
+execute foom2 (1, 1);
+ROLLBACK;
+
+-- subqueries in source relation
+BEGIN;
+MERGE INTO sq_target t
+USING (SELECT * FROM sq_source) s
+ON tid = sid
+WHEN MATCHED AND t.balance > delta THEN
+	UPDATE SET balance = t.balance + delta;
+SELECT * FROM sq_target ORDER BY tid;
+ROLLBACK;
+
+-- try a view
+CREATE VIEW v AS SELECT * FROM sq_source WHERE sid < 2;
+
+BEGIN;
+MERGE INTO sq_target
+USING v
+ON tid = sid
+WHEN MATCHED THEN
+    UPDATE SET balance = v.balance + delta;
+SELECT * FROM sq_target ORDER BY tid;
+ROLLBACK;
+
+-- ambiguous reference to a column
+BEGIN;
+MERGE INTO sq_target
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+ROLLBACK;
+
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+SELECT * FROM sq_target;
+ROLLBACK;
+
+-- CTEs
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+WITH targq AS (
+	SELECT * FROM v
+)
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE;
+ROLLBACK;
+
+-- RETURNING
+BEGIN;
+INSERT INTO sq_source (sid, balance, delta) VALUES (-1, -1, -10);
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND tid > 2 THEN
+    UPDATE SET balance = t.balance + delta
+WHEN NOT MATCHED THEN
+	INSERT (balance, tid) VALUES (balance + delta, sid)
+WHEN MATCHED AND tid < 2 THEN
+	DELETE
+RETURNING *;
+ROLLBACK;
+
+-- EXPLAIN
+CREATE TABLE ex_mtarget (a int, b int)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE ex_msource (a int, b int)
+  WITH (autovacuum_enabled=off);
+INSERT INTO ex_mtarget SELECT i, i*10 FROM generate_series(1,100,2) i;
+INSERT INTO ex_msource SELECT i, i*10 FROM generate_series(1,100,1) i;
+
+CREATE FUNCTION explain_merge(query text) RETURNS SETOF text
+LANGUAGE plpgsql AS
+$$
+DECLARE ln text;
+BEGIN
+    FOR ln IN
+        EXECUTE 'explain (analyze, timing off, summary off, costs off) ' ||
+		  query
+    LOOP
+        ln := regexp_replace(ln, '(Memory( Usage)?|Buckets|Batches): \S*',  '\1: xxx', 'g');
+        RETURN NEXT ln;
+    END LOOP;
+END;
+$$;
+
+-- only updates
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED THEN
+	UPDATE SET b = t.b + 1');
+
+-- only updates to selected tuples
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1');
+
+-- updates + deletes
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1
+WHEN MATCHED AND t.a >= 10 AND t.a <= 20 THEN
+	DELETE');
+
+-- only inserts
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN NOT MATCHED AND s.a < 10 THEN
+	INSERT VALUES (a, b)');
+
+-- all three
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
+WHEN MATCHED AND t.a < 10 THEN
+	UPDATE SET b = t.b + 1
+WHEN MATCHED AND t.a >= 30 AND t.a <= 40 THEN
+	DELETE
+WHEN NOT MATCHED AND s.a < 20 THEN
+	INSERT VALUES (a, b)');
+
+-- nothing
+SELECT explain_merge('
+MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a AND t.a < -1000
+WHEN MATCHED AND t.a < 10 THEN
+	DO NOTHING');
+
+DROP TABLE ex_msource, ex_mtarget;
+DROP FUNCTION explain_merge(text);
+
+-- Subqueries
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED THEN
+    UPDATE SET balance = (SELECT count(*) FROM sq_target);
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid
+WHEN MATCHED AND (SELECT count(*) > 0 FROM sq_target) THEN
+    UPDATE SET balance = 42;
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+
+BEGIN;
+MERGE INTO sq_target t
+USING v
+ON tid = sid AND (SELECT count(*) > 0 FROM sq_target)
+WHEN MATCHED THEN
+    UPDATE SET balance = 42;
+SELECT * FROM sq_target WHERE tid = 1;
+ROLLBACK;
+
+DROP TABLE sq_target CASCADE;
+DROP TABLE sq_source CASCADE;
+
+CREATE TABLE pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+
+CREATE TABLE part1 PARTITION OF pa_target FOR VALUES IN (1,4)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 PARTITION OF pa_target FOR VALUES IN (2,5,6)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 PARTITION OF pa_target FOR VALUES IN (3,8,9)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 PARTITION OF pa_target DEFAULT
+  WITH (autovacuum_enabled=off);
+
+CREATE TABLE pa_source (sid integer, delta float);
+-- insert many rows to the source table
+INSERT INTO pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+
+-- same with a constant qual
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid AND tid = 1
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+
+-- try updating the partition key column
+BEGIN;
+CREATE FUNCTION merge_func() RETURNS integer LANGUAGE plpgsql AS $$
+DECLARE
+  result integer;
+BEGIN
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+IF FOUND THEN
+  GET DIAGNOSTICS result := ROW_COUNT;
+END IF;
+RETURN result;
+END;
+$$;
+SELECT merge_func();
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+
+DROP TABLE pa_target CASCADE;
+
+-- The target table is partitioned in the same way, but this time by attaching
+-- partitions which have columns in different order, dropped columns etc.
+CREATE TABLE pa_target (tid integer, balance float, val text)
+	PARTITION BY LIST (tid);
+
+CREATE TABLE part1 (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part2 (balance float, tid integer, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part3 (tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+CREATE TABLE part4 (extraid text, tid integer, balance float, val text)
+  WITH (autovacuum_enabled=off);
+ALTER TABLE part4 DROP COLUMN extraid;
+
+ALTER TABLE pa_target ATTACH PARTITION part1 FOR VALUES IN (1,4);
+ALTER TABLE pa_target ATTACH PARTITION part2 FOR VALUES IN (2,5,6);
+ALTER TABLE pa_target ATTACH PARTITION part3 FOR VALUES IN (3,8,9);
+ALTER TABLE pa_target ATTACH PARTITION part4 DEFAULT;
+
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT id, id * 100, 'initial' FROM generate_series(1,14,2) AS id;
+
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+
+-- same with a constant qual
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid AND tid IN (1, 5)
+  WHEN MATCHED AND tid % 5 = 0 THEN DELETE
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+
+-- try updating the partition key column
+BEGIN;
+MERGE INTO pa_target t
+  USING pa_source s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+
+DROP TABLE pa_source;
+DROP TABLE pa_target CASCADE;
+
+-- Sub-partitioning
+CREATE TABLE pa_target (logts timestamp, tid integer, balance float, val text)
+	PARTITION BY RANGE (logts);
+
+CREATE TABLE part_m01 PARTITION OF pa_target
+	FOR VALUES FROM ('2017-01-01') TO ('2017-02-01')
+	PARTITION BY LIST (tid);
+CREATE TABLE part_m01_odd PARTITION OF part_m01
+	FOR VALUES IN (1,3,5,7,9) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m01_even PARTITION OF part_m01
+	FOR VALUES IN (2,4,6,8) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m02 PARTITION OF pa_target
+	FOR VALUES FROM ('2017-02-01') TO ('2017-03-01')
+	PARTITION BY LIST (tid);
+CREATE TABLE part_m02_odd PARTITION OF part_m02
+	FOR VALUES IN (1,3,5,7,9) WITH (autovacuum_enabled=off);
+CREATE TABLE part_m02_even PARTITION OF part_m02
+	FOR VALUES IN (2,4,6,8) WITH (autovacuum_enabled=off);
+
+CREATE TABLE pa_source (sid integer, delta float)
+  WITH (autovacuum_enabled=off);
+-- insert many rows to the source table
+INSERT INTO pa_source SELECT id, id * 10  FROM generate_series(1,14) AS id;
+-- insert a few rows in the target table (odd numbered tid)
+INSERT INTO pa_target SELECT '2017-01-31', id, id * 100, 'initial' FROM generate_series(1,9,3) AS id;
+INSERT INTO pa_target SELECT '2017-02-28', id, id * 100, 'initial' FROM generate_series(2,9,3) AS id;
+
+-- try simple MERGE
+BEGIN;
+MERGE INTO pa_target t
+  USING (SELECT '2017-01-15' AS slogts, * FROM pa_source WHERE sid < 10) s
+  ON t.tid = s.sid
+  WHEN MATCHED THEN
+    UPDATE SET balance = balance + delta, val = val || ' updated by merge'
+  WHEN NOT MATCHED THEN
+    INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
+SELECT * FROM pa_target ORDER BY tid;
+ROLLBACK;
+
+DROP TABLE pa_source;
+DROP TABLE pa_target CASCADE;
+
+-- some complex joins on the source side
+-- source relation is an unaliased join
+MERGE INTO cj_target t
+USING cj_source1 s1
+	INNER JOIN cj_source2 s2 ON sid1 = sid2
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid1, delta, sval);
+
+-- try accessing columns from either side of the source join
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2 AND scat = 20
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid2, delta, sval)
+WHEN MATCHED THEN
+	DELETE;
+
+-- some simple expressions in INSERT targetlist
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2
+ON t.tid = sid1
+WHEN NOT MATCHED THEN
+	INSERT VALUES (sid2, delta + scat, sval)
+WHEN MATCHED THEN
+	UPDATE SET val = val || ' updated by merge';
+
+MERGE INTO cj_target t
+USING cj_source2 s2
+	INNER JOIN cj_source1 s1 ON sid1 = sid2 AND scat = 20
+ON t.tid = sid1
+WHEN MATCHED THEN
+	UPDATE SET val = val || ' ' || delta::text;
+
+SELECT * FROM cj_target ORDER BY tid;
+
+ALTER TABLE cj_source1 RENAME COLUMN sid1 TO sid;
+ALTER TABLE cj_source2 RENAME COLUMN sid2 TO sid;
+
+TRUNCATE cj_target;
+
+MERGE INTO cj_target t
+USING cj_source1 s1
+	INNER JOIN cj_source2 s2 ON s1.sid = s2.sid
+ON t.tid = s1.sid
+WHEN NOT MATCHED THEN
+	INSERT VALUES (s2.sid, delta, sval);
+
+DROP TABLE cj_source2, cj_source1;
+DROP TABLE cj_target CASCADE;
+
+-- Function scans
+MERGE INTO fs_target t
+USING generate_series(1,100,1) AS id
+ON t.a = id
+WHEN MATCHED THEN
+	UPDATE SET b = b + id
+WHEN NOT MATCHED THEN
+	INSERT VALUES (id, -1);
+
+MERGE INTO fs_target t
+USING generate_series(1,100,2) AS id
+ON t.a = id
+WHEN MATCHED THEN
+	UPDATE SET b = b + id, c = 'updated '|| id.*::text
+WHEN NOT MATCHED THEN
+	INSERT VALUES (id, -1, 'inserted ' || id.*::text);
+
+SELECT count(*) FROM fs_target;
+DROP TABLE fs_target CASCADE;
+
+-- SERIALIZABLE test
+-- handled in isolation tests
+
+-- Inheritance-based partitioning
+CREATE TABLE measurement (
+    city_id         int not null,
+    logdate         date not null,
+    peaktemp        int,
+    unitsales       int
+) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2006m02 (
+    CHECK ( logdate >= DATE '2006-02-01' AND logdate < DATE '2006-03-01' )
+) INHERITS (measurement) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2006m03 (
+    CHECK ( logdate >= DATE '2006-03-01' AND logdate < DATE '2006-04-01' )
+) INHERITS (measurement) WITH (autovacuum_enabled=off);
+CREATE TABLE measurement_y2007m01 (
+    filler          text,
+    peaktemp        int,
+    logdate         date not null,
+    city_id         int not null,
+    unitsales       int
+    CHECK ( logdate >= DATE '2007-01-01' AND logdate < DATE '2007-02-01')
+) WITH (autovacuum_enabled=off);
+ALTER TABLE measurement_y2007m01 DROP COLUMN filler;
+ALTER TABLE measurement_y2007m01 INHERIT measurement;
+INSERT INTO measurement VALUES (0, '2005-07-21', 5, 15);
+
+CREATE OR REPLACE FUNCTION measurement_insert_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF ( NEW.logdate >= DATE '2006-02-01' AND
+         NEW.logdate < DATE '2006-03-01' ) THEN
+        INSERT INTO measurement_y2006m02 VALUES (NEW.*);
+    ELSIF ( NEW.logdate >= DATE '2006-03-01' AND
+            NEW.logdate < DATE '2006-04-01' ) THEN
+        INSERT INTO measurement_y2006m03 VALUES (NEW.*);
+    ELSIF ( NEW.logdate >= DATE '2007-01-01' AND
+            NEW.logdate < DATE '2007-02-01' ) THEN
+        INSERT INTO measurement_y2007m01 (city_id, logdate, peaktemp, unitsales)
+            VALUES (NEW.*);
+    ELSE
+        RAISE EXCEPTION 'Date out of range.  Fix the measurement_insert_trigger() function!';
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql ;
+CREATE TRIGGER insert_measurement_trigger
+    BEFORE INSERT ON measurement
+    FOR EACH ROW EXECUTE PROCEDURE measurement_insert_trigger();
+INSERT INTO measurement VALUES (1, '2006-02-10', 35, 10);
+INSERT INTO measurement VALUES (1, '2006-02-16', 45, 20);
+INSERT INTO measurement VALUES (1, '2006-03-17', 25, 10);
+INSERT INTO measurement VALUES (1, '2006-03-27', 15, 40);
+INSERT INTO measurement VALUES (1, '2007-01-15', 10, 10);
+INSERT INTO measurement VALUES (1, '2007-01-17', 10, 10);
+
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
+
+CREATE TABLE new_measurement (LIKE measurement) WITH (autovacuum_enabled=off);
+INSERT INTO new_measurement VALUES (0, '2005-07-21', 25, 20);
+INSERT INTO new_measurement VALUES (1, '2006-03-01', 20, 10);
+INSERT INTO new_measurement VALUES (1, '2006-02-16', 50, 10);
+INSERT INTO new_measurement VALUES (2, '2006-02-10', 20, 20);
+INSERT INTO new_measurement VALUES (1, '2006-03-27', NULL, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-17', NULL, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-15', 5, NULL);
+INSERT INTO new_measurement VALUES (1, '2007-01-16', 10, 10);
+
+BEGIN;
+MERGE INTO ONLY measurement m
+ USING new_measurement nm ON
+      (m.city_id = nm.city_id and m.logdate=nm.logdate)
+WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE
+WHEN MATCHED THEN UPDATE
+     SET peaktemp = greatest(m.peaktemp, nm.peaktemp),
+        unitsales = m.unitsales + coalesce(nm.unitsales, 0)
+WHEN NOT MATCHED THEN INSERT
+     (city_id, logdate, peaktemp, unitsales)
+   VALUES (city_id, logdate, peaktemp, unitsales);
+
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate, peaktemp;
+ROLLBACK;
+
+MERGE into measurement m
+ USING new_measurement nm ON
+      (m.city_id = nm.city_id and m.logdate=nm.logdate)
+WHEN MATCHED AND nm.peaktemp IS NULL THEN DELETE
+WHEN MATCHED THEN UPDATE
+     SET peaktemp = greatest(m.peaktemp, nm.peaktemp),
+        unitsales = m.unitsales + coalesce(nm.unitsales, 0)
+WHEN NOT MATCHED THEN INSERT
+     (city_id, logdate, peaktemp, unitsales)
+   VALUES (city_id, logdate, peaktemp, unitsales);
+
+SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
+
+BEGIN;
+MERGE INTO new_measurement nm
+ USING ONLY measurement m ON
+      (nm.city_id = m.city_id and nm.logdate=m.logdate)
+WHEN MATCHED THEN DELETE;
+
+SELECT * FROM new_measurement ORDER BY city_id, logdate;
+ROLLBACK;
+
+MERGE INTO new_measurement nm
+ USING measurement m ON
+      (nm.city_id = m.city_id and nm.logdate=m.logdate)
+WHEN MATCHED THEN DELETE;
+
+SELECT * FROM new_measurement ORDER BY city_id, logdate;
+
+DROP TABLE measurement, new_measurement CASCADE;
+DROP FUNCTION measurement_insert_trigger();
+
+RESET SESSION AUTHORIZATION;
+DROP TABLE target CASCADE;
+DROP TABLE target2 CASCADE;
+DROP TABLE source, source2;
+DROP FUNCTION merge_trigfunc();
+REVOKE CREATE ON SCHEMA public FROM regress_merge_privs;
+DROP USER regress_merge_privs;
+DROP USER regress_merge_no_privs;

--- a/test/sql/merge.sql
+++ b/test/sql/merge.sql
@@ -2,20 +2,22 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
--- Create conditions table with location and temperature
-CREATE TABLE conditions (
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+-- Create target table with location and temperature
+CREATE TABLE target (
    time        TIMESTAMPTZ       NOT NULL,
    location    SMALLINT          NOT NULL,
-   temperature DOUBLE PRECISION  NULL
+   temperature DOUBLE PRECISION  NULL,
+   val text default 'string -'
 );
 
 SELECT create_hypertable(
-  'conditions',
+  'target',
   'time',
   chunk_time_interval => INTERVAL '5 seconds');
 
-
-INSERT INTO conditions
+INSERT INTO target
 SELECT time, location, 14 as temperature
 FROM generate_series(
 	'2021-01-01 00:00:00',
@@ -24,20 +26,20 @@ FROM generate_series(
   ) as time,
 generate_series(1,4) as location;
 
--- Create conditions_updated table with location and temperature
-CREATE TABLE conditions_updated (
+-- Create source table with location and temperature
+CREATE TABLE source (
    time        TIMESTAMPTZ       NOT NULL,
    location    SMALLINT          NOT NULL,
    temperature DOUBLE PRECISION  NULL
 );
 
 SELECT create_hypertable(
-  'conditions_updated',
+  'source',
   'time',
   chunk_time_interval => INTERVAL '5 seconds');
 
--- Generate data that overlaps with conditions table
-INSERT INTO conditions_updated
+-- Generate data that overlaps with target table
+INSERT INTO source
 SELECT time, location, 80 as temperature
 FROM generate_series(
 	'2021-01-01 00:00:05',
@@ -47,40 +49,845 @@ FROM generate_series(
 generate_series(1,4) as location;
 
 -- Print table/rows/num of chunks
-select * from conditions order by time, location asc;
-select * from conditions_updated order by time, location asc;
-select hypertable_name, count(*) as num_of_chunks from timescaledb_information.chunks group by hypertable_name;
+select * from target order by time, location asc;
+select * from source order by time, location asc;
 
--- Print expected values in the conditions table once conditions_updated is merged into it
--- If a key exists in both tables, we take average of the temperature measured
--- average logic here is a mess but it works
-SELECT COALESCE(c.time, cu.time) as time,
-       COALESCE(c.location, cu.location) as location,
-       (COALESCE(c.temperature, cu.temperature) + COALESCE(cu.temperature, c.temperature))/2 as temperature
-FROM conditions AS c FULL JOIN conditions_updated AS cu
-ON c.time = cu.time AND c.location = cu.location;
+-- CREATE normal PostgreSQL tables
+CREATE TABLE target_pg AS SELECT * FROM target;
+CREATE TABLE source_pg AS SELECT * FROM source;
 
--- Test that normal PostgreSQL tables can merge without exceptions
-CREATE TABLE conditions_pg AS SELECT * FROM conditions;
-CREATE TABLE conditions_updated_pg AS SELECT * FROM conditions_updated;
-MERGE INTO conditions_pg c
-USING conditions_updated_pg cu
-ON c.time = cu.time AND c.location = cu.location
+-- Merge UPDATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
 WHEN MATCHED THEN
-UPDATE SET temperature = (c.temperature + cu.temperature)/2
-WHEN NOT MATCHED THEN
-INSERT (time, location, temperature) VALUES (cu.time, cu.location, cu.temperature);
-SELECT * FROM conditions_pg ORDER BY time, location ASC;
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
 
--- Merge conditions_updated into conditions
+-- Merge UPDATE matched rows for hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+
+-- Merge DELETE matched rows for hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- clean up tables
+DELETE FROM target_pg;
+DELETE FROM target;
+DELETE FROM source_pg;
+DELETE FROM source;
+
+INSERT INTO target
+SELECT time, location, 14 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:00',
+    '2021-01-01 00:00:09',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+
+INSERT INTO source
+SELECT time, location, 80 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:05',
+    '2021-01-01 00:00:14',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+
+INSERT INTO target_pg SELECT * FROM target;
+INSERT INTO source_pg SELECT * FROM source;
+
+-- Merge UPDATE matched rows and INSERT new row for unmatched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE'
+WHEN NOT MATCHED THEN
+INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+
+-- Merge UPDATE matched rows and INSERT new row for unmatched rows for hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE'
+WHEN NOT MATCHED THEN
+INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge INSERT with constant literals for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+
+-- Merge INSERT with constant literals for hypertables
+MERGE INTO target t
+USING source s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge with INSERT/DELETE/UPDATE on PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED AND t.location = 560076 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.location = 560083 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+
+-- Merge with INSERT/DELETE/UPDATE on hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED AND t.location = 560076 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.location = 560083 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge with Subqueries on PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location > (SELECT count(*) FROM source_pg)
+WHEN MATCHED AND t.temperature = 23 THEN
+ UPDATE SET temperature = (SELECT count(*) FROM target_pg) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'SUBQUERY string - INSERTED BY MERGE');
+
+-- Merge with Subqueries on hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location > (SELECT count(*) FROM source)
+WHEN MATCHED AND t.temperature = 23 THEN
+ UPDATE SET temperature = (SELECT count(*) FROM target) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'SUBQUERY string - INSERTED BY MERGE');
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- clean up tables
+DELETE FROM target_pg;
+DELETE FROM target;
+DELETE FROM source_pg;
+DELETE FROM source;
+
+-- TEST with target as hypertable and source as normal PG table
+INSERT INTO target
+SELECT time, location, 14 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:00',
+    '2021-01-01 00:00:09',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+
+INSERT INTO source
+SELECT time, location, 80 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:05',
+    '2021-01-01 00:00:14',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+
+INSERT INTO target_pg SELECT * FROM target;
+INSERT INTO source_pg SELECT * FROM source;
+
+-- Merge UPDATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
+
+-- Merge UPDATE with target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = (t.temperature + s.temperature)/2, val = val || ' UPDATED BY MERGE';
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+
+-- Merge DELETE with target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DELETE;
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge INSERT with constant literals for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+
+-- Merge INSERT with constant literals for target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source s
+ON t.location = 1234
+WHEN NOT MATCHED THEN
+INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, 'string - INSERTED BY MERGE');
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge with INSERT/DELETE/UPDATE on PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED AND t.temperature = 23 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+
+-- Merge with INSERT/DELETE/UPDATE on target as hypertables and source as normal PG tables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED  AND t.temperature = 23 THEN
+ UPDATE SET temperature = (t.temperature + s.temperature) * 2, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED  AND t.temperature = 47 THEN
+ DELETE
+WHEN NOT MATCHED THEN
+ INSERT (time, location, temperature, val) VALUES (s.time, s.location, s.temperature, 'string - INSERTED BY MERGE');
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+DROP TABLE target_pg CASCADE;
+DROP TABLE target CASCADE;
+DROP TABLE source_pg CASCADE;
+DROP TABLE source CASCADE;
+
+-- test MERGE with source being a PARTITION table
+CREATE TABLE source_pg(
+   id INT NOT NULL,
+   dev INT NOT NULL,
+   value INT,
+   CONSTRAINT cstr_source_pky PRIMARY KEY (id)
+) PARTITION BY LIST (id);
+
+CREATE TABLE source_1_2_3_4 PARTITION OF source_pg FOR VALUES IN (1,2,3,4);
+CREATE TABLE source_5_6_7_8 PARTITION OF source_pg FOR VALUES IN (5,6,7,8);
+
+INSERT INTO source_pg SELECT generate_series(1,8), 44,55;
+
+CREATE TABLE target (
+   ts TIMESTAMP WITH TIME ZONE NOT NULL,
+   id INT NOT NULL,
+   dev INT NOT NULL,
+   FOREIGN KEY (id)  REFERENCES source_pg(id) ON DELETE CASCADE
+);
+
+SELECT create_hypertable(
+   relation => 'target',
+   time_column_name => 'ts'
+);
+
+insert into target values ('2023-01-12 00:00:05'::timestamp with time zone, 1,2);
+insert into target values ('2023-01-12 00:00:10'::timestamp with time zone, 2,2);
+insert into target values ('2023-01-12 00:00:15'::timestamp with time zone, 3,2);
+insert into target values ('2023-01-12 00:00:20'::timestamp with time zone, 4,2);
+insert into target values ('2023-01-14 00:00:25'::timestamp with time zone, 5,2);
+insert into target values ('2023-01-14 00:00:30'::timestamp with time zone, 6,2);
+insert into target values ('2023-01-14 00:00:35'::timestamp with time zone, 7,2);
+insert into target values ('2023-01-14 00:00:40'::timestamp with time zone, 8,2);
+
+CREATE TABLE target_pg AS SELECT * FROM target;
+
+-- Merge UPDATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+UPDATE SET dev = (t.dev + s.dev)/2;
+
+-- Merge UPDATE matched rows for hypertables
+MERGE INTO target t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+UPDATE SET dev = (t.dev + s.dev)/2;
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+DELETE;
+
+-- Merge DELETE matched rows for hypertables
+MERGE INTO target t
+USING source_pg s
+ON t.id = s.id
+WHEN MATCHED THEN
+DELETE;
+
+-- ensure TARGET PG table and hypertable are same
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- clean up tables
+DROP TABLE target_pg CASCADE;
+DROP TABLE target CASCADE;
+DROP TABLE source_pg CASCADE;
+
+-- test MERGE with hypertables with time and space partitions
+CREATE TABLE target (
+     filler_1 int,
+     filler_2 int,
+     filler_3 int,
+     time timestamptz NOT NULL,
+     device_id int,
+     device_id_peer int,
+     v0 int,
+     v1 float,
+     v2 float,
+     v3 float
+ );
+
+SELECT create_hypertable ('target', 'time', 'device_id', 5);
+SELECT add_dimension('target', 'device_id_peer', 5);
+SELECT add_dimension('target', 'v2', 5);
+INSERT INTO target (time, device_id, device_id_peer, v0, v1, v2, v3)
+  SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 2, 1) gdevice (device_id);
+
+CREATE TABLE source (
+         filler_1 int,
+         filler_2 int,
+         filler_3 int,
+         time timestamptz NOT NULL,
+         device_id int
+  );
+SELECT create_hypertable ('source', 'time', 'device_id', 3);
+
+INSERT INTO source (time, device_id, filler_2, filler_3, filler_1)
+  SELECT time,
+    device_id,
+    device_id + 134,
+    device_id + 209,
+    device_id + 0.50127
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+-- create PG tables to compare PG target and hypertable target tables
+CREATE table target_pg as SELECT * FROM target;
+CREATE table source_pg as SELECT * FROM source;
+
+-- Merge UDPATE matched rows for normal PG tables
+MERGE INTO target_pg t
+USING source_pg s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET filler_2 = s.filler_1 + 100;
+
+-- Merge UDPATE matched rows for space partitioned hypertables
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET filler_2 = s.filler_1 + 100;
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge DELETE matched rows for normal PG tables
+MERGE INTO target_pg t
+       USING source_pg s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+-- Merge DELETE matched rows for space partitioned hypertables
+MERGE INTO target t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge INSERT matched rows for normal PG tables
+MERGE INTO target_pg t
+              USING source_pg s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+
+-- Merge INSERT matched rows for space partitioned hypertables
+MERGE INTO target t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- Merge with INSERT/DELETE/UPDATE on PG tables
+MERGE INTO target_pg t
+    USING source_pg s
+        ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED AND t.device_id_peer = 2 THEN
+                  UPDATE SET filler_2 = s.filler_1 + s.filler_2 + s.filler_3 + 100
+              WHEN MATCHED AND t.device_id_peer = 7 THEN
+                  DELETE
+              WHEN NOT MATCHED THEN
+                  INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                         (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+
+-- Merge with INSERT/DELETE/UPDATE on space partitioned hypertables
+MERGE INTO target t
+    USING source s
+        ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED AND t.device_id_peer = 2 THEN
+                  UPDATE SET filler_2 = s.filler_1 + s.filler_2 + s.filler_3 + 100
+              WHEN MATCHED AND t.device_id_peer = 7 THEN
+                  DELETE
+              WHEN NOT MATCHED THEN
+                  INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                         (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- clean up tables
+DROP TABLE target_pg CASCADE;
+DROP TABLE target CASCADE;
+DROP TABLE source_pg CASCADE;
+DROP TABLE source CASCADE;
+
+-- TEST with parition column place after similar data type column
+CREATE TABLE target (
+     filler_1 int,
+     filler_2 int,
+     filler_3 int,
+     time timestamptz NOT NULL,
+     device_id int,
+     device_id_peer int,
+     v0 int,
+     v1 float,
+     v2 float,
+     v3 float,
+     partition_column TIMESTAMPTZ NOT NULL
+ );
+
+SELECT create_hypertable ('target', 'partition_column');
+
+INSERT INTO target (time, device_id, device_id_peer, v0, v1, v2, v3, partition_column)
+  SELECT time,
+    device_id,
+    0,
+    device_id + 1,
+    device_id + 2,
+    device_id + 0.5,
+    NULL,
+    time + interval '10m'
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 2, 1) gdevice (device_id);
+
+CREATE TABLE source (
+         filler_1 int,
+         filler_2 int,
+         filler_3 int,
+         time timestamptz NOT NULL,
+         device_id int
+  );
+SELECT create_hypertable ('source', 'time', 'device_id', 3);
+
+INSERT INTO source (time, device_id, filler_2, filler_3, filler_1)
+  SELECT time,
+    device_id,
+    device_id + 134,
+    device_id + 209,
+    device_id + 0.50127
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+-- create PG tables to compare PG target and hypertable target tables
+CREATE table target_pg as SELECT * FROM target;
+
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, device_id_peer, v0, v1, v2, v3, partition_column) VALUES
+('2010-01-06 05:30:00+05:30', 23, 2, 11, 22, 33, 44, '2023-01-06 05:33:00+05:30');
+
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, device_id_peer, v0, v1, v2, v3, partition_column) VALUES
+('2010-01-06 05:30:00+05:30', 23, 2, 11, 22, 33, 44, '2023-01-06 05:33:00+05:30');
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN  MATCHED THEN
+DELETE;
+
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN  MATCHED THEN
+DELETE;
+
+SELECT CASE WHEN EXISTS (TABLE target EXCEPT TABLE target_pg)
+              OR EXISTS (TABLE target_pg EXCEPT TABLE target)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+MERGE INTO target_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
+
+-- time dimension column is NULL, this will report an null constraint violation error
 \set ON_ERROR_STOP 0
-MERGE INTO conditions c
-USING conditions_updated cu
-ON c.time = cu.time AND c.location = cu.location
-WHEN MATCHED THEN
-UPDATE SET temperature = (c.temperature + cu.temperature)/2
-WHEN NOT MATCHED THEN
-INSERT (time, location, temperature) VALUES (cu.time, cu.location, cu.temperature);
-
-SELECT * FROM conditions ORDER BY time, location ASC;
+MERGE INTO target t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (filler_1, filler_2, filler_3, time, device_id, device_id_peer, v0, v1, v2, v3) VALUES
+                     (s.filler_1, s.filler_2, s.filler_3, s.time, s.device_id, s.device_id + 10, 1,2,3,4);
 \set ON_ERROR_STOP 1
+
+DROP TABLE target CASCADE;
+DROP TABLE target_pg CASCADE;
+DROP TABLE source CASCADE;
+
+-- TEST with target table have CHECK constraints
+CREATE TABLE target (
+   time        TIMESTAMPTZ       NOT NULL,
+   location    SMALLINT          NOT NULL,
+   temperature DOUBLE PRECISION  NULL CHECK (temperature > 10),
+   val text default 'string -'
+);
+
+SELECT create_hypertable(
+  'target',
+  'time',
+  chunk_time_interval => INTERVAL '5 seconds');
+
+INSERT INTO target
+SELECT time, location, 14 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:00',
+    '2021-01-01 00:00:09',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+
+-- Create source table with location and temperature
+CREATE TABLE source (
+   time        TIMESTAMPTZ       NOT NULL,
+   location    SMALLINT          NOT NULL,
+   temperature DOUBLE PRECISION  NULL
+);
+
+-- Generate data that overlaps with target table
+INSERT INTO source
+SELECT time, location, 80 as temperature
+FROM generate_series(
+	'2021-01-01 00:00:05',
+    '2021-01-01 00:00:14',
+    INTERVAL '5 seconds'
+  ) as time,
+generate_series(1,4) as location;
+
+-- CREATE normal PostgreSQL tables
+CREATE TABLE target_pg AS SELECT * FROM target;
+
+-- Merge UPDATE/DELETE with DO NOTHING on pg tables
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DO NOTHING
+WHEN NOT MATCHED THEN
+DO NOTHING;
+
+-- Merge UPDATE/DELETE with DO NOTHING on hypertable
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+DO NOTHING
+WHEN NOT MATCHED THEN
+DO NOTHING;
+
+-- Error cases for Merge
+\set ON_ERROR_STOP 0
+
+-- Merge UPDATE should fail with check constraint violation
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE';
+
+-- Merge UPDATE should fail with check constraint violation
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE';
+
+-- Merge error with unreachable WHEN clause on pg tables
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.time < now() THEN
+DELETE
+WHEN NOT MATCHED THEN
+DO NOTHING;
+
+-- Merge error with unreachable WHEN clause on hypertable
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 8, val = val || ' UPDATED BY MERGE'
+WHEN MATCHED AND t.time < now() THEN
+DELETE
+WHEN NOT MATCHED THEN
+DO NOTHING;
+
+-- Merge error with unknown action in MERGE WHEN MATCHED clause on pg tables
+MERGE INTO target_pg t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+SELECT 1;
+
+-- Merge error with unknown action in MERGE WHEN MATCHED clause on hypertable
+MERGE INTO target t
+USING source s
+ON t.time = s.time AND t.location != s.location
+WHEN MATCHED THEN
+SELECT 1;
+
+-- Merge error cannot affect row a second time on pg tables
+MERGE INTO target_pg t
+USING source s
+ON  t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 28, val = val || ' UPDATED BY MERGE';
+
+-- Merge error cannot affect row a second time on hypertable
+MERGE INTO target t
+USING source s
+ON  t.location = s.location
+WHEN MATCHED THEN
+UPDATE SET temperature = 28, val = val || ' UPDATED BY MERGE';
+
+\set ON_ERROR_STOP 1
+
+DROP TABLE target CASCADE;
+DROP TABLE target_pg CASCADE;
+DROP TABLE source CASCADE;
+
+-- TEST for PERMISSIONS
+CREATE USER priv_user;
+CREATE USER non_priv_user;
+
+CREATE TABLE target (
+    value DOUBLE PRECISION NOT NULL,
+    time TIMESTAMPTZ NOT NULL
+);
+
+SELECT table_name FROM create_hypertable(
+                            'target'::regclass,
+                            'time'::name, chunk_time_interval=>interval '8 hours',
+                            create_default_indexes=> false);
+
+SELECT '2022-10-10 14:33:44.1234+05:30' as start_date \gset
+INSERT INTO target (value, time)
+  SELECT 1,t from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
+    generate_series(1,3) s;
+
+CREATE TABLE source (
+        time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        value DOUBLE PRECISION NOT NULL
+    );
+
+SELECT table_name FROM create_hypertable(
+                                'source'::regclass,
+                                'time'::name, chunk_time_interval=>interval '6 hours',
+                                create_default_indexes=> false);
+
+ALTER TABLE target OWNER TO priv_user;
+ALTER TABLE source OWNER TO priv_user;
+
+GRANT SELECT ON source TO non_priv_user;
+SET SESSION AUTHORIZATION non_priv_user;
+
+\set ON_ERROR_STOP 0
+-- non_priv_user does not have UPDATE privilege on target table
+MERGE INTO target
+USING source
+ON target.time = source.time
+WHEN MATCHED THEN
+	UPDATE SET value = 0;
+
+-- non_priv_user does not have DELETE privilege on target table
+MERGE INTO target
+USING source
+ON target.time = source.time
+WHEN MATCHED THEN
+	DELETE;
+
+-- non_priv_user does not have INSERT privilege on target table
+MERGE INTO target
+USING source
+ON target.time = source.time
+WHEN NOT MATCHED THEN
+	INSERT VALUES (10, '2023-01-15 00:00:10'::timestamp with time zone);
+
+\set ON_ERROR_STOP 1
+
+RESET SESSION AUTHORIZATION;
+DROP TABLE target;
+DROP TABLE source;
+DROP USER priv_user;
+DROP USER non_priv_user;

--- a/test/sql/ts_merge.sql
+++ b/test/sql/ts_merge.sql
@@ -1,0 +1,33 @@
+-- This file and its contents are licensed under the Apache License 2.0.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-APACHE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+\set ON_ERROR_STOP 0
+\set VERBOSITY default
+SET client_min_messages TO error;
+
+\set TEST_BASE_NAME ts_merge
+SELECT format('include/%s_load.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_NAME",
+    format('include/%s_load_ht.sql', :'TEST_BASE_NAME') AS "TEST_LOAD_HT_NAME",
+    format('include/%s_query.sql', :'TEST_BASE_NAME') AS "TEST_QUERY_NAME",
+    format('%s/results/%s_results.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_WITH_HYPERTABLE",
+    format('%s/results/%s_ht_results.out', :'TEST_OUTPUT_DIR', :'TEST_BASE_NAME') AS "TEST_RESULTS_WITH_NO_HYPERTABLE" \gset
+
+SELECT format('\! diff -u --label "Base pg table results" --label "Hyperatable results" %s %s', :'TEST_RESULTS_WITH_HYPERTABLE', :'TEST_RESULTS_WITH_NO_HYPERTABLE') AS "DIFF_CMD" \gset
+
+\ir :TEST_LOAD_NAME
+
+-- run tests on normal table
+\o :TEST_RESULTS_WITH_NO_HYPERTABLE
+\ir :TEST_QUERY_NAME
+\o
+
+\ir :TEST_LOAD_HT_NAME
+
+-- run tests on hypertable
+\o :TEST_RESULTS_WITH_HYPERTABLE
+\ir :TEST_QUERY_NAME
+\o
+
+:DIFF_CMD

--- a/tsl/src/planner.c
+++ b/tsl/src/planner.c
@@ -173,6 +173,21 @@ tsl_set_rel_pathlist_dml(PlannerInfo *root, RelOptInfo *rel, Index rti, RangeTbl
 		}
 	}
 #endif
+#if PG15_GE
+	/*
+	 * We do not support MERGE command with UPDATE/DELETE merge actions on
+	 * compressed hypertables, because Custom Scan (HypertableModify) node is
+	 * not generated in the plan for MERGE command on compressed hypertables
+	 */
+	if (ht != NULL && TS_HYPERTABLE_HAS_COMPRESSION_TABLE(ht))
+	{
+		if (root->parse->commandType == CMD_MERGE)
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("The MERGE command with UPDATE/DELETE merge actions is not support on "
+							"compressed hypertables")));
+	}
+#endif
 }
 
 /*

--- a/tsl/test/expected/dist_ref_table_join-12.out
+++ b/tsl/test/expected/dist_ref_table_join-12.out
@@ -1968,19 +1968,20 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 -- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
 -- Older PostgreSQL versions report an error because MERGE is not supported. This
 -- will be ignored due to the setting.
+-- Commenting below test as error meesage is different on windows vs unix.
+-- Issue #5725 is opened to track it.
 -------
-\set ON_ERROR_STOP 0
-MERGE INTO metric as target_0
-USING metric as input_0
-    inner join (select id from metric_name as input_1) as subq_0
-      ON (TRUE)
-ON target_0.id = input_0.id
-WHEN MATCHED
-   THEN DO NOTHING
-WHEN NOT MATCHED
-   THEN DO NOTHING;
-ERROR:  syntax error at or near "MERGE" at character 1
-\set ON_ERROR_STOP 1
+-- \set ON_ERROR_STOP 0
+-- MERGE INTO metric as target_0
+-- USING metric as input_0
+--    inner join (select id from metric_name as input_1) as subq_0
+--      ON (TRUE)
+-- ON target_0.id = input_0.id
+-- WHEN MATCHED
+--   THEN DO NOTHING
+-- WHEN NOT MATCHED
+--   THEN DO NOTHING;
+-- \set ON_ERROR_STOP 1
 -------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------

--- a/tsl/test/expected/dist_ref_table_join-13.out
+++ b/tsl/test/expected/dist_ref_table_join-13.out
@@ -1968,19 +1968,20 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 -- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
 -- Older PostgreSQL versions report an error because MERGE is not supported. This
 -- will be ignored due to the setting.
+-- Commenting below test as error meesage is different on windows vs unix.
+-- Issue #5725 is opened to track it.
 -------
-\set ON_ERROR_STOP 0
-MERGE INTO metric as target_0
-USING metric as input_0
-    inner join (select id from metric_name as input_1) as subq_0
-      ON (TRUE)
-ON target_0.id = input_0.id
-WHEN MATCHED
-   THEN DO NOTHING
-WHEN NOT MATCHED
-   THEN DO NOTHING;
-ERROR:  syntax error at or near "MERGE" at character 1
-\set ON_ERROR_STOP 1
+-- \set ON_ERROR_STOP 0
+-- MERGE INTO metric as target_0
+-- USING metric as input_0
+--    inner join (select id from metric_name as input_1) as subq_0
+--      ON (TRUE)
+-- ON target_0.id = input_0.id
+-- WHEN MATCHED
+--   THEN DO NOTHING
+-- WHEN NOT MATCHED
+--   THEN DO NOTHING;
+-- \set ON_ERROR_STOP 1
 -------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------

--- a/tsl/test/expected/dist_ref_table_join-14.out
+++ b/tsl/test/expected/dist_ref_table_join-14.out
@@ -1968,19 +1968,20 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 -- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
 -- Older PostgreSQL versions report an error because MERGE is not supported. This
 -- will be ignored due to the setting.
+-- Commenting below test as error meesage is different on windows vs unix.
+-- Issue #5725 is opened to track it.
 -------
-\set ON_ERROR_STOP 0
-MERGE INTO metric as target_0
-USING metric as input_0
-    inner join (select id from metric_name as input_1) as subq_0
-      ON (TRUE)
-ON target_0.id = input_0.id
-WHEN MATCHED
-   THEN DO NOTHING
-WHEN NOT MATCHED
-   THEN DO NOTHING;
-ERROR:  syntax error at or near "MERGE" at character 1
-\set ON_ERROR_STOP 1
+-- \set ON_ERROR_STOP 0
+-- MERGE INTO metric as target_0
+-- USING metric as input_0
+--    inner join (select id from metric_name as input_1) as subq_0
+--      ON (TRUE)
+-- ON target_0.id = input_0.id
+-- WHEN MATCHED
+--   THEN DO NOTHING
+-- WHEN NOT MATCHED
+--   THEN DO NOTHING;
+-- \set ON_ERROR_STOP 1
 -------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------

--- a/tsl/test/expected/dist_ref_table_join-15.out
+++ b/tsl/test/expected/dist_ref_table_join-15.out
@@ -2012,28 +2012,20 @@ DEBUG:  join pushdown on reference table is not supported for the used query
 -- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
 -- Older PostgreSQL versions report an error because MERGE is not supported. This
 -- will be ignored due to the setting.
+-- Commenting below test as error meesage is different on windows vs unix.
+-- Issue #5725 is opened to track it.
 -------
-\set ON_ERROR_STOP 0
-MERGE INTO metric as target_0
-USING metric as input_0
-    inner join (select id from metric_name as input_1) as subq_0
-      ON (TRUE)
-ON target_0.id = input_0.id
-WHEN MATCHED
-   THEN DO NOTHING
-WHEN NOT MATCHED
-   THEN DO NOTHING;
-LOG:  statement: MERGE INTO metric as target_0
-USING metric as input_0
-    inner join (select id from metric_name as input_1) as subq_0
-      ON (TRUE)
-ON target_0.id = input_0.id
-WHEN MATCHED
-   THEN DO NOTHING
-WHEN NOT MATCHED
-   THEN DO NOTHING;
-ERROR:  The MERGE command does not support hypertables in this version
-\set ON_ERROR_STOP 1
+-- \set ON_ERROR_STOP 0
+-- MERGE INTO metric as target_0
+-- USING metric as input_0
+--    inner join (select id from metric_name as input_1) as subq_0
+--      ON (TRUE)
+-- ON target_0.id = input_0.id
+-- WHEN MATCHED
+--   THEN DO NOTHING
+-- WHEN NOT MATCHED
+--   THEN DO NOTHING;
+-- \set ON_ERROR_STOP 1
 -------
 -- Tests without enable_per_data_node_queries (no pushdown supported)
 -------

--- a/tsl/test/expected/merge_compress.out
+++ b/tsl/test/expected/merge_compress.out
@@ -1,0 +1,114 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE target (
+    time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    series_id BIGINT NOT NULL,
+    partition_column TIMESTAMPTZ NOT NULL
+);
+SELECT table_name FROM create_hypertable(
+                            'target'::regclass,
+                            'partition_column'::name, chunk_time_interval=>interval '8 hours',
+                            create_default_indexes=> false);
+ table_name 
+------------
+ target
+(1 row)
+
+-- enable compression
+ALTER TABLE target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'series_id',
+    timescaledb.compress_orderby = 'partition_column, value'
+);
+SELECT '2022-10-10 14:33:44.1234+05:30' as start_date \gset
+INSERT INTO target (series_id, value, partition_column)
+  SELECT s,1,t from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
+    generate_series(1,3, 1) s;
+-- compress chunks
+SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
+  FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
+    c.hypertable_id = ht.id and ht.table_name = 'target' and c.compressed_chunk_id IS NULL;
+ count 
+-------
+     4
+(1 row)
+
+CREATE TABLE source (
+        time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        value DOUBLE PRECISION NOT NULL,
+        series_id BIGINT NOT NULL
+    );
+SELECT table_name FROM create_hypertable(
+                                'source'::regclass,
+                                'time'::name, chunk_time_interval=>interval '6 hours',
+                                create_default_indexes=> false);
+ table_name 
+------------
+ source
+(1 row)
+
+SELECT '2022-10-10 10:00:00.0123+05:30' as start_date \gset
+INSERT INTO source (time, series_id, value)
+  SELECT t, s,1 from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
+    generate_series(1,2, 1) s;
+\set ON_ERROR_STOP 0
+-- Merge UPDATE on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET series_id = (t.series_id * 0.123);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- Merge DELETE on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE;
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- Merge UPDATE/INSERT on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET series_id = (t.series_id * 0.123)
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- Merge DELETE/INSERT on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+\set ON_ERROR_STOP 1
+-- total compressed chunks
+SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
+    hypertable_name = 'target' GROUP BY is_compressed;
+ total compressed_chunks | is_compressed 
+-------------------------+---------------
+                       4 | t
+(1 row)
+
+-- Merge INSERT on compressed hypertables should work
+MERGE INTO target t
+            USING source s
+            ON t.partition_column = s.time AND t.value = s.value
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+-- you should notice 1 uncompressed chunk
+SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
+    hypertable_name = 'target' GROUP BY is_compressed;
+ total compressed_chunks | is_compressed 
+-------------------------+---------------
+                       1 | f
+                       4 | t
+(2 rows)
+
+DROP TABLE target;
+DROP TABLE source;

--- a/tsl/test/shared/expected/merge_dml.out
+++ b/tsl/test/shared/expected/merge_dml.out
@@ -1,0 +1,264 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- create source table
+CREATE TABLE source (
+         filler_1 int,
+         filler_2 int,
+         filler_3 int,
+         time timestamptz NOT NULL,
+         device_id int
+  );
+INSERT INTO source (time, device_id, filler_2, filler_3, filler_1)
+  SELECT time,
+    device_id,
+    device_id + 134,
+    device_id + 209,
+    device_id + 0.50127
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+-- create corresponding PG tables to compare against hypertables
+CREATE table metrics_pg as SELECT * FROM metrics;
+CREATE table metrics_space_pg as SELECT * FROM metrics_space;
+CREATE table metrics_compressed_pg as SELECT * FROM metrics_compressed;
+CREATE table metrics_space_compressed_pg as SELECT * FROM  metrics_space_compressed;
+-- MERGE UDPATE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+-- MERGE UDPATE matched rows for hypertable
+MERGE INTO metrics t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+ same
+(1 row)
+
+-- MERGE DELETE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+-- MERGE DELETE matched rows for hypertable
+MERGE INTO metrics t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+ same
+(1 row)
+
+-- MERGE INSERT/DELETE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+-- MERGE INSERT/DELETE matched rows for hypertable
+MERGE INTO metrics t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+ same
+(1 row)
+
+-- MERGE INSERT/DELETE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+-- MERGE INSERT/DELETE matched rows for hypertable
+MERGE INTO metrics t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+ same
+(1 row)
+
+-- MERGE UDPATE matched rows for normal PG tables
+MERGE INTO metrics_space_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+-- MERGE UDPATE matched rows for space partitioned hypertable
+MERGE INTO metrics_space t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics_space EXCEPT TABLE metrics_space_pg)
+              OR EXISTS (TABLE metrics_space_pg EXCEPT TABLE metrics_space)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+ same
+(1 row)
+
+-- MERGE DELETE matched rows for normal PG tables
+MERGE INTO metrics_space_pg t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+-- MERGE DELETE matched rows for space partitioned hypertable
+MERGE INTO metrics_space t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics_space EXCEPT TABLE metrics_space_pg)
+              OR EXISTS (TABLE metrics_space_pg EXCEPT TABLE metrics_space)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+ same
+(1 row)
+
+-- MERGE INSERT matched rows for normal PG tables
+MERGE INTO metrics_space_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+-- MERGE INSERT matched rows for space partitioned hypertable
+MERGE INTO metrics_space t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics_space EXCEPT TABLE metrics_space_pg)
+              OR EXISTS (TABLE metrics_space_pg EXCEPT TABLE metrics_space)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+ result 
+ same
+(1 row)
+
+\set ON_ERROR_STOP 0
+-- MERGE UDPATE matched rows for compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- MERGE DELETE matched rows for compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- MERGE UDPATE/INSERT matched rows for compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics)
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- MERGE DELETE/INSERT matched rows for compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- MERGE UDPATE matched rows for space partitioned compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- MERGE DELETE matched rows for space partitioned compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- MERGE UDPATE/INSERT matched rows for space partitioned compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics)
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+-- MERGE DELETE/INSERT matched rows for space partitioned compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+ERROR:  The MERGE command with UPDATE/DELETE merge actions is not support on compressed hypertables
+\set ON_ERROR_STOP 1

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -26,6 +26,12 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
   list(APPEND TEST_FILES_SHARED compression_dml.sql memoize.sql)
 endif()
 
+# this test was changing the contents of tables in shared_setup.sql thus causing
+# other dependent tests to fail. Hence runing this test in solo
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
+  list(APPEND SOLO_TESTS merge_dml.sql)
+endif()
+
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(APPEND TEST_FILES_SHARED dist_parallel_agg.sql dist_queries.sql
        timestamp_limits.sql with_clause_parser.sql)
@@ -64,6 +70,17 @@ endif()
 
 set(GROUP_MEMBERS 0)
 foreach(TEST_FILE ${TEST_FILES_SHARED})
+  string(REGEX REPLACE "(.+)\.sql" "\\1" TESTS_TO_RUN ${TEST_FILE})
+  if(GROUP_MEMBERS EQUAL 0)
+    file(APPEND ${TEST_SCHEDULE_SHARED} "\ntest: ")
+  endif()
+  file(APPEND ${TEST_SCHEDULE_SHARED} "${TESTS_TO_RUN} ")
+  math(EXPR GROUP_MEMBERS "(${GROUP_MEMBERS}+1)%${PARALLEL_GROUP_SIZE}")
+endforeach(TEST_FILE)
+file(APPEND ${TEST_SCHEDULE_SHARED} "\n")
+
+set(GROUP_MEMBERS 0)
+foreach(TEST_FILE ${SOLO_TESTS})
   string(REGEX REPLACE "(.+)\.sql" "\\1" TESTS_TO_RUN ${TEST_FILE})
   if(GROUP_MEMBERS EQUAL 0)
     file(APPEND ${TEST_SCHEDULE_SHARED} "\ntest: ")

--- a/tsl/test/shared/sql/merge_dml.sql
+++ b/tsl/test/shared/sql/merge_dml.sql
@@ -1,0 +1,262 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- create source table
+CREATE TABLE source (
+         filler_1 int,
+         filler_2 int,
+         filler_3 int,
+         time timestamptz NOT NULL,
+         device_id int
+  );
+
+INSERT INTO source (time, device_id, filler_2, filler_3, filler_1)
+  SELECT time,
+    device_id,
+    device_id + 134,
+    device_id + 209,
+    device_id + 0.50127
+FROM generate_series('2000-01-01 0:00:00+0'::timestamptz, '2000-01-05 23:55:00+0', '20m') gtime (time),
+    generate_series(1, 5, 1) gdevice (device_id);
+
+-- create corresponding PG tables to compare against hypertables
+CREATE table metrics_pg as SELECT * FROM metrics;
+CREATE table metrics_space_pg as SELECT * FROM metrics_space;
+CREATE table metrics_compressed_pg as SELECT * FROM metrics_compressed;
+CREATE table metrics_space_compressed_pg as SELECT * FROM  metrics_space_compressed;
+
+-- MERGE UDPATE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+
+-- MERGE UDPATE matched rows for hypertable
+MERGE INTO metrics t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- MERGE DELETE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+-- MERGE DELETE matched rows for hypertable
+MERGE INTO metrics t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- MERGE INSERT/DELETE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+
+-- MERGE INSERT/DELETE matched rows for hypertable
+MERGE INTO metrics t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- MERGE INSERT/DELETE matched rows for normal PG tables
+MERGE INTO metrics_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+
+-- MERGE INSERT/DELETE matched rows for hypertable
+MERGE INTO metrics t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN MATCHED THEN DELETE
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics EXCEPT TABLE metrics_pg)
+              OR EXISTS (TABLE metrics_pg EXCEPT TABLE metrics)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- MERGE UDPATE matched rows for normal PG tables
+MERGE INTO metrics_space_pg t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+
+-- MERGE UDPATE matched rows for space partitioned hypertable
+MERGE INTO metrics_space t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics_pg);
+
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics_space EXCEPT TABLE metrics_space_pg)
+              OR EXISTS (TABLE metrics_space_pg EXCEPT TABLE metrics_space)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- MERGE DELETE matched rows for normal PG tables
+MERGE INTO metrics_space_pg t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+-- MERGE DELETE matched rows for space partitioned hypertable
+MERGE INTO metrics_space t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics_space EXCEPT TABLE metrics_space_pg)
+              OR EXISTS (TABLE metrics_space_pg EXCEPT TABLE metrics_space)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+-- MERGE INSERT matched rows for normal PG tables
+MERGE INTO metrics_space_pg t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+
+-- MERGE INSERT matched rows for space partitioned hypertable
+MERGE INTO metrics_space t
+              USING source s
+              ON t.time = s.time AND t.device_id = s.device_id
+              WHEN NOT MATCHED THEN
+              INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     (s.time, s.device_id, 1,2,3,4);
+
+-- result should be 'same'
+SELECT CASE WHEN EXISTS (TABLE metrics_space EXCEPT TABLE metrics_space_pg)
+              OR EXISTS (TABLE metrics_space_pg EXCEPT TABLE metrics_space)
+            THEN 'different'
+            ELSE 'same'
+       END AS result;
+
+\set ON_ERROR_STOP 0
+
+-- MERGE UDPATE matched rows for compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics);
+
+-- MERGE DELETE matched rows for compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+-- MERGE UDPATE/INSERT matched rows for compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics)
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+
+-- MERGE DELETE/INSERT matched rows for compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+
+-- MERGE UDPATE matched rows for space partitioned compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics);
+
+-- MERGE DELETE matched rows for space partitioned compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE;
+
+-- MERGE UDPATE/INSERT matched rows for space partitioned compressed hypertable
+-- should report error as UPDATE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+USING source s
+ON t.time = s.time AND t.device_id = s.device_id
+WHEN MATCHED THEN
+UPDATE SET v1 = s.filler_1 * 1.23, v2 = (SELECT DISTINCT count(time) from metrics)
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+
+-- MERGE DELETE/INSERT matched rows for space partitioned compressed hypertable
+-- should report error as DELETE is not allowed on compressed hypertable
+MERGE INTO metrics_space_compressed t
+       USING source s
+       ON t.time = s.time AND t.device_id = s.device_id
+       WHEN MATCHED THEN
+       DELETE
+WHEN NOT MATCHED THEN
+INSERT (time, device_id, v0, v1, v2, v3) VALUES
+                     ('2021-11-01 00:00:05', 2, 1,2,3,4);
+
+\set ON_ERROR_STOP 1

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -117,6 +117,10 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
        compression_permissions.sql)
 endif()
 
+if((${PG_VERSION_MAJOR} GREATER_EQUAL "15"))
+  list(APPEND TEST_FILES merge_compress.sql)
+endif()
+
 set(SOLO_TESTS
     # dist_hypertable needs a lot of memory when the Sanitizer is active
     dist_hypertable-${PG_VERSION_MAJOR}

--- a/tsl/test/sql/dist_ref_table_join.sql.in
+++ b/tsl/test/sql/dist_ref_table_join.sql.in
@@ -418,18 +418,20 @@ ORDER BY name;
 -- can handle the MERGE command properly. ON_ERROR_STOP is disabled for this test.
 -- Older PostgreSQL versions report an error because MERGE is not supported. This
 -- will be ignored due to the setting.
+-- Commenting below test as error meesage is different on windows vs unix.
+-- Issue #5725 is opened to track it.
 -------
-\set ON_ERROR_STOP 0
-MERGE INTO metric as target_0
-USING metric as input_0
-    inner join (select id from metric_name as input_1) as subq_0
-      ON (TRUE)
-ON target_0.id = input_0.id
-WHEN MATCHED
-   THEN DO NOTHING
-WHEN NOT MATCHED
-   THEN DO NOTHING;
-\set ON_ERROR_STOP 1
+-- \set ON_ERROR_STOP 0
+-- MERGE INTO metric as target_0
+-- USING metric as input_0
+--    inner join (select id from metric_name as input_1) as subq_0
+--      ON (TRUE)
+-- ON target_0.id = input_0.id
+-- WHEN MATCHED
+--   THEN DO NOTHING
+-- WHEN NOT MATCHED
+--   THEN DO NOTHING;
+-- \set ON_ERROR_STOP 1
 
 -------
 -- Tests without enable_per_data_node_queries (no pushdown supported)

--- a/tsl/test/sql/merge_compress.sql
+++ b/tsl/test/sql/merge_compress.sql
@@ -1,0 +1,101 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE target (
+    time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    series_id BIGINT NOT NULL,
+    partition_column TIMESTAMPTZ NOT NULL
+);
+
+SELECT table_name FROM create_hypertable(
+                            'target'::regclass,
+                            'partition_column'::name, chunk_time_interval=>interval '8 hours',
+                            create_default_indexes=> false);
+
+-- enable compression
+ALTER TABLE target SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'series_id',
+    timescaledb.compress_orderby = 'partition_column, value'
+);
+
+SELECT '2022-10-10 14:33:44.1234+05:30' as start_date \gset
+INSERT INTO target (series_id, value, partition_column)
+  SELECT s,1,t from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
+    generate_series(1,3, 1) s;
+
+-- compress chunks
+SELECT count(compress_chunk(c.schema_name|| '.' || c.table_name))
+  FROM _timescaledb_catalog.chunk c, _timescaledb_catalog.hypertable ht where
+    c.hypertable_id = ht.id and ht.table_name = 'target' and c.compressed_chunk_id IS NULL;
+
+CREATE TABLE source (
+        time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        value DOUBLE PRECISION NOT NULL,
+        series_id BIGINT NOT NULL
+    );
+SELECT table_name FROM create_hypertable(
+                                'source'::regclass,
+                                'time'::name, chunk_time_interval=>interval '6 hours',
+                                create_default_indexes=> false);
+
+SELECT '2022-10-10 10:00:00.0123+05:30' as start_date \gset
+INSERT INTO source (time, series_id, value)
+  SELECT t, s,1 from generate_series(:'start_date'::timestamptz, :'start_date'::timestamptz + interval '1 day', '5m') t cross join
+    generate_series(1,2, 1) s;
+
+\set ON_ERROR_STOP 0
+
+-- Merge UPDATE on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET series_id = (t.series_id * 0.123);
+
+-- Merge DELETE on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE;
+
+-- Merge UPDATE/INSERT on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            UPDATE SET series_id = (t.series_id * 0.123)
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+
+-- Merge DELETE/INSERT on compressed hypertables should report error
+MERGE INTO target t
+            USING source s
+            ON t.value = s.value AND t.series_id = s.series_id
+            WHEN MATCHED THEN
+            DELETE
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+
+\set ON_ERROR_STOP 1
+
+-- total compressed chunks
+SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
+    hypertable_name = 'target' GROUP BY is_compressed;
+
+-- Merge INSERT on compressed hypertables should work
+MERGE INTO target t
+            USING source s
+            ON t.partition_column = s.time AND t.value = s.value
+            WHEN NOT MATCHED THEN
+            INSERT VALUES ('2021-11-01 00:00:05'::timestamp with time zone, 5, 210, '2021-11-01 00:00:05'::timestamp with time zone);
+
+-- you should notice 1 uncompressed chunk
+SELECT count(*) AS "total compressed_chunks", is_compressed FROM timescaledb_information.chunks WHERE
+    hypertable_name = 'target' GROUP BY is_compressed;
+
+DROP TABLE target;
+DROP TABLE source;


### PR DESCRIPTION
This patch does following:

1. Planner changes to create ChunkDispatch node when MERGE command
   has INSERT action.
2. Changes to map partition attributes from a tuple returned from
   child node of ChunkDispatch against physical targetlist, so that
   ChunkDispatch node can read the correct value from partition column.
3. Fixed issues with MERGE on compressed hypertable.
4. Added more testcases.
5. MERGE in distributed hypertables is not supported.
6. Since there is no Custom Scan (HypertableModify) node for MERGE
   with UPDATE/DELETE on compressed hypertables, we don't support this.

Fixes #5139
