### PR TITLE
Fix adding column with NULL constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #4926 Fix corruption when inserting into compressed chunks
+* #5152 Fix adding column with NULL constraint to compressed hypertable
+
+**Thanks**
+* @ikkala for reporting error when adding column with NULL constraint to compressed hypertable
 
 ## 2.9.1 (2022-12-23)
 

--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -281,6 +281,14 @@ check_altertable_add_column_for_compressed(Hypertable *ht, ColumnDef *col)
 			Constraint *constraint = lfirst_node(Constraint, lc);
 			switch (constraint->contype)
 			{
+				/*
+				 * We can safelly ignore NULL constraints because it does nothing
+				 * and according to Postgres docs is useless and exist just for
+				 * compatibility with other database systems
+				 * https://www.postgresql.org/docs/current/ddl-constraints.html#id-1.5.4.6.6
+				 */
+				case CONSTR_NULL:
+					continue;
 				case CONSTR_NOTNULL:
 					has_notnull = true;
 					continue;

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -72,7 +72,10 @@ WARNING:  column type "timestamp without time zone" used for "time" does not fol
 (1 row)
 
 ALTER TABLE records SET (timescaledb.compress = true);
-ALTER TABLE records ADD COLUMN col boolean DEFAULT false NOT NULL;
+ALTER TABLE records ADD COLUMN col1 boolean DEFAULT false NOT NULL;
+-- NULL constraints are useless and it is safe allow adding this
+-- column with NULL constraint to a compressed hypertable (Issue #5151)
+ALTER TABLE records ADD COLUMN col2 BOOLEAN NULL;
 DROP table records CASCADE;
 -- TABLESPACES
 -- For tablepaces with compressed chunks the semantics are the following:

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -46,7 +46,10 @@ ALTER TABLE test1 ALTER COLUMN b SET STATISTICS 10;
 CREATE TABLE records (time timestamp NOT NULL);
 SELECT create_hypertable('records', 'time');
 ALTER TABLE records SET (timescaledb.compress = true);
-ALTER TABLE records ADD COLUMN col boolean DEFAULT false NOT NULL;
+ALTER TABLE records ADD COLUMN col1 boolean DEFAULT false NOT NULL;
+-- NULL constraints are useless and it is safe allow adding this
+-- column with NULL constraint to a compressed hypertable (Issue #5151)
+ALTER TABLE records ADD COLUMN col2 BOOLEAN NULL;
 DROP table records CASCADE;
 
 -- TABLESPACES


### PR DESCRIPTION
Adding new column with NULL constraint to a compressed hypertable is raising an error but it make no sense because NULL constraints in Postgres does nothing, I mean it is useless and exist just for compatibility with other database systems:
https://www.postgresql.org/docs/current/ddl-constraints.html#id-1.5.4.6.6

Fixed it by ignoring the NULL constraints when we check for `ALTER TABLE .. ADD COLUMN ..` to a compressed hypertable.

Fixes #5151