### PR TITLE
Do not run regress workflows on benign changes

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -4,7 +4,15 @@ on:
     branches:
       - main
       - prerelease_test
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
 jobs:
   config:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-build-and-test-ignored.yaml
+++ b/.github/workflows/linux-build-and-test-ignored.yaml
@@ -1,0 +1,23 @@
+# Ignoring version of the corresponding workflow. These files are
+# needed to run required workflows even when the real workflow is not
+# executed because some files were ignored.
+name: Regression
+on:
+  push:
+    branches:
+      - prerelease_test
+    paths:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+  pull_request:
+    paths:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+jobs:
+  regress:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "No build required"

--- a/.github/workflows/linux-build-and-test.yaml
+++ b/.github/workflows/linux-build-and-test.yaml
@@ -11,7 +11,15 @@ on:
     branches:
       - main
       - prerelease_test
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
 jobs:
   matrixbuilder:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck-ignored.yaml
+++ b/.github/workflows/shellcheck-ignored.yaml
@@ -1,0 +1,22 @@
+# Ignoring version of the corresponding workflow. These files are
+# needed to run required workflows even when the real workflow is not
+# executed because some files were ignored.
+name: Shellcheck
+on:
+  pull_request:
+    paths-ignore:
+      - '**.sh'
+      - .github/workflows/shellcheck.yaml
+  push:
+    branches:
+      - prerelease_test
+    paths-ignore:
+      - '**.sh'
+      - .github/workflows/shellcheck.yaml
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "No build required"

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -2,10 +2,16 @@
 name: Shellcheck
 on:
   pull_request:
+    paths:
+      - '**.sh'
+      - .github/workflows/shellcheck.yaml
   push:
     branches:
       - main
       - prerelease_test
+    paths:
+      - '**.sh'
+      - .github/workflows/shellcheck.yaml
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -5,7 +5,17 @@ on:
     branches:
       - main
       - prerelease_test
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+      - 'bootstrap*'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+      - 'bootstrap*'
 jobs:
   config:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If only documentation is changed, the full regression check workflow will still be executed, so this commit will instead skip running the regression workflows if there are only changes to files that will not affect the success of the workflow.