### PR TITLE
Support CAGG names in hypertable_(detailed_)size

### DIFF
--- a/sql/size_utils.sql
+++ b/sql/size_utils.sql
@@ -194,9 +194,19 @@ BEGIN
         INNER JOIN _timescaledb_catalog.hypertable ht ON (ht.schema_name = n.nspname AND ht.table_name = c.relname)
         WHERE c.OID = hypertable;
 
-		IF table_name IS NULL THEN
-		    RETURN;
-		END IF;
+        IF table_name IS NULL THEN
+                SELECT h.schema_name, h.table_name, replication_factor > 0
+                INTO schema_name, table_name, is_distributed
+                FROM pg_class c
+                INNER JOIN pg_namespace n ON (n.OID = c.relnamespace)
+                INNER JOIN _timescaledb_catalog.continuous_agg a ON (a.user_view_schema = n.nspname AND a.user_view_name = c.relname)
+                INNER JOIN _timescaledb_catalog.hypertable h ON h.id = a.mat_hypertable_id
+                WHERE c.OID = hypertable;
+
+	        IF table_name IS NULL THEN
+                        RETURN;
+                END IF;
+        END IF;
 
         CASE WHEN is_distributed THEN
 			RETURN QUERY

--- a/tsl/test/expected/size_utils.out
+++ b/tsl/test/expected/size_utils.out
@@ -1,0 +1,70 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+-- Prepare test data for continuous aggregate size function tests
+CREATE TABLE hypersize(time timestamptz, device int);
+SELECT * FROM create_hypertable('hypersize', 'time');
+NOTICE:  adding not-null constraint to column "time"
+ hypertable_id | schema_name | table_name | created 
+---------------+-------------+------------+---------
+             1 | public      | hypersize  | t
+(1 row)
+
+INSERT INTO hypersize VALUES('2021-02-25', 1);
+-- Test size functions on empty continuous aggregate
+CREATE MATERIALIZED VIEW hypersize_cagg WITH (timescaledb.continuous) AS SELECT time_bucket('1 day', "time") AS bucket, AVG(device) AS value FROM hypersize GROUP BY 1 WITH NO DATA;
+SELECT format('%I.%I', h.schema_name, h.table_name) AS "MAT_HYPERTABLE_NAME"
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'hypersize_cagg'
+\gset
+SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
+ hypertable_size 
+-----------------
+           16384
+(1 row)
+
+SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+           0 |        8192 |        8192 |       16384 | 
+(1 row)
+
+SELECT * FROM hypertable_size('hypersize_cagg');
+ hypertable_size 
+-----------------
+           16384
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+           0 |        8192 |        8192 |       16384 | 
+(1 row)
+
+-- Test size functions on non-empty countinuous aggregate
+CALL refresh_continuous_aggregate('hypersize_cagg', NULL, NULL);
+SELECT * FROM hypertable_size('hypersize_cagg');
+ hypertable_size 
+-----------------
+           49152
+(1 row)
+
+SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+        8192 |       24576 |       16384 |       49152 | 
+(1 row)
+
+SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
+ hypertable_size 
+-----------------
+           49152
+(1 row)
+
+SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+ table_bytes | index_bytes | toast_bytes | total_bytes | node_name 
+-------------+-------------+-------------+-------------+-----------
+        8192 |       24576 |       16384 |       49152 | 
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -24,7 +24,8 @@ set(TEST_FILES
     move.sql
     partialize_finalize.sql
     reorder.sql
-    skip_scan.sql)
+    skip_scan.sql
+    size_utils.sql)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   list(

--- a/tsl/test/sql/size_utils.sql
+++ b/tsl/test/sql/size_utils.sql
@@ -1,0 +1,29 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+-- Prepare test data for continuous aggregate size function tests
+CREATE TABLE hypersize(time timestamptz, device int);
+SELECT * FROM create_hypertable('hypersize', 'time');
+INSERT INTO hypersize VALUES('2021-02-25', 1);
+
+-- Test size functions on empty continuous aggregate
+CREATE MATERIALIZED VIEW hypersize_cagg WITH (timescaledb.continuous) AS SELECT time_bucket('1 day', "time") AS bucket, AVG(device) AS value FROM hypersize GROUP BY 1 WITH NO DATA;
+SELECT format('%I.%I', h.schema_name, h.table_name) AS "MAT_HYPERTABLE_NAME"
+FROM _timescaledb_catalog.continuous_agg ca
+INNER JOIN _timescaledb_catalog.hypertable h ON(h.id = ca.mat_hypertable_id)
+WHERE user_view_name = 'hypersize_cagg'
+\gset
+
+SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
+SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+SELECT * FROM hypertable_size('hypersize_cagg');
+SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
+
+-- Test size functions on non-empty countinuous aggregate
+CALL refresh_continuous_aggregate('hypersize_cagg', NULL, NULL);
+SELECT * FROM hypertable_size('hypersize_cagg');
+SELECT * FROM hypertable_detailed_size('hypersize_cagg') ORDER BY node_name;
+SELECT * FROM hypertable_size(:'MAT_HYPERTABLE_NAME');
+SELECT * FROM hypertable_detailed_size(:'MAT_HYPERTABLE_NAME') ORDER BY node_name;
+


### PR DESCRIPTION
This small patch adds support for continuous aggregates to the
`hypertable_detailed_size` (and with that `hypertable_size`).
It adds an additional check to see if a continuous aggregate exists
if a hypertable with the given regclass name isn't found.

Disable-check: force-changelog-changed
