### PR TITLE
Fix CAgg on CAgg variable bucket size validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ accidentally triggering the load of a previous DB version.**
 **Bugfixes**
 * #4926 Fix corruption when inserting into compressed chunks
 * #5114 Fix issue with deleting data node and dropping database
-* #5130 Fix CAgg on CAgg variable bucket size validation
 * #5133 Fix CAgg on CAgg using different column order on the original hypertable
 * #5152 Fix adding column with NULL constraint to compressed hypertable
+* #5170 Fix CAgg on CAgg variable bucket size validation
 
 **Thanks**
 * @ikkala for reporting error when adding column with NULL constraint to compressed hypertable
 * @salquier-appvizer for reporting error on CAgg on CAgg using different column order on the original hypertable
-* @ssmoss for reporting error on CAgg on CAgg variable bucket size validation
+* @ssmoss, @adbnexxtlab and @ivanzamanov for reporting error on CAgg on CAgg variable bucket size validation
 
 ## 2.9.1 (2022-12-23)
 

--- a/tsl/test/expected/cagg_on_cagg.out
+++ b/tsl/test/expected/cagg_on_cagg.out
@@ -3,7 +3,8 @@
 -- LICENSE-TIMESCALE for a copy of the license.
 -- Global test variables
 \set IS_DISTRIBUTED FALSE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 -- ########################################################
 -- ## INTEGER data type tests
 -- ########################################################
@@ -776,8 +777,8 @@ psql:include/cagg_on_cagg_common.sql:158: ERROR:  relation "conditions_summary_1
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -785,6 +786,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                       View "public.conditions_summary_1"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_9.bucket,
+    _materialized_hypertable_9.temperature
+   FROM _timescaledb_internal._materialized_hypertable_9
+  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(2, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(2, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -795,8 +814,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -804,15 +823,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -832,8 +852,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -841,6 +861,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                       View "public.conditions_summary_1"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.temperature
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE _materialized_hypertable_10.bucket < COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(2, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(2, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -851,8 +889,8 @@ SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -860,7 +898,25 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                       View "public.conditions_summary_2"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_11.bucket,
+    _materialized_hypertable_11.temperature
+   FROM _timescaledb_internal._materialized_hypertable_11
+  WHERE _materialized_hypertable_11.bucket < COALESCE(_timescaledb_internal.cagg_watermark(11)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(2, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.cagg_watermark(11)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(2, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
@@ -885,8 +941,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -894,6 +950,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                       View "public.conditions_summary_1"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_12.bucket,
+    _materialized_hypertable_12.temperature
+   FROM _timescaledb_internal._materialized_hypertable_12
+  WHERE _materialized_hypertable_12.bucket < COALESCE(_timescaledb_internal.cagg_watermark(12)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(4, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(12)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(4, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -904,8 +978,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -913,15 +987,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be multiple of the time bucket width of "public.conditions_summary_1" [4].
-\set ON_ERROR_STOP 0
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater or equal than the time bucket width of "public.conditions_summary_1" [4].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMP data type tests
@@ -1687,8 +1762,8 @@ psql:include/cagg_on_cagg_common.sql:158: ERROR:  relation "conditions_summary_1
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1696,6 +1771,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_21.bucket,
+    _materialized_hypertable_21.temperature
+   FROM _timescaledb_internal._materialized_hypertable_21
+  WHERE _materialized_hypertable_21.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(21)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(21)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1706,8 +1799,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1715,16 +1808,17 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -1744,8 +1838,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1753,6 +1847,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_22.bucket,
+    _materialized_hypertable_22.temperature
+   FROM _timescaledb_internal._materialized_hypertable_22
+  WHERE _materialized_hypertable_22.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(22)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(22)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1763,8 +1875,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1772,15 +1884,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -1800,8 +1913,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1809,6 +1922,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_23.bucket,
+    _materialized_hypertable_23.temperature
+   FROM _timescaledb_internal._materialized_hypertable_23
+  WHERE _materialized_hypertable_23.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(23)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(23)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1819,8 +1950,8 @@ SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1828,7 +1959,25 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                                 View "public.conditions_summary_2"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_24.bucket,
+    _materialized_hypertable_24.temperature
+   FROM _timescaledb_internal._materialized_hypertable_24
+  WHERE _materialized_hypertable_24.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(24)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(24)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
@@ -1853,8 +2002,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1862,6 +2011,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_25.bucket,
+    _materialized_hypertable_25.temperature
+   FROM _timescaledb_internal._materialized_hypertable_25
+  WHERE _materialized_hypertable_25.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(25)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(25)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1872,8 +2039,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1881,15 +2048,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMPTZ data type tests
@@ -2653,8 +2821,8 @@ psql:include/cagg_on_cagg_common.sql:158: ERROR:  relation "conditions_summary_1
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2662,6 +2830,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_34.bucket,
+    _materialized_hypertable_34.temperature
+   FROM _timescaledb_internal._materialized_hypertable_34
+  WHERE _materialized_hypertable_34.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(34)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(34)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2672,8 +2858,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2681,16 +2867,17 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -2710,8 +2897,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2719,6 +2906,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_35.bucket,
+    _materialized_hypertable_35.temperature
+   FROM _timescaledb_internal._materialized_hypertable_35
+  WHERE _materialized_hypertable_35.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(35)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(35)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2729,8 +2934,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2738,15 +2943,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -2766,8 +2972,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2775,6 +2981,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_36.bucket,
+    _materialized_hypertable_36.temperature
+   FROM _timescaledb_internal._materialized_hypertable_36
+  WHERE _materialized_hypertable_36.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(36)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(36)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2785,8 +3009,8 @@ SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2794,7 +3018,25 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_37.bucket,
+    _materialized_hypertable_37.temperature
+   FROM _timescaledb_internal._materialized_hypertable_37
+  WHERE _materialized_hypertable_37.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(37)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(37)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
@@ -2819,8 +3061,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2828,6 +3070,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_38.bucket,
+    _materialized_hypertable_38.temperature
+   FROM _timescaledb_internal._materialized_hypertable_38
+  WHERE _materialized_hypertable_38.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(38)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(38)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2838,8 +3098,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2847,24 +3107,27 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
--- -- Validations using time bucket with timezone (ref issue #5126)
+-- Validations using time bucket with timezone (ref issue #5126)
 --
 \set TIME_DIMENSION_DATATYPE TIMESTAMPTZ
-\set IS_TIME_DIMENSION_WITH_TIMEZONE TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1_5m
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2_1h
-\set BUCKET_TZNAME 'US/Pacific'
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
@@ -2880,8 +3143,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2889,6 +3152,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_39.bucket,
+    _materialized_hypertable_39.temperature
+   FROM _timescaledb_internal._materialized_hypertable_39
+  WHERE _materialized_hypertable_39.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(39)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(39)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2899,8 +3180,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2908,14 +3189,31 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_40.bucket,
+    _materialized_hypertable_40.temperature
+   FROM _timescaledb_internal._materialized_hypertable_40
+  WHERE _materialized_hypertable_40.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(40)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket, 'US/Pacific'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(40)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket, 'US/Pacific'::text));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_TZNAME 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'16 minutes\''
 \set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
@@ -2931,8 +3229,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2940,6 +3238,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_41.bucket,
+    _materialized_hypertable_41.temperature
+   FROM _timescaledb_internal._materialized_hypertable_41
+  WHERE _materialized_hypertable_41.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(41)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(41)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2950,8 +3266,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2959,13 +3275,380 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 5 mins].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Variable bucket size with the same timezones
+--
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_42.bucket,
+    _materialized_hypertable_42.temperature
+   FROM _timescaledb_internal._materialized_hypertable_42
+  WHERE _materialized_hypertable_42.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(42)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(42)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_43.bucket,
+    _materialized_hypertable_43.temperature
+   FROM _timescaledb_internal._materialized_hypertable_43
+  WHERE _materialized_hypertable_43.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(43)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(43)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Variable bucket size with different timezones
+--
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_44.bucket,
+    _materialized_hypertable_44.temperature
+   FROM _timescaledb_internal._materialized_hypertable_44
+  WHERE _materialized_hypertable_44.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_45.bucket,
+    _materialized_hypertable_45.temperature
+   FROM _timescaledb_internal._materialized_hypertable_45
+  WHERE _materialized_hypertable_45.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- TZ bucket on top of non-TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_46.bucket,
+    _materialized_hypertable_46.temperature
+   FROM _timescaledb_internal._materialized_hypertable_46
+  WHERE _materialized_hypertable_46.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_47.bucket,
+    _materialized_hypertable_47.temperature
+   FROM _timescaledb_internal._materialized_hypertable_47
+  WHERE _materialized_hypertable_47.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- non-TZ bucket on top of TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_48.bucket,
+    _materialized_hypertable_48.temperature
+   FROM _timescaledb_internal._materialized_hypertable_48
+  WHERE _materialized_hypertable_48.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_49.bucket,
+    _materialized_hypertable_49.temperature
+   FROM _timescaledb_internal._materialized_hypertable_49
+  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;

--- a/tsl/test/expected/cagg_on_cagg_dist_ht.out
+++ b/tsl/test/expected/cagg_on_cagg_dist_ht.out
@@ -37,7 +37,8 @@ GRANT USAGE ON FOREIGN SERVER :DATA_NODE_1, :DATA_NODE_2, :DATA_NODE_3 TO PUBLIC
 GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 -- Global test variables
 \set IS_DISTRIBUTED TRUE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 -- ########################################################
 -- ## INTEGER data type tests
 -- ########################################################
@@ -810,8 +811,8 @@ psql:include/cagg_on_cagg_common.sql:158: ERROR:  relation "conditions_summary_1
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -819,6 +820,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                       View "public.conditions_summary_1"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_9.bucket,
+    _materialized_hypertable_9.temperature
+   FROM _timescaledb_internal._materialized_hypertable_9
+  WHERE _materialized_hypertable_9.bucket < COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(2, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(9)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(2, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -829,8 +848,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -838,15 +857,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [5] should be multiple of the time bucket width of "public.conditions_summary_1" [2].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -866,8 +886,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -875,6 +895,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                       View "public.conditions_summary_1"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_10.bucket,
+    _materialized_hypertable_10.temperature
+   FROM _timescaledb_internal._materialized_hypertable_10
+  WHERE _materialized_hypertable_10.bucket < COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(2, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(10)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(2, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -885,8 +923,8 @@ SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -894,7 +932,25 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                       View "public.conditions_summary_2"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_11.bucket,
+    _materialized_hypertable_11.temperature
+   FROM _timescaledb_internal._materialized_hypertable_11
+  WHERE _materialized_hypertable_11.bucket < COALESCE(_timescaledb_internal.cagg_watermark(11)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(2, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.cagg_watermark(11)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(2, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
@@ -919,8 +975,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -928,6 +984,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                       View "public.conditions_summary_1"
+   Column    |  Type   | Collation | Nullable | Default | Storage | Description 
+-------------+---------+-----------+----------+---------+---------+-------------
+ bucket      | integer |           |          |         | plain   | 
+ temperature | numeric |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_12.bucket,
+    _materialized_hypertable_12.temperature
+   FROM _timescaledb_internal._materialized_hypertable_12
+  WHERE _materialized_hypertable_12.bucket < COALESCE(_timescaledb_internal.cagg_watermark(12)::integer, '-2147483648'::integer)
+UNION ALL
+ SELECT time_bucket(4, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.cagg_watermark(12)::integer, '-2147483648'::integer)
+  GROUP BY (time_bucket(4, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -938,8 +1012,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -947,15 +1021,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be multiple of the time bucket width of "public.conditions_summary_1" [4].
-\set ON_ERROR_STOP 0
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [2] should be greater or equal than the time bucket width of "public.conditions_summary_1" [4].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- cleanup
 DROP TABLE conditions;
@@ -1724,8 +1799,8 @@ psql:include/cagg_on_cagg_common.sql:158: ERROR:  relation "conditions_summary_1
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1733,6 +1808,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_21.bucket,
+    _materialized_hypertable_21.temperature
+   FROM _timescaledb_internal._materialized_hypertable_21
+  WHERE _materialized_hypertable_21.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(21)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(21)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1743,8 +1836,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1752,16 +1845,17 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -1781,8 +1875,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1790,6 +1884,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_22.bucket,
+    _materialized_hypertable_22.temperature
+   FROM _timescaledb_internal._materialized_hypertable_22
+  WHERE _materialized_hypertable_22.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(22)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(22)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1800,8 +1912,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1809,15 +1921,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -1837,8 +1950,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1846,6 +1959,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_23.bucket,
+    _materialized_hypertable_23.temperature
+   FROM _timescaledb_internal._materialized_hypertable_23
+  WHERE _materialized_hypertable_23.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(23)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(23)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1856,8 +1987,8 @@ SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1865,7 +1996,25 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                                 View "public.conditions_summary_2"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_24.bucket,
+    _materialized_hypertable_24.temperature
+   FROM _timescaledb_internal._materialized_hypertable_24
+  WHERE _materialized_hypertable_24.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(24)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(24)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
@@ -1890,8 +2039,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -1899,6 +2048,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                                 View "public.conditions_summary_1"
+   Column    |            Type             | Collation | Nullable | Default | Storage | Description 
+-------------+-----------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp without time zone |           |          |         | plain   | 
+ temperature | numeric                     |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_25.bucket,
+    _materialized_hypertable_25.temperature
+   FROM _timescaledb_internal._materialized_hypertable_25
+  WHERE _materialized_hypertable_25.bucket < COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(25)), '-infinity'::timestamp without time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp_without_timezone(_timescaledb_internal.cagg_watermark(25)), '-infinity'::timestamp without time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -1909,8 +2076,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -1918,15 +2085,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- ########################################################
 -- ## TIMESTAMPTZ data type tests
@@ -2690,8 +2858,8 @@ psql:include/cagg_on_cagg_common.sql:158: ERROR:  relation "conditions_summary_1
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2699,6 +2867,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_34.bucket,
+    _materialized_hypertable_34.temperature
+   FROM _timescaledb_internal._materialized_hypertable_34
+  WHERE _materialized_hypertable_34.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(34)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(34)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2709,8 +2895,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2718,16 +2904,17 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with fixed-width bucket on top of one using variable-width bucket
 DETAIL:  Continuous aggregate with a fixed time bucket width (e.g. 61 days) cannot be created on top of one using variable time bucket width (e.g. 1 month).
 The variance can lead to the fixed width one not being a multiple of the variable width one.
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for non-multiple bucket sizes
@@ -2747,8 +2934,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2756,6 +2943,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_35.bucket,
+    _materialized_hypertable_35.temperature
+   FROM _timescaledb_internal._materialized_hypertable_35
+  WHERE _materialized_hypertable_35.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(35)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(35)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2766,8 +2971,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2775,15 +2980,16 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 3 hours] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validation test for equal bucket sizes
@@ -2803,8 +3009,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2812,6 +3018,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_36.bucket,
+    _materialized_hypertable_36.temperature
+   FROM _timescaledb_internal._materialized_hypertable_36
+  WHERE _materialized_hypertable_36.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(36)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(36)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2822,8 +3046,8 @@ SHOULD WORK because new bucket should be greater than previous
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2831,7 +3055,25 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_37.bucket,
+    _materialized_hypertable_37.temperature
+   FROM _timescaledb_internal._materialized_hypertable_37
+  WHERE _materialized_hypertable_37.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(37)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(37)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
@@ -2856,8 +3098,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2865,6 +3107,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_38.bucket,
+    _materialized_hypertable_38.temperature
+   FROM _timescaledb_internal._materialized_hypertable_38
+  WHERE _materialized_hypertable_38.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(38)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 2 hours'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(38)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 2 hours'::interval, conditions."time"));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2875,8 +3135,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2884,24 +3144,27 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
-DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 2 hours].
-\set ON_ERROR_STOP 0
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
+DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 1 hour] should be greater or equal than the time bucket width of "public.conditions_summary_1" [@ 2 hours].
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 --
 -- Validations using time bucket with timezone (ref issue #5126)
 --
 \set TIME_DIMENSION_DATATYPE TIMESTAMPTZ
-\set IS_TIME_DIMENSION_WITH_TIMEZONE TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1_5m
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2_1h
-\set BUCKET_TZNAME 'US/Pacific'
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
@@ -2917,8 +3180,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2926,6 +3189,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_39.bucket,
+    _materialized_hypertable_39.temperature
+   FROM _timescaledb_internal._materialized_hypertable_39
+  WHERE _materialized_hypertable_39.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(39)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(39)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2936,8 +3217,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2945,14 +3226,31 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_40.bucket,
+    _materialized_hypertable_40.temperature
+   FROM _timescaledb_internal._materialized_hypertable_40
+  WHERE _materialized_hypertable_40.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(40)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket, 'US/Pacific'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(40)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 hour'::interval, conditions_summary_1.bucket, 'US/Pacific'::text));
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
-\set BUCKET_TZNAME 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'16 minutes\''
 \set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
@@ -2968,8 +3266,8 @@ DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -2977,6 +3275,24 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_41.bucket,
+    _materialized_hypertable_41.temperature
+   FROM _timescaledb_internal._materialized_hypertable_41
+  WHERE _materialized_hypertable_41.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(41)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(41)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 5 mins'::interval, conditions."time", 'US/Pacific'::text));
+
 --
 -- CAGG on CAGG (2th level)
 --
@@ -2987,8 +3303,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -2996,15 +3312,382 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-psql:include/cagg_on_cagg_validations.sql:41: ERROR:  cannot create continuous aggregate with incompatible bucket width
+psql:include/cagg_on_cagg_validations.sql:43: ERROR:  cannot create continuous aggregate with incompatible bucket width
 DETAIL:  Time bucket width of "public.conditions_summary_2" [@ 16 mins] should be multiple of the time bucket width of "public.conditions_summary_1" [@ 5 mins].
-\set ON_ERROR_STOP 0
+\d+ :CAGG_NAME_2TH_LEVEL
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 --
 -- Cleanup
 --
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
-psql:include/cagg_on_cagg_validations.sql:48: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+psql:include/cagg_on_cagg_validations.sql:53: NOTICE:  materialized view "conditions_summary_2" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Variable bucket size with the same timezones
+--
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_42.bucket,
+    _materialized_hypertable_42.temperature
+   FROM _timescaledb_internal._materialized_hypertable_42
+  WHERE _materialized_hypertable_42.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(42)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(42)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_43.bucket,
+    _materialized_hypertable_43.temperature
+   FROM _timescaledb_internal._materialized_hypertable_43
+  WHERE _materialized_hypertable_43.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(43)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(43)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- Variable bucket size with different timezones
+--
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_44.bucket,
+    _materialized_hypertable_44.temperature
+   FROM _timescaledb_internal._materialized_hypertable_44
+  WHERE _materialized_hypertable_44.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(44)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'US/Pacific'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_45.bucket,
+    _materialized_hypertable_45.temperature
+   FROM _timescaledb_internal._materialized_hypertable_45
+  WHERE _materialized_hypertable_45.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(45)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- TZ bucket on top of non-TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_46.bucket,
+    _materialized_hypertable_46.temperature
+   FROM _timescaledb_internal._materialized_hypertable_46
+  WHERE _materialized_hypertable_46.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time") AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(46)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time"));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_47.bucket,
+    _materialized_hypertable_47.temperature
+   FROM _timescaledb_internal._materialized_hypertable_47
+  WHERE _materialized_hypertable_47.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(47)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket, 'UTC'::text));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
+--
+-- non-TZ bucket on top of TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set CAGG_NAME_1ST_LEVEL conditions_summary_1
+\set CAGG_NAME_2TH_LEVEL conditions_summary_2
+--
+-- CAGG on hypertable (1st level)
+--
+CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM conditions
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_1ST_LEVEL
+                               View "public.conditions_summary_1"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_48.bucket,
+    _materialized_hypertable_48.temperature
+   FROM _timescaledb_internal._materialized_hypertable_48
+  WHERE _materialized_hypertable_48.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text) AS bucket,
+    sum(conditions.temperature) AS temperature
+   FROM conditions
+  WHERE conditions."time" >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(48)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 day'::interval, conditions."time", 'UTC'::text));
+
+--
+-- CAGG on CAGG (2th level)
+--
+\set VERBOSITY default
+\set ON_ERROR_STOP 0
+\echo :WARNING_MESSAGE
+-- SHOULD WORK
+CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
+WITH (timescaledb.continuous) AS
+SELECT
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
+  \else
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
+  \endif
+  SUM(temperature) AS temperature
+FROM :CAGG_NAME_1ST_LEVEL
+GROUP BY 1
+WITH NO DATA;
+\d+ :CAGG_NAME_2TH_LEVEL
+                               View "public.conditions_summary_2"
+   Column    |           Type           | Collation | Nullable | Default | Storage | Description 
+-------------+--------------------------+-----------+----------+---------+---------+-------------
+ bucket      | timestamp with time zone |           |          |         | plain   | 
+ temperature | numeric                  |           |          |         | main    | 
+View definition:
+ SELECT _materialized_hypertable_49.bucket,
+    _materialized_hypertable_49.temperature
+   FROM _timescaledb_internal._materialized_hypertable_49
+  WHERE _materialized_hypertable_49.bucket < COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+UNION ALL
+ SELECT time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket) AS bucket,
+    sum(conditions_summary_1.temperature) AS temperature
+   FROM conditions_summary_1
+  WHERE conditions_summary_1.bucket >= COALESCE(_timescaledb_internal.to_timestamp(_timescaledb_internal.cagg_watermark(49)), '-infinity'::timestamp with time zone)
+  GROUP BY (time_bucket('@ 1 mon'::interval, conditions_summary_1.bucket));
+
+\set ON_ERROR_STOP 1
+\set VERBOSITY terse
+--
+-- Cleanup
+--
+DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_2TH_LEVEL;
 DROP MATERIALIZED VIEW IF EXISTS :CAGG_NAME_1ST_LEVEL;
 -- Cleanup
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER;

--- a/tsl/test/sql/cagg_on_cagg.sql
+++ b/tsl/test/sql/cagg_on_cagg.sql
@@ -4,7 +4,8 @@
 
 -- Global test variables
 \set IS_DISTRIBUTED FALSE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 
 -- ########################################################
 -- ## INTEGER data type tests
@@ -183,20 +184,63 @@ SET timezone TO 'UTC';
 \ir include/cagg_on_cagg_validations.sql
 
 --
--- -- Validations using time bucket with timezone (ref issue #5126)
+-- Validations using time bucket with timezone (ref issue #5126)
 --
 \set TIME_DIMENSION_DATATYPE TIMESTAMPTZ
-\set IS_TIME_DIMENSION_WITH_TIMEZONE TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1_5m
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2_1h
-\set BUCKET_TZNAME 'US/Pacific'
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 
-\set BUCKET_TZNAME 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'16 minutes\''
 \set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Variable bucket size with the same timezones
+--
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Variable bucket size with different timezones
+--
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- TZ bucket on top of non-TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- non-TZ bucket on top of TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql

--- a/tsl/test/sql/cagg_on_cagg_dist_ht.sql
+++ b/tsl/test/sql/cagg_on_cagg_dist_ht.sql
@@ -22,7 +22,8 @@ GRANT CREATE ON SCHEMA public TO :ROLE_DEFAULT_PERM_USER;
 
 -- Global test variables
 \set IS_DISTRIBUTED TRUE
-\set IS_TIME_DIMENSION_WITH_TIMEZONE FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
 
 -- ########################################################
 -- ## INTEGER data type tests
@@ -206,19 +207,62 @@ SET timezone TO 'UTC';
 -- Validations using time bucket with timezone (ref issue #5126)
 --
 \set TIME_DIMENSION_DATATYPE TIMESTAMPTZ
-\set IS_TIME_DIMENSION_WITH_TIMEZONE TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
 \set CAGG_NAME_1ST_LEVEL conditions_summary_1_5m
 \set CAGG_NAME_2TH_LEVEL conditions_summary_2_1h
-\set BUCKET_TZNAME 'US/Pacific'
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'1 hour\''
 \set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 
-\set BUCKET_TZNAME 'US/Pacific'
 \set BUCKET_WIDTH_1ST 'INTERVAL \'5 minutes\''
 \set BUCKET_WIDTH_2TH 'INTERVAL \'16 minutes\''
 \set WARNING_MESSAGE '-- SHOULD ERROR because non-multiple bucket sizes'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Variable bucket size with the same timezones
+--
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- Variable bucket size with different timezones
+--
+\set BUCKET_TZNAME_1ST 'US/Pacific'
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- TZ bucket on top of non-TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST FALSE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH TRUE
+\set BUCKET_TZNAME_2TH 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
+\ir include/cagg_on_cagg_validations.sql
+
+--
+-- non-TZ bucket on top of TZ bucket
+--
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_1ST TRUE
+\set IS_TIME_DIMENSION_WITH_TIMEZONE_2TH FALSE
+\set BUCKET_TZNAME_1ST 'UTC'
+\set BUCKET_WIDTH_1ST 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_2TH 'INTERVAL \'1 month\''
+\set WARNING_MESSAGE '-- SHOULD WORK'
 \ir include/cagg_on_cagg_validations.sql
 
 -- Cleanup

--- a/tsl/test/sql/include/cagg_on_cagg_validations.sql
+++ b/tsl/test/sql/include/cagg_on_cagg_validations.sql
@@ -11,8 +11,8 @@
 CREATE MATERIALIZED VIEW :CAGG_NAME_1ST_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_1ST
+    time_bucket(:BUCKET_WIDTH_1ST, "time", :'BUCKET_TZNAME_1ST') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_1ST, "time") AS bucket,
   \endif
@@ -20,6 +20,8 @@ SELECT
 FROM conditions
 GROUP BY 1
 WITH NO DATA;
+
+\d+ :CAGG_NAME_1ST_LEVEL
 
 --
 -- CAGG on CAGG (2th level)
@@ -30,8 +32,8 @@ WITH NO DATA;
 CREATE MATERIALIZED VIEW :CAGG_NAME_2TH_LEVEL
 WITH (timescaledb.continuous) AS
 SELECT
-  \if :IS_TIME_DIMENSION_WITH_TIMEZONE
-    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME') AS bucket,
+  \if :IS_TIME_DIMENSION_WITH_TIMEZONE_2TH
+    time_bucket(:BUCKET_WIDTH_2TH, "bucket", :'BUCKET_TZNAME_2TH') AS bucket,
   \else
     time_bucket(:BUCKET_WIDTH_2TH, "bucket") AS bucket,
   \endif
@@ -39,7 +41,10 @@ SELECT
 FROM :CAGG_NAME_1ST_LEVEL
 GROUP BY 1
 WITH NO DATA;
-\set ON_ERROR_STOP 0
+
+\d+ :CAGG_NAME_2TH_LEVEL
+
+\set ON_ERROR_STOP 1
 \set VERBOSITY terse
 
 --


### PR DESCRIPTION
Previous attempt to fix it (PR #5130) was not entirely correct because the bucket width calculation for interval width was wrong.

Fixed it by properly calculate the bucket width for intervals using the Postgres internal function `interval_part` to extract the epoch of the interval and execute the validations. For integer widths use the already calculated bucket width.

Fixes #5158, #5168