### PR TITLE
Add missing ignore files

### DIFF
--- a/.github/workflows/linux-32bit-build-and-test-ignored.yaml
+++ b/.github/workflows/linux-32bit-build-and-test-ignored.yaml
@@ -1,0 +1,24 @@
+# Ignoring version of the corresponding workflow. These files are
+# needed to run required workflows even when the real workflow is not
+# executed because some files were ignored.
+name: Regression Linux i386
+on:
+  push:
+    branches:
+      - prerelease_test
+    paths:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+  pull_request:
+    paths:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+jobs:
+  regress_linux_32bit:
+    name: PG${{ matrix.pg }} ${{ matrix.build_type }} linux-i386
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "No build required"

--- a/.github/workflows/windows-build-and-test-ignored.yaml
+++ b/.github/workflows/windows-build-and-test-ignored.yaml
@@ -1,0 +1,25 @@
+# Ignoring version of the corresponding workflow. These files are
+# needed to run required workflows even when the real workflow is not
+# executed because some files were ignored.
+name: Regression Windows
+on:
+  push:
+    branches:
+      - prerelease_test
+    paths:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+      - 'bootstrap*'
+  pull_request:
+    paths:
+      - '**.md'
+      - 'LICENSE*'
+      - NOTICE
+      - 'bootstrap*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "No build required"


### PR DESCRIPTION
The workflow ignore files for 32-bit Linux builds and Windows was missing from #5156 so these are added here.