### PR TITLE
Add RFCs to repositories

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,52 @@
+# Summary
+
+A summary of the feature, usually a single paragraph.
+
+# Rationale
+
+The motivation for the feature. It can include any of the sections
+below, but does not have to.
+
+## Situation
+
+The current situation, typically with examples of how things currently
+work. This is intended to give context to the problem description so
+that it can easily be understood.
+
+## Problem
+
+The problem with the current situation, e.g., things that break,
+things that make the solution hard to use, or things that affect
+performance.
+
+## Expected outcome
+
+The goals, or expected outcome of the solution
+
+# Reference-level description
+
+The commands, their parameters, and any other description that would
+go into a reference manual about the feature. Please include examples
+of usage as well.
+
+This part of the RFC is used by the documentation team to make sure
+that the feature is properly documented, but is also a good
+demonstration of how the feature would work and be used and hence good
+material for discussing the design.
+
+# Open Issues
+
+Issues remaining to resolve either by incorporating them into the
+design or discard them (with a reason for why). This section is
+usually empty once the RFC is ready, but there is no strict
+requirement that is has to be empty.
+
+# Future work
+
+Work that is not included, but which might be interesting to follow up
+with in a future RFC.
+
+# Status
+
+| **Issue**   | Link to issue |
+| **Version** | Version added |

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,62 @@
+# Requests for Comments
+
+The procedure is loosely based on the procedure used for [Rust
+RFCs](https://github.com/rust-lang/rfcs). 
+
+Requests for comments is intended to be a consistent approach to
+discussing and proposing changes to TimescaleDB and allow feedback on
+the change before it is implemented.
+
+Note that many smaller fixes can be handled as a simple issue using
+the normal GitHub workflow but the RFCs are intended to support more
+substantial changes that might require a wider audience and broader
+discussion.
+
+Changes that require an RFC:
+- Semantic or syntactic changes that are not a bugfix.
+- Adding or removing features.
+
+As a guideline, any code change that is not a bugfix but would require
+updating the documentation should be an RFC.
+
+Changes that do not require an RFC:
+- Documentation updates
+- Refactorings that do not change semantics nor require documentation
+  updates.
+- Addition, removal, or update of internal functions. These are mostly
+  focused on developers and for that reason an RFC is not necessary.
+
+## Submitting an RFC
+
+1. Copy `0000-template.md` into `0000-new-feature.md`. Do not assign
+   an RFC number and just use `0000` for the number.
+2. Fill in the details in the RFC. Please be careful about giving
+   enough context so that the motivation for the RFC can be
+   understood. In particular, example usage will help a lot as well as
+   a description of the current situation to understand what it
+   intends to solve.
+3. Create a pull request. This will be discussed and you should be
+   prepared to handle feedback on the proposal.
+4. Once all comments have been handled and discussed, create an issue
+   with the contents of the proposal.
+5. Use the issue number of the created issue to rename your RFC, e.g.,
+   `1234-new-feature.md` in the pull request and fill in the issue
+   number in the RFC.
+6. Update the pull request message and the commit to include `RFC for
+   #1234` so that it is easy to find the discussions about the feature
+   once starting to work with the issue.
+
+## Implementing an RFC
+
+An RFC does not have to picked up directly, and depending on
+priorities it might be picked up at a later time. Since each RFC has
+an issue, it will be easy to find the associated issue and prioritize
+and work with it using normal GitHub workflows.
+
+If you decide to work on an RFC, you should assign yourself to
+it. Since this is occationally forgotten, it might be prudent to add a
+comment to the issue and check if anybody is already working on it, if
+you're not sure.
+
+
+


### PR DESCRIPTION
This commit adds a separate directory for RFCs that can be used for changes. The commit contains a template RFC and a README with a description of the RFC procedure.

The procedure is intended to be as lightweight as possible, but still provide a platform for discussions as well as provide sufficient information for documenting and using the feature later.