### PR TITLE
Fix dist_cagg flaky test

### DIFF
--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -1450,6 +1450,7 @@ create_alter_data_node_tuple(TupleDesc tupdesc, const char *node_name, List *opt
 	MemSet(nulls, false, sizeof(nulls));
 
 	values[AttrNumberGetAttrOffset(Anum_alter_data_node_node_name)] = CStringGetDatum(node_name);
+	values[AttrNumberGetAttrOffset(Anum_alter_data_node_available)] = BoolGetDatum(true);
 
 	foreach (lc, options)
 	{


### PR DESCRIPTION
Function alter_data_node() return uninitialized value for "available" option when it is not presented in the option list.

Fix #5154