### PR TITLE
Fix ChunkAppend, ConstraintAwareAppend child subplan

### DIFF
--- a/src/nodes/chunk_append/planner.c
+++ b/src/nodes/chunk_append/planner.c
@@ -368,6 +368,9 @@ ts_chunk_append_get_scan_plan(Plan *plan)
 		case T_TidScan:
 		case T_ValuesScan:
 		case T_WorkTableScan:
+#if PG14_GE
+		case T_TidRangeScan:
+#endif
 			return (Scan *) plan;
 			break;
 		case T_CustomScan:

--- a/src/nodes/constraint_aware_append/constraint_aware_append.c
+++ b/src/nodes/constraint_aware_append/constraint_aware_append.c
@@ -222,6 +222,9 @@ ca_append_begin(CustomScanState *node, EState *estate, int eflags)
 			case T_WorkTableScan:
 			case T_ForeignScan:
 			case T_CustomScan:
+#if PG14_GE
+			case T_TidRangeScan:
+#endif
 			{
 				/*
 				 * If this is a base rel (chunk), check if it can be
@@ -441,6 +444,9 @@ constraint_aware_append_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPa
 			case T_WorkTableScan:
 			case T_ForeignScan:
 			case T_CustomScan:
+#if PG14_GE
+			case T_TidRangeScan:
+#endif
 			{
 				List *chunk_clauses = NIL;
 				ListCell *lc;

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -974,3 +974,35 @@ ERROR:  insert or update on table "_hyper_21_21_chunk" violates foreign key cons
 DROP TABLE regular cascade;
 NOTICE:  drop cascades to 2 other objects
 DROP TABLE timescale cascade;
+-- github issue 4872
+-- If subplan of ChunkAppend is TidRangeScan, then SELECT on
+-- hypertable fails with error "invalid child of chunk append: Node (26)"
+create table tidrangescan_test (
+  time timestamp with time zone,
+  some_column bigint
+);
+select create_hypertable('tidrangescan_test', 'time');
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (22,public,tidrangescan_test,t)
+(1 row)
+
+insert into tidrangescan_test (time, some_column) values ('2023-02-12 00:00:00+02:40', 1);
+insert into tidrangescan_test (time, some_column) values ('2023-02-12 00:00:10+02:40', 2);
+insert into tidrangescan_test (time, some_column) values ('2023-02-12 00:00:20+02:40', 3);
+-- Below query will generate plan as
+-- Custom Scan (ChunkAppend)
+--   ->  Tid Range Scan
+-- However when traversing ChunkAppend node, Tid Range Scan node is not
+-- recognised as a valid child node of ChunkAppend which causes error
+-- "invalid child of chunk append: Node (26)" when below query is executed
+select * from tidrangescan_test where time > '2023-02-12 00:00:00+02:40'::timestamp with time zone - interval '5 years' and ctid < '(1,1)'::tid ORDER BY time;
+             time             | some_column 
+------------------------------+-------------
+ Sat Feb 11 13:20:00 2023 PST |           1
+ Sat Feb 11 13:20:10 2023 PST |           2
+ Sat Feb 11 13:20:20 2023 PST |           3
+(3 rows)
+
+drop table tidrangescan_test;

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -1637,3 +1637,41 @@ SELECT device, _ts_meta_sequence_num, _ts_meta_count FROM :COMP_CHUNK ORDER BY 1
       8 |                    10 |              1
 (17 rows)
 
+-- github issue 4872
+-- If subplan of ConstraintAwareAppend is TidRangeScan, then SELECT on
+-- hypertable fails with error "invalid child of chunk append: Node (26)"
+CREATE TABLE tidrangescan_test(time timestamptz, device_id int, v1 float, v2 float);
+SELECT create_hypertable('tidrangescan_test','time');
+NOTICE:  adding not-null constraint to column "time"
+        create_hypertable        
+---------------------------------
+ (35,public,tidrangescan_test,t)
+(1 row)
+
+INSERT INTO tidrangescan_test SELECT generate_series('2000-01-01'::timestamptz,'2000-01-10','1m'),1,0.25,0.75;
+CREATE MATERIALIZED VIEW tidrangescan_expr WITH (timescaledb.continuous)
+ AS
+ SELECT
+   time_bucket('1d', time) AS time,
+   'Const'::text AS Const,
+   4.3::numeric AS "numeric",
+   first(tidrangescan_test,time),
+   CASE WHEN true THEN 'foo' ELSE 'bar' END,
+   COALESCE(NULL,'coalesce'),
+   avg(v1) + avg(v2) AS avg1,
+   avg(v1+v2) AS avg2,
+   count(*) AS cnt
+ FROM tidrangescan_test
+ WHERE ctid < '(1,1)'::tid GROUP BY 1 WITH NO DATA;
+CALL refresh_continuous_aggregate('tidrangescan_expr', NULL, NULL);
+SET timescaledb.enable_chunk_append to off;
+SET enable_indexscan to off;
+SELECT time, const, numeric,first, avg1, avg2 FROM tidrangescan_expr ORDER BY time LIMIT 5;
+             time             | const | numeric |                    first                     | avg1 | avg2 
+------------------------------+-------+---------+----------------------------------------------+------+------
+ Fri Dec 31 16:00:00 1999 PST | Const |     4.3 | ("Sat Jan 01 00:00:00 2000 PST",1,0.25,0.75) |    1 |    1
+ Wed Jan 05 16:00:00 2000 PST | Const |     4.3 | ("Wed Jan 05 16:00:00 2000 PST",1,0.25,0.75) |    1 |    1
+(2 rows)
+
+RESET timescaledb.enable_chunk_append;
+RESET enable_indexscan;


### PR DESCRIPTION
When TidRangeScan is child of ChunkAppend or ConstraintAwareAppend node, an
error is reported as "invalid child of chunk append: Node (26)". This patch
fixes the issue by recognising TidRangeScan as a valid child.

Fixes: #4872