### PR TITLE
Don't enable clang-tidy by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,15 +468,9 @@ else()
   message(STATUS "Regress checks and isolation checks disabled")
 endif()
 
-if(CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
-  set(LINTER_DEFAULT ON)
-else()
-  set(LINTER_DEFAULT OFF)
-endif()
-
 # Linter support via clang-tidy. Enabled when using clang as compiler
 option(LINTER "Enable linter support using clang-tidy (ON when using clang)"
-       ${LINTER_DEFAULT})
+       OFF)
 
 set(LINTER_STRICT_DEFAULT OFF)
 option(LINTER_STRICT "Treat linter warnings as errors" ${LINTER_STRICT_DEFAULT})


### PR DESCRIPTION
This is aimed at developers. If we enable it by default, it confuses our users and slows down the build for them.

Fixes https://github.com/timescale/timescaledb/issues/5092


Disable-check: force-changelog-changed