### PR TITLE
Release 2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,20 @@ accidentally triggering the load of a previous DB version.**
 
 **Bugfixes**
 * #4926 Fix corruption when inserting into compressed chunks
-* #5114 Fix issue with deleting data node and dropping database
-* #5133 Fix CAgg on CAgg using different column order on the original hypertable
-* #5152 Fix adding column with NULL constraint to compressed hypertable
+
+## 2.9.2 (2023-01-18)
+
+This release contains bug fixes since the 2.9.1 release.
+We recommend that you upgrade at the next available opportunity.
+
+**Bugfixes**
+* #5180 Fix dist_cagg flaky test
 * #5170 Fix CAgg on CAgg variable bucket size validation
+* #5114 Fix issue with deleting data node and dropping database
+* #5133 Fix CAgg on CAgg different column order on the original hypertable
+* #5152 Fix adding column with NULL constraint to compressed hypertable
+* #5181 Fix ChunkAppend, ConstraintAwareAppend child subplan
+* #5193 Fix repartition behavior when attaching data node
 
 **Thanks**
 * @ikkala for reporting error when adding column with NULL constraint to compressed hypertable

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -41,7 +41,8 @@ set(MOD_FILES
     updates/2.7.2--2.8.0.sql
     updates/2.8.0--2.8.1.sql
     updates/2.8.1--2.9.0.sql
-    updates/2.9.0--2.9.1.sql)
+    updates/2.9.0--2.9.1.sql
+    updates/2.9.1--2.9.2.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.10.0-dev
-update_from_version = 2.9.1
+update_from_version = 2.9.2
 downgrade_to_version = 2.9.1


### PR DESCRIPTION
This release contains bug fixes since the 2.9.1 release. We recommend that you upgrade at the next available opportunity.

**Bugfixes**
* #5180 Fix dist_cagg flaky test
* #5170 Fix CAgg on CAgg variable bucket size validation
* #5114 Fix issue with deleting data node and dropping database
* #5133 Fix CAgg on CAgg different column order on the original hypertable
* #5152 Fix adding column with NULL constraint to compressed hypertable
* #5181 Fix ChunkAppend, ConstraintAwareAppend child subplan
* #5193 Fix repartition behavior when attaching data node