### PR TITLE
Add scan plan logic for remote joins

### DIFF
--- a/tsl/src/fdw/data_node_scan_plan.c
+++ b/tsl/src/fdw/data_node_scan_plan.c
@@ -836,7 +836,7 @@ data_node_scan_plan_create(PlannerInfo *root, RelOptInfo *rel, CustomPath *best_
 
 	memset(&scaninfo, 0, sizeof(ScanInfo));
 
-	fdw_scan_info_init(&scaninfo, root, rel, &best_path->path, clauses);
+	fdw_scan_info_init(&scaninfo, root, rel, &best_path->path, clauses, NULL);
 
 	cscan->methods = &data_node_scan_plan_methods;
 	cscan->custom_plans = custom_plans;

--- a/tsl/src/fdw/fdw.c
+++ b/tsl/src/fdw/fdw.c
@@ -139,7 +139,7 @@ get_foreign_plan(PlannerInfo *root, RelOptInfo *foreignrel, Oid foreigntableid,
 
 	memset(&info, 0, sizeof(ScanInfo));
 
-	fdw_scan_info_init(&info, root, foreignrel, &best_path->path, scan_clauses);
+	fdw_scan_info_init(&info, root, foreignrel, &best_path->path, scan_clauses, outer_plan);
 
 	/*
 	 * Create the ForeignScan node for the given relation.

--- a/tsl/src/fdw/scan_plan.h
+++ b/tsl/src/fdw/scan_plan.h
@@ -40,7 +40,7 @@ typedef Path *(*CreateUpperPathFunc)(PlannerInfo *root, RelOptInfo *rel, PathTar
 									 List *pathkeys, Path *fdw_outerpath, List *fdw_private);
 
 extern void fdw_scan_info_init(ScanInfo *scaninfo, PlannerInfo *root, RelOptInfo *rel,
-							   Path *best_path, List *scan_clauses);
+							   Path *best_path, List *scan_clauses, Plan *outer_plan);
 
 extern void fdw_add_paths_with_pathkeys_for_rel(PlannerInfo *root, RelOptInfo *rel, Path *epq_path,
 												CreatePathFunc create_scan_path);


### PR DESCRIPTION
This patch adds the missing functionality to create scan plans for remote joins. Most of the code is a backport from PG Upstream.