### PR TITLE
Fix use of prepared statement in async module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ accidentally triggering the load of a previous DB version.**
 * #4804 Skip bucketing when start or end of refresh job is null
 * #4926 Fix corruption when inserting into compressed chunks
 * #5218 Add role-level security to job error log
+* #5214 Fix use of prepared statement in async module
 
 ## 2.9.2 (2023-01-26)
 


### PR DESCRIPTION
Broken code caused the async connection module to never send queries
using prepared statements. Instead, queries were sent using the
parameterized query statement instead.

The regression was introduced a long time ago in commit https://github.com/timescale/timescaledb/commit/86858e36e9fb6243d52191bcedc6be05ee2ab734

Fix this so that prepared statements are used when created.