### PR TITLE
Fix concurrent locking with chunk_data_node table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ accidentally triggering the load of a previous DB version.**
 * #5317 Fix some incorrect memory handling
 * #5367 Rename columns in old-style continuous aggregates
 * #5384 Fix Hierarchical Continuous Aggregates chunk_interval_size
+* #5153 Fix concurrent locking with chunk_data_node table
 
 **Thanks**
 * @Medvecrab for discovering an issue with copying NameData when forming heap tuples.

--- a/tsl/src/chunk_api.c
+++ b/tsl/src/chunk_api.c
@@ -19,6 +19,8 @@
 #include <fmgr.h>
 #include <funcapi.h>
 #include <miscadmin.h>
+#include <storage/lmgr.h>
+#include <storage/lockdefs.h>
 #include <utils/array.h>
 #include <utils/builtins.h>
 #include <utils/jsonb.h>
@@ -1775,6 +1777,7 @@ chunk_api_call_chunk_drop_replica(const Chunk *chunk, const char *node_name, Oid
 	 * This chunk might have this data node as primary, change that association
 	 * if so. Then delete the chunk_id and node_name association.
 	 */
+	LockRelationOid(chunk->table_id, ShareUpdateExclusiveLock);
 	chunk_update_foreign_server_if_needed(chunk, serverid, false);
 	ts_chunk_data_node_delete_by_chunk_id_and_node_name(chunk->fd.id, node_name);
 }

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -25,6 +25,8 @@
 #include <nodes/parsenodes.h>
 #include <nodes/nodes.h>
 #include <nodes/value.h>
+#include <storage/lockdefs.h>
+#include <storage/lmgr.h>
 #include <utils/acl.h>
 #include <utils/builtins.h>
 #include <utils/array.h>
@@ -1157,6 +1159,8 @@ data_node_modify_hypertable_data_nodes(const char *node_name, List *hypertable_d
 			{
 				ChunkDataNode *cdn = lfirst(cs_lc);
 				const Chunk *chunk = ts_chunk_get_by_id(cdn->fd.chunk_id, true);
+				LockRelationOid(chunk->table_id, ShareUpdateExclusiveLock);
+
 				chunk_update_foreign_server_if_needed(chunk, cdn->foreign_server_oid, false);
 				ts_chunk_data_node_delete_by_chunk_id_and_node_name(cdn->fd.chunk_id,
 																	NameStr(cdn->fd.node_name));

--- a/tsl/test/isolation/expected/dist_ha_chunk_drop.out
+++ b/tsl/test/isolation/expected/dist_ha_chunk_drop.out
@@ -1,0 +1,57 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s1_init s1_set_unavailable s3_lock_enable s1_insert s2_insert s3_lock_release s1_set_available
+node_name  
+-----------
+data_node_1
+(1 row)
+
+node_name  
+-----------
+data_node_2
+(1 row)
+
+node_name  
+-----------
+data_node_3
+(1 row)
+
+node_name  
+-----------
+data_node_4
+(1 row)
+
+created
+-------
+t      
+(1 row)
+
+step s1_init: INSERT INTO metric1(ts, val, dev_id) SELECT s.*, 3.14, d.* FROM generate_series('2021-08-17 00:00:00'::timestamp, '2021-08-17 00:00:59'::timestamp, '1 s'::interval) s CROSS JOIN generate_series(1, 500) d;
+step s1_set_unavailable: SELECT alter_data_node('data_node_4', available=>false);
+alter_data_node                       
+--------------------------------------
+(data_node_4,localhost,55432,cdha_4,f)
+(1 row)
+
+step s3_lock_enable: SELECT debug_waitpoint_enable('chunk_data_node_delete');
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_insert: INSERT INTO metric1(ts, val, dev_id) SELECT s.*, 3.14, d.* FROM generate_series('2021-08-17 00:01:00'::timestamp, '2021-08-17 00:01:59'::timestamp, '1 s'::interval) s CROSS JOIN generate_series(1, 249) d; <waiting ...>
+step s2_insert: INSERT INTO metric1(ts, val, dev_id) SELECT s.*, 3.14, d.* FROM generate_series('2021-08-17 00:01:00'::timestamp, '2021-08-17 00:01:59'::timestamp, '1 s'::interval) s CROSS JOIN generate_series(250, 499) d; <waiting ...>
+step s3_lock_release: SELECT debug_waitpoint_release('chunk_data_node_delete');
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s1_insert: <... completed>
+step s2_insert: <... completed>
+step s1_set_available: SELECT alter_data_node('data_node_4', available=>true);
+alter_data_node                       
+--------------------------------------
+(data_node_4,localhost,55432,cdha_4,t)
+(1 row)
+

--- a/tsl/test/isolation/expected/dist_restore_point.out
+++ b/tsl/test/isolation/expected/dist_restore_point.out
@@ -1,6 +1,11 @@
 Parsed test spec with 3 sessions
 
 starting permutation: s3_lock_enable s1_create_dist_rp s2_insert s3_lock_count s3_lock_release
+delete_data_node
+----------------
+t               
+(1 row)
+
 node_name  
 -----------
 data_node_1
@@ -56,6 +61,11 @@ t
 step s2_insert: <... completed>
 
 starting permutation: s2_begin s2_insert s3_lock_enable s1_create_dist_rp s3_lock_count s2_commit s3_lock_count s3_lock_release
+delete_data_node
+----------------
+t               
+(1 row)
+
 node_name  
 -----------
 data_node_1
@@ -122,6 +132,11 @@ t
 step s2_commit: <... completed>
 
 starting permutation: s3_lock_enable s1_create_dist_rp s2_create_dist_rp s3_lock_count s3_lock_release
+delete_data_node
+----------------
+t               
+(1 row)
+
 node_name  
 -----------
 data_node_1
@@ -185,6 +200,11 @@ t
 
 
 starting permutation: s3_lock_enable s1_create_dist_rp s2_dist_exec s3_lock_count s3_lock_release
+delete_data_node
+----------------
+t               
+(1 row)
+
 node_name  
 -----------
 data_node_1
@@ -240,6 +260,11 @@ t
 step s2_dist_exec: <... completed>
 
 starting permutation: s3_lock_enable s1_create_dist_rp s2_create_dist_ht s3_lock_count s3_lock_release
+delete_data_node
+----------------
+t               
+(1 row)
+
 node_name  
 -----------
 data_node_1
@@ -303,6 +328,11 @@ t
 
 
 starting permutation: s3_lock_enable s1_create_dist_rp s2_drop_dist_ht s3_lock_count s3_lock_release
+delete_data_node
+----------------
+t               
+(1 row)
+
 node_name  
 -----------
 data_node_1
@@ -356,136 +386,3 @@ t
 (4 rows)
 
 step s2_drop_dist_ht: <... completed>
-
-starting permutation: s3_lock_enable s1_create_dist_rp s2_add_dn s3_lock_count s3_lock_count_fs s3_lock_release s3_lock_count_fs
-node_name  
------------
-data_node_1
-(1 row)
-
-node_name  
------------
-data_node_2
-(1 row)
-
-node_name  
------------
-data_node_3
-(1 row)
-
-created
--------
-t      
-(1 row)
-
-step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
-debug_waitpoint_enable
-----------------------
-                      
-(1 row)
-
-step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
-step s2_add_dn: SELECT node_name FROM add_data_node('data_node_4', host => 'localhost', database => 'cdrp_4'); <waiting ...>
-step s3_lock_count: 
-	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
-	       remote_txn_locks() as remote_txn_locks;
-
-cdrp_locks|remote_txn_locks
-----------+----------------
-         2|               1
-(1 row)
-
-step s3_lock_count_fs: SELECT foreign_server_locks() as foreign_server_locks;
-foreign_server_locks
---------------------
-                   2
-(1 row)
-
-step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
-debug_waitpoint_release
------------------------
-                       
-(1 row)
-
-step s1_create_dist_rp: <... completed>
-valid_lsn
----------
-t        
-t        
-t        
-t        
-(4 rows)
-
-step s2_add_dn: <... completed>
-node_name  
------------
-data_node_4
-(1 row)
-
-step s3_lock_count_fs: SELECT foreign_server_locks() as foreign_server_locks;
-foreign_server_locks
---------------------
-                   0
-(1 row)
-
-
-starting permutation: s3_lock_enable s1_create_dist_rp s2_del_dn s3_lock_count s3_lock_release
-node_name  
------------
-data_node_1
-(1 row)
-
-node_name  
------------
-data_node_2
-(1 row)
-
-node_name  
------------
-data_node_3
-(1 row)
-
-created
--------
-t      
-(1 row)
-
-step s3_lock_enable: SELECT debug_waitpoint_enable('create_distributed_restore_point_lock');
-debug_waitpoint_enable
-----------------------
-                      
-(1 row)
-
-step s1_create_dist_rp: SELECT restore_point > pg_lsn('0/0') as valid_lsn FROM create_distributed_restore_point('s1_test'); <waiting ...>
-step s2_del_dn: SELECT * FROM delete_data_node('data_node_4'); <waiting ...>
-step s3_lock_count: 
-	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
-	       remote_txn_locks() as remote_txn_locks;
-
-cdrp_locks|remote_txn_locks
-----------+----------------
-         2|               2
-(1 row)
-
-step s3_lock_release: SELECT debug_waitpoint_release('create_distributed_restore_point_lock');
-debug_waitpoint_release
------------------------
-                       
-(1 row)
-
-step s1_create_dist_rp: <... completed>
-valid_lsn
----------
-t        
-t        
-t        
-t        
-t        
-(5 rows)
-
-step s2_del_dn: <... completed>
-delete_data_node
-----------------
-t               
-(1 row)
-

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_TEMPLATES_MODULE_DEBUG
     reorder_vs_insert.spec.in
     reorder_vs_select.spec.in
     remote_create_chunk.spec.in
+    dist_ha_chunk_drop.spec.in
     dist_restore_point.spec.in
     dist_cmd_exec.spec.in
     cagg_drop_chunks_iso.spec.in

--- a/tsl/test/isolation/specs/dist_ha_chunk_drop.spec.in
+++ b/tsl/test/isolation/specs/dist_ha_chunk_drop.spec.in
@@ -1,0 +1,66 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+#
+# Test concurrent insert into dist hypertable after a data node marked
+# as unavailable would produce 'tuple concurrently deleted` error.
+#
+# The problem occurs because of missing tuple level locking during scan and concurrent
+# delete from chunk_data_node table afterwards, which should be treated as
+# `SELECT … FOR UPDATE`.
+#
+setup
+{
+	CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_enable';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_release';
+
+	CREATE OR REPLACE FUNCTION debug_waitpoint_id(TEXT) RETURNS BIGINT LANGUAGE C VOLATILE STRICT
+	AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_id';
+
+	CREATE TABLE metric1(ts TIMESTAMPTZ NOT NULL, val FLOAT8 NOT NULL, dev_id INT4 NOT NULL);
+}
+
+setup { SELECT node_name FROM add_data_node('data_node_1', host => 'localhost', database => 'cdha_1', if_not_exists => true); }
+setup { SELECT node_name FROM add_data_node('data_node_2', host => 'localhost', database => 'cdha_2', if_not_exists => true); }
+setup { SELECT node_name FROM add_data_node('data_node_3', host => 'localhost', database => 'cdha_3', if_not_exists => true); }
+setup { SELECT node_name FROM add_data_node('data_node_4', host => 'localhost', database => 'cdha_4', if_not_exists => true); }
+setup { SELECT created FROM create_distributed_hypertable('metric1', 'ts', 'dev_id', chunk_time_interval => INTERVAL '1 hour', replication_factor => 4); }
+
+teardown
+{
+   DROP TABLE metric1;
+}
+
+# bootstrap cluster with data
+session "s1"
+setup
+{
+	SET application_name = 's1';
+}
+step "s1_init"            { INSERT INTO metric1(ts, val, dev_id) SELECT s.*, 3.14, d.* FROM generate_series('2021-08-17 00:00:00'::timestamp, '2021-08-17 00:00:59'::timestamp, '1 s'::interval) s CROSS JOIN generate_series(1, 500) d; }
+step "s1_set_unavailable" { SELECT alter_data_node('data_node_4', available=>false); }
+step "s1_set_available"   { SELECT alter_data_node('data_node_4', available=>true); }
+step "s1_insert"          { INSERT INTO metric1(ts, val, dev_id) SELECT s.*, 3.14, d.* FROM generate_series('2021-08-17 00:01:00'::timestamp, '2021-08-17 00:01:59'::timestamp, '1 s'::interval) s CROSS JOIN generate_series(1, 249) d; }
+
+# concurrent session
+session "s2"
+setup
+{
+	SET application_name = 's2';
+}
+step "s2_insert"          { INSERT INTO metric1(ts, val, dev_id) SELECT s.*, 3.14, d.* FROM generate_series('2021-08-17 00:01:00'::timestamp, '2021-08-17 00:01:59'::timestamp, '1 s'::interval) s CROSS JOIN generate_series(250, 499) d; }
+
+# locking session
+session "s3"
+setup
+{
+	SET application_name = 's3';
+}
+step "s3_lock_enable"   { SELECT debug_waitpoint_enable('chunk_data_node_delete'); }
+step "s3_lock_release"  { SELECT debug_waitpoint_release('chunk_data_node_delete'); }
+
+permutation "s1_init" "s1_set_unavailable" "s3_lock_enable" "s1_insert" "s2_insert" "s3_lock_release" "s1_set_available"

--- a/tsl/test/isolation/specs/dist_restore_point.spec.in
+++ b/tsl/test/isolation/specs/dist_restore_point.spec.in
@@ -32,10 +32,11 @@ setup
 
 	CREATE TABLE IF NOT EXISTS disttable(time timestamptz NOT NULL, device int, temp float);
 }
+setup { SELECT true AS delete_data_node FROM delete_data_node('data_node_4', if_exists => true); }
 setup { SELECT node_name FROM add_data_node('data_node_1', host => 'localhost', database => 'cdrp_1', if_not_exists => true); }
 setup { SELECT node_name FROM add_data_node('data_node_2', host => 'localhost', database => 'cdrp_2', if_not_exists => true); }
 setup { SELECT node_name FROM add_data_node('data_node_3', host => 'localhost', database => 'cdrp_3', if_not_exists => true); }
-setup { SELECT created FROM create_distributed_hypertable('disttable', 'time', 'device'); }
+setup { SELECT created FROM create_distributed_hypertable('disttable', 'time', 'device', data_nodes => ARRAY['data_node_1', 'data_node_2', 'data_node_3']); }
 
 teardown
 {
@@ -63,8 +64,6 @@ step "s2_create_dist_rp" { SELECT restore_point > pg_lsn('0/0') as valid_lsn FRO
 step "s2_insert"         { INSERT INTO disttable VALUES ('2019-08-02 10:45', 0, 0.0); }
 step "s2_begin"          { BEGIN; }
 step "s2_commit"         { COMMIT; }
-step "s2_add_dn"         { SELECT node_name FROM add_data_node('data_node_4', host => 'localhost', database => 'cdrp_4'); }
-step "s2_del_dn"         { SELECT * FROM delete_data_node('data_node_4'); }
 step "s2_create_dist_ht" {
 	CREATE TABLE disttable2(time timestamptz NOT NULL, device int, temp float);
 	SELECT created FROM create_distributed_hypertable('disttable2', 'time', 'device');
@@ -85,7 +84,6 @@ step "s3_lock_count"    {
 	SELECT waitpoint_locks('create_distributed_restore_point_lock') as cdrp_locks, 
 	       remote_txn_locks() as remote_txn_locks;
 }
-step "s3_lock_count_fs" { SELECT foreign_server_locks() as foreign_server_locks; }
 
 # case 1: new transaction DML/commit during the create_distributed_restore_point()
 permutation "s3_lock_enable" "s1_create_dist_rp" "s2_insert" "s3_lock_count" "s3_lock_release"
@@ -104,9 +102,3 @@ permutation "s3_lock_enable" "s1_create_dist_rp" "s2_create_dist_ht" "s3_lock_co
 
 # case 6: concurrent DDL/commit during the create_distributed_restore_point()
 permutation "s3_lock_enable" "s1_create_dist_rp" "s2_drop_dist_ht" "s3_lock_count" "s3_lock_release"
-
-# case 7: concurrent add_data_node() during the create_distributed_restore_point()
-permutation "s3_lock_enable" "s1_create_dist_rp" "s2_add_dn" "s3_lock_count" "s3_lock_count_fs" "s3_lock_release" "s3_lock_count_fs"
-
-# case 8: concurrent delete_data_node() during the create_distributed_restore_point()
-permutation "s3_lock_enable" "s1_create_dist_rp" "s2_del_dn" "s3_lock_count" "s3_lock_release"


### PR DESCRIPTION
Concurrent insert into dist hypertable after a data node marked as unavailable would produce 'tuple concurrently deleted` error.

The problem occurs because of missing tuple level locking during scan and concurrent delete from chunk_data_node table afterwards, which should be treated as `SELECT … FOR UPDATE` case instead.

Fix #5153