### PR TITLE
Fix next_start calculation for fixed schedules 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ accidentally triggering the load of a previous DB version.**
 * #5218 Add role-level security to job error log
 * #5214 Fix use of prepared statement in async module
 * #5290 Compression can't be enabled on continuous aggregates when segmentby/orderby columns need quotation
+* #5239 Fix next_start calculation for fixed schedules
 
 ## 2.9.3 (2023-02-03)
 
@@ -34,6 +35,7 @@ upgrade as soon as possible.
 **Thanks**
 * @ssmoss for reporting issues on continuous aggregates
 * @jaskij for reporting the compliation issue that occurred with clang
+
 
 ## 2.9.2 (2023-01-26)
 

--- a/tsl/test/expected/fixed_schedules.out
+++ b/tsl/test/expected/fixed_schedules.out
@@ -1,0 +1,807 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+select '2023-01-02 11:53:19.059771+02'::timestamptz as finish_time \gset
+select :'finish_time'::timestamptz - interval '5 sec' as start_time \gset
+-- years
+select ts_test_next_scheduled_execution_slot('1 year', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "1 yr",
+ts_test_next_scheduled_execution_slot('1 year', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "1 yr timezone",
+ts_test_next_scheduled_execution_slot('10 year', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "10 yr",
+ts_test_next_scheduled_execution_slot('10 year', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "10 yr timezone";
+                1 yr                 |            1 yr timezone            |                10 yr                |           10 yr timezone            
+-------------------------------------+-------------------------------------+-------------------------------------+-------------------------------------
+ Tue Jan 02 01:53:14.059771 2024 PST | Tue Jan 02 01:53:14.059771 2024 PST | Sun Jan 02 01:53:14.059771 2033 PST | Sun Jan 02 01:53:14.059771 2033 PST
+(1 row)
+
+-- weeks
+select ts_test_next_scheduled_execution_slot('1 week', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "1 week",
+ts_test_next_scheduled_execution_slot('1 week', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "1 week timezone",
+ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "2 week",
+ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "2 week timezone";
+               1 week                |           1 week timezone           |               2 week                |           2 week timezone           
+-------------------------------------+-------------------------------------+-------------------------------------+-------------------------------------
+ Mon Jan 09 01:53:14.059771 2023 PST | Mon Jan 09 01:53:14.059771 2023 PST | Mon Jan 16 01:53:14.059771 2023 PST | Mon Jan 16 01:53:14.059771 2023 PST
+(1 row)
+
+-- months
+select ts_test_next_scheduled_execution_slot('1 month', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "1 month",
+ts_test_next_scheduled_execution_slot('1 month', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "1 month timezone",
+ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "2 month",
+ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "2 month timezone";
+               1 month               |          1 month timezone           |               2 month               |          2 month timezone           
+-------------------------------------+-------------------------------------+-------------------------------------+-------------------------------------
+ Thu Feb 02 01:53:14.059771 2023 PST | Thu Feb 02 01:53:14.059771 2023 PST | Thu Mar 02 01:53:14.059771 2023 PST | Thu Mar 02 01:53:14.059771 2023 PST
+(1 row)
+
+-- timezone in Berlin changes between 1 and 2 am
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 hour\''
+\set START_TIME_BEFORE_SUMMER_SWITCH 'TIMESTAMPTZ \'2022-03-27 01:00:00\''
+\set FINISH_TIME_AFTER_SUMMER_SWITCH 'TIMESTAMPTZ \'2022-03-27 01:19:20\''
+\set START_TIME_BEFORE_WINTER_SWITCH 'TIMESTAMPTZ \'2022-10-30 01:01:00\''
+\set FINISH_TIME_AFTER_WINTER_SWITCH 'TIMESTAMPTZ \'2022-10-30 01:10:19\''
+\ir include/scheduler_fixed_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+ initial_start_summer_switch  | first_finish_time_summer_switch 
+------------------------------+---------------------------------
+ Sun Mar 27 01:00:00 2022 CET | Sun Mar 27 01:19:20 2022 CET
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Mar 27 03:00:00 2022 CEST | Sun Mar 27 03:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Mar 27 04:00:00 2022 CEST | Sun Mar 27 04:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Mar 27 05:00:00 2022 CEST | Sun Mar 27 05:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Mar 27 06:00:00 2022 CEST | Sun Mar 27 06:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Mar 27 07:00:00 2022 CEST | Sun Mar 27 07:00:00 2022 CEST
+(1 row)
+
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+  initial_start_winter_switch  | first_finish_time_winter_switch 
+-------------------------------+---------------------------------
+ Sun Oct 30 01:01:00 2022 CEST | Sun Oct 30 01:10:19 2022 CEST
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Oct 30 02:01:00 2022 CEST | Sun Oct 30 02:01:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Oct 30 02:01:00 2022 CET | Sun Oct 30 02:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Oct 30 03:01:00 2022 CET | Sun Oct 30 03:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Oct 30 04:01:00 2022 CET | Sun Oct 30 04:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Oct 30 05:00:00 2022 CET | Sun Oct 30 05:00:00 2022 CET
+(1 row)
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 day\''
+\ir include/scheduler_fixed_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+ initial_start_summer_switch  | first_finish_time_summer_switch 
+------------------------------+---------------------------------
+ Sun Mar 27 01:00:00 2022 CET | Sun Mar 27 01:19:20 2022 CET
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Mon Mar 28 01:00:00 2022 CEST | Mon Mar 28 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Tue Mar 29 01:00:00 2022 CEST | Tue Mar 29 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Tue Mar 29 02:00:00 2022 CEST | Wed Mar 30 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Wed Mar 30 02:00:00 2022 CEST | Thu Mar 31 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Thu Mar 31 02:00:00 2022 CEST | Fri Apr 01 01:00:00 2022 CEST
+(1 row)
+
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+  initial_start_winter_switch  | first_finish_time_winter_switch 
+-------------------------------+---------------------------------
+ Sun Oct 30 01:01:00 2022 CEST | Sun Oct 30 01:10:19 2022 CEST
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Mon Oct 31 01:01:00 2022 CET | Mon Oct 31 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Tue Nov 01 00:01:00 2022 CET | Tue Nov 01 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Nov 02 00:01:00 2022 CET | Wed Nov 02 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Thu Nov 03 00:01:00 2022 CET | Thu Nov 03 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Thu Nov 03 01:00:00 2022 CET | Fri Nov 04 01:00:00 2022 CET
+(1 row)
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 week\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 week\''
+\ir include/scheduler_fixed_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+ initial_start_summer_switch  | first_finish_time_summer_switch 
+------------------------------+---------------------------------
+ Sun Mar 27 01:00:00 2022 CET | Sun Mar 27 01:19:20 2022 CET
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Apr 03 01:00:00 2022 CEST | Sun Apr 03 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Apr 10 01:00:00 2022 CEST | Sun Apr 10 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Apr 10 02:00:00 2022 CEST | Sun Apr 17 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Apr 17 02:00:00 2022 CEST | Sun Apr 24 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Apr 24 02:00:00 2022 CEST | Sun May 01 01:00:00 2022 CEST
+(1 row)
+
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+  initial_start_winter_switch  | first_finish_time_winter_switch 
+-------------------------------+---------------------------------
+ Sun Oct 30 01:01:00 2022 CEST | Sun Oct 30 01:10:19 2022 CEST
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Nov 06 01:01:00 2022 CET | Sun Nov 06 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Nov 13 00:01:00 2022 CET | Sun Nov 13 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Nov 20 00:01:00 2022 CET | Sun Nov 20 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Nov 27 00:01:00 2022 CET | Sun Nov 27 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Nov 27 01:00:00 2022 CET | Sun Dec 04 01:00:00 2022 CET
+(1 row)
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 month\''
+\ir include/scheduler_fixed_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+ initial_start_summer_switch  | first_finish_time_summer_switch 
+------------------------------+---------------------------------
+ Sun Mar 27 01:00:00 2022 CET | Sun Mar 27 01:19:20 2022 CET
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Wed Apr 27 01:00:00 2022 CEST | Wed Apr 27 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Fri May 27 01:00:00 2022 CEST | Fri May 27 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Mon Jun 27 01:00:00 2022 CEST | Mon Jun 27 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Wed Jul 27 01:00:00 2022 CEST | Wed Jul 27 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sat Aug 27 01:00:00 2022 CEST | Sat Aug 27 01:00:00 2022 CEST
+(1 row)
+
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+  initial_start_winter_switch  | first_finish_time_winter_switch 
+-------------------------------+---------------------------------
+ Sun Oct 30 01:01:00 2022 CEST | Sun Oct 30 01:10:19 2022 CEST
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Nov 30 01:01:00 2022 CET | Wed Nov 30 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Fri Dec 30 01:01:00 2022 CET | Fri Dec 30 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Mon Jan 30 01:01:00 2023 CET | Mon Jan 30 01:01:00 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Tue Feb 28 01:01:00 2023 CET | Tue Feb 28 01:01:00 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Mon Mar 27 01:00:00 2023 CEST | Mon Mar 27 01:00:00 2023 CEST
+(1 row)
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 year\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 year\''
+\ir include/scheduler_fixed_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+ initial_start_summer_switch  | first_finish_time_summer_switch 
+------------------------------+---------------------------------
+ Sun Mar 27 01:00:00 2022 CET | Sun Mar 27 01:19:20 2022 CET
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Mon Mar 27 01:00:00 2023 CEST | Mon Mar 27 01:00:00 2023 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Mar 27 01:00:00 2024 CET | Wed Mar 27 01:00:00 2024 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Thu Mar 27 01:00:00 2025 CET | Thu Mar 27 01:00:00 2025 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Fri Mar 27 01:00:00 2026 CET | Fri Mar 27 01:00:00 2026 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sat Mar 27 01:00:00 2027 CET | Sat Mar 27 01:00:00 2027 CET
+(1 row)
+
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+  initial_start_winter_switch  | first_finish_time_winter_switch 
+-------------------------------+---------------------------------
+ Sun Oct 30 01:01:00 2022 CEST | Sun Oct 30 01:10:19 2022 CEST
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Mon Oct 30 01:01:00 2023 CET | Mon Oct 30 01:01:00 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Oct 30 01:01:00 2024 CET | Wed Oct 30 01:01:00 2024 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Thu Oct 30 01:01:00 2025 CET | Thu Oct 30 01:01:00 2025 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Fri Oct 30 01:01:00 2026 CET | Fri Oct 30 01:01:00 2026 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sat Mar 27 01:00:00 2027 CET | Sat Mar 27 01:00:00 2027 CET
+(1 row)
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'2 month\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'2 month\''
+\ir include/scheduler_fixed_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+ initial_start_summer_switch  | first_finish_time_summer_switch 
+------------------------------+---------------------------------
+ Sun Mar 27 01:00:00 2022 CET | Sun Mar 27 01:19:20 2022 CET
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Fri May 27 01:00:00 2022 CEST | Fri May 27 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Wed Jul 27 01:00:00 2022 CEST | Wed Jul 27 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Tue Sep 27 01:00:00 2022 CEST | Tue Sep 27 01:00:00 2022 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sun Nov 27 01:00:00 2022 CET | Sun Nov 27 01:00:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Fri Jan 27 01:00:00 2023 CET | Fri Jan 27 01:00:00 2023 CET
+(1 row)
+
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+  initial_start_winter_switch  | first_finish_time_winter_switch 
+-------------------------------+---------------------------------
+ Sun Oct 30 01:01:00 2022 CEST | Sun Oct 30 01:10:19 2022 CEST
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Fri Dec 30 01:01:00 2022 CET | Fri Dec 30 01:01:00 2022 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Tue Feb 28 01:01:00 2023 CET | Tue Feb 28 01:01:00 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Sun Apr 30 01:01:00 2023 CEST | Sun Apr 30 01:01:00 2023 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Fri Jun 30 01:01:00 2023 CEST | Fri Jun 30 01:01:00 2023 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Thu Jul 27 01:00:00 2023 CEST | Thu Jul 27 01:00:00 2023 CEST
+(1 row)
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'2 year\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'2 year\''
+\ir include/scheduler_fixed_common.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+\set client_min_messages = DEBUG;
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+ initial_start_summer_switch  | first_finish_time_summer_switch 
+------------------------------+---------------------------------
+ Sun Mar 27 01:00:00 2022 CET | Sun Mar 27 01:19:20 2022 CET
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Mar 27 01:00:00 2024 CET | Wed Mar 27 01:00:00 2024 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Fri Mar 27 01:00:00 2026 CET | Fri Mar 27 01:00:00 2026 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone        |         with_timezone         
+-------------------------------+-------------------------------
+ Mon Mar 27 01:00:00 2028 CEST | Mon Mar 27 01:00:00 2028 CEST
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Mar 27 01:00:00 2030 CET | Wed Mar 27 01:00:00 2030 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sat Mar 27 01:00:00 2032 CET | Sat Mar 27 01:00:00 2032 CET
+(1 row)
+
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+  initial_start_winter_switch  | first_finish_time_winter_switch 
+-------------------------------+---------------------------------
+ Sun Oct 30 01:01:00 2022 CEST | Sun Oct 30 01:10:19 2022 CEST
+(1 row)
+
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Oct 30 01:01:00 2024 CET | Wed Oct 30 01:01:00 2024 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Fri Oct 30 01:01:00 2026 CET | Fri Oct 30 01:01:00 2026 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Mon Oct 30 01:01:00 2028 CET | Mon Oct 30 01:01:00 2028 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Wed Oct 30 01:01:00 2030 CET | Wed Oct 30 01:01:00 2030 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+       without_timezone       |        with_timezone         
+------------------------------+------------------------------
+ Sat Mar 27 01:00:00 2032 CET | Sat Mar 27 01:00:00 2032 CET
+(1 row)
+

--- a/tsl/test/expected/scheduler_fixed.out
+++ b/tsl/test/expected/scheduler_fixed.out
@@ -194,3 +194,68 @@ select :'t3' as without_timezone, :'t3_tz' as with_timezone;
 -- test some unacceptable values for schedule interval
 select add_job('job_5', schedule_interval => interval '1 month 1week', initial_start => :'initial_start'::timestamptz);
 ERROR:  month intervals cannot have day or time component
+\set client_min_messages = DEBUG;
+select '2023-01-02 11:53:19.059771+02'::timestamptz as finish_time \gset
+-- years
+select ts_test_next_scheduled_execution_slot('1 year', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Tue Jan 02 10:53:16.059771 2024 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot('2 year', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Thu Jan 02 10:53:16.059771 2025 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot('10 year', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Sun Jan 02 10:53:16.059771 2033 CET
+(1 row)
+
+-- weeks
+select ts_test_next_scheduled_execution_slot('1 week', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Mon Jan 09 10:53:16.059771 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Mon Jan 16 10:53:16.059771 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Mon Jan 16 10:53:16.059771 2023 CET
+(1 row)
+
+-- months
+select ts_test_next_scheduled_execution_slot('10 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Thu Nov 02 10:53:16.059771 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot('10 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec', 'Europe/Athens');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Thu Nov 02 10:53:16.059771 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Thu Mar 02 10:53:16.059771 2023 CET
+(1 row)
+
+select ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec', 'Europe/Athens');
+ ts_test_next_scheduled_execution_slot 
+---------------------------------------
+ Thu Mar 02 10:53:16.059771 2023 CET
+(1 row)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -95,7 +95,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     remote_txn.sql
     transparent_decompression_queries.sql
     tsl_tables.sql
-    license_tsl.sql)
+    license_tsl.sql
+    fixed_schedules.sql)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
 if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))

--- a/tsl/test/sql/fixed_schedules.sql
+++ b/tsl/test/sql/fixed_schedules.sql
@@ -1,0 +1,64 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+\set client_min_messages = DEBUG;
+
+select '2023-01-02 11:53:19.059771+02'::timestamptz as finish_time \gset
+select :'finish_time'::timestamptz - interval '5 sec' as start_time \gset
+
+-- years
+select ts_test_next_scheduled_execution_slot('1 year', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "1 yr",
+ts_test_next_scheduled_execution_slot('1 year', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "1 yr timezone",
+ts_test_next_scheduled_execution_slot('10 year', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "10 yr",
+ts_test_next_scheduled_execution_slot('10 year', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "10 yr timezone";
+
+-- weeks
+select ts_test_next_scheduled_execution_slot('1 week', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "1 week",
+ts_test_next_scheduled_execution_slot('1 week', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "1 week timezone",
+ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "2 week",
+ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "2 week timezone";
+
+-- months
+select ts_test_next_scheduled_execution_slot('1 month', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "1 month",
+ts_test_next_scheduled_execution_slot('1 month', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "1 month timezone",
+ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'start_time'::timestamptz) as "2 month",
+ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'start_time'::timestamptz, 'Europe/Athens') as "2 month timezone";
+
+-- timezone in Berlin changes between 1 and 2 am
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 hour\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 hour\''
+\set START_TIME_BEFORE_SUMMER_SWITCH 'TIMESTAMPTZ \'2022-03-27 01:00:00\''
+\set FINISH_TIME_AFTER_SUMMER_SWITCH 'TIMESTAMPTZ \'2022-03-27 01:19:20\''
+\set START_TIME_BEFORE_WINTER_SWITCH 'TIMESTAMPTZ \'2022-10-30 01:01:00\''
+\set FINISH_TIME_AFTER_WINTER_SWITCH 'TIMESTAMPTZ \'2022-10-30 01:10:19\''
+\ir include/scheduler_fixed_common.sql
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 day\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 day\''
+\ir include/scheduler_fixed_common.sql
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 week\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 week\''
+\ir include/scheduler_fixed_common.sql
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 month\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 month\''
+\ir include/scheduler_fixed_common.sql
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'1 year\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'1 year\''
+\ir include/scheduler_fixed_common.sql
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'2 month\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'2 month\''
+\ir include/scheduler_fixed_common.sql
+
+\set BUCKET_WIDTH_WINTER_SUMMER 'INTERVAL \'2 year\''
+\set BUCKET_WIDTH_SUMMER_WINTER 'INTERVAL \'2 year\''
+\ir include/scheduler_fixed_common.sql

--- a/tsl/test/sql/include/scheduler_fixed_common.sql
+++ b/tsl/test/sql/include/scheduler_fixed_common.sql
@@ -1,0 +1,51 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\c :TEST_DBNAME :ROLE_SUPERUSER
+
+CREATE OR REPLACE FUNCTION ts_test_next_scheduled_execution_slot(schedule_interval INTERVAL, finish_time TIMESTAMPTZ, initial_start TIMESTAMPTZ, timezone TEXT = NULL)
+RETURNS TIMESTAMPTZ AS :MODULE_PATHNAME LANGUAGE C VOLATILE;
+
+\set client_min_messages = DEBUG;
+
+-- test what happens across DST
+-- go from +1 to +2
+set timezone to 'Europe/Berlin';
+-- DST switch on March 27th 2022, in particular, between 1am and 2 am (old time)
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :FINISH_TIME_AFTER_SUMMER_SWITCH, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_SUMMER_SWITCH as initial_start_summer_switch, :FINISH_TIME_AFTER_SUMMER_SWITCH as first_finish_time_summer_switch;
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+--------- and then +2 to +1
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH) as t1 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :FINISH_TIME_AFTER_WINTER_SWITCH, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin')
+as t1_tz \gset
+select :START_TIME_BEFORE_WINTER_SWITCH as initial_start_winter_switch, :FINISH_TIME_AFTER_WINTER_SWITCH as first_finish_time_winter_switch;
+select :'t1' as without_timezone, :'t1_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t2 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t1_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t2_tz \gset
+select :'t2' as without_timezone, :'t2_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t3 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t2_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, timezone => 'Europe/Berlin') as t3_tz \gset
+select :'t3' as without_timezone, :'t3_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH) as t4 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_SUMMER_WINTER, :'t3_tz'::timestamptz, :START_TIME_BEFORE_WINTER_SWITCH, 'Europe/Berlin') as t4_tz \gset
+select :'t4' as without_timezone, :'t4_tz' as with_timezone;
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH) as t5 \gset
+select ts_test_next_scheduled_execution_slot(:BUCKET_WIDTH_WINTER_SUMMER, :'t4_tz'::timestamptz, :START_TIME_BEFORE_SUMMER_SWITCH, 'Europe/Berlin') as t5_tz \gset
+select :'t5' as without_timezone, :'t5_tz' as with_timezone;
+

--- a/tsl/test/sql/scheduler_fixed.sql
+++ b/tsl/test/sql/scheduler_fixed.sql
@@ -122,3 +122,21 @@ select :'t3' as without_timezone, :'t3_tz' as with_timezone;
 \set ON_ERROR_STOP 0
 -- test some unacceptable values for schedule interval
 select add_job('job_5', schedule_interval => interval '1 month 1week', initial_start => :'initial_start'::timestamptz);
+
+\set client_min_messages = DEBUG;
+
+select '2023-01-02 11:53:19.059771+02'::timestamptz as finish_time \gset
+
+-- years
+select ts_test_next_scheduled_execution_slot('1 year', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+select ts_test_next_scheduled_execution_slot('2 year', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+select ts_test_next_scheduled_execution_slot('10 year', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+-- weeks
+select ts_test_next_scheduled_execution_slot('1 week', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+select ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+select ts_test_next_scheduled_execution_slot('2 week', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+-- months
+select ts_test_next_scheduled_execution_slot('10 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+select ts_test_next_scheduled_execution_slot('10 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec', 'Europe/Athens');
+select ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec');
+select ts_test_next_scheduled_execution_slot('2 month', :'finish_time'::timestamptz, :'finish_time'::timestamptz - interval '3 sec', 'Europe/Athens');


### PR DESCRIPTION
This patch fixes several issues with next_start calculation.

- Previously, the offset was added twice in some cases.
This is fixed by this patch.

- Additionally, schedule intervals with month components
were not handled correctly.
Internally, time_bucket with origin is used to calculate
the next start. However, in the case of month intervals, the
timestamp calculated for a bucket is always aligned on the first
day of the month, regardless of origin.
Therefore, previously the result was aligned with origin by adding
the difference between origin and its respective time bucket.
This difference was computed as a fixed length interval in terms
of days and time. That computation led to incorrect computation of
next start occasionally, for example when a job should be executed on
the last day of a month.
That is fixed by adding an appropriate interval of months to
initial_start and letting Postgres handle this computation properly.

Fixes #5216