### PR TITLE
Allow RETURNING clause when inserting into compressed chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Features**
+* #5241 Allow RETURNING clause when inserting into compressed chunks
+
 **Bugfixes**
 * #4804 Skip bucketing when start or end of refresh job is null
 * #4926 Fix corruption when inserting into compressed chunks

--- a/src/nodes/chunk_dispatch/chunk_insert_state.c
+++ b/src/nodes/chunk_dispatch/chunk_insert_state.c
@@ -596,11 +596,11 @@ ts_chunk_insert_state_create(const Chunk *chunk, ChunkDispatch *dispatch)
 												 chunk->fd.status,
 												 CHUNK_INSERT,
 												 true);
-	if (has_compressed_chunk &&
-		(onconflict_action != ONCONFLICT_NONE || chunk_dispatch_has_returning(dispatch)))
+
+	if (has_compressed_chunk && onconflict_action != ONCONFLICT_NONE)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("insert with ON CONFLICT or RETURNING clause is not supported on "
+				 errmsg("insert with ON CONFLICT clause is not supported on "
 						"compressed chunks")));
 
 	rel = table_open(chunk->table_id, RowExclusiveLock);

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -207,7 +207,7 @@ ERROR:  cannot update/delete rows from chunk "_hyper_1_1_chunk" as it is compres
 insert into foo values(10, 12, 12, 12)
 on conflict( a, b)
 do update set b = excluded.b;
-ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
+ERROR:  insert with ON CONFLICT clause is not supported on compressed chunks
 --TEST2c Do DML directly on the chunk.
 insert into _timescaledb_internal._hyper_1_2_chunk values(10, 12, 12, 12);
 update _timescaledb_internal._hyper_1_2_chunk

--- a/tsl/test/expected/compression_insert-12.out
+++ b/tsl/test/expected/compression_insert-12.out
@@ -831,11 +831,23 @@ INSERT INTO test_ordering VALUES (106) RETURNING *;
   106
 (1 row)
 
--- insert into compressed chunk does not support RETURNING
-\set ON_ERROR_STOP 0
-INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
-\set ON_ERROR_STOP 1
+-- insert into compressed chunk does support RETURNING
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING *;
+ time 
+------
+   23
+   24
+  115
+(3 rows)
+
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING tableoid::regclass, *;
+                 tableoid                 | time 
+------------------------------------------+------
+ _timescaledb_internal._hyper_13_20_chunk |   23
+ _timescaledb_internal._hyper_13_20_chunk |   24
+ _timescaledb_internal._hyper_13_22_chunk |  115
+(3 rows)
+
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              

--- a/tsl/test/expected/compression_insert-13.out
+++ b/tsl/test/expected/compression_insert-13.out
@@ -831,11 +831,23 @@ INSERT INTO test_ordering VALUES (106) RETURNING *;
   106
 (1 row)
 
--- insert into compressed chunk does not support RETURNING
-\set ON_ERROR_STOP 0
-INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
-\set ON_ERROR_STOP 1
+-- insert into compressed chunk does support RETURNING
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING *;
+ time 
+------
+   23
+   24
+  115
+(3 rows)
+
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING tableoid::regclass, *;
+                 tableoid                 | time 
+------------------------------------------+------
+ _timescaledb_internal._hyper_13_20_chunk |   23
+ _timescaledb_internal._hyper_13_20_chunk |   24
+ _timescaledb_internal._hyper_13_22_chunk |  115
+(3 rows)
+
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              

--- a/tsl/test/expected/compression_insert-14.out
+++ b/tsl/test/expected/compression_insert-14.out
@@ -831,11 +831,23 @@ INSERT INTO test_ordering VALUES (106) RETURNING *;
   106
 (1 row)
 
--- insert into compressed chunk does not support RETURNING
-\set ON_ERROR_STOP 0
-INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
-\set ON_ERROR_STOP 1
+-- insert into compressed chunk does support RETURNING
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING *;
+ time 
+------
+   23
+   24
+  115
+(3 rows)
+
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING tableoid::regclass, *;
+                 tableoid                 | time 
+------------------------------------------+------
+ _timescaledb_internal._hyper_13_20_chunk |   23
+ _timescaledb_internal._hyper_13_20_chunk |   24
+ _timescaledb_internal._hyper_13_22_chunk |  115
+(3 rows)
+
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              

--- a/tsl/test/expected/compression_insert-15.out
+++ b/tsl/test/expected/compression_insert-15.out
@@ -831,11 +831,23 @@ INSERT INTO test_ordering VALUES (106) RETURNING *;
   106
 (1 row)
 
--- insert into compressed chunk does not support RETURNING
-\set ON_ERROR_STOP 0
-INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-ERROR:  insert with ON CONFLICT or RETURNING clause is not supported on compressed chunks
-\set ON_ERROR_STOP 1
+-- insert into compressed chunk does support RETURNING
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING *;
+ time 
+------
+   23
+   24
+  115
+(3 rows)
+
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING tableoid::regclass, *;
+                 tableoid                 | time 
+------------------------------------------+------
+ _timescaledb_internal._hyper_13_20_chunk |   23
+ _timescaledb_internal._hyper_13_20_chunk |   24
+ _timescaledb_internal._hyper_13_22_chunk |  115
+(3 rows)
+
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 NOTICE:  chunk "_hyper_13_20_chunk" is already compressed
               compress_chunk              

--- a/tsl/test/sql/compression_insert.sql.in
+++ b/tsl/test/sql/compression_insert.sql.in
@@ -541,10 +541,9 @@ INSERT INTO test_ordering VALUES (105),(104),(103);
 INSERT INTO test_ordering VALUES (21), (22),(113);
 SELECT count(*) FROM test_ordering;
 INSERT INTO test_ordering VALUES (106) RETURNING *;
--- insert into compressed chunk does not support RETURNING
-\set ON_ERROR_STOP 0
-INSERT INTO test_ordering VALUES (23), (24),(115) RETURNING *;
-\set ON_ERROR_STOP 1
+-- insert into compressed chunk does support RETURNING
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING *;
+INSERT INTO test_ordering VALUES (23), (24), (115) RETURNING tableoid::regclass, *;
 
 SELECT compress_chunk(format('%I.%I',chunk_schema,chunk_name), true) FROM timescaledb_information.chunks WHERE hypertable_name = 'test_ordering';
 


### PR DESCRIPTION
Recent refactorings in the INSERT into compressed chunk code path allowed us to support this feature but the check to prevent users from using this feature was not removed as part of that patch. This patch removes the blocker code and adds a minimal test case.