### PR TITLE
Make connection establishment interruptible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ accidentally triggering the load of a previous DB version.**
 **Features**
 * #5241 Allow RETURNING clause when inserting into compressed chunks
 * #5245 Mange life-cycle of connections via memory contexts
+* #5246 Make connection establishment interruptible
 
 **Bugfixes**
 * #4804 Skip bucketing when start or end of refresh job is null

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -57,15 +57,11 @@ typedef struct TSConnectionError
  * `remote_connection_cache_get_connection` instead. Must be closed with
  * `remote_connection_close`
  */
-extern TSConnection *remote_connection_open_with_options(const char *node_name,
-														 List *connection_options,
-														 bool set_dist_id);
-extern TSConnection *remote_connection_open_with_options_nothrow(const char *node_name,
-																 List *connection_options,
-																 char **errmsg);
-extern TSConnection *remote_connection_open_by_id(TSConnectionId id);
-extern TSConnection *remote_connection_open(Oid server_id, Oid user_id);
-extern TSConnection *remote_connection_open_nothrow(Oid server_id, Oid user_id, char **errmsg);
+extern TSConnection *remote_connection_open(const char *node_name, List *connection_options,
+											char **errmsg);
+extern TSConnection *remote_connection_open_session(const char *node_name, List *connection_options,
+													bool set_dist_id);
+extern TSConnection *remote_connection_open_session_by_id(TSConnectionId id);
 extern List *remote_connection_prepare_auth_options(const ForeignServer *server, Oid user_id);
 extern int remote_connection_xact_depth_get(const TSConnection *conn);
 extern int remote_connection_xact_depth_inc(TSConnection *conn);

--- a/tsl/src/remote/connection_cache.c
+++ b/tsl/src/remote/connection_cache.c
@@ -164,7 +164,7 @@ connection_cache_create_entry(Cache *cache, CacheQuery *query)
 	 * remote_connection_close at cleanup is critical.
 	 */
 	old = MemoryContextSwitchTo(ts_cache_memory_ctx(cache));
-	entry->conn = remote_connection_open_by_id(*id);
+	entry->conn = remote_connection_open_session_by_id(*id);
 	MemoryContextSwitchTo(old);
 
 	/* Set the hash values of the foreign server and role for cache

--- a/tsl/src/remote/txn_resolve.c
+++ b/tsl/src/remote/txn_resolve.c
@@ -61,7 +61,8 @@ Datum
 remote_txn_heal_data_node(PG_FUNCTION_ARGS)
 {
 	Oid foreign_server_oid = PG_GETARG_OID(0);
-	TSConnection *conn = remote_connection_open(foreign_server_oid, GetUserId());
+	TSConnectionId id = remote_connection_id(foreign_server_oid, GetUserId());
+	TSConnection *conn = remote_connection_open_session_by_id(id);
 	int resolved = 0;
 
 	/*

--- a/tsl/test/expected/remote_connection.out
+++ b/tsl/test/expected/remote_connection.out
@@ -55,7 +55,7 @@ SELECT * FROM test.get_connection_stats();
 \set ON_ERROR_STOP 0
 SELECT test.send_remote_query_that_generates_exception();
 ERROR:  XX000: bad query error thrown from test
-LOCATION:  ts_test_bad_remote_query, connection.c:206
+LOCATION:  ts_test_bad_remote_query, connection.c:216
 \set ON_ERROR_STOP 1
 SELECT * FROM test.get_connection_stats();
  connections_created | connections_closed | results_created | results_cleared 

--- a/tsl/test/src/remote/connection.c
+++ b/tsl/test/src/remote/connection.c
@@ -28,17 +28,27 @@
 TSConnection *
 get_connection()
 {
-	return remote_connection_open_with_options(
-		"testdb",
-		list_make4(makeDefElem("user",
-							   (Node *) makeString(GetUserNameFromId(GetUserId(), false)),
-							   -1),
-				   makeDefElem("host", (Node *) makeString("localhost"), -1),
-				   makeDefElem("dbname", (Node *) makeString(get_database_name(MyDatabaseId)), -1),
-				   makeDefElem("port",
-							   (Node *) makeString(pstrdup(GetConfigOption("port", false, false))),
-							   -1)),
-		false);
+	return remote_connection_open_session("testdb",
+										  list_make4(makeDefElem("user",
+																 (Node *) makeString(
+																	 GetUserNameFromId(GetUserId(),
+																					   false)),
+																 -1),
+													 makeDefElem("host",
+																 (Node *) makeString("localhost"),
+																 -1),
+													 makeDefElem("dbname",
+																 (Node *) makeString(
+																	 get_database_name(
+																		 MyDatabaseId)),
+																 -1),
+													 makeDefElem("port",
+																 (Node *) makeString(pstrdup(
+																	 GetConfigOption("port",
+																					 false,
+																					 false))),
+																 -1)),
+										  false);
 }
 
 static void


### PR DESCRIPTION
Refactor the data node connection establishment so that it is interruptible, e.g., by ctrl-c or `statement_timeout`.

Previously, the connection establishment used blocking libpq calls. By instead using asynchronous connection APIs and integrating with PostgreSQL interrupt handling, the connection establishment can be canceled by an interrupt caused by a statement timeout or a user.

Fixes #2757