### PR TITLE
Run dist_move_chunk as a solo test in PG15

### DIFF
--- a/.github/gh_matrix_builder.py
+++ b/.github/gh_matrix_builder.py
@@ -138,9 +138,8 @@ def macos_config(overrides):
 
 
 # common installcheck_args for all pg15 tests
-# dist_move_chunk is skipped due to #4972
 # partialize_finalize is ignored due to #4937
-pg15_installcheck_args = "SKIPS='dist_move_chunk' IGNORES='partialize_finalize'"
+pg15_installcheck_args = "IGNORES='partialize_finalize'"
 
 # always test debug build on latest of all supported pg versions
 m["include"].append(build_debug_config({"pg": PG12_LATEST}))

--- a/.github/workflows/linux-32bit-build-and-test.yaml
+++ b/.github/workflows/linux-32bit-build-and-test.yaml
@@ -44,7 +44,6 @@ jobs:
         build_type: [ Debug ]
         include:
           - pg: ${{ fromJson(needs.config.outputs.pg15_latest) }}
-            skips_version: dist_move_chunk
             ignores_version: partialize_finalize
 
     steps:
@@ -89,7 +88,7 @@ jobs:
       run: |
         set -o pipefail
         export LANG=C.UTF-8
-        sudo -u postgres make -k -C build installcheck IGNORES="${IGNORES} ${{ matrix.ignores_version }}" SKIPS="${SKIPS} ${{ matrix.skips_version }}" | tee installcheck.log
+        sudo -u postgres make -k -C build installcheck IGNORES="${IGNORES} ${{ matrix.ignores_version }}" SKIPS="${SKIPS}" | tee installcheck.log
 
     - name: Show regression diffs
       if: always()

--- a/.github/workflows/windows-build-and-test-ignored.yaml
+++ b/.github/workflows/windows-build-and-test-ignored.yaml
@@ -52,7 +52,7 @@ jobs:
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         ignores: ["chunk_adaptive metadata"]
         tsl_ignores: ["compression_algos remote_connection"]
-        tsl_skips: ["bgw_db_scheduler bgw_db_scheduler_fixed cagg_ddl_dist_ht data_fetcher dist_compression dist_move_chunk dist_remote_error remote_txn"]
+        tsl_skips: ["bgw_db_scheduler bgw_db_scheduler_fixed cagg_ddl_dist_ht data_fetcher dist_compression dist_remote_error remote_txn"]
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]
         include:
           - pg: 12

--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -54,7 +54,7 @@ jobs:
         build_type: ${{ fromJson(needs.config.outputs.build_type) }}
         ignores: ["chunk_adaptive metadata"]
         tsl_ignores: ["compression_algos remote_connection"]
-        tsl_skips: ["bgw_db_scheduler bgw_db_scheduler_fixed cagg_ddl_dist_ht data_fetcher dist_compression dist_move_chunk dist_remote_error remote_txn"]
+        tsl_skips: ["bgw_db_scheduler bgw_db_scheduler_fixed cagg_ddl_dist_ht data_fetcher dist_compression dist_remote_error remote_txn"]
         pg_config: ["-cfsync=off -cstatement_timeout=60s"]
         include:
           - pg: 12

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -130,6 +130,12 @@ set(SOLO_TESTS
     reorder
     telemetry_stats-${PG_VERSION_MAJOR})
 
+# In PG15.0 and PG15.1, dist_move_chunk can get stuck when run in parallel with
+# other tests as mentioned in #4972.
+if(${PG_VERSION_MAJOR} EQUAL "15" AND ${PG_VERSION_MINOR} LESS "2")
+  list(APPEND SOLO_TESTS dist_move_chunk)
+endif()
+
 set(TEST_TEMPLATES
     compression_insert.sql.in cagg_union_view.sql.in plan_skip_scan.sql.in
     transparent_decompression.sql.in


### PR DESCRIPTION
When run in a parallel group, the dist_move_chunk test can get into a deadlock with another test running a 'DROP DATABASE' command. So, mark it as a solo test to disallow it from running in a parallel group.

Closes #4972

Disable-check: force-changelog-changed