### PR TITLE
Make data node command execution interruptible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ accidentally triggering the load of a previous DB version.**
 * #5241 Allow RETURNING clause when inserting into compressed chunks
 * #5245 Mange life-cycle of connections via memory contexts
 * #5246 Make connection establishment interruptible
+* #5253 Make data node command execution interruptible
 
 **Bugfixes**
 * #4804 Skip bucketing when start or end of refresh job is null

--- a/tsl/src/data_node.c
+++ b/tsl/src/data_node.c
@@ -257,7 +257,6 @@ data_node_get_connection(const char *const data_node, RemoteTxnPrepStmtOption co
 	const ForeignServer *server;
 	TSConnectionId id;
 
-	Assert(data_node != NULL);
 	server = data_node_get_foreign_server(data_node, ACL_NO_CHECK, false, false);
 	id = remote_connection_id(server->serverid, GetUserId());
 

--- a/tsl/src/remote/connection.h
+++ b/tsl/src/remote/connection.h
@@ -71,6 +71,7 @@ extern void remote_connection_xact_transition_end(TSConnection *conn);
 extern bool remote_connection_xact_is_transitioning(const TSConnection *conn);
 extern bool remote_connection_ping(const char *node_name);
 extern void remote_connection_close(TSConnection *conn);
+extern PGresult *remote_connection_get_result(const TSConnection *conn);
 extern PGresult *remote_connection_exec(TSConnection *conn, const char *cmd);
 extern PGresult *remote_connection_execf(TSConnection *conn, const char *fmt, ...)
 	pg_attribute_printf(2, 3);

--- a/tsl/test/shared/expected/dist_queries.out
+++ b/tsl/test/shared/expected/dist_queries.out
@@ -1,6 +1,11 @@
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- Function for testing command execution on data nodes
+CREATE OR REPLACE PROCEDURE test.data_node_exec(node_name NAME, command TEXT)
+AS :TSL_MODULE_PATHNAME, 'ts_data_node_exec' LANGUAGE C;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
 -- Test DataNodeScan with subquery with one-time filter
 SELECT
   id
@@ -77,3 +82,32 @@ SELECT * FROM matches_reference ORDER BY 1,2,3,4;
 (3 rows)
 
 ROLLBACK;
+-- Test query/command cancelation with statement_timeout
+SET statement_timeout=200;
+-- Execute long-running query on data nodes
+\set ON_ERROR_STOP 0
+-- distribute_exec() uses async functions
+CALL distributed_exec('SELECT pg_sleep(200)');
+ERROR:  canceling statement due to statement timeout
+-- data_node_exec() directly calls PQexec-style functions
+CALL test.data_node_exec('data_node_1', 'SELECT pg_sleep(200)');
+ERROR:  canceling statement due to statement timeout
+-- test weird parameters
+CALL test.data_node_exec(NULL, 'SELECT pg_sleep(200)');
+ERROR:  data node name cannot be NULL
+CALL test.data_node_exec('-', 'SELECT pg_sleep(200)');
+ERROR:  server "-" does not exist
+CALL test.data_node_exec('data_node_1', NULL);
+ERROR:  command string cannot be NULL
+RESET statement_timeout;
+\set ON_ERROR_STOP 1
+-- Data node connections should be IDLE
+SELECT node_name, database, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1;
+  node_name  |  database   | connection_status | transaction_status | processing 
+-------------+-------------+-------------------+--------------------+------------
+ data_node_1 | data_node_1 | OK                | IDLE               | f
+ data_node_2 | data_node_2 | OK                | IDLE               | f
+ data_node_3 | data_node_3 | OK                | IDLE               | f
+(3 rows)
+

--- a/tsl/test/shared/sql/CMakeLists.txt
+++ b/tsl/test/shared/sql/CMakeLists.txt
@@ -8,7 +8,6 @@ set(TEST_FILES_SHARED
     dist_distinct_pushdown.sql
     dist_gapfill.sql
     dist_insert.sql
-    dist_queries.sql
     extension.sql
     subtract_integer_from_now.sql)
 
@@ -27,8 +26,8 @@ if((${PG_VERSION_MAJOR} GREATER_EQUAL "14"))
 endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  list(APPEND TEST_FILES_SHARED dist_parallel_agg.sql timestamp_limits.sql
-       with_clause_parser.sql)
+  list(APPEND TEST_FILES_SHARED dist_parallel_agg.sql dist_queries.sql
+       timestamp_limits.sql with_clause_parser.sql)
   list(APPEND TEST_TEMPLATES_SHARED constify_now.sql.in space_constraint.sql.in
        dist_remote_error.sql.in)
 endif(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/tsl/test/shared/sql/dist_queries.sql
+++ b/tsl/test/shared/sql/dist_queries.sql
@@ -2,6 +2,12 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 
+\c :TEST_DBNAME :ROLE_SUPERUSER
+-- Function for testing command execution on data nodes
+CREATE OR REPLACE PROCEDURE test.data_node_exec(node_name NAME, command TEXT)
+AS :TSL_MODULE_PATHNAME, 'ts_data_node_exec' LANGUAGE C;
+SET ROLE :ROLE_DEFAULT_PERM_USER;
+
 -- Test DataNodeScan with subquery with one-time filter
 SELECT
   id
@@ -56,3 +62,21 @@ SELECT 9, 'old trafford', 'MNU', 'MNC'
 WHERE NOT EXISTS (SELECT 1 FROM upsert);
 SELECT * FROM matches_reference ORDER BY 1,2,3,4;
 ROLLBACK;
+
+-- Test query/command cancelation with statement_timeout
+SET statement_timeout=200;
+-- Execute long-running query on data nodes
+\set ON_ERROR_STOP 0
+-- distribute_exec() uses async functions
+CALL distributed_exec('SELECT pg_sleep(200)');
+-- data_node_exec() directly calls PQexec-style functions
+CALL test.data_node_exec('data_node_1', 'SELECT pg_sleep(200)');
+-- test weird parameters
+CALL test.data_node_exec(NULL, 'SELECT pg_sleep(200)');
+CALL test.data_node_exec('-', 'SELECT pg_sleep(200)');
+CALL test.data_node_exec('data_node_1', NULL);
+RESET statement_timeout;
+\set ON_ERROR_STOP 1
+-- Data node connections should be IDLE
+SELECT node_name, database, connection_status, transaction_status, processing
+FROM _timescaledb_internal.show_connection_cache() ORDER BY 1;


### PR DESCRIPTION
The function to execute remote commands on data nodes used a blocking libpq API that doesn't integrate with PostgreSQL interrupt handling, making it impossible for a user or statement timeout to cancel a remote command.

Refactor the remote command execution function to use a non-blocking API and integrate with PostgreSQL signal handling via WaitEventSets.

Partial fix for #4958.