### PR TITLE
Make remote COPY calls interruptible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ accidentally triggering the load of a previous DB version.**
 * #5246 Make connection establishment interruptible
 * #5253 Make data node command execution interruptible
 * #5243 Enable real-time aggregation for continuous aggregates with joins
+* #5256 Make remote COPY calls interruptible
 
 **Bugfixes**
 * #4926 Fix corruption when inserting into compressed chunks

--- a/tsl/src/remote/txn.c
+++ b/tsl/src/remote/txn.c
@@ -135,7 +135,7 @@ remote_txn_begin(RemoteTxn *entry, int curlevel)
 	{
 		TSConnectionError err;
 
-		if (!remote_connection_end_copy(entry->conn, &err))
+		if (!remote_connection_end_copy_in(entry->conn, &err))
 			remote_connection_error_elog(&err, ERROR);
 	}
 

--- a/tsl/test/expected/dist_copy_long.out
+++ b/tsl/test/expected/dist_copy_long.out
@@ -194,6 +194,40 @@ select count(*) from uk_price_paid;
  200003
 (1 row)
 
+-- Test COPY with statement timeouts
+truncate uk_price_paid;
+set statement_timeout=200;
+\set ON_ERROR_STOP 0
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
+ERROR:  canceling statement due to statement timeout
+\set ON_ERROR_STOP 1
+reset statement_timeout;
+-- Test that distributed insert with copy works with statement timeouts
+truncate uk_price_paid;
+set timescaledb.enable_distributed_insert_with_copy=true;
+set statement_timeout=200;
+\set ON_ERROR_STOP 0
+insert into uk_price_paid select * from uk_price_paid_r2;
+ERROR:  canceling statement due to statement timeout
+\set ON_ERROR_STOP 1
+reset statement_timeout;
+-- Also timeout a query, but need a bigger data set
+\copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
+\set ON_ERROR_STOP 0
+-- try very small timeout
+set statement_timeout=1;
+select * from uk_price_paid;
+ERROR:  canceling statement due to statement timeout
+-- try a little bigger timeout
+set statement_timeout=20;
+select * from uk_price_paid;
+ERROR:  canceling statement due to statement timeout
+-- even bigger timeout
+set statement_timeout=100;
+select * from uk_price_paid;
+ERROR:  canceling statement due to statement timeout
+\set ON_ERROR_STOP 1
+reset statement_timeout;
 -- Teardown
 \c :TEST_DBNAME :ROLE_CLUSTER_SUPERUSER
 DROP DATABASE :DN_DBNAME_1;


### PR DESCRIPTION
Refactor COPY code for both "in" and "out" mode so that it is non-blocking and interruptible. This will allow canceling queries and ingest paths that use COPY between the access node and data nodes. Canceling can be done using statement timeouts or user
interrupts (ctrl-c).

Closes https://github.com/timescale/timescaledb/issues/4958