### PR TITLE
Improve Realtime Continuous Aggregate performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ accidentally triggering the load of a previous DB version.**
 
 **Features**
 * #5212 Allow pushdown of reference table joins
+* #5221 Improve Realtime Continuous Aggregate performance
 * #5312 Add timeout support to the ping_data_node()
 * #5361 Add parallel support for partialize_agg()
 * #5252 Improve unique constraint support on compressed hypertables
@@ -26,6 +27,7 @@ accidentally triggering the load of a previous DB version.**
 **Thanks**
 * @nikolaps for reporting an issue with the COPY fetcher
 * @S-imo-n for reporting the issue on Background Worker Scheduler crash
+* @kovetskiy and @DZDomi for reporting peformance regression in Realtime Continuous Aggregates
 
 ## 2.10.1 (2023-03-07)
 

--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -404,6 +404,18 @@ CREATE TABLE _timescaledb_catalog.continuous_aggs_invalidation_threshold (
 
 SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_invalidation_threshold', '');
 
+CREATE TABLE _timescaledb_catalog.continuous_aggs_watermark (
+  mat_hypertable_id integer NOT NULL,
+  watermark bigint NOT NULL,
+  -- table constraints
+  CONSTRAINT continuous_aggs_watermark_pkey PRIMARY KEY (mat_hypertable_id),
+  CONSTRAINT continuous_aggs_watermark_mat_hypertable_id_fkey FOREIGN KEY (mat_hypertable_id) REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE
+);
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_watermark', '');
+
+
+
 -- this does not have an FK on the materialization table since INSERTs to this
 -- table are performance critical
 CREATE TABLE _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log (

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -2,3 +2,18 @@ DROP FUNCTION _timescaledb_internal.ping_data_node(NAME);
 
 CREATE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME, timeout INTERVAL = NULL) RETURNS BOOLEAN
 AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;
+
+CREATE TABLE _timescaledb_catalog.continuous_aggs_watermark (
+  mat_hypertable_id integer NOT NULL,
+  watermark bigint NOT NULL,
+  -- table constraints
+  CONSTRAINT continuous_aggs_watermark_pkey PRIMARY KEY (mat_hypertable_id),
+  CONSTRAINT continuous_aggs_watermark_mat_hypertable_id_fkey FOREIGN KEY (mat_hypertable_id) REFERENCES _timescaledb_catalog.continuous_agg (mat_hypertable_id) ON DELETE CASCADE
+);
+
+GRANT SELECT ON _timescaledb_catalog.continuous_aggs_watermark TO PUBLIC;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.continuous_aggs_watermark', '');
+
+CREATE FUNCTION _timescaledb_internal.cagg_watermark_materialized(hypertable_id INTEGER)
+RETURNS INT8 AS '@MODULE_PATHNAME@', 'ts_continuous_agg_watermark_materialized' LANGUAGE C STABLE STRICT PARALLEL SAFE;

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -4,3 +4,9 @@ CREATE OR REPLACE FUNCTION _timescaledb_internal.ping_data_node(node_name NAME) 
 AS '@MODULE_PATHNAME@', 'ts_data_node_ping' LANGUAGE C VOLATILE;
 
 DROP FUNCTION IF EXISTS _timescaledb_internal.get_approx_row_count(REGCLASS);
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.continuous_aggs_watermark;
+
+DROP TABLE IF EXISTS _timescaledb_catalog.continuous_aggs_watermark;
+
+DROP FUNCTION IF EXISTS _timescaledb_internal.cagg_watermark_materialized(hypertable_id INTEGER);

--- a/sql/util_time.sql
+++ b/sql/util_time.sql
@@ -72,5 +72,8 @@ RETURNS BIGINT AS '@MODULE_PATHNAME@', 'ts_time_to_internal' LANGUAGE C VOLATILE
 CREATE OR REPLACE FUNCTION _timescaledb_internal.cagg_watermark(hypertable_id INTEGER)
 RETURNS INT8 AS '@MODULE_PATHNAME@', 'ts_continuous_agg_watermark' LANGUAGE C STABLE STRICT PARALLEL SAFE;
 
+CREATE OR REPLACE FUNCTION _timescaledb_internal.cagg_watermark_materialized(hypertable_id INTEGER)
+RETURNS INT8 AS '@MODULE_PATHNAME@', 'ts_continuous_agg_watermark_materialized' LANGUAGE C STABLE STRICT PARALLEL SAFE;
+
 CREATE OR REPLACE FUNCTION _timescaledb_internal.subtract_integer_from_now( hypertable_relid REGCLASS, lag INT8 )
 RETURNS INT8 AS '@MODULE_PATHNAME@', 'ts_subtract_integer_from_now' LANGUAGE C STABLE STRICT;

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -165,7 +165,7 @@ extern TSDLLEXPORT List *ts_hypertable_get_available_data_node_server_oids(const
 extern TSDLLEXPORT HypertableType ts_hypertable_get_type(const Hypertable *ht);
 extern TSDLLEXPORT void ts_hypertable_func_call_on_data_nodes(const Hypertable *ht,
 															  FunctionCallInfo fcinfo);
-extern TSDLLEXPORT Datum ts_hypertable_get_open_dim_max_value(const Hypertable *ht,
+extern TSDLLEXPORT int64 ts_hypertable_get_open_dim_max_value(const Hypertable *ht,
 															  int dimension_index, bool *isnull);
 
 extern TSDLLEXPORT bool ts_hypertable_has_compression_table(const Hypertable *ht);

--- a/src/ts_catalog/CMakeLists.txt
+++ b/src/ts_catalog/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/chunk_data_node.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compression_chunk_size.c
     ${CMAKE_CURRENT_SOURCE_DIR}/continuous_agg.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/continuous_aggs_watermark.c
     ${CMAKE_CURRENT_SOURCE_DIR}/dimension_partition.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hypertable_compression.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hypertable_data_node.c

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -120,6 +120,10 @@ static const TableInfoDef catalog_table_names[_MAX_CATALOG_TABLES + 1] = {
 		.schema_name = INTERNAL_SCHEMA_NAME,
 		.table_name = JOB_ERRORS_TABLE_NAME,
 	},
+	[CONTINUOUS_AGGS_WATERMARK] = {
+		.schema_name = CATALOG_SCHEMA_NAME,
+		.table_name = CONTINUOUS_AGGS_WATERMARK_TABLE_NAME,
+	},
 	[_MAX_CATALOG_TABLES] = {
 		.schema_name = "invalid schema",
 		.table_name = "invalid table",
@@ -250,6 +254,12 @@ static const TableIndexDef catalog_table_index_definitions[_MAX_CATALOG_TABLES] 
 		.length = _MAX_CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_INDEX,
 		.names = (char *[]) {
 			[CONTINUOUS_AGGS_MATERIALIZATION_INVALIDATION_LOG_IDX] = "continuous_aggs_materialization_invalidation_log_idx",
+		},
+	},
+	[CONTINUOUS_AGGS_WATERMARK] = {
+		.length = _MAX_CONTINUOUS_AGGS_WATERMARK_INDEX,
+		.names = (char *[]) {
+			[CONTINUOUS_AGGS_WATERMARK_PKEY] = "continuous_aggs_watermark_pkey",
 		},
 	},
 	[HYPERTABLE_COMPRESSION] = {

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -57,6 +57,7 @@ typedef enum CatalogTable
 	CHUNK_COPY_OPERATION,
 	CONTINUOUS_AGGS_BUCKET_FUNCTION,
 	JOB_ERRORS,
+	CONTINUOUS_AGGS_WATERMARK,
 	/* Don't forget updating catalog.c when adding new tables! */
 	_MAX_CATALOG_TABLES,
 } CatalogTable;
@@ -1171,6 +1172,39 @@ typedef enum Anum_continuous_aggs_materialization_invalidation_log_idx
 
 #define Natts_continuous_aggs_materialization_invalidation_log_idx                                 \
 	(_Anum_continuous_aggs_materialization_invalidation_log_idx_max - 1)
+
+/****** CONTINUOUS_AGGS_WATERMARK_TABLE definitions*/
+#define CONTINUOUS_AGGS_WATERMARK_TABLE_NAME "continuous_aggs_watermark"
+typedef enum Anum_continuous_aggs_watermark
+{
+	Anum_continuous_aggs_watermark_mat_hypertable_id = 1,
+	Anum_continuous_aggs_watermark_watermark,
+	_Anum_continuous_aggs_watermark_max,
+} Anum_continuous_aggs_watermark;
+
+#define Natts_continuous_aggs_watermark (_Anum_continuous_aggs_watermark_max - 1)
+
+typedef struct FormData_continuous_aggs_watermark
+{
+	int32 mat_hypertable_id;
+	int64 watermark;
+} FormData_continuous_aggs_watermark;
+
+typedef FormData_continuous_aggs_watermark *Form_continuous_aggs_watermark;
+
+enum
+{
+	CONTINUOUS_AGGS_WATERMARK_PKEY = 0,
+	_MAX_CONTINUOUS_AGGS_WATERMARK_INDEX,
+};
+
+typedef enum Anum_continuous_aggs_watermark_pkey
+{
+	Anum_continuous_aggs_watermark_pkey_mat_hypertable_id = 1,
+	_Anum_continuous_aggs_watermark_pkey_max,
+} Anum_continuous_aggs_watermark_pkey;
+
+#define Natts_continuous_aggs_watermark_pkey (_Anum_continuous_aggs_watermark_pkey_max - 1)
 
 #define HYPERTABLE_COMPRESSION_TABLE_NAME "hypertable_compression"
 typedef enum Anum_hypertable_compression

--- a/src/ts_catalog/continuous_aggs_watermark.c
+++ b/src/ts_catalog/continuous_aggs_watermark.c
@@ -1,0 +1,402 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+/*
+ * This file handles continuous aggs watermark functions.
+ */
+
+#include <postgres.h>
+#include <access/xact.h>
+#include <fmgr.h>
+#include <miscadmin.h>
+#include <utils/acl.h>
+
+#include "ts_catalog/continuous_agg.h"
+#include "ts_catalog/continuous_aggs_watermark.h"
+#include "hypertable.h"
+
+typedef struct ContinuousAggregateWatermark
+{
+	int32 mat_hypertable_id;
+	MemoryContext mctx;
+	MemoryContextCallback cb;
+	CommandId cid;
+	int64 value;
+} ContinuousAggregateWatermark;
+
+/*
+ * Cache the watermark in the current transaction for better performance
+ * (by avoiding repeated max bucket calculations). The watermark will be
+ * reset at the end of the transaction, when the watermark function's input
+ * argument (materialized hypertable ID) changes, or when a new command is
+ * executed.
+ *
+ * One could potentially create a hashtable of watermarks keyed on materialized
+ * hypertable ID, but this is left as a future optimization since it doesn't
+ * seem to be common case that multiple continuous aggregates exist in the same
+ * query. Besides, the planner can constify calls to the watermark function
+ * during planning since the function is STABLE. Therefore, this is only a
+ * fallback if the planner needs to constify it many times (e.g., if used as
+ * an index condition on many chunks).
+ */
+static ContinuousAggregateWatermark *cagg_watermark_cache = NULL;
+
+/*
+ * Callback handler to reset the watermark after the transaction ends. This is
+ * triggered by the deletion of the associated memory context.
+ */
+static void
+cagg_watermark_reset(void *arg)
+{
+	cagg_watermark_cache = NULL;
+}
+
+/*
+ * ContinuousAggregateWatermark is valid for the duration of one command execution on the same
+ * materialized hypertable.
+ */
+static bool
+cagg_watermark_is_valid(const ContinuousAggregateWatermark *cagg_watermark, int32 mat_hypertable_id)
+{
+	return cagg_watermark != NULL && cagg_watermark->mat_hypertable_id == mat_hypertable_id &&
+		   cagg_watermark->cid == GetCurrentCommandId(false);
+}
+
+static void
+cagg_watermark_init_scan_by_mat_hypertable_id(ScanIterator *iterator, const int32 mat_hypertable_id)
+{
+	iterator->ctx.index = catalog_get_index(ts_catalog_get(),
+											CONTINUOUS_AGGS_WATERMARK,
+											CONTINUOUS_AGGS_WATERMARK_PKEY);
+
+	ts_scan_iterator_scan_key_init(iterator,
+								   Anum_continuous_aggs_watermark_pkey_mat_hypertable_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(mat_hypertable_id));
+}
+
+static int64
+cagg_watermark_get(Hypertable *mat_ht)
+{
+	PG_USED_FOR_ASSERTS_ONLY short count = 0;
+	Datum watermark = (Datum) 0;
+	bool value_isnull = true;
+	ScanIterator iterator =
+		ts_scan_iterator_create(CONTINUOUS_AGGS_WATERMARK, AccessShareLock, CurrentMemoryContext);
+
+	cagg_watermark_init_scan_by_mat_hypertable_id(&iterator, mat_ht->fd.id);
+
+	ts_scanner_foreach(&iterator)
+	{
+		watermark = slot_getattr(ts_scan_iterator_slot(&iterator),
+								 Anum_continuous_aggs_watermark_watermark,
+								 &value_isnull);
+		count++;
+	}
+	Assert(count <= 1);
+	ts_scan_iterator_close(&iterator);
+
+	if (value_isnull)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("watermark not defined for continuous aggregate: %d", mat_ht->fd.id)));
+
+	return DatumGetInt64(watermark);
+}
+
+static ContinuousAggregateWatermark *
+cagg_watermark_create(const ContinuousAgg *cagg, MemoryContext top_mctx)
+{
+	Hypertable *ht;
+	ContinuousAggregateWatermark *watermark;
+	MemoryContext mctx = AllocSetContextCreate(top_mctx,
+											   "ContinuousAggregateWatermark function",
+											   ALLOCSET_DEFAULT_SIZES);
+
+	watermark = MemoryContextAllocZero(mctx, sizeof(ContinuousAggregateWatermark));
+	watermark->mctx = mctx;
+	watermark->mat_hypertable_id = cagg->data.mat_hypertable_id;
+	watermark->cid = GetCurrentCommandId(false);
+	watermark->cb.func = cagg_watermark_reset;
+	MemoryContextRegisterResetCallback(mctx, &watermark->cb);
+
+	/* Hypertable associated to the Continuous Aggregate */
+	ht = ts_hypertable_get_by_id(cagg->data.mat_hypertable_id);
+
+	if (NULL == ht)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid materialization hypertable ID: %d",
+						cagg->data.mat_hypertable_id)));
+
+	/* Get the stored watermark */
+	watermark->value = cagg_watermark_get(ht);
+
+	return watermark;
+}
+
+TS_FUNCTION_INFO_V1(ts_continuous_agg_watermark);
+
+/*
+ * Get the watermark for a real-time aggregation query on a continuous
+ * aggregate.
+ *
+ * The watermark determines where the materialization ends for a continuous
+ * aggregate. It is used by real-time aggregation as the threshold between the
+ * materialized data and real-time data in the UNION query.
+ *
+ * The watermark is stored into `_timescaledb_catalog.continuous_aggs_watermark`
+ * catalog table by the `refresh_continuous_agregate` procedure. It is defined
+ * as the end of the last (highest) bucket in the materialized hypertable of a
+ * continuous aggregate.
+ *
+ * The materialized hypertable ID is given as input argument.
+ */
+Datum
+ts_continuous_agg_watermark(PG_FUNCTION_ARGS)
+{
+	const int32 mat_hypertable_id = PG_GETARG_INT32(0);
+	ContinuousAgg *cagg;
+	AclResult aclresult;
+
+	if (NULL != cagg_watermark_cache)
+	{
+		if (cagg_watermark_is_valid(cagg_watermark_cache, mat_hypertable_id))
+			PG_RETURN_INT64(cagg_watermark_cache->value);
+
+		MemoryContextDelete(cagg_watermark_cache->mctx);
+	}
+
+	cagg = ts_continuous_agg_find_by_mat_hypertable_id(mat_hypertable_id);
+
+	if (NULL == cagg)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid materialized hypertable ID: %d", mat_hypertable_id)));
+
+	/*
+	 * Preemptive permission check to ensure the function complains about lack
+	 * of permissions on the cagg rather than the materialized hypertable
+	 */
+	aclresult = pg_class_aclcheck(cagg->relid, GetUserId(), ACL_SELECT);
+	aclcheck_error(aclresult, OBJECT_MATVIEW, get_rel_name(cagg->relid));
+	cagg_watermark_cache = cagg_watermark_create(cagg, TopTransactionContext);
+
+	PG_RETURN_INT64(cagg_watermark_cache->value);
+}
+
+static int64
+cagg_compute_watermark(ContinuousAgg *cagg, int64 watermark, bool isnull)
+{
+	if (isnull)
+	{
+		watermark = ts_time_get_min(cagg->partition_type);
+	}
+	else
+	{
+		/*
+		 * The materialized hypertable is already bucketed, which means the
+		 * max is the start of the last bucket. Add one bucket to move to the
+		 * point where the materialized data ends.
+		 */
+		if (ts_continuous_agg_bucket_width_variable(cagg))
+		{
+			/*
+			 * Since `value` is already bucketed, `bucketed = true` flag can
+			 * be added to ts_compute_beginning_of_the_next_bucket_variable() as
+			 * an optimization, if necessary.
+			 */
+			watermark =
+				ts_compute_beginning_of_the_next_bucket_variable(watermark, cagg->bucket_function);
+		}
+		else
+		{
+			watermark = ts_time_saturating_add(watermark,
+											   ts_continuous_agg_bucket_width(cagg),
+											   cagg->partition_type);
+		}
+	}
+
+	return watermark;
+}
+
+TS_FUNCTION_INFO_V1(ts_continuous_agg_watermark_materialized);
+
+/*
+ * Get the materialized watermark for a real-time aggregation query on a
+ * continuous aggregate.
+ *
+ * The difference between this function and `ts_continuous_agg_watermark` is
+ * that this one get the max open dimension of the materialization hypertable
+ * insted of get the stored value in the catalog table.
+ */
+Datum
+ts_continuous_agg_watermark_materialized(PG_FUNCTION_ARGS)
+{
+	const int32 mat_hypertable_id = PG_GETARG_INT32(0);
+	ContinuousAgg *cagg;
+	AclResult aclresult;
+	bool isnull;
+	Hypertable *ht;
+	int64 watermark;
+
+	cagg = ts_continuous_agg_find_by_mat_hypertable_id(mat_hypertable_id);
+
+	if (NULL == cagg)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid materialized hypertable ID: %d", mat_hypertable_id)));
+
+	/*
+	 * Preemptive permission check to ensure the function complains about lack
+	 * of permissions on the cagg rather than the materialized hypertable
+	 */
+	aclresult = pg_class_aclcheck(cagg->relid, GetUserId(), ACL_SELECT);
+	aclcheck_error(aclresult, OBJECT_MATVIEW, get_rel_name(cagg->relid));
+
+	ht = ts_hypertable_get_by_id(cagg->data.mat_hypertable_id);
+	watermark = ts_hypertable_get_open_dim_max_value(ht, 0, &isnull);
+
+	watermark = cagg_compute_watermark(cagg, watermark, isnull);
+
+	PG_RETURN_INT64(watermark);
+}
+
+TSDLLEXPORT void
+ts_cagg_watermark_insert(Hypertable *mat_ht, int64 watermark, bool watermark_isnull)
+{
+	Catalog *catalog = ts_catalog_get();
+	Relation rel =
+		table_open(catalog_get_table_id(catalog, CONTINUOUS_AGGS_WATERMARK), RowExclusiveLock);
+	TupleDesc desc = RelationGetDescr(rel);
+	Datum values[Natts_continuous_aggs_watermark];
+	bool nulls[Natts_continuous_aggs_watermark] = { false };
+	CatalogSecurityContext sec_ctx;
+
+	/* if trying to insert a NULL watermark then get the MIN value for the time dimension */
+	if (watermark_isnull)
+	{
+		const Dimension *dim = hyperspace_get_open_dimension(mat_ht->space, 0);
+
+		if (NULL == dim)
+			elog(ERROR, "invalid open dimension index %d", 0);
+
+		watermark = ts_time_get_min(ts_dimension_get_partition_type(dim));
+	}
+
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_watermark_mat_hypertable_id)] =
+		Int32GetDatum(mat_ht->fd.id);
+	values[AttrNumberGetAttrOffset(Anum_continuous_aggs_watermark_watermark)] =
+		Int64GetDatum(watermark);
+
+	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
+	ts_catalog_insert_values(rel, desc, values, nulls);
+	ts_catalog_restore_user(&sec_ctx);
+
+	table_close(rel, NoLock);
+}
+
+typedef struct WatermarkUpdate
+{
+	int64 watermark;
+	bool force_update;
+} WatermarkUpdate;
+
+static ScanTupleResult
+cagg_watermark_update_scan_internal(TupleInfo *ti, void *data)
+{
+	WatermarkUpdate *watermark_update = data;
+	bool should_free;
+	HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
+	Form_continuous_aggs_watermark form = (Form_continuous_aggs_watermark) GETSTRUCT(tuple);
+
+	if (watermark_update->watermark > form->watermark || watermark_update->force_update)
+	{
+		HeapTuple new_tuple = heap_copytuple(tuple);
+		form = (Form_continuous_aggs_watermark) GETSTRUCT(new_tuple);
+		form->watermark = watermark_update->watermark;
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
+	}
+	else
+	{
+		elog(DEBUG1,
+			 "hypertable %d existing watermark >= new watermark " INT64_FORMAT " " INT64_FORMAT,
+			 form->mat_hypertable_id,
+			 form->watermark,
+			 watermark_update->watermark);
+		watermark_update->watermark = form->watermark;
+	}
+
+	if (should_free)
+		heap_freetuple(tuple);
+
+	return SCAN_DONE;
+}
+
+static void
+cagg_watermark_update_internal(int32 mat_hypertable_id, int64 new_watermark, bool force_update)
+{
+	bool watermark_updated;
+	ScanKeyData scankey[1];
+	WatermarkUpdate data = { .watermark = new_watermark, .force_update = force_update };
+
+	ScanKeyInit(&scankey[0],
+				Anum_continuous_aggs_watermark_mat_hypertable_id,
+				BTEqualStrategyNumber,
+				F_INT4EQ,
+				Int32GetDatum(mat_hypertable_id));
+
+	watermark_updated = ts_catalog_scan_one(CONTINUOUS_AGGS_WATERMARK /*=table*/,
+											CONTINUOUS_AGGS_WATERMARK_PKEY /*=indexid*/,
+											scankey /*=scankey*/,
+											1 /*=num_keys*/,
+											cagg_watermark_update_scan_internal /*=tuple_found*/,
+											RowExclusiveLock /*=lockmode*/,
+											CONTINUOUS_AGGS_WATERMARK_TABLE_NAME /*=table_name*/,
+											&data /*=data*/);
+
+	if (!watermark_updated)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("watermark not defined for continuous aggregate: %d", mat_hypertable_id)));
+	}
+}
+
+TSDLLEXPORT void
+ts_cagg_watermark_update(Hypertable *mat_ht, int64 watermark, bool watermark_isnull,
+						 bool force_update)
+{
+	ContinuousAgg *cagg = ts_continuous_agg_find_by_mat_hypertable_id(mat_ht->fd.id);
+
+	if (NULL == cagg)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("invalid materialized hypertable ID: %d", mat_ht->fd.id)));
+
+	watermark = cagg_compute_watermark(cagg, watermark, watermark_isnull);
+	cagg_watermark_update_internal(mat_ht->fd.id, watermark, force_update);
+
+	return;
+}
+
+TSDLLEXPORT void
+ts_cagg_watermark_delete_by_mat_hypertable_id(int32 mat_hypertable_id)
+{
+	ScanIterator iterator =
+		ts_scan_iterator_create(CONTINUOUS_AGGS_WATERMARK, RowExclusiveLock, CurrentMemoryContext);
+
+	cagg_watermark_init_scan_by_mat_hypertable_id(&iterator, mat_hypertable_id);
+
+	ts_scanner_foreach(&iterator)
+	{
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		ts_catalog_delete_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti));
+	}
+	ts_scan_iterator_close(&iterator);
+}

--- a/src/ts_catalog/continuous_aggs_watermark.h
+++ b/src/ts_catalog/continuous_aggs_watermark.h
@@ -1,0 +1,21 @@
+/*
+ * This file and its contents are licensed under the Apache License 2.0.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-APACHE for a copy of the license.
+ */
+
+#ifndef TIMESCALEDB_CONTINUOUS_AGGS_WATERMARK_H
+#define TIMESCALEDB_CONTINUOUS_AGGS_WATERMARK_H
+
+#include <postgres.h>
+
+#include "export.h"
+#include "hypertable.h"
+
+extern TSDLLEXPORT void ts_cagg_watermark_delete_by_mat_hypertable_id(int32 mat_hypertable_id);
+extern TSDLLEXPORT void ts_cagg_watermark_insert(Hypertable *mat_ht, int64 watermark,
+												 bool watermark_isnull);
+extern TSDLLEXPORT void ts_cagg_watermark_update(Hypertable *mat_ht, int64 watermark,
+												 bool watermark_isnull, bool force_update);
+
+#endif /* TIMESCALEDB_CONTINUOUS_AGGS_WATERMARK_H */

--- a/test/expected/drop_rename_hypertable.out
+++ b/test/expected/drop_rename_hypertable.out
@@ -208,6 +208,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
  _timescaledb_catalog | continuous_aggs_hypertable_invalidation_log      | table | super_user
  _timescaledb_catalog | continuous_aggs_invalidation_threshold           | table | super_user
  _timescaledb_catalog | continuous_aggs_materialization_invalidation_log | table | super_user
+ _timescaledb_catalog | continuous_aggs_watermark                        | table | super_user
  _timescaledb_catalog | dimension                                        | table | super_user
  _timescaledb_catalog | dimension_partition                              | table | super_user
  _timescaledb_catalog | dimension_slice                                  | table | super_user
@@ -217,7 +218,7 @@ SELECT * FROM _timescaledb_catalog.hypertable;
  _timescaledb_catalog | metadata                                         | table | super_user
  _timescaledb_catalog | remote_txn                                       | table | super_user
  _timescaledb_catalog | tablespace                                       | table | super_user
-(23 rows)
+(24 rows)
 
 \dt "_timescaledb_internal".*
                           List of relations

--- a/tsl/src/continuous_aggs/invalidation_threshold.c
+++ b/tsl/src/continuous_aggs/invalidation_threshold.c
@@ -295,7 +295,7 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 	if (max_refresh)
 	{
 		bool isnull;
-		Datum maxdat = ts_hypertable_get_open_dim_max_value(ht, 0, &isnull);
+		int64 maxval = ts_hypertable_get_open_dim_max_value(ht, 0, &isnull);
 
 		if (isnull)
 		{
@@ -325,8 +325,6 @@ invalidation_threshold_compute(const ContinuousAgg *cagg, const InternalTimeRang
 		}
 		else
 		{
-			int64 maxval = ts_time_value_to_internal(maxdat, refresh_window->type);
-
 			if (ts_continuous_agg_bucket_width_variable(cagg))
 			{
 				return ts_compute_beginning_of_the_next_bucket_variable(maxval,

--- a/tsl/src/continuous_aggs/materialize.h
+++ b/tsl/src/continuous_aggs/materialize.h
@@ -35,7 +35,7 @@ typedef struct InternalTimeRange
 	int64 end;	 /* exclusive */
 } InternalTimeRange;
 
-void continuous_agg_update_materialization(SchemaAndName partial_view,
+void continuous_agg_update_materialization(Hypertable *mat_ht, SchemaAndName partial_view,
 										   SchemaAndName materialization_table,
 										   const NameData *time_column_name,
 										   InternalTimeRange new_materialization_range,

--- a/tsl/src/continuous_aggs/refresh.c
+++ b/tsl/src/continuous_aggs/refresh.c
@@ -269,7 +269,8 @@ continuous_agg_refresh_execute(const CaggRefreshState *refresh,
 
 	Assert(time_dim != NULL);
 
-	continuous_agg_update_materialization(refresh->partial_view,
+	continuous_agg_update_materialization(refresh->cagg_ht,
+										  refresh->partial_view,
 										  cagg_hypertable_name,
 										  &time_dim->fd.column_name,
 										  *bucketed_refresh_window,

--- a/tsl/test/expected/cagg_refresh.out
+++ b/tsl/test/expected/cagg_refresh.out
@@ -125,6 +125,7 @@ LOG:  statement: CALL refresh_continuous_aggregate('daily_temp', '2020-04-30', '
 DEBUG:  refreshing continuous aggregate "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sun May 03 17:00:00 2020 PDT ]
 DEBUG:  hypertable 1 existing watermark >= new invalidation threshold 1588723200000000 1588550400000000
 DEBUG:  invalidation refresh on "daily_temp" in window [ Thu Apr 30 17:00:00 2020 PDT, Sat May 02 17:00:00 2020 PDT ]
+DEBUG:  hypertable 2 existing watermark >= new watermark 1588723200000000 1588464000000000
 RESET client_min_messages;
 LOG:  statement: RESET client_min_messages;
 -- Compare the aggregate to the equivalent query on the source table

--- a/tsl/test/expected/cagg_union_view-12.out
+++ b/tsl/test/expected/cagg_union_view-12.out
@@ -741,20 +741,25 @@ NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
 NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
 -- Watermarks at min for the above caggs:
-SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+SELECT
+  user_view_name,
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id) = _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id) AS is_equal
 FROM _timescaledb_catalog.continuous_agg
-ORDER BY 1,2;
- user_view_name  |    cagg_watermark    
------------------+----------------------
- bigint_agg      | -9223372036854775808
- boundary_view   |                   30
- date_agg        |  -210866803200000000
- int_agg         |          -2147483648
- mat_m1          |                   25
- metrics_summary |      946771200000000
- smallint_agg    |               -32768
- timestamp_agg   |  -210866803200000000
- timestamptz_agg |  -210866803200000000
+NATURAL JOIN _timescaledb_catalog.continuous_aggs_watermark
+ORDER BY 1, 2, 3;
+ user_view_name  |    cagg_watermark    | cagg_watermark_materialized | is_equal 
+-----------------+----------------------+-----------------------------+----------
+ bigint_agg      | -9223372036854775808 |        -9223372036854775808 | t
+ boundary_view   |                   30 |                          30 | t
+ date_agg        |  -210866803200000000 |         -210866803200000000 | t
+ int_agg         |          -2147483648 |                 -2147483648 | t
+ mat_m1          |                   25 |                          25 | t
+ metrics_summary |      946771200000000 |             946771200000000 | t
+ smallint_agg    |               -32768 |                      -32768 | t
+ timestamp_agg   |  -210866803200000000 |         -210866803200000000 | t
+ timestamptz_agg |  -210866803200000000 |         -210866803200000000 | t
 (9 rows)
 
 INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
@@ -898,3 +903,115 @@ SELECT _timescaledb_internal.cagg_watermark(NULL);
 (1 row)
 
 \set ON_ERROR_STOP 1
+-- Remove stored watermark, so query and refresh should error
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_aggs_watermark;
+\set ON_ERROR_STOP 0
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 16
+SELECT * FROM int_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 17
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 18
+SELECT * FROM date_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 19
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 20
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 21
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 17
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 16
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 18
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
+\set ON_ERROR_STOP 1
+-- Fix all continuous aggregates inserting materialized watermark into the metadata table
+INSERT INTO _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark)
+SELECT a.mat_hypertable_id, _timescaledb_internal.cagg_watermark_materialized(a.mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg a
+LEFT JOIN _timescaledb_catalog.continuous_aggs_watermark b ON b.mat_hypertable_id = a.mat_hypertable_id
+WHERE b.mat_hypertable_id IS NULL
+ORDER BY 1;
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ bucket |          avg           
+--------+------------------------
+      0 |     4.2500000000000000
+     10 |    19.0000000000000000
+  32760 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+   bucket   |          avg           
+------------+------------------------
+          0 |     1.5000000000000000
+          5 |     7.0000000000000000
+         15 |    19.0000000000000000
+ 2147483645 | 1.00000000000000000000
+(4 rows)
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+       bucket        |          avg           
+---------------------+------------------------
+                   0 |     4.2500000000000000
+                  10 |    19.0000000000000000
+ 9223372036854775800 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+    bucket    |          avg           
+--------------+------------------------
+ 12-31-2019   | 1.00000000000000000000
+ 01-02-2020   |     2.0000000000000000
+ 01-06-2020   |     6.0000000000000000
+ 01-08-2020   |     8.0000000000000000
+ 12-31-294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+           bucket           |          avg           
+----------------------------+------------------------
+ Tue Dec 31 00:00:00 2019   | 1.00000000000000000000
+ Thu Jan 02 00:00:00 2020   |     2.0000000000000000
+ Mon Jan 06 00:00:00 2020   |     6.0000000000000000
+ Wed Jan 08 00:00:00 2020   |     8.0000000000000000
+ Thu Dec 31 00:00:00 294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+             bucket             |          avg           
+--------------------------------+------------------------
+ Mon Dec 30 16:00:00 2019 PST   | 1.00000000000000000000
+ Wed Jan 01 16:00:00 2020 PST   |     2.0000000000000000
+ Sun Jan 05 16:00:00 2020 PST   |     6.0000000000000000
+ Tue Jan 07 16:00:00 2020 PST   |     8.0000000000000000
+ Wed Dec 30 16:00:00 294246 PST | 1.00000000000000000000
+(5 rows)
+
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date

--- a/tsl/test/expected/cagg_union_view-13.out
+++ b/tsl/test/expected/cagg_union_view-13.out
@@ -744,20 +744,25 @@ NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
 NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
 -- Watermarks at min for the above caggs:
-SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+SELECT
+  user_view_name,
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id) = _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id) AS is_equal
 FROM _timescaledb_catalog.continuous_agg
-ORDER BY 1,2;
- user_view_name  |    cagg_watermark    
------------------+----------------------
- bigint_agg      | -9223372036854775808
- boundary_view   |                   30
- date_agg        |  -210866803200000000
- int_agg         |          -2147483648
- mat_m1          |                   25
- metrics_summary |      946771200000000
- smallint_agg    |               -32768
- timestamp_agg   |  -210866803200000000
- timestamptz_agg |  -210866803200000000
+NATURAL JOIN _timescaledb_catalog.continuous_aggs_watermark
+ORDER BY 1, 2, 3;
+ user_view_name  |    cagg_watermark    | cagg_watermark_materialized | is_equal 
+-----------------+----------------------+-----------------------------+----------
+ bigint_agg      | -9223372036854775808 |        -9223372036854775808 | t
+ boundary_view   |                   30 |                          30 | t
+ date_agg        |  -210866803200000000 |         -210866803200000000 | t
+ int_agg         |          -2147483648 |                 -2147483648 | t
+ mat_m1          |                   25 |                          25 | t
+ metrics_summary |      946771200000000 |             946771200000000 | t
+ smallint_agg    |               -32768 |                      -32768 | t
+ timestamp_agg   |  -210866803200000000 |         -210866803200000000 | t
+ timestamptz_agg |  -210866803200000000 |         -210866803200000000 | t
 (9 rows)
 
 INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
@@ -901,3 +906,115 @@ SELECT _timescaledb_internal.cagg_watermark(NULL);
 (1 row)
 
 \set ON_ERROR_STOP 1
+-- Remove stored watermark, so query and refresh should error
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_aggs_watermark;
+\set ON_ERROR_STOP 0
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 16
+SELECT * FROM int_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 17
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 18
+SELECT * FROM date_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 19
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 20
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 21
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 17
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 16
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 18
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
+\set ON_ERROR_STOP 1
+-- Fix all continuous aggregates inserting materialized watermark into the metadata table
+INSERT INTO _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark)
+SELECT a.mat_hypertable_id, _timescaledb_internal.cagg_watermark_materialized(a.mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg a
+LEFT JOIN _timescaledb_catalog.continuous_aggs_watermark b ON b.mat_hypertable_id = a.mat_hypertable_id
+WHERE b.mat_hypertable_id IS NULL
+ORDER BY 1;
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ bucket |          avg           
+--------+------------------------
+      0 |     4.2500000000000000
+     10 |    19.0000000000000000
+  32760 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+   bucket   |          avg           
+------------+------------------------
+          0 |     1.5000000000000000
+          5 |     7.0000000000000000
+         15 |    19.0000000000000000
+ 2147483645 | 1.00000000000000000000
+(4 rows)
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+       bucket        |          avg           
+---------------------+------------------------
+                   0 |     4.2500000000000000
+                  10 |    19.0000000000000000
+ 9223372036854775800 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+    bucket    |          avg           
+--------------+------------------------
+ 12-31-2019   | 1.00000000000000000000
+ 01-02-2020   |     2.0000000000000000
+ 01-06-2020   |     6.0000000000000000
+ 01-08-2020   |     8.0000000000000000
+ 12-31-294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+           bucket           |          avg           
+----------------------------+------------------------
+ Tue Dec 31 00:00:00 2019   | 1.00000000000000000000
+ Thu Jan 02 00:00:00 2020   |     2.0000000000000000
+ Mon Jan 06 00:00:00 2020   |     6.0000000000000000
+ Wed Jan 08 00:00:00 2020   |     8.0000000000000000
+ Thu Dec 31 00:00:00 294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+             bucket             |          avg           
+--------------------------------+------------------------
+ Mon Dec 30 16:00:00 2019 PST   | 1.00000000000000000000
+ Wed Jan 01 16:00:00 2020 PST   |     2.0000000000000000
+ Sun Jan 05 16:00:00 2020 PST   |     6.0000000000000000
+ Tue Jan 07 16:00:00 2020 PST   |     8.0000000000000000
+ Wed Dec 30 16:00:00 294246 PST | 1.00000000000000000000
+(5 rows)
+
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date

--- a/tsl/test/expected/cagg_union_view-14.out
+++ b/tsl/test/expected/cagg_union_view-14.out
@@ -744,20 +744,25 @@ NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
 NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
 -- Watermarks at min for the above caggs:
-SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+SELECT
+  user_view_name,
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id) = _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id) AS is_equal
 FROM _timescaledb_catalog.continuous_agg
-ORDER BY 1,2;
- user_view_name  |    cagg_watermark    
------------------+----------------------
- bigint_agg      | -9223372036854775808
- boundary_view   |                   30
- date_agg        |  -210866803200000000
- int_agg         |          -2147483648
- mat_m1          |                   25
- metrics_summary |      946771200000000
- smallint_agg    |               -32768
- timestamp_agg   |  -210866803200000000
- timestamptz_agg |  -210866803200000000
+NATURAL JOIN _timescaledb_catalog.continuous_aggs_watermark
+ORDER BY 1, 2, 3;
+ user_view_name  |    cagg_watermark    | cagg_watermark_materialized | is_equal 
+-----------------+----------------------+-----------------------------+----------
+ bigint_agg      | -9223372036854775808 |        -9223372036854775808 | t
+ boundary_view   |                   30 |                          30 | t
+ date_agg        |  -210866803200000000 |         -210866803200000000 | t
+ int_agg         |          -2147483648 |                 -2147483648 | t
+ mat_m1          |                   25 |                          25 | t
+ metrics_summary |      946771200000000 |             946771200000000 | t
+ smallint_agg    |               -32768 |                      -32768 | t
+ timestamp_agg   |  -210866803200000000 |         -210866803200000000 | t
+ timestamptz_agg |  -210866803200000000 |         -210866803200000000 | t
 (9 rows)
 
 INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
@@ -901,3 +906,115 @@ SELECT _timescaledb_internal.cagg_watermark(NULL);
 (1 row)
 
 \set ON_ERROR_STOP 1
+-- Remove stored watermark, so query and refresh should error
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_aggs_watermark;
+\set ON_ERROR_STOP 0
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 16
+SELECT * FROM int_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 17
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 18
+SELECT * FROM date_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 19
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 20
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 21
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 17
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 16
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 18
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
+\set ON_ERROR_STOP 1
+-- Fix all continuous aggregates inserting materialized watermark into the metadata table
+INSERT INTO _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark)
+SELECT a.mat_hypertable_id, _timescaledb_internal.cagg_watermark_materialized(a.mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg a
+LEFT JOIN _timescaledb_catalog.continuous_aggs_watermark b ON b.mat_hypertable_id = a.mat_hypertable_id
+WHERE b.mat_hypertable_id IS NULL
+ORDER BY 1;
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ bucket |          avg           
+--------+------------------------
+      0 |     4.2500000000000000
+     10 |    19.0000000000000000
+  32760 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+   bucket   |          avg           
+------------+------------------------
+          0 |     1.5000000000000000
+          5 |     7.0000000000000000
+         15 |    19.0000000000000000
+ 2147483645 | 1.00000000000000000000
+(4 rows)
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+       bucket        |          avg           
+---------------------+------------------------
+                   0 |     4.2500000000000000
+                  10 |    19.0000000000000000
+ 9223372036854775800 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+    bucket    |          avg           
+--------------+------------------------
+ 12-31-2019   | 1.00000000000000000000
+ 01-02-2020   |     2.0000000000000000
+ 01-06-2020   |     6.0000000000000000
+ 01-08-2020   |     8.0000000000000000
+ 12-31-294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+           bucket           |          avg           
+----------------------------+------------------------
+ Tue Dec 31 00:00:00 2019   | 1.00000000000000000000
+ Thu Jan 02 00:00:00 2020   |     2.0000000000000000
+ Mon Jan 06 00:00:00 2020   |     6.0000000000000000
+ Wed Jan 08 00:00:00 2020   |     8.0000000000000000
+ Thu Dec 31 00:00:00 294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+             bucket             |          avg           
+--------------------------------+------------------------
+ Mon Dec 30 16:00:00 2019 PST   | 1.00000000000000000000
+ Wed Jan 01 16:00:00 2020 PST   |     2.0000000000000000
+ Sun Jan 05 16:00:00 2020 PST   |     6.0000000000000000
+ Tue Jan 07 16:00:00 2020 PST   |     8.0000000000000000
+ Wed Dec 30 16:00:00 294246 PST | 1.00000000000000000000
+(5 rows)
+
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date

--- a/tsl/test/expected/cagg_union_view-15.out
+++ b/tsl/test/expected/cagg_union_view-15.out
@@ -747,20 +747,25 @@ NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
 NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
 -- Watermarks at min for the above caggs:
-SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+SELECT
+  user_view_name,
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id) = _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id) AS is_equal
 FROM _timescaledb_catalog.continuous_agg
-ORDER BY 1,2;
- user_view_name  |    cagg_watermark    
------------------+----------------------
- bigint_agg      | -9223372036854775808
- boundary_view   |                   30
- date_agg        |  -210866803200000000
- int_agg         |          -2147483648
- mat_m1          |                   25
- metrics_summary |      946771200000000
- smallint_agg    |               -32768
- timestamp_agg   |  -210866803200000000
- timestamptz_agg |  -210866803200000000
+NATURAL JOIN _timescaledb_catalog.continuous_aggs_watermark
+ORDER BY 1, 2, 3;
+ user_view_name  |    cagg_watermark    | cagg_watermark_materialized | is_equal 
+-----------------+----------------------+-----------------------------+----------
+ bigint_agg      | -9223372036854775808 |        -9223372036854775808 | t
+ boundary_view   |                   30 |                          30 | t
+ date_agg        |  -210866803200000000 |         -210866803200000000 | t
+ int_agg         |          -2147483648 |                 -2147483648 | t
+ mat_m1          |                   25 |                          25 | t
+ metrics_summary |      946771200000000 |             946771200000000 | t
+ smallint_agg    |               -32768 |                      -32768 | t
+ timestamp_agg   |  -210866803200000000 |         -210866803200000000 | t
+ timestamptz_agg |  -210866803200000000 |         -210866803200000000 | t
 (9 rows)
 
 INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
@@ -904,3 +909,115 @@ SELECT _timescaledb_internal.cagg_watermark(NULL);
 (1 row)
 
 \set ON_ERROR_STOP 1
+-- Remove stored watermark, so query and refresh should error
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_aggs_watermark;
+\set ON_ERROR_STOP 0
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 16
+SELECT * FROM int_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 17
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 18
+SELECT * FROM date_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 19
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 20
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+ERROR:  watermark not defined for continuous aggregate: 21
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 17
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 16
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+ERROR:  watermark not defined for continuous aggregate: 18
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date
+\set ON_ERROR_STOP 1
+-- Fix all continuous aggregates inserting materialized watermark into the metadata table
+INSERT INTO _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark)
+SELECT a.mat_hypertable_id, _timescaledb_internal.cagg_watermark_materialized(a.mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg a
+LEFT JOIN _timescaledb_catalog.continuous_aggs_watermark b ON b.mat_hypertable_id = a.mat_hypertable_id
+WHERE b.mat_hypertable_id IS NULL
+ORDER BY 1;
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+ bucket |          avg           
+--------+------------------------
+      0 |     4.2500000000000000
+     10 |    19.0000000000000000
+  32760 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+   bucket   |          avg           
+------------+------------------------
+          0 |     1.5000000000000000
+          5 |     7.0000000000000000
+         15 |    19.0000000000000000
+ 2147483645 | 1.00000000000000000000
+(4 rows)
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+       bucket        |          avg           
+---------------------+------------------------
+                   0 |     4.2500000000000000
+                  10 |    19.0000000000000000
+ 9223372036854775800 | 1.00000000000000000000
+(3 rows)
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+    bucket    |          avg           
+--------------+------------------------
+ 12-31-2019   | 1.00000000000000000000
+ 01-02-2020   |     2.0000000000000000
+ 01-06-2020   |     6.0000000000000000
+ 01-08-2020   |     8.0000000000000000
+ 12-31-294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+           bucket           |          avg           
+----------------------------+------------------------
+ Tue Dec 31 00:00:00 2019   | 1.00000000000000000000
+ Thu Jan 02 00:00:00 2020   |     2.0000000000000000
+ Mon Jan 06 00:00:00 2020   |     6.0000000000000000
+ Wed Jan 08 00:00:00 2020   |     8.0000000000000000
+ Thu Dec 31 00:00:00 294246 | 1.00000000000000000000
+(5 rows)
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+             bucket             |          avg           
+--------------------------------+------------------------
+ Mon Dec 30 16:00:00 2019 PST   | 1.00000000000000000000
+ Wed Jan 01 16:00:00 2020 PST   |     2.0000000000000000
+ Sun Jan 05 16:00:00 2020 PST   |     6.0000000000000000
+ Tue Jan 07 16:00:00 2020 PST   |     8.0000000000000000
+ Wed Dec 30 16:00:00 294246 PST | 1.00000000000000000000
+(5 rows)
+
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+NOTICE:  continuous aggregate "date_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamp_agg" is already up-to-date
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+NOTICE:  continuous aggregate "timestamptz_agg" is already up-to-date

--- a/tsl/test/shared/expected/extension.out
+++ b/tsl/test/shared/expected/extension.out
@@ -37,6 +37,7 @@ ORDER BY pronamespace::regnamespace::text COLLATE "C", p.oid::regprocedure::text
  _timescaledb_internal.cagg_migrate_plan_exists(integer)
  _timescaledb_internal.cagg_migrate_pre_validation(text,text,text)
  _timescaledb_internal.cagg_watermark(integer)
+ _timescaledb_internal.cagg_watermark_materialized(integer)
  _timescaledb_internal.calculate_chunk_interval(integer,bigint,bigint)
  _timescaledb_internal.chunk_constraint_add_table_constraint(_timescaledb_catalog.chunk_constraint)
  _timescaledb_internal.chunk_drop_replica(regclass,name)

--- a/tsl/test/sql/cagg_union_view.sql.in
+++ b/tsl/test/sql/cagg_union_view.sql.in
@@ -379,9 +379,14 @@ CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
 
 -- Watermarks at min for the above caggs:
-SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
+SELECT
+  user_view_name,
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id),
+  _timescaledb_internal.cagg_watermark(mat_hypertable_id) = _timescaledb_internal.cagg_watermark_materialized(mat_hypertable_id) AS is_equal
 FROM _timescaledb_catalog.continuous_agg
-ORDER BY 1,2;
+NATURAL JOIN _timescaledb_catalog.continuous_aggs_watermark
+ORDER BY 1, 2, 3;
 
 INSERT INTO smallint_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
 INSERT INTO int_table VALUES (1, 1), (2, 2), (6, 6), (8, 8), (19, 19);
@@ -397,7 +402,6 @@ CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
 CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
 CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
 CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
-
 
 -- Watermarks should reflect the new materializations
 SELECT user_view_name, _timescaledb_internal.cagg_watermark(mat_hypertable_id)
@@ -456,3 +460,67 @@ SELECT _timescaledb_internal.cagg_watermark(100);
 -- NULL hypertable ID. Function is STRICT, so does nothing:
 SELECT _timescaledb_internal.cagg_watermark(NULL);
 \set ON_ERROR_STOP 1
+
+-- Remove stored watermark, so query and refresh should error
+\c :TEST_DBNAME :ROLE_SUPERUSER
+DELETE FROM _timescaledb_catalog.continuous_aggs_watermark;
+
+\set ON_ERROR_STOP 0
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);
+\set ON_ERROR_STOP 1
+
+-- Fix all continuous aggregates inserting materialized watermark into the metadata table
+INSERT INTO _timescaledb_catalog.continuous_aggs_watermark (mat_hypertable_id, watermark)
+SELECT a.mat_hypertable_id, _timescaledb_internal.cagg_watermark_materialized(a.mat_hypertable_id)
+FROM _timescaledb_catalog.continuous_agg a
+LEFT JOIN _timescaledb_catalog.continuous_aggs_watermark b ON b.mat_hypertable_id = a.mat_hypertable_id
+WHERE b.mat_hypertable_id IS NULL
+ORDER BY 1;
+
+SELECT * FROM smallint_agg
+ORDER BY 1,2;
+
+SELECT * FROM int_agg
+ORDER BY 1,2;
+
+SELECT * FROM bigint_agg
+ORDER BY 1,2;
+
+SELECT * FROM date_agg
+ORDER BY 1,2;
+
+SELECT * FROM timestamp_agg
+ORDER BY 1,2;
+
+SELECT * FROM timestamptz_agg
+ORDER BY 1,2;
+
+CALL refresh_continuous_aggregate('int_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('smallint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('bigint_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('date_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamp_agg', NULL, NULL);
+CALL refresh_continuous_aggregate('timestamptz_agg', NULL, NULL);


### PR DESCRIPTION
When calling the `cagg_watermark` function to get the watermark of a
Continuous Aggregate we execute a `SELECT MAX(time_dimension)` query
in the underlying materialization hypertable.

The problem is that a `SELECT MAX(time_dimention)` query can be
expensive because it will scan all hypertable chunks increasing the
planning time for a Realtime Continuous Aggregates.

Improved it by creating a new catalog table to serve as a cache table
to store the current Continous Aggregate watermark in the following
situations:
- Create CAgg: store the minimum value of hypertable time dimension
  data type;
- Refresh CAgg: store the last value of the time dimension materialized
  in the underlying materialization hypertable (or the minimum value of
  materialization hypertable time dimension data type if there's no
  data materialized);
- Drop CAgg Chunks: the same as refresh cagg.

Closes #4699, #5307

