### PR TITLE
Bump version of setup-wsl github action

### DIFF
--- a/.github/workflows/windows-build-and-test.yaml
+++ b/.github/workflows/windows-build-and-test.yaml
@@ -79,7 +79,7 @@ jobs:
       TABLESPACE2: D:\tablespace2\
     steps:
     - name: Setup WSL
-      uses: Vampire/setup-wsl@v1
+      uses: Vampire/setup-wsl@v2
       with:
         additional-packages:
           cmake


### PR DESCRIPTION
The currently used version pulls in Node.js 12 which is deprecated on github.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Disable-check: force-changelog-changed
