### PR TITLE
Fix the python code style check 

### DIFF
--- a/.github/workflows/code_style.yaml
+++ b/.github/workflows/code_style.yaml
@@ -82,7 +82,12 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          pip install black prospector psutil
+          pip install --upgrade pip
+          # Inexplicably, at some point pip started to insist on installing
+          # prospector==1.7.7, which is incompatible with the new pylint.
+          pip install black prospector==1.8.4 psutil pylint
+          pip list
+          pip list --user
       - name: Checkout source
         uses: actions/checkout@v3
       - name: Run prospector


### PR DESCRIPTION
For an unknown reason, pip started to install an older version of
prospector which is incompatible with the current pylint. Require the
new prospector version explicitly.

Disable-check: force-changelog-changed