### PR TITLE
Improve automated backports

### DIFF
--- a/.github/workflows/changelog-check.yaml
+++ b/.github/workflows/changelog-check.yaml
@@ -5,7 +5,7 @@ name: Check CHANGELOG.md updated
     # It's important to check that the changelog is updated with bug fixes that
     # we backport to the release branches, so these branches are included as
     # well.
-    branches: [main, "[0-9]+.[0-9]+.x"]
+    branches: [main, '[0-9]+.[0-9]+.x']
 jobs:
   # Check that the CHANGELOG is updated by the pull request. This can be
   # disabled by adding a trailer line of the following form to the

--- a/.pull-review
+++ b/.pull-review
@@ -66,4 +66,4 @@ file_blacklist:
   - test/expected/*.out
 
 label_blacklist:
-  - pr-backport
+  - is-auto-backport


### PR DESCRIPTION
A follow-up for the review comments in the previous PR https://github.com/timescale/timescaledb/pull/5227

1. Create one backport PR per one source PR, even with multiple commits.
1. Add a comment to the source PR if we fail to backport it for some reason.

Disable-check: force-changelog-changed