### PR TITLE
When backporting, fetch the main branch with large depth

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -2,11 +2,16 @@ name: Backport Bug Fixes
 on:
   schedule:
     # Run weekdays 12:00 on main branch, so that it doesn't wreak havoc on
-    # weekends.
+    # weekends. Good to have regular runs so that we can react to changes in
+    # issue tags, or retry some spurious network errors, or whatever.
     - cron: '0 12 * * 1-5'
   workflow_dispatch:
   push:
     branches:
+      # Ideally we want to create a backport PR as soon as the fix is merged
+      # into the main branch
+      - main
+
       # You can run and debug new versions of the backport script by pushing it
       # to this branch. workflow_dispatch can only be run through github cli for
       # branches that are not main, so it's inconvenient.

--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -10,6 +10,11 @@ from github import Github  # This is PyGithub.
 import requests
 
 
+# Limit our history search and fetch depth to this value, not to get stuck in
+# case of a bug.
+HISTORY_DEPTH = 1000
+
+
 def run_query(query):
     """A simple function to use requests.post to make the GraphQL API call."""
 
@@ -162,9 +167,12 @@ print(
     f"Will commit as {os.environ['GIT_COMMITTER_NAME']} <{os.environ['GIT_COMMITTER_EMAIL']}>"
 )
 
-# Fetch the sources
-git_check(f"fetch {source_remote}")
-git_check(f"fetch {target_remote}")
+# Fetch the main branch. Apparently the local repo can be shallow in some cases
+# in Github Actions, so specify the depth. --unshallow will complain on normal
+# repositories, this is why we don't use it here.
+git_check(
+    f"fetch --quiet --depth={HISTORY_DEPTH} {source_remote} main:refs/remotes/{source_remote}/main"
+)
 
 # Find out what is the branch corresponding to the previous version compared to
 # main. We will backport to that branch.
@@ -181,7 +189,19 @@ previous_version_parts = previous_version.split(".")
 previous_version_parts[-1] = "x"
 backport_target = ".".join(previous_version_parts)
 
-print(f"Will backport to {backport_target}")
+print(f"Will backport to {backport_target}.")
+
+# Fetch the target branch. Apparently the local repo can be shallow in some cases
+# in Github Actions, so specify the depth. --unshallow will complain on normal
+# repositories, this is why we don't use it here.
+git_check(
+    f"fetch --quiet --depth={HISTORY_DEPTH} {target_remote} {backport_target}:refs/remotes/{target_remote}/{backport_target}"
+)
+
+# Also fetch all branches from the target repository, because we use the presence
+# of the backport branches to determine that a backport exists. It's not convenient
+# to query for branch existence through the PyGithub API.
+git_check(f"fetch {target_remote}")
 
 # Find out which commits are unique to main and target branch. Also build sets of
 # the titles of these commits. We will compare the titles to check whether a
@@ -189,15 +209,17 @@ print(f"Will backport to {backport_target}")
 main_commits = [
     line.split("\t")
     for line in git_output(
-        f'log -1000 --pretty="format:%h\t%s" {source_remote}/{backport_target}..{source_remote}/main'
+        f'log -{HISTORY_DEPTH} --pretty="format:%h\t%s" {target_remote}/{backport_target}..{source_remote}/main'
     ).splitlines()
     if line
 ]
 
+print(f"Have {len(main_commits)} new commits in the main branch.")
+
 branch_commits = [
     line.split("\t")
     for line in git_output(
-        f'log -1000 --pretty="format:%h\t%s" {source_remote}/main..{source_remote}/{backport_target}'
+        f'log -{HISTORY_DEPTH} --pretty="format:%h\t%s" {source_remote}/main..{target_remote}/{backport_target}'
     ).splitlines()
     if line
 ]
@@ -340,11 +362,22 @@ def report_backport_not_done(original_pr, reason, details=None):
 
 # Now, go over the list of PRs that we have collected, and try to backport
 # each of them.
-for pr_info in prs_to_backport.values():
+print(f"Have {len(prs_to_backport)} PRs to backport.")
+for index, pr_info in enumerate(prs_to_backport.values()):
+    print()
+
+    # Don't want to have an endless loop that modifies the repository in an
+    # unattended script. The already backported/conflicted PRs shouldn't even
+    # get into this list, so the low number is OK, it will still make progress.
+    if index > 5:
+        print(f"{index} PRs processed, stopping as a precaution.")
+        sys.exit(0)
+
     original_pr = pr_info.pygithub_pr
     backport_branch = f"backport/{backport_target}/{original_pr.number}"
 
-    # If there is already a backport branch for this PR, just skip it.
+    # If there is already a backport branch for this PR, this probably means
+    # that we already created the backport PR. Skip it.
     if (
         git_returncode(f"rev-parse {target_remote}/{backport_branch} > /dev/null 2>&1")
         == 0


### PR DESCRIPTION
Apparently in some cases we're getting a shallow repo in the Github Actions.

Disable-check: force-changelog-changed