### PR TITLE
Release 2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,26 @@ accidentally triggering the load of a previous DB version.**
 * #5246 Make connection establishment interruptible
 
 **Bugfixes**
-* #4804 Skip bucketing when start or end of refresh job is null
 * #4926 Fix corruption when inserting into compressed chunks
 * #5218 Add role-level security to job error log
 * #5214 Fix use of prepared statement in async module
+
+## 2.9.3 (2023-02-03)
+
+This release contains bug fixes since the 2.9.2 release.
+This release is high priority for upgrade. We strongly recommend that you
+upgrade as soon as possible.
+
+**Bugfixes**
+* #4804 Skip bucketing when start or end of refresh job is null
+* #5108 Fix column ordering in compressed table index not following the order of a multi-column segment by definition
+* #5187 Don't enable clang-tidy by default
+* #5255 Fix year not being considered as a multiple of day/month in hierarchical continuous aggregates
 * #5259 Lock down search_path in SPI calls
-* #5255 Fix year not multiple of day/month in nested CAgg
+
+**Thanks**
+* @ssmoss for reporting issues on continuous aggregates
+* @jaskij for reporting the compliation issue that occurred with clang
 
 ## 2.9.2 (2023-01-26)
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -42,7 +42,8 @@ set(MOD_FILES
     updates/2.8.0--2.8.1.sql
     updates/2.8.1--2.9.0.sql
     updates/2.9.0--2.9.1.sql
-    updates/2.9.1--2.9.2.sql)
+    updates/2.9.1--2.9.2.sql
+    updates/2.9.2--2.9.3.sql)
 
 # The downgrade file to generate a downgrade script for the current version, as
 # specified in version.config

--- a/version.config
+++ b/version.config
@@ -1,3 +1,3 @@
 version = 2.10.0-dev
-update_from_version = 2.9.2
+update_from_version = 2.9.3
 downgrade_to_version = 2.9.2


### PR DESCRIPTION
This release contains bug fixes since the 2.9.2 release.
This release is high priority for upgrade. We strongly recommend that you upgrade as soon as possible.

**Bugfixes**
* https://github.com/timescale/timescaledb/pull/4804 Skip bucketing when start or end of refresh job is null
* https://github.com/timescale/timescaledb/pull/5108 Fix column ordering in compressed table index not following the order of a multi-column segment by definition
* https://github.com/timescale/timescaledb/pull/5187 Don't enable clang-tidy by default
* https://github.com/timescale/timescaledb/pull/5255 Fix year not being considered as a multiple of day/month in hierarchical continuous aggregates
* https://github.com/timescale/timescaledb/pull/5259 Lock down search_path in SPI calls