### PR TITLE
Compression can't be enabled on continuous aggregates when segmentby/orderby columns need quotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ accidentally triggering the load of a previous DB version.**
 * #4926 Fix corruption when inserting into compressed chunks
 * #5218 Add role-level security to job error log
 * #5214 Fix use of prepared statement in async module
+* #5290 Compression can't be enabled on continuous aggregates when segmentby/orderby columns need quotation
 
 ## 2.9.3 (2023-02-03)
 

--- a/tsl/test/expected/compression_ddl.out
+++ b/tsl/test/expected/compression_ddl.out
@@ -1273,3 +1273,28 @@ Triggers:
     ts_insert_blocker BEFORE INSERT ON _timescaledb_internal._compressed_hypertable_23 FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker()
 
 DROP TABLE metric CASCADE;
+-- Creating hypertable
+CREATE TABLE "tEst2" (
+    "Id" uuid NOT NULL,
+    "Time" timestamp with time zone NOT NULL,
+    CONSTRAINT "test2_pkey" PRIMARY KEY ("Id", "Time")
+);
+SELECT create_hypertable(
+  '"tEst2"',
+  'Time',
+  chunk_time_interval => INTERVAL '1 day'
+);
+  create_hypertable  
+---------------------
+ (24,public,tEst2,t)
+(1 row)
+
+alter table "tEst2" set (timescaledb.compress=true, timescaledb.compress_segmentby='"Id"');
+CREATE MATERIALIZED VIEW "tEst2_mv"
+WITH (timescaledb.continuous) AS
+SELECT "Id" as "Idd",
+   time_bucket(INTERVAL '1 day', "Time") AS "bUcket"
+FROM public."tEst2"
+GROUP BY "Idd", "bUcket";
+NOTICE:  continuous aggregate "tEst2_mv" is already up-to-date
+ALTER MATERIALIZED VIEW "tEst2_mv" SET (timescaledb.compress = true);

--- a/tsl/test/sql/compression_ddl.sql
+++ b/tsl/test/sql/compression_ddl.sql
@@ -549,3 +549,26 @@ WHERE uc_hypertable.table_name like 'metric' \gset
 
 DROP TABLE metric CASCADE;
 
+-- Creating hypertable
+CREATE TABLE "tEst2" (
+    "Id" uuid NOT NULL,
+    "Time" timestamp with time zone NOT NULL,
+    CONSTRAINT "test2_pkey" PRIMARY KEY ("Id", "Time")
+);
+
+SELECT create_hypertable(
+  '"tEst2"',
+  'Time',
+  chunk_time_interval => INTERVAL '1 day'
+);
+
+alter table "tEst2" set (timescaledb.compress=true, timescaledb.compress_segmentby='"Id"');
+
+CREATE MATERIALIZED VIEW "tEst2_mv"
+WITH (timescaledb.continuous) AS
+SELECT "Id" as "Idd",
+   time_bucket(INTERVAL '1 day', "Time") AS "bUcket"
+FROM public."tEst2"
+GROUP BY "Idd", "bUcket";
+
+ALTER MATERIALIZED VIEW "tEst2_mv" SET (timescaledb.compress = true);


### PR DESCRIPTION
consider the sql commands:
```
drop table if EXISTS "tEst2" ;
-- Creating hypertable
CREATE TABLE IF NOT EXISTS "tEst2" (
    "Id" uuid NOT NULL,
    "Time" timestamp with time zone NOT NULL,
    CONSTRAINT "test2_pkey" PRIMARY KEY ("Id", "Time")
);

SELECT create_hypertable(
  '"tEst2"',
  'Time',
  chunk_time_interval => INTERVAL '1 day'
);

alter table "tEst2" set (timescaledb.compress=true, timescaledb.compress_segmentby='"Id"');

DROP MATERIALIZED VIEW if EXISTS "tEst2_mv";

CREATE MATERIALIZED VIEW "tEst2_mv"
WITH (timescaledb.continuous) AS
SELECT "Id" as "Idd",
   time_bucket(INTERVAL '1 day', "Time") AS "bUcket"
FROM public."tEst2" 
GROUP BY "Idd", "bUcket";

ALTER MATERIALIZED VIEW "tEst2_mv" SET (timescaledb.compress = true);
```

before this patch the last command failed because:
* the `Idd` column lost quotation; leading to `ERROR:  column "idd" does not exist` 
* or the `bUcket` column lost quotation; leading to `ERROR:  column "bucket" does not exist` 