### PR TITLE
Fix compression_hypertable ordering reliance

### DIFF
--- a/tsl/test/expected/compression_hypertable.out
+++ b/tsl/test/expected/compression_hypertable.out
@@ -71,20 +71,18 @@ NOTICE:  adding not-null constraint to column "Time"
 
 INSERT INTO test1 SELECT t,  gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd()::text FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-28 1:00', '1 hour') t;
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = '"Time" DESC');
-SELECT
-  $$
-  SELECT * FROM test1 ORDER BY "Time"
-  $$ AS "QUERY" \gset
-SELECT 'test1' AS "HYPERTABLE_NAME" \gset
+\set QUERY 'SELECT * FROM test1'
+\set QUERY_ORDER 'ORDER BY "Time"'
+\set HYPERTABLE_NAME 'test1'
 \ir include/compression_test_hypertable.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
 psql:include/compression_test_hypertable.sql:7: NOTICE:  table "original_result" does not exist, skipping
- count_compressed 
-------------------
-               27
+ count compress 
+----------------
+             27
 (1 row)
 
  timescaledb_pre_restore 
@@ -97,19 +95,19 @@ psql:include/compression_test_hypertable.sql:7: NOTICE:  table "original_result"
  t
 (1 row)
 
-                                     ?column?                                      | count 
------------------------------------------------------------------------------------+-------
- Number of rows different between original and query on compressed data (expect 0) |     0
+ table | diff between original and compressed 
+-------+--------------------------------------
+ test1 |                                    0
 (1 row)
 
- count_decompressed 
---------------------
-                 27
+ count decompress 
+------------------
+               27
 (1 row)
 
-                                                   ?column?                                                   | count 
---------------------------------------------------------------------------------------------------------------+-------
- Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+ table | diff between original and compressed/decompressed 
+-------+---------------------------------------------------
+ test1 |                                                 0
 (1 row)
 
 \set TYPE timestamptz
@@ -206,19 +204,17 @@ ALTER TABLE test2 ADD COLUMN d INT;
 --write to both old chunks and new chunks with different column #s
 INSERT INTO test2 SELECT t, gen_rand_minstd(), gen_rand_minstd()::text, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-06 1:00', '1 hour') t;
 ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'c, "Time" DESC');
-SELECT
-  $$
-  SELECT * FROM test2 ORDER BY c, "Time"
-  $$ AS "QUERY" \gset
-SELECT 'test2' AS "HYPERTABLE_NAME" \gset
+\set QUERY 'SELECT * FROM test2'
+\set QUERY_ORDER 'ORDER BY c,"Time"'
+\set HYPERTABLE_NAME 'test2'
 \ir include/compression_test_hypertable.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                5
+ count compress 
+----------------
+              5
 (1 row)
 
  timescaledb_pre_restore 
@@ -231,19 +227,19 @@ SELECT 'test2' AS "HYPERTABLE_NAME" \gset
  t
 (1 row)
 
-                                     ?column?                                      | count 
------------------------------------------------------------------------------------+-------
- Number of rows different between original and query on compressed data (expect 0) |     0
+ table | diff between original and compressed 
+-------+--------------------------------------
+ test2 |                                    0
 (1 row)
 
- count_decompressed 
---------------------
-                  5
+ count decompress 
+------------------
+                5
 (1 row)
 
-                                                   ?column?                                                   | count 
---------------------------------------------------------------------------------------------------------------+-------
- Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+ table | diff between original and compressed/decompressed 
+-------+---------------------------------------------------
+ test2 |                                                 0
 (1 row)
 
 \set TYPE int
@@ -321,16 +317,17 @@ group by location ORDER BY location;
  POR      | 18721
 (2 rows)
 
-SELECT $$ SELECT * FROM test4 ORDER BY timec $$ AS "QUERY" \gset
-SELECT 'test4' AS "HYPERTABLE_NAME" \gset
+\set QUERY 'SELECT * FROM test4'
+\set QUERY_ORDER 'ORDER BY timec'
+\set HYPERTABLE_NAME 'test4'
 \ir include/compression_test_hypertable.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                1
+ count compress 
+----------------
+              1
 (1 row)
 
  timescaledb_pre_restore 
@@ -343,19 +340,19 @@ SELECT 'test4' AS "HYPERTABLE_NAME" \gset
  t
 (1 row)
 
-                                     ?column?                                      | count 
------------------------------------------------------------------------------------+-------
- Number of rows different between original and query on compressed data (expect 0) |     0
+ table | diff between original and compressed 
+-------+--------------------------------------
+ test4 |                                    0
 (1 row)
 
- count_decompressed 
---------------------
-                  1
+ count decompress 
+------------------
+                1
 (1 row)
 
-                                                   ?column?                                                   | count 
---------------------------------------------------------------------------------------------------------------+-------
- Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+ table | diff between original and compressed/decompressed 
+-------+---------------------------------------------------
+ test4 |                                                 0
 (1 row)
 
 \set TYPE TIMESTAMPTZ
@@ -434,16 +431,17 @@ insert into test5
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timestamp, '2 hour'), 'device_2', gen_rand_minstd();
 insert into test5
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timestamp, '2 hour'), NULL, gen_rand_minstd();
-SELECT $$ SELECT * FROM test5 ORDER BY device_id, time $$ AS "QUERY" \gset
-SELECT 'test5' AS "HYPERTABLE_NAME" \gset
+\set QUERY 'SELECT * FROM test5'
+\set QUERY_ORDER 'ORDER BY device_id, time'
+\set HYPERTABLE_NAME 'test5'
 \ir include/compression_test_hypertable.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-               10
+ count compress 
+----------------
+             10
 (1 row)
 
  timescaledb_pre_restore 
@@ -456,19 +454,19 @@ SELECT 'test5' AS "HYPERTABLE_NAME" \gset
  t
 (1 row)
 
-                                     ?column?                                      | count 
------------------------------------------------------------------------------------+-------
- Number of rows different between original and query on compressed data (expect 0) |     0
+ table | diff between original and compressed 
+-------+--------------------------------------
+ test5 |                                    0
 (1 row)
 
- count_decompressed 
---------------------
-                 10
+ count decompress 
+------------------
+               10
 (1 row)
 
-                                                   ?column?                                                   | count 
---------------------------------------------------------------------------------------------------------------+-------
- Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+ table | diff between original and compressed/decompressed 
+-------+---------------------------------------------------
+ test5 |                                                 0
 (1 row)
 
 \set TYPE TEXT
@@ -514,16 +512,17 @@ INSERT INTO test6 SELECT t, d, customtype_in((t + d)::TEXT::cstring)
   FROM generate_series(1, 200) t, generate_series(1, 3) d;
 INSERT INTO test6 SELECT t, NULL, customtype_in(t::TEXT::cstring)
   FROM generate_series(1, 200) t;
-\set QUERY 'SELECT * FROM test6 ORDER BY device_id, time'
+\set QUERY 'SELECT * FROM test6'
+\set QUERY_ORDER 'ORDER BY device_id, time'
 \set HYPERTABLE_NAME 'test6'
 \ir include/compression_test_hypertable.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                5
+ count compress 
+----------------
+              5
 (1 row)
 
  timescaledb_pre_restore 
@@ -536,19 +535,19 @@ INSERT INTO test6 SELECT t, NULL, customtype_in(t::TEXT::cstring)
  t
 (1 row)
 
-                                     ?column?                                      | count 
------------------------------------------------------------------------------------+-------
- Number of rows different between original and query on compressed data (expect 0) |     0
+ table | diff between original and compressed 
+-------+--------------------------------------
+ test6 |                                    0
 (1 row)
 
- count_decompressed 
---------------------
-                  5
+ count decompress 
+------------------
+                5
 (1 row)
 
-                                                   ?column?                                                   | count 
---------------------------------------------------------------------------------------------------------------+-------
- Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+ table | diff between original and compressed/decompressed 
+-------+---------------------------------------------------
+ test6 |                                                 0
 (1 row)
 
 \set TYPE INT
@@ -591,16 +590,17 @@ INSERT INTO test7
   SELECT t, d, '2019/07/07 01:30', gen_rand_minstd(), NULL
   FROM generate_series(10, 20) t,
        generate_series('2019/03/01'::DATE, '2019/03/10', '1d') d;
-\set QUERY 'SELECT * FROM test7 ORDER BY time, c1'
+\set QUERY 'SELECT * FROM test7'
+\set QUERY_ORDER 'ORDER BY time, c1'
 \set HYPERTABLE_NAME 'test7'
 \ir include/compression_test_hypertable.sql
 -- This file and its contents are licensed under the Timescale License.
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-TIMESCALE for a copy of the license.
 \set ECHO errors
- count_compressed 
-------------------
-                1
+ count compress 
+----------------
+              1
 (1 row)
 
  timescaledb_pre_restore 
@@ -613,19 +613,19 @@ INSERT INTO test7
  t
 (1 row)
 
-                                     ?column?                                      | count 
------------------------------------------------------------------------------------+-------
- Number of rows different between original and query on compressed data (expect 0) |     0
+ table | diff between original and compressed 
+-------+--------------------------------------
+ test7 |                                    0
 (1 row)
 
- count_decompressed 
---------------------
-                  1
+ count decompress 
+------------------
+                1
 (1 row)
 
-                                                   ?column?                                                   | count 
---------------------------------------------------------------------------------------------------------------+-------
- Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+ table | diff between original and compressed/decompressed 
+-------+---------------------------------------------------
+ test7 |                                                 0
 (1 row)
 
 \set TYPE INT

--- a/tsl/test/sql/compression_hypertable.sql
+++ b/tsl/test/sql/compression_hypertable.sql
@@ -50,12 +50,9 @@ INSERT INTO test1 SELECT t,  gen_rand_minstd(), gen_rand_minstd(), gen_rand_mins
 
 ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = '"Time" DESC');
 
-SELECT
-  $$
-  SELECT * FROM test1 ORDER BY "Time"
-  $$ AS "QUERY" \gset
-
-SELECT 'test1' AS "HYPERTABLE_NAME" \gset
+\set QUERY 'SELECT * FROM test1'
+\set QUERY_ORDER 'ORDER BY "Time"'
+\set HYPERTABLE_NAME 'test1'
 
 \ir include/compression_test_hypertable.sql
 \set TYPE timestamptz
@@ -103,12 +100,10 @@ INSERT INTO test2 SELECT t, gen_rand_minstd(), gen_rand_minstd()::text, gen_rand
 
 ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby = '', timescaledb.compress_orderby = 'c, "Time" DESC');
 
-SELECT
-  $$
-  SELECT * FROM test2 ORDER BY c, "Time"
-  $$ AS "QUERY" \gset
+\set QUERY 'SELECT * FROM test2'
+\set QUERY_ORDER 'ORDER BY c,"Time"'
+\set HYPERTABLE_NAME 'test2'
 
-SELECT 'test2' AS "HYPERTABLE_NAME" \gset
 \ir include/compression_test_hypertable.sql
 
 \set TYPE int
@@ -146,9 +141,9 @@ select location, count(*)
 from test4
 group by location ORDER BY location;
 
-SELECT $$ SELECT * FROM test4 ORDER BY timec $$ AS "QUERY" \gset
-
-SELECT 'test4' AS "HYPERTABLE_NAME" \gset
+\set QUERY 'SELECT * FROM test4'
+\set QUERY_ORDER 'ORDER BY timec'
+\set HYPERTABLE_NAME 'test4'
 
 \ir include/compression_test_hypertable.sql
 \set TYPE TIMESTAMPTZ
@@ -188,10 +183,9 @@ select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timest
 insert into test5
 select generate_series('2018-01-01 00:00'::timestamp, '2018-01-10 00:00'::timestamp, '2 hour'), NULL, gen_rand_minstd();
 
-
-SELECT $$ SELECT * FROM test5 ORDER BY device_id, time $$ AS "QUERY" \gset
-
-SELECT 'test5' AS "HYPERTABLE_NAME" \gset
+\set QUERY 'SELECT * FROM test5'
+\set QUERY_ORDER 'ORDER BY device_id, time'
+\set HYPERTABLE_NAME 'test5'
 
 \ir include/compression_test_hypertable.sql
 \set TYPE TEXT
@@ -220,8 +214,8 @@ INSERT INTO test6 SELECT t, d, customtype_in((t + d)::TEXT::cstring)
 INSERT INTO test6 SELECT t, NULL, customtype_in(t::TEXT::cstring)
   FROM generate_series(1, 200) t;
 
-\set QUERY 'SELECT * FROM test6 ORDER BY device_id, time'
-
+\set QUERY 'SELECT * FROM test6'
+\set QUERY_ORDER 'ORDER BY device_id, time'
 \set HYPERTABLE_NAME 'test6'
 
 \ir include/compression_test_hypertable.sql
@@ -248,8 +242,8 @@ INSERT INTO test7
   FROM generate_series(10, 20) t,
        generate_series('2019/03/01'::DATE, '2019/03/10', '1d') d;
 
-\set QUERY 'SELECT * FROM test7 ORDER BY time, c1'
-
+\set QUERY 'SELECT * FROM test7'
+\set QUERY_ORDER 'ORDER BY time, c1'
 \set HYPERTABLE_NAME 'test7'
 
 \ir include/compression_test_hypertable.sql

--- a/tsl/test/sql/include/compression_test_hypertable.sql
+++ b/tsl/test/sql/include/compression_test_hypertable.sql
@@ -9,10 +9,7 @@ DROP TABLE IF EXISTS original_result;
 
 CREATE TABLE original_result AS :QUERY;
 
-SELECT count(compress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_compressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NULL;
+SELECT count(compress_chunk(c, true)) AS "count compress" FROM show_chunks(:'HYPERTABLE_NAME') c;
 
 --dump & restore while data is in compressed state.
 \c postgres :ROLE_SUPERUSER
@@ -31,30 +28,26 @@ SELECT timescaledb_post_restore();
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 
 with original AS (
-  SELECT row_number() OVER() row_number, * FROM original_result
+  SELECT row_number() OVER() row_number, * FROM (SELECT * FROM original_result :QUERY_ORDER) qo
 ),
 decompressed AS (
-  SELECT row_number() OVER() row_number, * FROM (:QUERY) as q
+  SELECT row_number() OVER() row_number, * FROM (:QUERY :QUERY_ORDER) as q
 )
-SELECT 'Number of rows different between original and query on compressed data (expect 0)', count(*)
+SELECT :'HYPERTABLE_NAME' AS table, count(*) AS "diff between original and compressed"
 FROM original
 FULL OUTER JOIN decompressed ON (original.row_number = decompressed.row_number)
 WHERE (original.*) IS DISTINCT FROM (decompressed.*);
 
-SELECT count(decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_decompressed
-FROM _timescaledb_catalog.chunk chunk
-INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
-WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NOT NULL;
-
+SELECT count(decompress_chunk(c)) AS "count decompress" FROM show_chunks(:'HYPERTABLE_NAME') c;
 
 --run data on data that's been compressed and decompressed, make sure it's the same.
 with original AS (
-  SELECT row_number() OVER() row_number, * FROM original_result
+  SELECT row_number() OVER() row_number, * FROM (SELECT * FROM original_result :QUERY_ORDER) qo
 ),
 uncompressed AS (
-  SELECT row_number() OVER() row_number, * FROM (:QUERY) as q
+  SELECT row_number() OVER() row_number, * FROM (:QUERY :QUERY_ORDER) as q
 )
-SELECT 'Number of rows different between original and data that has been compressed and then decompressed (expect 0)', count(*)
+SELECT :'HYPERTABLE_NAME' AS table, count(*) AS "diff between original and compressed/decompressed"
 FROM original
 FULL OUTER JOIN uncompressed ON (original.row_number = uncompressed.row_number)
 WHERE (original.*) IS DISTINCT FROM (uncompressed.*);


### PR DESCRIPTION
The hypertable_compression test had on implicit reliance on the ordering of tuples when querying the materialized results. This patch makes the ordering explicit in this test.

Disable-check: force-changelog-changed
