### PR TITLE
Warn about mismatched chunk cache sizes

### DIFF
--- a/coccinelle/ereport_pg12.cocci
+++ b/coccinelle/ereport_pg12.cocci
@@ -11,6 +11,14 @@ expression E1, E2;
 
 // We pass two or more expressions to ereport
 
-+ /* ereport uses PG 12.3+ syntax */
++ /*
++  * Please enclose the auxiliary ereport arguments into parentheses for
++  * compatibility with PG 12. Example:
++  *
++  * ereport(ERROR, ( errmsg(...), errdetail(...) ) );
++  *                ^-----------add these---------^
++  *
++  * See https://github.com/postgres/postgres/commit/a86715451653c730d637847b403b0420923956f7
++  */
 ereport(K1, E1, E2, ...);
 

--- a/test/expected/insert_single.out
+++ b/test/expected/insert_single.out
@@ -479,6 +479,15 @@ INSERT INTO "nondefault_mem_settings" VALUES
 ('2001-03-20T09:00:00', 30.6),
 ('2002-03-20T09:00:00', 31.9),
 ('2003-03-20T09:00:00', 32.9);
+--warning about mismatched cache sizes
+SET timescaledb.max_open_chunks_per_insert = 100;
+WARNING:  insert cache size is larger than hypertable chunk cache size
+SET timescaledb.max_cached_chunks_per_hypertable = 10;
+WARNING:  insert cache size is larger than hypertable chunk cache size
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-05-20T09:00:00', 36.6),
+('2002-05-20T09:00:00', 37.9),
+('2003-05-20T09:00:00', 38.9);
 --unlimited
 SET timescaledb.max_open_chunks_per_insert = 0;
 SET timescaledb.max_cached_chunks_per_hypertable = 0;
@@ -497,10 +506,13 @@ SELECT * FROM "nondefault_mem_settings";
  Tue Mar 20 09:00:00 2001 | 30.6
  Wed Mar 20 09:00:00 2002 | 31.9
  Thu Mar 20 09:00:00 2003 | 32.9
+ Sun May 20 09:00:00 2001 | 36.6
+ Mon May 20 09:00:00 2002 | 37.9
+ Tue May 20 09:00:00 2003 | 38.9
  Fri Apr 20 09:00:00 2001 | 33.6
  Sat Apr 20 09:00:00 2002 | 34.9
  Sun Apr 20 09:00:00 2003 | 35.9
-(11 rows)
+(14 rows)
 
 --test rollback
 BEGIN;
@@ -527,7 +539,7 @@ SAVEPOINT savepoint_2;
 SAVEPOINT
 \set ON_ERROR_STOP 0
 INSERT INTO "data_records" ("time", "value") VALUES (3, -1);
-ERROR:  new row for relation "_hyper_13_34_chunk" violates check constraint "data_records_value_check"
+ERROR:  new row for relation "_hyper_13_37_chunk" violates check constraint "data_records_value_check"
 \set ON_ERROR_STOP 1
 ROLLBACK TO SAVEPOINT savepoint_2;
 ROLLBACK

--- a/test/sql/insert_single.sql
+++ b/test/sql/insert_single.sql
@@ -154,6 +154,14 @@ INSERT INTO "nondefault_mem_settings" VALUES
 ('2002-03-20T09:00:00', 31.9),
 ('2003-03-20T09:00:00', 32.9);
 
+--warning about mismatched cache sizes
+SET timescaledb.max_open_chunks_per_insert = 100;
+SET timescaledb.max_cached_chunks_per_hypertable = 10;
+INSERT INTO "nondefault_mem_settings" VALUES
+('2001-05-20T09:00:00', 36.6),
+('2002-05-20T09:00:00', 37.9),
+('2003-05-20T09:00:00', 38.9);
+
 --unlimited
 SET timescaledb.max_open_chunks_per_insert = 0;
 SET timescaledb.max_cached_chunks_per_hypertable = 0;

--- a/tsl/test/expected/dist_copy_available_dns.out
+++ b/tsl/test/expected/dist_copy_available_dns.out
@@ -111,6 +111,7 @@ SELECT * FROM chunk_query_data_node WHERE hypertable_name = 'uk_price_paid' LIMI
 (5 rows)
 
 set timescaledb.max_open_chunks_per_insert = 1117;
+WARNING:  insert cache size is larger than hypertable chunk cache size
 SET ROLE :ROLE_CLUSTER_SUPERUSER;
 SELECT * FROM alter_data_node('data_node_1', available=>true);
   node_name  |   host    | port  |           database           | available 

--- a/tsl/test/expected/dist_copy_long.out
+++ b/tsl/test/expected/dist_copy_long.out
@@ -116,6 +116,7 @@ select count(*) from uk_price_paid;
 
 truncate uk_price_paid;
 set timescaledb.max_open_chunks_per_insert = 1117;
+WARNING:  insert cache size is larger than hypertable chunk cache size
 \copy uk_price_paid from program 'zcat < data/prices-100k-random-1.tsv.gz';
 select count(*) from uk_price_paid;
  count  


### PR DESCRIPTION
Just noticed abysmal INSERT performance when experimenting with one of our customers' data set, and turns out my cache sizes were misconfigured, leading to constant hypertable chunk cache thrashing. Show a warning to detect this misconfiguration. Also use more generous defaults, we're not supposed to run on a microwave (unlike Postgres).

Disable-check: force-changelog-changed