### PR TITLE
Fix some incorrect memory handling

### DIFF
--- a/src/process_utility.c
+++ b/src/process_utility.c
@@ -1505,7 +1505,8 @@ process_relations_in_namespace(GrantStmt *stmt, Name schema_name, Oid namespaceI
 
 	while ((tuple = heap_getnext(scan, ForwardScanDirection)) != NULL)
 	{
-		Name relname = &((Form_pg_class) GETSTRUCT(tuple))->relname;
+		Name relname = palloc0(NAMEDATALEN);
+		namestrcpy (relname, NameStr(((Form_pg_class) GETSTRUCT(tuple))->relname));
 
 		/* these are being added for the first time into this list */
 		process_grant_add_by_name(stmt, false, schema_name, relname);

--- a/src/ts_catalog/metadata.c
+++ b/src/ts_catalog/metadata.c
@@ -156,8 +156,13 @@ ts_metadata_insert(const char *metadata_key, Datum metadata_value, Oid type,
 	}
 
 	/* We have to copy the key here because heap_form_tuple will copy NAMEDATALEN
-	 * into the tuple instead of checking length. */
-	strlcpy(key_data, metadata_key, NAMEDATALEN);
+	 * into the tuple instead of checking length.
+	 * We use strncpy to fill the rest of buffer with zeroes to avoid junk
+	 * and then manually set the last symbol to 0, akin to namestrcpy;
+	 */
+	
+	strncpy(key_data, metadata_key, NAMEDATALEN);
+	key_data[NAMEDATALEN - 1] = '\0';
 
 	/* Insert into the catalog table for persistence */
 	values[AttrNumberGetAttrOffset(Anum_metadata_key)] = CStringGetDatum(key_data);


### PR DESCRIPTION
While running TimescaleDB under valgrind I've found two cases of incorrect memory handling.

Case 1: When creating timescaledb extension, during the insertion of metadata there is some junk in memory that is not zeroed before writing there.
Changes in metadata.c fix this.

Case 2: When executing GRANT smth ON ALL TABLES IN SCHEMA some_schema and deconstructing this statement into granting to individual tables, process of copying names of those tables is wrong. Currently, you aren't copying the data itself, but an address to data on a page in some buffer. There's a problem - when the page in this buffer changes, copied address would lead to wrong data. Changes in process_utility.c fix this by allocating memory and then copying needed relname there.

Fixes #5311