### PR TITLE
Use NameData and namestrcpy for names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ accidentally triggering the load of a previous DB version.**
 * #5214 Fix use of prepared statement in async module
 * #5290 Compression can't be enabled on continuous aggregates when segmentby/orderby columns need quotation
 * #5239 Fix next_start calculation for fixed schedules
+* #5336 Use NameData and namestrcpy for names
 
 ## 2.9.3 (2023-02-03)
 

--- a/scripts/test_update_from_tag.sh
+++ b/scripts/test_update_from_tag.sh
@@ -43,8 +43,12 @@ remove_containers() {
     docker rm -vf ${CONTAINER_CLEAN_RESTORE} 2>/dev/null
     docker rm -vf ${CONTAINER_UPDATED}  2>/dev/null
     docker rm -vf ${CONTAINER_CLEAN_RERUN} 2>/dev/null
-    docker volume rm -f ${CLEAN_VOLUME} 2>/dev/null
-    docker volume rm -f ${UPDATE_VOLUME} 2>/dev/null
+    if [[ -n "${CLEAN_VOLUME}" ]]; then
+	docker volume rm -f ${CLEAN_VOLUME} 2>/dev/null
+    fi
+    if [[ -n "${UPDATE_VOLUME}" ]]; then
+	docker volume rm -f ${UPDATE_VOLUME} 2>/dev/null
+    fi
 }
 
 cleanup() {

--- a/src/partitioning.h
+++ b/src/partitioning.h
@@ -25,8 +25,8 @@
 
 typedef struct PartitioningFunc
 {
-	char schema[NAMEDATALEN];
-	char name[NAMEDATALEN];
+	NameData schema;
+	NameData name;
 	Oid rettype;
 
 	/*
@@ -38,7 +38,7 @@ typedef struct PartitioningFunc
 
 typedef struct PartitioningInfo
 {
-	char column[NAMEDATALEN];
+	NameData column;
 	AttrNumber column_attnum;
 	DimensionType dimtype;
 	PartitioningFunc partfunc;

--- a/src/ts_catalog/catalog.c
+++ b/src/ts_catalog/catalog.c
@@ -381,7 +381,7 @@ static void
 catalog_database_info_init(CatalogDatabaseInfo *info)
 {
 	info->database_id = MyDatabaseId;
-	strlcpy(info->database_name, get_database_name(MyDatabaseId), NAMEDATALEN);
+	namestrcpy(&info->database_name, get_database_name(MyDatabaseId));
 	info->schema_id = get_namespace_oid(CATALOG_SCHEMA_NAME, false);
 	info->owner_uid = catalog_owner();
 

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -1378,7 +1378,7 @@ typedef struct CatalogTableInfo
 
 typedef struct CatalogDatabaseInfo
 {
-	char database_name[NAMEDATALEN];
+	NameData database_name;
 	Oid database_id;
 	Oid schema_id;
 	Oid owner_uid;


### PR DESCRIPTION
Using `strlcpy` to copy variables holding PostgreSQL names can cause issues since names are fixed-size types of length 64. This means that any data that follows the initial null-terminated string will also be part of the data.

Instead of using `const char*` for PostgreSQL names, use `NameData` type for PostgreSQL names and use `namestrcpy` to copy them rather than `strlcpy`, which is a safe alternative since it will write null characters to the entire buffer.